### PR TITLE
fix(server): close mkstemp fd in _tokenize_prompt to prevent fd leak

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -88,8 +88,12 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
         prompt = tokenizer.apply_chat_template(
             msgs, tokenize=False, add_generation_prompt=True)
         ids = tokenizer.encode(prompt, add_special_tokens=False)
-        tmp = Path(tempfile.mkstemp(suffix=".bin")[1])
-        with open(tmp, "wb") as f:
+        # mkstemp returns (fd, path). The previous code kept only the
+        # path and discarded fd, leaking 1 file descriptor per request.
+        # os.fdopen() takes ownership of the fd and closes it on __exit__.
+        fd, path = tempfile.mkstemp(suffix=".bin")
+        tmp = Path(path)
+        with os.fdopen(fd, "wb") as f:
             for t in ids:
                 f.write(struct.pack("<i", int(t)))
         return tmp


### PR DESCRIPTION
## The bug

In `dflash/scripts/server.py`, `_tokenize_prompt()` calls:

```python
tmp = Path(tempfile.mkstemp(suffix=".bin")[1])
```

`tempfile.mkstemp()` returns `(fd, path)`. This code keeps only the path (index `[1]`) and discards `fd`. Python's GC does **not** close integer file descriptors, so the fd stays open in the OS until the process dies. **Every chat request leaks exactly one fd.**

Under sustained load the process hits `RLIMIT_NOFILE` (default 1024 on a systemd service without explicit `LimitNOFILE=`). Once the wall is reached, `socket.accept()` starts throwing `OSError: [Errno 24] Too many open files` and the API stops accepting new HTTP connections — even though the model process itself is still healthy.

## Reproduction

In our deployment we have Lucebox sitting behind ~6 concurrent client services (4 Hermes agents + a Hindsight memory server + a Honcho peer-model service + a Firecrawl extractor, all OpenAI-compatible). Within roughly an hour of normal aux traffic, FD count reached **1023/1024** and new requests were rejected.

`/proc/<lucebox-pid>/fd` showed the composition: only ~5 actual sockets and pipes, and **~1000 orphan `/tmp/tmp*.bin` file descriptors** — exactly the pattern of a leaked `mkstemp` fd.

Journal log excerpt:

```
OSError: [Errno 24] Too many open files
socket.accept() out of system resource
socket: <asyncio.TransportSocket fd=8, family=2, type=1, proto=6, laddr=('0.0.0.0', 8001)>
```

## The fix

Use `os.fdopen(fd, "wb")` which takes ownership of `fd` and closes it when the `with` block exits:

```python
fd, path = tempfile.mkstemp(suffix=".bin")
tmp = Path(path)
with os.fdopen(fd, "wb") as f:
    for t in ids:
        f.write(struct.pack("<i", int(t)))
```

The on-disk temp file is still cleaned up by the existing `prompt_bin.unlink()` in `chat_completions` (both streaming and non-streaming paths), so there is no change to disk behaviour — only the fd lifecycle changes.

## Verification

- Before fix: FD count delta across 3 probe chat requests = **+3** (one fd leaked per request)
- After fix: FD count delta across 3 probe chat requests = **0** ✓

Also raised `LimitNOFILE` from the default 1024 to 65536 on our systemd unit as a defence-in-depth measure (unrelated to this PR). The code change alone is the correct fix; the limit bump is independent and up to the operator.