### PR TITLE
feat: add DFlash for Windows

### DIFF
--- a/dflash/.gitignore
+++ b/dflash/.gitignore
@@ -15,3 +15,4 @@ Makefile
 __pycache__/
 *.pyc
 .venv/
+models/

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -63,9 +63,15 @@ target_link_libraries(dflash27b
         ggml-base
 )
 
-target_compile_options(dflash27b PRIVATE
-    -Wall -Wextra -Wno-unused-parameter -Wno-unused-function
-)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+     target_compile_options(dflash27b PRIVATE
+         $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wextra -Wno-unused-parameter -Wno-unused-function>
+     )
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     target_compile_options(dflash27b PRIVATE
+         $<$<COMPILE_LANGUAGE:CXX>:/W4 /permissive->
+     )
+endif()
 
 # ─── Tests (numerics vs oracle) ────────────────────────────────────
 

--- a/dflash/scripts/run.py
+++ b/dflash/scripts/run.py
@@ -80,7 +80,12 @@ def main():
     im_end_id = tokenizer.encode("<|im_end|>", add_special_tokens=False)
     im_end_id = im_end_id[0] if im_end_id else -1
 
+    args.bin = str(Path(args.bin).resolve())
+    bin_dir = str(Path(args.bin).parent)
+    dll_dir = str(Path(args.bin).parent / "bin")
     env = {**os.environ}
+    if sys.platform == "win32":
+        env["PATH"] = dll_dir + os.pathsep + bin_dir + os.pathsep + env.get("PATH", "")
     if args.kv_q4:
         env["DFLASH27B_KV_Q4"] = "1"
 
@@ -92,18 +97,23 @@ def main():
               file=sys.stderr, flush=True)
 
         r, w = os.pipe()
+        if sys.platform == "win32":
+            import msvcrt
+            os.set_inheritable(w, True)
+            stream_fd_val = int(msvcrt.get_osfhandle(w))
+        else:
+            stream_fd_val = w
         cmd = [args.bin, args.target, draft_path, in_bin,
                str(args.n_gen), out_bin,
                "--fast-rollback", "--ddtree", f"--ddtree-budget={args.budget}",
-               f"--stream-fd={w}"]
+               f"--stream-fd={stream_fd_val}"]
         if sys.platform == "win32":
-            os.set_inheritable(w, True)
             proc = subprocess.Popen(cmd, env=env, close_fds=False,
-                                    stdout=subprocess.DEVNULL,
+                                    stdout=sys.stderr,
                                     stderr=subprocess.PIPE)
         else:
             proc = subprocess.Popen(cmd, pass_fds=(w,), env=env,
-                                    stdout=subprocess.DEVNULL,
+                                    stdout=sys.stderr,
                                     stderr=subprocess.PIPE)
         os.close(w)
 
@@ -126,6 +136,10 @@ def main():
             return
         finally:
             proc.wait()
+            err = proc.stderr.read()
+            if err:
+                sys.stderr.buffer.write(err)
+                sys.stderr.flush()
         print(file=sys.stderr, flush=True)
         print(f"[run] generated {generated} tokens", file=sys.stderr, flush=True)
 

--- a/dflash/scripts/run.py
+++ b/dflash/scripts/run.py
@@ -20,7 +20,7 @@ def default_paths():
     return {
         "target": "models/Qwen3.5-27B-Q4_K_M.gguf",
         "draft":  str(Path.home() / ".cache/huggingface/hub/models--z-lab--Qwen3.5-27B-DFlash/snapshots"),
-        "bin":    "build/test_dflash",
+        "bin":    "build/test_dflash" + (".exe" if sys.platform == "win32" else ""),
     }
 
 
@@ -96,9 +96,15 @@ def main():
                str(args.n_gen), out_bin,
                "--fast-rollback", "--ddtree", f"--ddtree-budget={args.budget}",
                f"--stream-fd={w}"]
-        proc = subprocess.Popen(cmd, pass_fds=(w,), env=env,
-                                stdout=subprocess.DEVNULL,
-                                stderr=subprocess.PIPE)
+        if sys.platform == "win32":
+            os.set_inheritable(w, True)
+            proc = subprocess.Popen(cmd, env=env, close_fds=False,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.PIPE)
+        else:
+            proc = subprocess.Popen(cmd, pass_fds=(w,), env=env,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.PIPE)
         os.close(w)
 
         generated = 0

