### PR TITLE
docs: fix readme consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-  <a href="https://www.lucebox.com"><img src="https://img.shields.io/badge/lucebox.com-f5c842?style=for-the-badge&logo=safari&logoColor=f5c842&labelColor=090909" alt="lucebox.com"></a>
+  <a href="https://lucebox.com"><img src="https://img.shields.io/badge/lucebox.com-f5c842?style=for-the-badge&logo=safari&logoColor=f5c842&labelColor=090909" alt="lucebox.com"></a>
   <a href="https://discord.gg/yHfswqZmJQ"><img src="https://img.shields.io/badge/Discord-f5c842?style=for-the-badge&logo=discord&logoColor=f5c842&labelColor=090909" alt="Discord"></a>
-  <a href="https://www.lucebox.com/blog"><img src="https://img.shields.io/badge/Blog-f5c842?style=for-the-badge&logo=rss&logoColor=f5c842&labelColor=090909" alt="Blog"></a>
+  <a href="https://lucebox.com/blog"><img src="https://img.shields.io/badge/Blog-f5c842?style=for-the-badge&logo=rss&logoColor=f5c842&labelColor=090909" alt="Blog"></a>
 </p>
 
 <p align="center">
@@ -57,7 +57,7 @@ python final_bench.py
 
 **What makes it work:** 82 blocks, 512 threads, one persistent kernel. No CPU round-trips between layers. Weights streamed straight from HuggingFace. Cooperative grid sync instead of ~100 kernel launches per token. Power ceiling hit before compute ceiling, so DVFS converts tight execution straight into saved watts.
 
