### PR TITLE
fix(server): sensible default max_ctx + tokenizer auto-detect + Qwen3.6 bench numbers

### DIFF
--- a/dflash/README.md
+++ b/dflash/README.md
@@ -89,6 +89,17 @@ DFLASH_TARGET=models/Qwen3.6-27B-Q4_K_M.gguf python3 scripts/bench_he.py --n-gen
 | Qwen3.6-27B Q4_K_M | HumanEval (10 prompts, n_gen=128) | 4.74 | 30.6% | 73.67 |
 | Qwen3.6-27B Q4_K_M | Math (10 prompts, n_gen=128) | 3.63 | 23.7% | 57.00 |
 
+Full `bench_llm.py` suite on **Qwen3.6-27B UD-Q4_K_XL** (unsloth Dynamic 2.0, 10 prompts, n_gen=256, RTX 3090 24 GB, auto-fit `--max-ctx`):
+
+| Bench | AR tok/s | DFlash tok/s | AL | Speedup |
+|---|---:|---:|---:|---:|
+| HumanEval | 34.90 | 78.16 | 5.94 | **2.24×** |
+| GSM8K | 34.89 | 59.65 | 4.43 | **1.71×** |
+| Math500 | 35.13 | 69.77 | 5.15 | **1.99×** |
+| **Mean** | 34.97 | 69.19 | 5.17 | **1.98×** |
+
+Compare to Qwen3.5-27B on the same harness: 2.87× / 2.21× / 2.56× — cross-generation drop of ~22% uniformly from the draft mismatch, but still a clean ~2× with zero retraining.
+
 Numbers will move once a Qwen3.6-matched DFlash draft lands; swap it in via `DFLASH_DRAFT=...` without rebuilding.
 
 ## Quick start

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -47,6 +47,47 @@ def resolve_draft(root: Path) -> Path:
     raise FileNotFoundError(f"no model.safetensors under {root}")
 
 
+# Models known to share the qwen35 GGUF arch + vocab. Verified via
+# tokenizer.ggml.pre == "qwen35" and identical eos/pad/bos token IDs.
+_QWEN35_FAMILY_TOKENIZERS = {
+    "Qwen3.5-27B": "Qwen/Qwen3.5-27B",
+    "Qwen3.6-27B": "Qwen/Qwen3.6-27B",
+}
+
+
+def _tokenizer_id_from_gguf(gguf_path: Path) -> str:
+    """Infer the HuggingFace tokenizer repo from a GGUF target file.
+
+    The GGUF file encodes its own tokenizer so in principle we could use that
+    directly, but `test_dflash` drives generation through the HF tokenizer for
+    chat-template application. We match on `general.basename` / `general.name`
+    metadata; if anything goes wrong we fall back to the historical default
+    (Qwen/Qwen3.5-27B) so existing setups don't break.
+    """
+    default = "Qwen/Qwen3.5-27B"
+    try:
+        from gguf import GGUFReader  # type: ignore
+        r = GGUFReader(str(gguf_path))
+        for key in ("general.basename", "general.name"):
+            f = r.fields.get(key)
+            if f is None or not f.data:
+                continue
+            import numpy as np
+            p = f.parts[f.data[0]]
+            if not isinstance(p, np.ndarray):
+                continue
+            try:
+                val = bytes(p).decode("utf-8", errors="replace")
+            except Exception:
+                continue
+            for known, repo in _QWEN35_FAMILY_TOKENIZERS.items():
+                if known.lower() in val.lower():
+                    return repo
+    except Exception:
+        pass
+    return default
+
+
 class ChatMessage(BaseModel):
     role: str
     content: str
@@ -206,8 +247,19 @@ def main():
     ap.add_argument("--draft",  type=Path, default=DEFAULT_DRAFT_ROOT)
     ap.add_argument("--bin",    type=Path, default=DEFAULT_BIN)
     ap.add_argument("--budget", type=int,  default=DEFAULT_BUDGET)
-    default_ctx = 131072 if os.environ.get("DFLASH27B_KV_Q4") == "1" else 6144
-    ap.add_argument("--max-ctx", type=int, default=default_ctx, help="Maximum context length")
+    # Attention compute currently scales with --max-ctx, not the actual
+    # prompt+gen length (see https://github.com/Luce-Org/lucebox-hub/issues/10).
+    # Default 16384 fits most API workloads without the 20×+ slowdown users
+    # hit with --max-ctx=131072 on short requests. Bump via --max-ctx if you
+    # actually need long-context serving.
+    default_ctx = 16384
+    ap.add_argument("--max-ctx", type=int, default=default_ctx,
+                    help=f"Maximum context length (default: {default_ctx}; "
+                         "oversizing this — e.g. 131072 on short prompts — "
+                         "can slow attention 20×+ until issue #10 is fixed)")
+    ap.add_argument("--tokenizer", type=str, default=None,
+                    help="HuggingFace tokenizer repo ID (default: auto-detect "
+                         "from target GGUF basename; falls back to Qwen/Qwen3.5-27B)")
     ap.add_argument("--daemon", action="store_true", help="Run with persistent model daemon (now default)")
     args = ap.parse_args()
 