--- a/dflash/src/gguf_target_loader.cpp
+++ b/dflash/src/gguf_target_loader.cpp
@@ -45,23 +45,32 @@
 
 #include "internal.h"
 
-#include <cerrno>
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <fcntl.h>
 #include <string>
+
+#if !defined(_WIN32)
+#include <cerrno>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 namespace dflash27b {
 
 // CpuEmbedder destructor + embed() method
 CpuEmbedder::~CpuEmbedder() {
+#if defined(_WIN32)
+    if (mmap_addr)                         UnmapViewOfFile(mmap_addr);
+    if (mmap_hmap)                         CloseHandle(mmap_hmap);
+    if (mmap_hfile != INVALID_HANDLE_VALUE) CloseHandle(mmap_hfile);
+#else
     if (mmap_addr) ::munmap(mmap_addr, mmap_len);
     if (mmap_fd >= 0) ::close(mmap_fd);
+#endif
 }
 
 bool CpuEmbedder::embed(const int32_t * ids, int n, float * out_f32) const {
@@ -85,9 +94,38 @@ namespace {
 struct Mmap {
     void *  addr = nullptr;
     size_t  len  = 0;
+#if defined(_WIN32)
+    HANDLE  hFile = INVALID_HANDLE_VALUE;
+    HANDLE  hMap  = nullptr;
+#else
     int     fd   = -1;
+#endif
 
     bool open_ro(const std::string & path, std::string & err) {
+#if defined(_WIN32)
+        hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hFile == INVALID_HANDLE_VALUE) {
+            err = "CreateFileA: " + path + ": error " + std::to_string(GetLastError());
+            return false;
+        }
+        LARGE_INTEGER sz;
+        if (!GetFileSizeEx(hFile, &sz)) {
+            err = "GetFileSizeEx: error " + std::to_string(GetLastError());
+            return false;
+        }
+        len = (size_t)sz.QuadPart;
+        hMap = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+        if (!hMap) {
+            err = "CreateFileMappingA: error " + std::to_string(GetLastError());
+            return false;
+        }
+        addr = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+        if (!addr) {
+            err = "MapViewOfFile: error " + std::to_string(GetLastError());
+            return false;
+        }
+#else
         fd = ::open(path.c_str(), O_RDONLY);
         if (fd < 0) { err = "open: " + path + ": " + std::strerror(errno); return false; }
         struct stat st;
@@ -95,13 +133,29 @@ struct Mmap {
         len = (size_t)st.st_size;
         addr = ::mmap(nullptr, len, PROT_READ, MAP_PRIVATE, fd, 0);
         if (addr == MAP_FAILED) { err = "mmap: " + std::string(std::strerror(errno)); addr = nullptr; return false; }
+#endif
         return true;
     }
-    // Ownership transfer: release the mmap handle without unmapping.
-    void release() { addr = nullptr; fd = -1; len = 0; }
+    // Ownership transfer: release handles without unmapping.
+    void release() {
+        addr = nullptr;
+        len  = 0;
+#if defined(_WIN32)
+        hFile = INVALID_HANDLE_VALUE;
+        hMap  = nullptr;
+#else
+        fd = -1;
+#endif
+    }
     ~Mmap() {
+#if defined(_WIN32)
+        if (addr)                        UnmapViewOfFile(addr);
+        if (hMap)                        CloseHandle(hMap);
+        if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
+#else
         if (addr) ::munmap(addr, len);
         if (fd >= 0) ::close(fd);
+#endif
     }
 };
 
@@ -354,7 +408,12 @@ bool load_target_gguf(const std::string & path,
     //       rows on demand without uploading the full embedding table to GPU.
     out.embedder.mmap_addr      = mm.addr;
     out.embedder.mmap_len       = mm.len;
+#if defined(_WIN32)
+    out.embedder.mmap_hfile     = mm.hFile;
+    out.embedder.mmap_hmap      = mm.hMap;
+#else
     out.embedder.mmap_fd        = mm.fd;
+#endif
     out.embedder.tok_embd_bytes = (const uint8_t *)mm.addr + tok_embd_off;
     out.embedder.tok_embd_type  = tok_embd_type;
     out.embedder.n_embd         = out.n_embd;

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -8,6 +8,16 @@
 #include <string>
 #include <vector>
 
+#if defined(_WIN32)
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
 #include "ggml.h"
 #include "ggml-backend.h"
 #include "gguf.h"
@@ -71,7 +81,12 @@ struct TargetLayer {
 struct CpuEmbedder {
     void *           mmap_addr = nullptr;
     size_t           mmap_len  = 0;
+#if defined(_WIN32)
+    HANDLE           mmap_hfile = INVALID_HANDLE_VALUE;
+    HANDLE           mmap_hmap  = nullptr;
+#else
     int              mmap_fd   = -1;
+#endif
     const uint8_t *  tok_embd_bytes = nullptr;  // into the mmap region
     ggml_type        tok_embd_type  = GGML_TYPE_COUNT;
     int64_t          n_embd = 0;

--- a/dflash/src/safetensors_draft.cpp
+++ b/dflash/src/safetensors_draft.cpp
@@ -29,16 +29,28 @@
 
 #include "internal.h"
 
-#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
 #include <string>
+
+#if defined(_WIN32)
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <cerrno>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
+
 #include <unordered_map>
 #include <vector>
 
@@ -159,11 +171,40 @@ ggml_type st_dtype_to_ggml(const std::string & dt) {
 }
 
 struct Mmap {
-    void *  addr = nullptr;
-    size_t  len  = 0;
-    int     fd   = -1;
+    void *  addr    = nullptr;
+    size_t  len     = 0;
+#if defined(_WIN32)
+    HANDLE  hFile   = INVALID_HANDLE_VALUE;
+    HANDLE  hMap    = nullptr;
+#else
+    int     fd      = -1;
+#endif
 
     bool open_ro(const std::string & path, std::string & err) {
+#if defined(_WIN32)
+        hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hFile == INVALID_HANDLE_VALUE) {
+            err = "CreateFileA: " + path + ": error " + std::to_string(GetLastError());
+            return false;
+        }
+        LARGE_INTEGER sz;
+        if (!GetFileSizeEx(hFile, &sz)) {
+            err = "GetFileSizeEx: error " + std::to_string(GetLastError());
+            return false;
+        }
+        len = (size_t)sz.QuadPart;
+        hMap = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+        if (!hMap) {
+            err = "CreateFileMappingA: error " + std::to_string(GetLastError());
+            return false;
+        }
+        addr = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+        if (!addr) {
+            err = "MapViewOfFile: error " + std::to_string(GetLastError());
+            return false;
+        }
+#else
         fd = ::open(path.c_str(), O_RDONLY);
         if (fd < 0) {
             err = "open: " + path + ": " + std::strerror(errno);
@@ -181,12 +222,19 @@ struct Mmap {
             addr = nullptr;
             return false;
         }
+#endif
         return true;
     }
 
     ~Mmap() {
+#if defined(_WIN32)
+        if (addr)                        UnmapViewOfFile(addr);
+        if (hMap)                        CloseHandle(hMap);
+        if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
+#else
         if (addr) ::munmap(addr, len);
         if (fd >= 0) ::close(fd);
+#endif
     }
 };
 

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -776,11 +776,17 @@ int main(int argc, char ** argv) {
 
     // Helper: write a committed token to the stream fd immediately (int32 LE).
     // Caller invokes after every out_all.push_back(tok) when stream_fd >= 0.
+    // On Windows stream_fd holds a Win32 HANDLE value (passed via msvcrt.get_osfhandle).
     auto stream_emit = [&](int32_t tok) {
         if (stream_fd < 0) return;
         int32_t v = tok;
+#if defined(_WIN32)
+        DWORD written;
+        WriteFile((HANDLE)(intptr_t)stream_fd, &v, sizeof(v), &written, nullptr);
+#else
         ssize_t n = ::write(stream_fd, &v, sizeof(v));
         (void)n;
+#endif
     };
     if (fast_rollback && seq_verify && !ddtree_mode) {
         std::fprintf(stderr, "--fast-rollback and --seq-verify are mutually exclusive\n");

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -48,7 +48,21 @@ extern "C" void dflash27b_launch_bf16_to_f32(const void * src,
 #include <cinttypes>
 #include <cmath>
 #include <cstdint>
+
+#if defined(_WIN32)
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#include <io.h>
+#ifdef _WIN64
+#define ssize_t __int64
+#else
+#define ssize_t long
+#endif
+#else
 #include <unistd.h>
+#endif
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/dflash/test/test_generate.cpp
+++ b/dflash/test/test_generate.cpp
@@ -27,8 +27,19 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <unistd.h>
 #include <vector>
+
+#if defined(_WIN32)
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace dflash27b;
 
@@ -124,8 +135,13 @@ int main(int argc, char ** argv) {
     auto stream_emit = [&](int32_t tok) {
         if (stream_fd < 0) return;
         int32_t v = tok;
+#if defined(_WIN32)
+        DWORD written;
+        WriteFile((HANDLE)(intptr_t)stream_fd, &v, sizeof(v), &written, nullptr);
+#else
         ssize_t n = ::write(stream_fd, &v, sizeof(v));
         (void)n;
+#endif
     };
 
     // ── Load model and cache


### PR DESCRIPTION
This adds support for building Dflash on Windows

```ps1
cmake -B build -S . -DCMAKE_CUDA_ARCHITECTURES=86 -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel
```

Tested with Qwen 27B on RTX3090 compiled with MSVC + Cuda. and got `93.53 tok/s`

```ps1
### 2. Recursive
[timing] per-step averages over 35 steps (ms):
  draft_build    0.39
  draft_copyfeat 0.10
  draft_set      0.06
  draft_compute  9.40
  draft_logits   7.79
  snapshot_ssm   0.00
  verify_build   2.76
  verify_set     0.84
  verify_compute 45.92
  verify_logits  0.00
  accept         8.58
  restore_ssm    0.00
  replay_build   0.00
  replay_set     0.00
  replay_compute 0.00
  replay_logits  0.00
  ----- sum     75.85

[dflash] generated 256 tokens in 2.737 s  ΓåÆ  93.53 tok/s
[dflash] 35 draft steps, accepted=256/560 (45.7% per step), avg commit/step=7.31
[dflash] output tail: 11 292 283 292 11 264 478 292 198 262 460 292 198 71093 271 13962 220 17 13 82930 
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 24575 MiB):
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes, VRAM: 24575 MiB

[run] generated 256 tokens
```

Also, tested with Qwopus on RTX3090 compiled with MSVC + Cuda and got `67.24 tok/s`. Using the Qwen 27B kernel, so the acceptance was lower due to mismatch 

```ps1
[run] prompt 14 tokens, streaming up to 256 tokens…
[cfg] seq_verify=0 fast_rollback=1 ddtree=1 budget=22 temp=1.00 chain_seed=1
[target] target loaded: 851 tensors on GPU 14.73 GiB, tok_embd 682 MiB CPU-only (q4_K)

[timing] per-step averages over 48 steps (ms):
  draft_build    0.57
  draft_copyfeat 0.12
  draft_set      0.06
  draft_compute  9.64
  draft_logits   8.36
  snapshot_ssm   0.00
  verify_build   3.03
  verify_set     1.08
  verify_compute 46.26
  verify_logits  0.00
  accept         8.91
  restore_ssm    0.00
  replay_build   0.00
  replay_set     0.00
  replay_compute 0.00
  replay_logits  0.00
  ----- sum     78.03

[dflash] generated 256 tokens in 3.881 s  ΓåÆ  65.96 tok/s
[dflash] 48 draft steps, accepted=256/768 (33.3% per step), avg commit/step=5.33
[dflash] output tail: 11 307 478 220 16 1590 198 1734 264 11 292 283 292 11 264 478 292 198 260 460 
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 24575 MiB):
  Device 0: NVIDIA GeForce RTX 3090, compute capability 8.6, VMM: yes, VRAM: 24575 MiB

[run] generated 256 tokens
```