-[Full writeup →](megakernel/README.md) · [Benchmarks →](megakernel/RESULTS.md) · [Blog post →](https://www.lucebox.com/blog/megakernel)
+[Full writeup →](megakernel/README.md) · [Benchmarks →](megakernel/RESULTS.md) · [Blog post →](https://lucebox.com/blog/megakernel)
 
 ---
 
@@ -108,7 +108,7 @@ What we ported and tuned:
 - DDTree budget swept for RTX 3090 + Q4_K_M target: **budget=22** is the sweet spot.
 - Q4_0 KV cache + sliding `target_feat` ring to fit 128K context in 24 GB with ~3% AL hit.
 
-[Full writeup →](dflash/README.md) · [Benchmarks →](dflash/RESULTS.md) · [Blog post →](https://www.lucebox.com/blog/dflash27b)
+[Full writeup →](dflash/README.md) · [Benchmarks →](dflash/RESULTS.md) · [Blog post →](https://lucebox.com/blog/dflash27b)
 
 ---
 
@@ -181,12 +181,12 @@ Per-project citations live in each subproject's README.
 ## Community
 
 - **Discord**: [discord.gg/yHfswqZmJQ](https://discord.gg/yHfswqZmJQ)
-- **Website**: [lucebox.com](https://www.lucebox.com)
+- **Website**: [lucebox.com](https://lucebox.com)
 - **Issues**: [github.com/Luce-Org/lucebox-hub/issues](https://github.com/Luce-Org/lucebox-hub/issues)
-- **Blog**: [lucebox.com/blog](https://www.lucebox.com/blog)
+- **Blog**: [lucebox.com/blog](https://lucebox.com/blog)
 
 ---
 
 <p align="center">
-  <sub><a href="LICENSE">MIT</a> · <a href="https://www.lucebox.com">Lucebox.com</a></sub>
+  <sub><a href="LICENSE">MIT</a> · <a href="https://lucebox.com">Lucebox.com</a></sub>
 </p>

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ AI-assisted development flips that calculus. Rewrites that took a quarter now fi
 
 ## Requirements
 
-NVIDIA RTX 3090 (sm_86) only, CUDA 12+, PyTorch 2.0+.
+Built and benchmarked on NVIDIA RTX 3090 (2020); portable to other Ampere+ (sm_86+) NVIDIA GPUs with minor tuning. CUDA 12+, PyTorch 2.0+.
 dflash needs CMake 3.18+ and `--recurse-submodules` for the pinned `Luce-Org/llama.cpp@luce-dflash` fork (three tree-mode ggml ops).
 
 **Optional, find your GPU's sweet spot:** `sudo nvidia-smi -pl 220` (megakernel hits best tok/J at 220 W).
@@ -148,7 +148,7 @@ lucebox-hub/
   Q1 2026    ▮▮▮▮▮▮▮▮▮▮    RTX 3090 kernels & optimizations
   Q2 2026    ▮▮▮▮▮▯▯▯▯▯    Ryzen AI MAX+ 395 optimizations
   Q2 2026    ▮▮▯▯▯▯▯▯▯▯    Heterogeneous CPU + GPU latency optimizations
-  Q2 2026    ▮▯▯▯▯▯▯▯▯▯    CLI for local AI
+  Q2 2026    ▮▯▯▯▯▯▯▯▯▯    Lucebox OS for local AI machines
   Q3 2026    ▯▯▯▯▯▯▯▯▯▯    Lucebox official launch
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-  <a href="https://lucebox.com"><img src="https://img.shields.io/badge/lucebox.com-f5c842?style=for-the-badge&logo=safari&logoColor=f5c842&labelColor=090909" alt="lucebox.com"></a>
+  <a href="https://www.lucebox.com"><img src="https://img.shields.io/badge/lucebox.com-f5c842?style=for-the-badge&logo=safari&logoColor=f5c842&labelColor=090909" alt="lucebox.com"></a>
   <a href="https://discord.gg/yHfswqZmJQ"><img src="https://img.shields.io/badge/Discord-f5c842?style=for-the-badge&logo=discord&logoColor=f5c842&labelColor=090909" alt="Discord"></a>
-  <a href="https://lucebox.com/blog"><img src="https://img.shields.io/badge/Blog-f5c842?style=for-the-badge&logo=rss&logoColor=f5c842&labelColor=090909" alt="Blog"></a>
+  <a href="https://www.lucebox.com/blog"><img src="https://img.shields.io/badge/Blog-f5c842?style=for-the-badge&logo=rss&logoColor=f5c842&labelColor=090909" alt="Blog"></a>
 </p>
 
 <p align="center">
@@ -57,7 +57,7 @@ python final_bench.py
 
 **What makes it work:** 82 blocks, 512 threads, one persistent kernel. No CPU round-trips between layers. Weights streamed straight from HuggingFace. Cooperative grid sync instead of ~100 kernel launches per token. Power ceiling hit before compute ceiling, so DVFS converts tight execution straight into saved watts.
 
-[Full writeup →](megakernel/README.md) · [Benchmarks →](megakernel/RESULTS.md) · [Blog post →](https://lucebox.com/blog/megakernel)
+[Full writeup →](megakernel/README.md) · [Benchmarks →](megakernel/RESULTS.md) · [Blog post →](https://www.lucebox.com/blog/megakernel)
 
 ---
 
@@ -124,7 +124,7 @@ AI-assisted development flips that calculus. Rewrites that took a quarter now fi
 
 ## Requirements
 
-NVIDIA GPU (Ampere+, sm_86+), CUDA 12+, PyTorch 2.0+. Tested on RTX 3090 (2020).
+NVIDIA RTX 3090 (sm_86) only, CUDA 12+, PyTorch 2.0+.
 dflash needs CMake 3.18+ and `--recurse-submodules` for the pinned `Luce-Org/llama.cpp@luce-dflash` fork (three tree-mode ggml ops).
 
 **Optional, find your GPU's sweet spot:** `sudo nvidia-smi -pl 220` (megakernel hits best tok/J at 220 W).
@@ -148,6 +148,8 @@ lucebox-hub/
   Q1 2026    ▮▮▮▮▮▮▮▮▮▮    RTX 3090 kernels & optimizations
   Q2 2026    ▮▮▮▮▮▯▯▯▯▯    Ryzen AI MAX+ 395 optimizations
   Q2 2026    ▮▮▯▯▯▯▯▯▯▯    Heterogeneous CPU + GPU latency optimizations
+  Q2 2026    ▮▯▯▯▯▯▯▯▯▯    CLI for local AI
+  Q3 2026    ▯▯▯▯▯▯▯▯▯▯    Lucebox official launch
 ```
 
 ---
@@ -179,12 +181,12 @@ Per-project citations live in each subproject's README.
 ## Community
 
 - **Discord**: [discord.gg/yHfswqZmJQ](https://discord.gg/yHfswqZmJQ)
-- **Website**: [lucebox.com](https://lucebox.com)
+- **Website**: [lucebox.com](https://www.lucebox.com)
 - **Issues**: [github.com/Luce-Org/lucebox-hub/issues](https://github.com/Luce-Org/lucebox-hub/issues)
-- **Blog**: [lucebox.com/blog](https://lucebox.com/blog)
+- **Blog**: [lucebox.com/blog](https://www.lucebox.com/blog)
 
 ---
 
 <p align="center">
-  <sub><a href="LICENSE">MIT</a> · <a href="https://lucebox.com">Lucebox.com</a></sub>
+  <sub><a href="LICENSE">MIT</a> · <a href="https://www.lucebox.com">Lucebox.com</a></sub>
 </p>

--- a/dflash/README.md
+++ b/dflash/README.md
@@ -13,7 +13,7 @@
   Qwen3.5-27B at up to 207 tok/s<sup>*</sup> on a single RTX 3090 (HumanEval 10-prompt bench mean 129.5 tok/s at DDTree budget=22). 128K context on 24 GB.<br/>
   3.43× faster than autoregressive (+15% over chain spec decoding), 2.8× faster than SGLang AWQ.<br/>
   <sub><sup>*</sup>Demo run: 207.6 tok/s DFlash vs 38.0 tok/s AR (5.46×).</sub><br/><br/>
-  <a href="https://www.lucebox.com/blog/dflash27b">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://www.lucebox.com">lucebox.com</a>
+  <a href="https://lucebox.com/blog/dflash27b">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://lucebox.com">lucebox.com</a>
 </p>
 
 <p align="center">
@@ -191,6 +191,6 @@ Open an issue or PR against `Luce-Org/lucebox-hub`. Good first picks:
 
 ---
 
-MIT · [Lucebox](https://www.lucebox.com) · [Discord](https://discord.gg/yHfswqZmJQ)
+MIT · [Lucebox](https://lucebox.com) · [Discord](https://discord.gg/yHfswqZmJQ)
 
 Inspired by [z-lab/DFlash](https://arxiv.org/abs/2602.06036), [liranringel/ddtree](https://github.com/liranringel/ddtree), [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp).

--- a/dflash/README.md
+++ b/dflash/README.md
@@ -13,7 +13,7 @@
   Qwen3.5-27B at up to 207 tok/s<sup>*</sup> on a single RTX 3090 (HumanEval 10-prompt bench mean 129.5 tok/s at DDTree budget=22). 128K context on 24 GB.<br/>
   3.43× faster than autoregressive (+15% over chain spec decoding), 2.8× faster than SGLang AWQ.<br/>
   <sub><sup>*</sup>Demo run: 207.6 tok/s DFlash vs 38.0 tok/s AR (5.46×).</sub><br/><br/>
-  <a href="https://www.lucebox.com/blog/dflash27b">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://lucebox.com">lucebox.com</a>
+  <a href="https://www.lucebox.com/blog/dflash27b">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://www.lucebox.com">lucebox.com</a>
 </p>
 
 <p align="center">
@@ -191,6 +191,6 @@ Open an issue or PR against `Luce-Org/lucebox-hub`. Good first picks:
 
 ---
 
-MIT · [Lucebox](https://lucebox.com) · [Discord](https://discord.gg/yHfswqZmJQ)
+MIT · [Lucebox](https://www.lucebox.com) · [Discord](https://discord.gg/yHfswqZmJQ)
 
 Inspired by [z-lab/DFlash](https://arxiv.org/abs/2602.06036), [liranringel/ddtree](https://github.com/liranringel/ddtree), [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp).

--- a/megakernel/README.md
+++ b/megakernel/README.md
@@ -114,7 +114,7 @@ python final_bench.py    # runs pp520 tg128 (properly warmed), prints tok/s
 ```
 
 **Requirements:**
-- NVIDIA RTX 3090 (sm_86) only
+- Built and benchmarked on NVIDIA RTX 3090 (2020); portable to other Ampere+ (sm_86+) NVIDIA GPUs with minor tuning
 - CUDA 12+
 - PyTorch 2.0+
 - ~1.5 GB VRAM for BF16 weights

--- a/megakernel/README.md
+++ b/megakernel/README.md
@@ -8,7 +8,7 @@
   <strong>The first megakernel for hybrid DeltaNet/Attention LLMs.</strong><br/>
   All 24 layers of Qwen 3.5-0.8B in a single CUDA dispatch.<br/>
   1.87 tok/J on a 2020 GPU, matching Apple's latest silicon at 2x the throughput.<br/><br/>
-  <a href="https://www.lucebox.com/blog/megakernel">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://www.lucebox.com">lucebox.com</a>
+  <a href="https://lucebox.com/blog/megakernel">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://lucebox.com">lucebox.com</a>
 </p>
 
 ---
@@ -180,7 +180,7 @@ Questions, ideas, or want to see what others are building? Join the [Luce Discor
 
 ---
 
-MIT · [Lucebox](https://www.lucebox.com)
+MIT · [Lucebox](https://lucebox.com)
 
 Built with [Claude](https://claude.ai)
 

--- a/megakernel/README.md
+++ b/megakernel/README.md
@@ -8,7 +8,7 @@
   <strong>The first megakernel for hybrid DeltaNet/Attention LLMs.</strong><br/>
   All 24 layers of Qwen 3.5-0.8B in a single CUDA dispatch.<br/>
   1.87 tok/J on a 2020 GPU, matching Apple's latest silicon at 2x the throughput.<br/><br/>
-  <a href="https://lucebox.com/blog/megakernel">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://lucebox.com">lucebox.com</a>
+  <a href="https://www.lucebox.com/blog/megakernel">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://www.lucebox.com">lucebox.com</a>
 </p>
 
 ---
@@ -65,9 +65,9 @@ Sweet spot at 220W: 95% of the speed, 30% less power. The curve is nonlinear, ti
 | tok/s | 267 | 229 | **411** |
 | Power | 350W | ~130W | 220W |
 | tok/J | 0.76 | 1.76 | **1.87** |
-| GPU price | ~$700 | $2,499+ (system) | ~$700 |
+| GPU price | ~$900 | $2,499+ (system) | ~$900 |
 
-A $700 GPU from 2020, power-limited to 220W, matches Apple's latest chip on efficiency while delivering 1.8x the throughput.
+A $900 GPU from 2020, power-limited to 220W, matches Apple's latest chip on efficiency while delivering 1.8x the throughput.
 
 ## How it works
 
@@ -114,7 +114,7 @@ python final_bench.py    # runs pp520 tg128 (properly warmed), prints tok/s
 ```
 
 **Requirements:**
-- NVIDIA GPU (Ampere+), tested on RTX 3090
+- NVIDIA RTX 3090 (sm_86) only
 - CUDA 12+
 - PyTorch 2.0+
 - ~1.5 GB VRAM for BF16 weights
@@ -173,14 +173,14 @@ llama.cpp is the most widely used local inference engine. It's what most people 
 
 ## Why an RTX 3090?
 
-Deliberately chosen as the "worst case" for NVIDIA: a 2020 GPU, widely dismissed as power-hungry, available for ~$900-1,000 used. If the software gap is real on old hardware, it's even larger on newer cards.
+Deliberately chosen as the "worst case" for NVIDIA: a 2020 GPU, widely dismissed as power-hungry, available for ~$900 used. If the software gap is real on old hardware, it's even larger on newer cards.
 ## Community
 
 Questions, ideas, or want to see what others are building? Join the [Luce Discord](https://discord.gg/yHfswqZmJQ).
 
 ---
 
-MIT · [Lucebox](https://lucebox.com)
+MIT · [Lucebox](https://www.lucebox.com)
 
 Built with [Claude](https://claude.ai)
 


### PR DESCRIPTION
## Summary

Small README polish pass, four fixes:

- **Price unified to `~$900`.** `megakernel/README.md` contradicted itself: `~$700` in the 3090 vs M5 Max table, `~$900-1,000` in the "Why an RTX 3090?" section. Now both say `~$900`.
- **GPU scope honest.** Hub and megakernel READMEs said `Ampere+, sm_86+`, but sm_80 is Ampere (A100), and the megakernel has hardcoded 3090 constants. Reworded to `Built and benchmarked on NVIDIA RTX 3090 (2020); portable to other Ampere+ (sm_86+) NVIDIA GPUs with minor tuning`. Reflects reality: 3090 is the tested target, other Ampere+ cards need small tuning. (`dflash/README.md` untouched, already lists supported cards.)
- **Roadmap extended.** Added `Lucebox OS for local AI machines` to Q2 2026 and `Lucebox official launch` to Q3 2026.
- **Blog/website URLs standardized to `https://lucebox.com` (apex, no www).** One blog link used `www`, the rest didn't. All canonical lucebox.com links now use the apex domain.

No code changes. Docs-only.

## Test plan

- [ ] Render README.md on GitHub, confirm badges + blog links land on `https://lucebox.com/...`
- [ ] Render `megakernel/README.md`, confirm price shows `$900` everywhere and requirements read 'portable with minor tuning'
- [ ] Render `dflash/README.md`, confirm footer link goes to `lucebox.com`
- [ ] Confirm roadmap block renders with Q1 / Q2 (×3 including Lucebox OS) / Q3 entries