### PR TITLE
fix(scripts): auto-fit --max-ctx to prompt size

### DIFF
--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -61,9 +61,20 @@ def run_ar(path):
     return float(m.group(1)) if m else 0.0
 
 
-def run_df(path):
+def _auto_max_ctx(n_prompt):
+    # Auto-fit attention budget: prompt + gen + small verify pad, aligned to
+    # FATTN_KQ_STRIDE=256. Oversizing max_ctx makes attention stride over
+    # unused KV and can cost >20× prefill time (32K prompt + --kv-q4 +
+    # max_ctx=131072 → 1035s vs 38s at max_ctx=32768). See scripts/run.py.
+    pad = 64  # covers q_len=16 + ddtree budget up to 22 with margin
+    return ((n_prompt + N_GEN + pad + 255) // 256) * 256
+
+
+def run_df(path, n_prompt):
+    max_ctx = _auto_max_ctx(n_prompt)
     r = subprocess.run([TEST_DFLASH, TARGET, DRAFT, path, str(N_GEN), "/tmp/df_out.bin",
-                        "--fast-rollback", "--ddtree", f"--ddtree-budget={BUDGET}"],
+                        "--fast-rollback", "--ddtree", f"--ddtree-budget={BUDGET}",
+                        f"--max-ctx={max_ctx}"],
                        capture_output=True, text=True, timeout=300)
     tps = re.search(r"→\s+(\d+\.\d+)\s+tok/s", r.stdout)
     al  = re.search(r"avg commit/step=(\d+\.\d+)", r.stdout)
@@ -89,7 +100,7 @@ def main():
             if n == 0 or n > 3500:
                 continue
             ar = run_ar(path)
-            df, al = run_df(path)
+            df, al = run_df(path, n)
             if ar > 0: ar_tps.append(ar)
             if df > 0: df_tps.append(df); df_al.append(al)
             print(f"  [{i+1:02d}/{N_SAMPLE}] n_tok={n:4d}  AR={ar:6.2f}  DFlash={df:7.2f}  AL={al:5.2f}", flush=True)

--- a/dflash/scripts/run.py
+++ b/dflash/scripts/run.py
@@ -56,6 +56,12 @@ def main():
     ap.add_argument("--system", type=str, default=None)
     ap.add_argument("--kv-q4", action="store_true",
                     help="Q4_0 KV cache (required for max_ctx=131072)")
+    ap.add_argument("--max-ctx", type=int, default=0,
+                    help="Override max KV context (default: auto-fit "
+                         "prompt+n_gen+block, aligned to 256). Passing a "
+                         "value much larger than needed (e.g. 131072 on a "
+                         "16K prompt) massively degrades attention speed "
+                         "because the kernel strides over unused KV.")
     args = ap.parse_args()
 
     prompt_text = args.prompt if args.prompt else sys.stdin.read().strip()
@@ -93,7 +99,18 @@ def main():
         in_bin  = os.path.join(tmp, "prompt.bin")
         out_bin = os.path.join(tmp, "out.bin")
         n_tok = tokenize(tokenizer, text, in_bin)
-        print(f"[run] prompt {n_tok} tokens, streaming up to {args.n_gen} tokens…",
+        # Auto-fit max_ctx: prompt + gen + a small verify pad, aligned to
+        # FATTN_KQ_STRIDE=256. Oversizing this is a performance trap —
+        # attention compute scales with the allocated max_ctx, not the
+        # actual filled kv_len, so a 131072 max_ctx on a 16K prompt runs
+        # attention 8× slower than necessary (verified: 32K prompt with
+        # max_ctx=131072 + --kv-q4 → 1035s prefill vs 38s at max_ctx=32768).
+        if args.max_ctx > 0:
+            max_ctx = args.max_ctx
+        else:
+            pad = 64  # covers q_len=16 + ddtree budget up to 22 with margin
+            max_ctx = ((n_tok + args.n_gen + pad + 255) // 256) * 256
+        print(f"[run] prompt {n_tok} tokens, streaming up to {args.n_gen} tokens, max_ctx={max_ctx}",
               file=sys.stderr, flush=True)
 
         r, w = os.pipe()
@@ -106,6 +123,7 @@ def main():
         cmd = [args.bin, args.target, draft_path, in_bin,
                str(args.n_gen), out_bin,
                "--fast-rollback", "--ddtree", f"--ddtree-budget={args.budget}",
+               f"--max-ctx={max_ctx}",
                f"--stream-fd={stream_fd_val}"]
         if sys.platform == "win32":
             proc = subprocess.Popen(cmd, env=env, close_fds=False,


### PR DESCRIPTION
Fixes #10.

## Summary

`scripts/run.py` and `scripts/bench_llm.py` didn't pass `--max-ctx` to `test_dflash`, so users testing long-context following the README's `--max-ctx=131072` example would oversize the KV budget relative to their actual prompt. That's a **27× prefill slowdown** at 32K with `--kv-q4`, because the FA kernel strides over unused KV.

This patch auto-fits `--max-ctx = align_up(prompt + n_gen + 64, 256)` by default. The 64-token pad covers `q_len=16` plus DDTree budget up to 22 with margin. Users who want a larger budget can still pass `--max-ctx=N` explicitly in `run.py`; `bench_llm.py` always auto-fits since it runs per-prompt.

## Measurements (RTX 3090, Qwen3.5-27B Q4_K_M target + BF16 draft)

| Prompt | KV | `--max-ctx` | Prefill | Gen tok/s | AL |
|---|---|---:|---:|---:|---:|
| 32K | Q8_0 (default) | 32768 tight | **38 s** | **42.0** | 4.41 |
| 32K | Q4_0 | 131072 oversize | 1035 s | 1.10 | 4.13 |
| 64K | Q4_0 | 131072 oversize | 1014 s | 3.97 | 4.06 |
| 64K | Q4_0 | 66048 auto-fit | **126 s** | **18.35** | 4.20 |

Output quality unaffected (`last_tok` bit-exact on all paths). This is strictly a perf fix.

## Test plan

- [x] `python3 scripts/run.py --prompt "def fibonacci(n):" --draft models/draft/model.safetensors` — short prompt, prints `max_ctx=512`, output bit-exact.
- [x] 64K prompt with `--kv-q4`: prefill 126 s vs 1014 s before.
- [x] `python3 scripts/bench_llm.py` full suite (HumanEval / GSM8K / Math500) — expected to complete at or above README speeds, since per-prompt max_ctx is now tight.