@@ -219,8 +271,8 @@ def main():
     if not draft.is_file():
         raise SystemExit(f"draft safetensors not found at {args.draft}")
 
-    tokenizer = AutoTokenizer.from_pretrained(
-        "Qwen/Qwen3.5-27B", trust_remote_code=True)
+    tokenizer_id = args.tokenizer or _tokenizer_id_from_gguf(args.target)
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_id, trust_remote_code=True)
     stop_ids = set()
     for s in ("<|im_end|>", "<|endoftext|>"):
         ids = tokenizer.encode(s, add_special_tokens=False)
@@ -231,11 +283,12 @@ def main():
 
     import uvicorn
     print(f"Luce DFlash OpenAI server on http://{args.host}:{args.port}")
-    print(f"  target = {args.target}")
-    print(f"  draft  = {draft}")
-    print(f"  bin    = {args.bin}")
-    print(f"  budget = {args.budget}")
-    print(f"  max_ctx= {args.max_ctx}")
+    print(f"  target    = {args.target}")
+    print(f"  draft     = {draft}")
+    print(f"  bin       = {args.bin}")
+    print(f"  budget    = {args.budget}")
+    print(f"  max_ctx   = {args.max_ctx}")
+    print(f"  tokenizer = {tokenizer_id}")
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")
 
 


### PR DESCRIPTION
Three small daemon quality-of-life fixes bundled for review efficiency.

## 1. Default `max_ctx` lowered from 131072 → 16384

Related: #10 (the attention-scales-with-max_ctx perf trap).

Current default of `131072` (when `DFLASH27B_KV_Q4=1`) causes every short-prompt API request to pay a 20×+ slowdown, because the FA kernel strides over the full allocated context instead of the actual filled `kv_len`. Reproduced after pulling latest main and the daemon-mode commits (#7): a 32K prompt with `--kv-q4 --max-ctx=131072` still takes >5 min of prefill vs. 38 s at `--max-ctx=32768`.

16384 fits typical chat / code / RAG workloads without the trap; users who genuinely need long context can still pass `--max-ctx=131072` explicitly.

Help text now points at #10 so anyone surprised can follow the thread.

## 2. Tokenizer auto-detect

`server.py` previously hardcoded `Qwen/Qwen3.5-27B`. Now:

- Reads `general.basename` / `general.name` from the target GGUF.
- Maps Qwen3.5-27B → `Qwen/Qwen3.5-27B`, Qwen3.6-27B → `Qwen/Qwen3.6-27B` (both validated to share `tokenizer.ggml.pre = "qwen35"` + identical eos/pad/bos IDs).
- Falls back to the historical default on any error so existing configs don't regress.
- `--tokenizer <repo_id>` override added for sibling models that land in the qwen35 arch family but aren't in the registry yet.

Startup banner now prints which tokenizer was picked.

## 3. Qwen3.6-27B `bench_llm.py` numbers added to README

The `Qwen3.6 27b experimental` commit (b373478) added prose but limited numbers. This adds the full 3-task `bench_llm.py` suite on **Qwen3.6-27B UD-Q4_K_XL** (unsloth Dynamic 2.0, 10 prompts, n_gen=256, RTX 3090 24 GB, auto-fit `--max-ctx`):

| Bench | AR tok/s | DFlash tok/s | AL | Speedup |
|---|---:|---:|---:|---:|
| HumanEval | 34.90 | 78.16 | 5.94 | **2.24×** |
| GSM8K | 34.89 | 59.65 | 4.43 | **1.71×** |
| Math500 | 35.13 | 69.77 | 5.15 | **1.99×** |
| **Mean** | 34.97 | 69.19 | 5.17 | **1.98×** |

For reference, the same harness on Qwen3.5-27B gave 2.87× / 2.21× / 2.56× — cross-generation drop of ~22% uniformly, driven entirely by the draft's hidden-state mismatch against 3.6. Still a clean ~2× with zero retraining.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('dflash/scripts/server.py').read())"` — parses clean.
- [x] `_tokenizer_id_from_gguf()` resolves Qwen3.5-27B, Qwen3.6-27B, and bogus paths correctly (unit-tested interactively).
- [x] `server.py --help` still renders with the new flags.
- [ ] End-to-end: `DFLASH27B_KV_Q4=1 python3 scripts/server.py --target .../Qwen3.6-27B-UD-Q4_K_XL.gguf` boots, serves a request via `/v1/chat/completions` (tested locally on RTX 3090 before this PR; banner now shows `tokenizer = Qwen/Qwen3.6-27B` and `max_ctx = 16384`).