### PR TITLE
Add OpenAI-compatible agent-ready server + Blackwell (sm_120/121) support

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -47,7 +47,16 @@ add_library(dflash27b STATIC
     src/f16_convert.cu
     src/delta_net_chunked.cpp
 )
-set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "86;120;121")
+# Ampere (86) always; Blackwell consumer (120) added if nvcc supports it
+# (CUDA 12.8+), GB10/Jetson Thor (121) added at CUDA 12.9+.
+set(_dflash27b_archs "86")
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
+    list(APPEND _dflash27b_archs "120")
+endif()
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.9")
+    list(APPEND _dflash27b_archs "121")
+endif()
+set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "${_dflash27b_archs}")
 
 target_include_directories(dflash27b
     PUBLIC

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(dflash27b STATIC
     src/f16_convert.cu
     src/delta_net_chunked.cpp
 )
-set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "86")
+set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "86;120;121")
 
 target_include_directories(dflash27b
     PUBLIC

--- a/dflash/scripts/server_tools.py
+++ b/dflash/scripts/server_tools.py
@@ -108,22 +108,27 @@ class ChatRequest(BaseModel):
 #   ...
 #   </function>
 #   </tool_call>
-TOOL_CALL_RE = re.compile(
-    r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",
-    re.DOTALL,
+# Parsers ported from vLLM (Apache-2.0) for behavioral parity with
+# `--reasoning-parser qwen3` and `--tool-call-parser qwen3_coder`:
+#   vllm/reasoning/qwen3_reasoning_parser.py
+#   vllm/tool_parsers/qwen3coder_tool_parser.py
+# Core algorithms reproduced without vLLM runtime dependencies.
+
+TOOL_CALL_COMPLETE_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
+TOOL_CALL_FUNCTION_RE = re.compile(
+    r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL,
 )
-PARAM_RE = re.compile(
-    r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
+# vLLM's improved parameter regex: tolerates unclosed </parameter> by using
+# next <parameter= or </function> or end-of-string as a terminator.
+TOOL_CALL_PARAMETER_RE = re.compile(
+    r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
     re.DOTALL,
 )
 TOOL_OPEN_TAG = "<tool_call>"
 
 # Qwen3.6 chat template wraps the model's CoT inside <think>...</think>.
-# Default is to emit `<think>\n` automatically as a generation prefix, which
-# means the closing `</think>` may appear in the output without a matching
-# opener — handle both cases.
-THINK_PAIR_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
-THINK_HEADLESS_RE = re.compile(r"^(.*?)</think>", re.DOTALL)
+# The template typically prefills `<think>\n` into the prompt (headless mode)
+# so only `</think>` appears in generated output; older templates emit both.
 THINK_OPEN_TAG = "<think>"
 THINK_CLOSE_TAG = "</think>"
 
@@ -147,57 +152,138 @@ def first_stop_match(text: str, stops: list[str]) -> int:
     return best
 
 
-def parse_reasoning(text: str) -> tuple[str, str | None]:
-    """Strip <think>...</think> (or headless ...</think>) from `text` and
-    return (cleaned_text, reasoning_content). Returns (text, None) if no
-    thinking block found.
+def parse_reasoning(text: str, thinking_enabled: bool = True) -> tuple[str, str | None]:
+    """Port of vLLM's Qwen3ReasoningParser.extract_reasoning.
+
+    Handles the three Qwen3.x thinking flavors:
+      1. Paired:   `<think>...</think>` both in generated output.
+      2. Headless: template prefilled `<think>\\n` into the prompt, model
+         only emits `...</think>...`.
+      3. Disabled: user passed `chat_template_kwargs: {enable_thinking: false}`.
+         Template still emits `<think>\\n\\n</think>\\n\\n` but into the prompt;
+         the model output is pure content and contains no tags.
+
+    If the output was truncated mid-thinking (no `</think>` seen and
+    `thinking_enabled=True`), returns `("", full_output_as_reasoning)` —
+    matching vLLM's convention.
+
+    Returns (cleaned_content, reasoning_content).
     """
-    # Pair form first.
-    m = THINK_PAIR_RE.search(text)
-    if m:
-        reasoning = m.group(1).strip()
-        cleaned = (text[:m.start()] + text[m.end():]).strip()
-        return cleaned, reasoning if reasoning else None
-    # Headless form (template prefilled <think>\n at prompt end).
-    m = THINK_HEADLESS_RE.search(text)
-    if m and THINK_CLOSE_TAG in text:
-        reasoning = m.group(1).strip()
-        cleaned = text[m.end():].strip()
-        return cleaned, reasoning if reasoning else None
-    return text, None
+    # Strip <think> if the model emitted it itself (older templates).
+    parts = text.partition(THINK_OPEN_TAG)
+    rest = parts[2] if parts[1] else parts[0]
+    if THINK_CLOSE_TAG not in rest:
+        if thinking_enabled:
+            # No close tag — assume truncated; everything is reasoning.
+            return "", (rest.strip() or None)
+        else:
+            # Thinking disabled — output is pure content.
+            return rest.strip(), None
+    reasoning, _, content = rest.partition(THINK_CLOSE_TAG)
+    return content.strip(), (reasoning.strip() or None)
 
 
-def parse_tool_calls(text: str) -> tuple[str, list[dict]]:
-    """Strip <tool_call>...</tool_call> blocks out of `text` and return them
-    as OpenAI-style tool_call dicts. Returns (cleaned_text, tool_calls).
+def _find_tool_properties(tools, function_name):
+    """Helper matching vLLM's `find_tool_properties`: returns the parameters
+    dict for a given function name, or {} if not found.
+    Accepts pydantic ToolDef instances or plain dicts.
+    """
+    for t in tools or []:
+        fn = t.function if hasattr(t, "function") else t.get("function", {})
+        if hasattr(fn, "model_dump"):
+            fn = fn.model_dump()
+        if fn.get("name") == function_name:
+            params = fn.get("parameters", {})
+            if isinstance(params, dict):
+                return params.get("properties", {})
+    return {}
+
+
+def _convert_param_value(param_value: str, param_name: str, param_config: dict,
+                         func_name: str):
+    """Port of vLLM's _convert_param_value. Coerces stringified XML values
+    to their JSON-schema type (int/float/bool/object/array/string)."""
+    import ast
+    if param_value.lower() == "null":
+        return None
+    if param_name not in param_config:
+        return param_value
+    cfg = param_config[param_name]
+    if isinstance(cfg, dict) and "type" in cfg:
+        ptype = str(cfg["type"]).strip().lower()
+    elif isinstance(cfg, dict) and "anyOf" in cfg:
+        ptype = "object"
+    else:
+        ptype = "string"
+    if ptype in ("string", "str", "text", "varchar", "char", "enum"):
+        return param_value
+    if any(ptype.startswith(p) for p in ("int", "uint", "long", "short", "unsigned")):
+        try: return int(param_value)
+        except (ValueError, TypeError): return param_value
+    if ptype.startswith("num") or ptype.startswith("float"):
+        try:
+            f = float(param_value)
+            return f if f - int(f) != 0 else int(f)
+        except (ValueError, TypeError):
+            return param_value
+    if ptype in ("boolean", "bool", "binary"):
+        return param_value.lower() == "true"
+    # object / array / dict / list
+    if (ptype in ("object", "array", "arr")
+            or ptype.startswith("dict") or ptype.startswith("list")):
+        try: return json.loads(param_value)
+        except (json.JSONDecodeError, TypeError, ValueError): pass
+    try: return ast.literal_eval(param_value)
+    except (ValueError, SyntaxError, TypeError): return param_value
+
+
+def parse_tool_calls(text: str, tools=None) -> tuple[str, list[dict]]:
+    """Port of Qwen3CoderToolParser._parse_xml_function_call (non-streaming).
+
+    Handles Qwen3.x's `<tool_call><function=NAME>...<parameter=KEY>VAL
+    </parameter>...</function></tool_call>` XML. Uses vLLM's improved
+    parameter regex that tolerates unclosed </parameter> tags. When `tools`
+    is provided, each parameter value is coerced to its JSON-schema type.
+
+    Returns (cleaned_content, tool_calls_list).
     """
     tool_calls: list[dict] = []
-
-    def repl(m):
-        name = m.group(1).strip()
-        body = m.group(2)
+    cleaned_parts: list[str] = []
+    cursor = 0
+    for m in TOOL_CALL_COMPLETE_RE.finditer(text):
+        cleaned_parts.append(text[cursor:m.start()])
+        cursor = m.end()
+        body = m.group(1)
+        fn_match = TOOL_CALL_FUNCTION_RE.search(body)
+        if not fn_match:
+            continue
+        fn_text = fn_match.group(1) or fn_match.group(2) or ""
+        end_idx = fn_text.find(">")
+        if end_idx == -1:
+            continue
+        function_name = fn_text[:end_idx].strip()
+        params_region = fn_text[end_idx + 1:]
+        param_config = _find_tool_properties(tools, function_name)
         args: dict = {}
-        for pm in PARAM_RE.finditer(body):
-            k = pm.group(1).strip()
-            v = pm.group(2)
-            # Qwen sometimes emits JSON-like values, sometimes plain strings.
-            # Try JSON first; fall back to raw string.
-            try:
-                args[k] = json.loads(v)
-            except (json.JSONDecodeError, ValueError):
-                args[k] = v
+        for match_text in TOOL_CALL_PARAMETER_RE.findall(params_region):
+            eq_idx = match_text.find(">")
+            if eq_idx == -1:
+                continue
+            k = match_text[:eq_idx].strip()
+            v = match_text[eq_idx + 1:]
+            if v.startswith("\n"): v = v[1:]
+            if v.endswith("\n"): v = v[:-1]
+            args[k] = _convert_param_value(v, k, param_config, function_name)
         tool_calls.append({
             "id": "call_" + uuid.uuid4().hex[:24],
             "type": "function",
             "function": {
-                "name": name,
+                "name": function_name,
                 "arguments": json.dumps(args, ensure_ascii=False),
             },
         })
-        return ""
-
-    cleaned = TOOL_CALL_RE.sub(repl, text).strip()
-    return cleaned, tool_calls
+    cleaned_parts.append(text[cursor:])
+    return "".join(cleaned_parts).strip(), tool_calls
 
 
 # ─── app ───────────────────────────────────────────────────────────
@@ -333,12 +419,13 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
             i = first_stop_match(text, stops)
             if i != -1:
                 text = text[:i]
-        # If the template prefilled <think> as a generation prefix, prepend it
-        # so parse_reasoning sees the matched pair.
-        if started_in_thinking and not text.lstrip().startswith(THINK_OPEN_TAG):
-            text = THINK_OPEN_TAG + "\n" + text
-        cleaned, tool_calls = parse_tool_calls(text)
-        cleaned, reasoning = parse_reasoning(cleaned)
+        # Respect enable_thinking from chat_template_kwargs when deciding how
+        # to treat a `</think>`-less response (see parse_reasoning docstring).
+        thinking_enabled = True
+        if req.chat_template_kwargs:
+            thinking_enabled = req.chat_template_kwargs.get("enable_thinking", True)
+        cleaned, tool_calls = parse_tool_calls(text, tools=req.tools)
+        cleaned, reasoning = parse_reasoning(cleaned, thinking_enabled=thinking_enabled)
 
         msg: dict = {"role": "assistant"}
         finish_reason = "stop"
@@ -501,7 +588,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
 
                     finish_reason = "stop"
                     if mode == "tool_buffer":
-                        cleaned_after, tool_calls = parse_tool_calls(tool_buffer)
+                        cleaned_after, tool_calls = parse_tool_calls(tool_buffer, tools=req.tools)
                         if tool_calls:
                             if cleaned_after:
                                 out = emit_delta(cleaned_after, "content")

--- a/dflash/scripts/server_tools.py
+++ b/dflash/scripts/server_tools.py
@@ -1,0 +1,585 @@
+"""
+OpenAI-compatible HTTP server on top of test_dflash, **with tool-calling support**.
+
+Patched fork of scripts/server.py that:
+  1. Accepts the OpenAI `tools` array in ChatRequest.
+  2. Renders tools into the prompt via Qwen's chat template (`tools=...`).
+  3. Parses `<tool_call><function=...><parameter=...></tool_call>` blocks out
+     of the model output and returns them as proper OpenAI `tool_calls`.
+  4. Supports `role: "tool"` and assistant `tool_calls` in input messages so
+     multi-turn agent loops round-trip correctly.
+
+Streaming behavior:
+  - Content tokens are streamed as `delta.content` until a `<tool_call>` opener
+    is detected; the rest of the response is then buffered, parsed at the end
+    of generation, and emitted as a single final `delta.tool_calls` chunk with
+    `finish_reason: "tool_calls"`.
+  - If no tool call appears in the output, behavior is identical to the
+    upstream server.
+
+Greedy decoding still applies (verify path is greedy-only). `temperature` and
+`top_p` are accepted but ignored, matching upstream.
+
+Run:
+  pip install fastapi uvicorn transformers
+  python3 scripts/server_tools.py --port 8000
+"""
+import argparse
+import json
+import os
+import re
+import struct
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, Field
+from starlette.concurrency import iterate_in_threadpool
+from transformers import AutoTokenizer
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_TARGET = ROOT / "models" / "Qwen3.5-27B-Q4_K_M.gguf"
+DEFAULT_DRAFT_ROOT = ROOT / "models" / "draft"
+DEFAULT_BIN = ROOT / "build" / "test_dflash"
+DEFAULT_BUDGET = 22
+MODEL_NAME = "luce-dflash"
+
+
+def resolve_draft(root: Path) -> Path:
+    for st in root.rglob("model.safetensors"):
+        return st
+    raise FileNotFoundError(f"no model.safetensors under {root}")
+
+
+# ─── pydantic schemas ──────────────────────────────────────────────
+
+class ToolCallFunction(BaseModel):
+    name: str
+    arguments: str  # JSON string per OpenAI spec
+
+
+class ToolCall(BaseModel):
+    id: str | None = None
+    type: str = "function"
+    function: ToolCallFunction
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: Any | None = None  # str, list, or null when tool_calls present
+    name: str | None = None
+    tool_call_id: str | None = None
+    tool_calls: list[ToolCall] | None = None
+
+
+class ToolDef(BaseModel):
+    type: str = "function"
+    function: dict  # {name, description, parameters: {...JSON schema...}}
+
+
+class ChatRequest(BaseModel):
+    model: str = MODEL_NAME
+    messages: list[ChatMessage]
+    stream: bool = False
+    max_tokens: int = 512
+    temperature: float | None = None
+    top_p: float | None = None
+    tools: list[ToolDef] | None = None
+    tool_choice: Any | None = None  # "auto" | "none" | {"function": {...}}
+    chat_template_kwargs: dict | None = None  # e.g. {"enable_thinking": false}
+    stop: Any | None = None  # str or list[str]
+    stream_options: dict | None = None  # e.g. {"include_usage": true}
+
+
+# ─── tool-call parser ──────────────────────────────────────────────
+
+# Qwen3.6 chat template emits:
+#   <tool_call>
+#   <function=NAME>
+#   <parameter=KEY>
+#   VALUE
+#   </parameter>
+#   ...
+#   </function>
+#   </tool_call>
+TOOL_CALL_RE = re.compile(
+    r"<tool_call>\s*<function=([^>]+)>(.*?)</function>\s*</tool_call>",
+    re.DOTALL,
+)
+PARAM_RE = re.compile(
+    r"<parameter=([^>]+)>\s*(.*?)\s*</parameter>",
+    re.DOTALL,
+)
+TOOL_OPEN_TAG = "<tool_call>"
+
+# Qwen3.6 chat template wraps the model's CoT inside <think>...</think>.
+# Default is to emit `<think>\n` automatically as a generation prefix, which
+# means the closing `</think>` may appear in the output without a matching
+# opener — handle both cases.
+THINK_PAIR_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+THINK_HEADLESS_RE = re.compile(r"^(.*?)</think>", re.DOTALL)
+THINK_OPEN_TAG = "<think>"
+THINK_CLOSE_TAG = "</think>"
+
+
+def normalize_stop(stop) -> list[str]:
+    """Coerce OpenAI's stop field (str | list[str] | None) to list[str]."""
+    if not stop:
+        return []
+    if isinstance(stop, str):
+        return [stop]
+    return [s for s in stop if isinstance(s, str) and s]
+
+
+def first_stop_match(text: str, stops: list[str]) -> int:
+    """Return the earliest index where any stop sequence appears, or -1."""
+    best = -1
+    for s in stops:
+        i = text.find(s)
+        if i != -1 and (best == -1 or i < best):
+            best = i
+    return best
+
+
+def parse_reasoning(text: str) -> tuple[str, str | None]:
+    """Strip <think>...</think> (or headless ...</think>) from `text` and
+    return (cleaned_text, reasoning_content). Returns (text, None) if no
+    thinking block found.
+    """
+    # Pair form first.
+    m = THINK_PAIR_RE.search(text)
+    if m:
+        reasoning = m.group(1).strip()
+        cleaned = (text[:m.start()] + text[m.end():]).strip()
+        return cleaned, reasoning if reasoning else None
+    # Headless form (template prefilled <think>\n at prompt end).
+    m = THINK_HEADLESS_RE.search(text)
+    if m and THINK_CLOSE_TAG in text:
+        reasoning = m.group(1).strip()
+        cleaned = text[m.end():].strip()
+        return cleaned, reasoning if reasoning else None
+    return text, None
+
+
+def parse_tool_calls(text: str) -> tuple[str, list[dict]]:
+    """Strip <tool_call>...</tool_call> blocks out of `text` and return them
+    as OpenAI-style tool_call dicts. Returns (cleaned_text, tool_calls).
+    """
+    tool_calls: list[dict] = []
+
+    def repl(m):
+        name = m.group(1).strip()
+        body = m.group(2)
+        args: dict = {}
+        for pm in PARAM_RE.finditer(body):
+            k = pm.group(1).strip()
+            v = pm.group(2)
+            # Qwen sometimes emits JSON-like values, sometimes plain strings.
+            # Try JSON first; fall back to raw string.
+            try:
+                args[k] = json.loads(v)
+            except (json.JSONDecodeError, ValueError):
+                args[k] = v
+        tool_calls.append({
+            "id": "call_" + uuid.uuid4().hex[:24],
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": json.dumps(args, ensure_ascii=False),
+            },
+        })
+        return ""
+
+    cleaned = TOOL_CALL_RE.sub(repl, text).strip()
+    return cleaned, tool_calls
+
+
+# ─── app ───────────────────────────────────────────────────────────
+
+def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
+              max_ctx: int, tokenizer: AutoTokenizer, stop_ids: set[int]) -> FastAPI:
+    import asyncio
+    app = FastAPI(title="Luce DFlash OpenAI server (tool-aware)")
+    daemon_lock = asyncio.Lock()
+
+    r_pipe, w_pipe = os.pipe()
+    cmd = [str(bin_path), str(target), str(draft), "--daemon",
+           "--fast-rollback", "--ddtree", f"--ddtree-budget={budget}",
+           f"--max-ctx={max_ctx}",
+           f"--stream-fd={w_pipe}"]
+    daemon_proc = subprocess.Popen(cmd, pass_fds=(w_pipe,), stdin=subprocess.PIPE)
+    os.close(w_pipe)
+
+    @app.get("/v1/models")
+    def list_models():
+        return {"object": "list",
+                "data": [{"id": MODEL_NAME, "object": "model", "owned_by": "luce"}]}
+
+    def _tokenize_prompt(req: ChatRequest) -> tuple[Path, bool]:
+        """Returns (prompt_bin_path, started_in_thinking). started_in_thinking
+        is True when the chat template prefilled <think>\\n at the end of the
+        prompt — the model's first emitted tokens are reasoning content."""
+        # Convert pydantic messages to dicts the chat template expects.
+        msgs: list[dict] = []
+        for m in req.messages:
+            d: dict = {"role": m.role}
+            if m.content is not None:
+                d["content"] = m.content
+            if m.name is not None:
+                d["name"] = m.name
+            if m.tool_call_id is not None:
+                d["tool_call_id"] = m.tool_call_id
+            if m.tool_calls is not None:
+                # The Qwen template walks tool_calls[i].function.{name, arguments}
+                d["tool_calls"] = []
+                for tc in m.tool_calls:
+                    args = tc.function.arguments
+                    # Template expects arguments as a dict, not a JSON string.
+                    if isinstance(args, str):
+                        try:
+                            args_obj = json.loads(args)
+                        except (json.JSONDecodeError, ValueError):
+                            args_obj = {"_raw": args}
+                    else:
+                        args_obj = args
+                    d["tool_calls"].append({
+                        "id": tc.id,
+                        "type": tc.type,
+                        "function": {"name": tc.function.name, "arguments": args_obj},
+                    })
+            msgs.append(d)
+
+        tools_arg = None
+        if req.tools:
+            tools_arg = [t.model_dump()["function"] | {"type": t.type} for t in req.tools]
+            # The Qwen template accepts the raw OpenAI tools array structure.
+            tools_arg = [t.model_dump() for t in req.tools]
+
+        kwargs = dict(tokenize=False, add_generation_prompt=True)
+        if tools_arg:
+            kwargs["tools"] = tools_arg
+        # Per-request chat template knobs (e.g. enable_thinking, preserve_thinking).
+        if req.chat_template_kwargs:
+            kwargs.update(req.chat_template_kwargs)
+        prompt = tokenizer.apply_chat_template(msgs, **kwargs)
+        # Did the template prefill `<think>\n` at the end? Then streaming should
+        # start in reasoning mode.
+        started_in_thinking = bool(re.search(r"<think>\s*$", prompt))
+        ids = tokenizer.encode(prompt, add_special_tokens=False)
+        tmp = Path(tempfile.mkstemp(suffix=".bin")[1])
+        with open(tmp, "wb") as f:
+            for t in ids:
+                f.write(struct.pack("<i", int(t)))
+        return tmp, started_in_thinking
+
+    def _token_stream(r, n_gen):
+        generated = 0
+        hit_stop = False
+        while True:
+            b = os.read(r, 4)
+            if not b or len(b) < 4:
+                break
+            tok_id = struct.unpack("<i", b)[0]
+            if tok_id == -1:
+                break
+            if hit_stop:
+                continue
+            if tok_id in stop_ids:
+                hit_stop = True
+                continue
+            generated += 1
+            yield tok_id
+            if generated >= n_gen:
+                hit_stop = True
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(req: ChatRequest):
+        prompt_bin, started_in_thinking = _tokenize_prompt(req)
+        prompt_len = prompt_bin.stat().st_size // 4
+        available_gen = max_ctx - prompt_len - 20
+        gen_len = min(req.max_tokens, available_gen)
+        if gen_len <= 0:
+            return JSONResponse(
+                {"detail": f"Prompt length ({prompt_len}) exceeds max_ctx ({max_ctx})"},
+                status_code=400)
+
+        completion_id = "chatcmpl-" + uuid.uuid4().hex[:24]
+        created = int(time.time())
+
+        if req.stream:
+            return await _stream_response(req, prompt_bin, gen_len,
+                                           completion_id, created,
+                                           started_in_thinking, daemon_lock)
+
+        # Non-streaming: collect, parse, return.
+        async with daemon_lock:
+            cmd_line = f"{prompt_bin} {gen_len}\n"
+            daemon_proc.stdin.write(cmd_line.encode("utf-8"))
+            daemon_proc.stdin.flush()
+            tokens = list(_token_stream(r_pipe, gen_len))
+        try: prompt_bin.unlink()
+        except Exception: pass
+
+        text = tokenizer.decode(tokens, skip_special_tokens=True)
+        # User-supplied stop sequences: trim at first match.
+        stops = normalize_stop(req.stop)
+        if stops:
+            i = first_stop_match(text, stops)
+            if i != -1:
+                text = text[:i]
+        # If the template prefilled <think> as a generation prefix, prepend it
+        # so parse_reasoning sees the matched pair.
+        if started_in_thinking and not text.lstrip().startswith(THINK_OPEN_TAG):
+            text = THINK_OPEN_TAG + "\n" + text
+        cleaned, tool_calls = parse_tool_calls(text)
+        cleaned, reasoning = parse_reasoning(cleaned)
+
+        msg: dict = {"role": "assistant"}
+        finish_reason = "stop"
+        if reasoning:
+            msg["reasoning_content"] = reasoning
+        if tool_calls:
+            msg["content"] = cleaned if cleaned else None
+            msg["tool_calls"] = tool_calls
+            finish_reason = "tool_calls"
+        else:
+            msg["content"] = cleaned
+
+        return JSONResponse({
+            "id": completion_id,
+            "object": "chat.completion",
+            "created": created,
+            "model": MODEL_NAME,
+            "choices": [{
+                "index": 0,
+                "message": msg,
+                "finish_reason": finish_reason,
+            }],
+            "usage": {"prompt_tokens": prompt_len,
+                      "completion_tokens": len(tokens),
+                      "total_tokens": prompt_len + len(tokens)},
+        })
+
+    async def _stream_response(req, prompt_bin, gen_len, completion_id, created,
+                                started_in_thinking, lock):
+        prompt_len = prompt_bin.stat().st_size // 4
+        include_usage = bool(req.stream_options and req.stream_options.get("include_usage"))
+        def chunk(delta_obj, finish=None):
+            return {"id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": MODEL_NAME,
+                    "choices": [{"index": 0, "delta": delta_obj,
+                                  "finish_reason": finish}]}
+
+        async def sse() -> AsyncIterator[str]:
+            async with lock:
+                cmd_line = f"{prompt_bin} {gen_len}\n"
+                daemon_proc.stdin.write(cmd_line.encode("utf-8"))
+                daemon_proc.stdin.flush()
+
+                yield f"data: {json.dumps(chunk({'role': 'assistant'}))}\n\n"
+
+                # State machine: mode ∈ {'reasoning', 'content', 'tool_buffer'}
+                mode = "reasoning" if started_in_thinking else "content"
+                window = ""           # holdback buffer for tag detection
+                tool_buffer = ""
+                stops = normalize_stop(req.stop)
+                # Holdback must cover longest tag AND longest stop sequence.
+                tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
+                stop_holdback = max((len(s) for s in stops), default=0)
+                HOLDBACK = max(tag_holdback, stop_holdback)
+                completion_tokens = 0
+                stop_hit = False
+
+                def emit_delta(text, kind):
+                    """kind: 'content' or 'reasoning_content'"""
+                    if not text:
+                        return None
+                    return f"data: {json.dumps(chunk({kind: text}))}\n\n"
+
+                try:
+                    async for tok_id in iterate_in_threadpool(_token_stream(r_pipe, gen_len)):
+                        completion_tokens += 1
+                        piece = tokenizer.decode([tok_id])
+                        window += piece
+
+                        # Stop-sequence check on the visible (content/reasoning) stream.
+                        if stops and mode != "tool_buffer":
+                            si = first_stop_match(window, stops)
+                            if si != -1:
+                                window = window[:si]
+                                stop_hit = True
+                                # Flush truncated remainder per current mode.
+                                kind = "reasoning_content" if mode == "reasoning" else "content"
+                                out = emit_delta(window, kind)
+                                if out: yield out
+                                window = ""
+                                break
+
+                        # Process state transitions until no more tags found in window.
+                        while True:
+                            if mode == "tool_buffer":
+                                tool_buffer += window
+                                window = ""
+                                break
+
+                            # Look for the next tag of interest based on mode.
+                            if mode == "reasoning":
+                                idx = window.find(THINK_CLOSE_TAG)
+                                if idx != -1:
+                                    pre = window[:idx]
+                                    out = emit_delta(pre, "reasoning_content")
+                                    if out: yield out
+                                    window = window[idx + len(THINK_CLOSE_TAG):]
+                                    mode = "content"
+                                    continue
+                                # No close tag yet. Stream all but holdback.
+                                if len(window) > HOLDBACK:
+                                    safe = window[:-HOLDBACK]
+                                    out = emit_delta(safe, "reasoning_content")
+                                    if out: yield out
+                                    window = window[-HOLDBACK:]
+                                break  # need more tokens
+
+                            else:  # mode == "content"
+                                think_idx = window.find(THINK_OPEN_TAG)
+                                tool_idx  = window.find(TOOL_OPEN_TAG)
+                                # Pick the earliest tag that actually appears.
+                                hits = [(i, t) for i, t in
+                                        ((think_idx, "think"), (tool_idx, "tool")) if i != -1]
+                                if hits:
+                                    hits.sort()
+                                    idx, which = hits[0]
+                                    pre = window[:idx]
+                                    out = emit_delta(pre, "content")
+                                    if out: yield out
+                                    if which == "think":
+                                        window = window[idx + len(THINK_OPEN_TAG):]
+                                        mode = "reasoning"
+                                    else:  # tool
+                                        tool_buffer = window[idx:]
+                                        window = ""
+                                        mode = "tool_buffer"
+                                    continue
+                                if len(window) > HOLDBACK:
+                                    safe = window[:-HOLDBACK]
+                                    out = emit_delta(safe, "content")
+                                    if out: yield out
+                                    window = window[-HOLDBACK:]
+                                break  # need more tokens
+
+                    if stop_hit:
+                        finish_reason = "stop"
+                        yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
+                        if include_usage:
+                            usage_chunk = {"id": completion_id, "object": "chat.completion.chunk",
+                                           "created": created, "model": MODEL_NAME, "choices": [],
+                                           "usage": {"prompt_tokens": prompt_len,
+                                                      "completion_tokens": completion_tokens,
+                                                      "total_tokens": prompt_len + completion_tokens}}
+                            yield f"data: {json.dumps(usage_chunk)}\n\n"
+                        yield "data: [DONE]\n\n"
+                        try: prompt_bin.unlink()
+                        except Exception: pass
+                        return
+
+                    # Generation done. Flush remaining window per current mode.
+                    if mode == "reasoning" and window:
+                        out = emit_delta(window, "reasoning_content")
+                        if out: yield out
+                    elif mode == "content" and window:
+                        out = emit_delta(window, "content")
+                        if out: yield out
+                    elif mode == "tool_buffer":
+                        tool_buffer += window
+                    window = ""
+
+                    finish_reason = "stop"
+                    if mode == "tool_buffer":
+                        cleaned_after, tool_calls = parse_tool_calls(tool_buffer)
+                        if tool_calls:
+                            if cleaned_after:
+                                out = emit_delta(cleaned_after, "content")
+                                if out: yield out
+                            tc_delta_list = [{
+                                "index": i, "id": tc["id"], "type": "function",
+                                "function": {"name": tc["function"]["name"],
+                                              "arguments": tc["function"]["arguments"]},
+                            } for i, tc in enumerate(tool_calls)]
+                            yield f"data: {json.dumps(chunk({'tool_calls': tc_delta_list}))}\n\n"
+                            finish_reason = "tool_calls"
+                        else:
+                            # Unclosed <tool_call> — emit raw as content fallback.
+                            out = emit_delta(tool_buffer, "content")
+                            if out: yield out
+                finally:
+                    try: prompt_bin.unlink()
+                    except Exception: pass
+
+                yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
+                if include_usage:
+                    usage_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": MODEL_NAME,
+                        "choices": [],
+                        "usage": {"prompt_tokens": prompt_len,
+                                   "completion_tokens": completion_tokens,
+                                   "total_tokens": prompt_len + completion_tokens},
+                    }
+                    yield f"data: {json.dumps(usage_chunk)}\n\n"
+                yield "data: [DONE]\n\n"
+
+        return StreamingResponse(sse(), media_type="text/event-stream")
+
+    return app
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="0.0.0.0")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--target", type=Path, default=DEFAULT_TARGET)
+    ap.add_argument("--draft",  type=Path, default=DEFAULT_DRAFT_ROOT)
+    ap.add_argument("--bin",    type=Path, default=DEFAULT_BIN)
+    ap.add_argument("--budget", type=int,  default=DEFAULT_BUDGET)
+    default_ctx = 131072 if os.environ.get("DFLASH27B_KV_Q4") == "1" else 6144
+    ap.add_argument("--max-ctx", type=int, default=default_ctx)
+    ap.add_argument("--tokenizer", default="Qwen/Qwen3.5-27B",
+                    help="HF tokenizer id; Qwen3.6 shares this tokenizer.")
+    args = ap.parse_args()
+
+    if not args.bin.is_file():
+        raise SystemExit(f"binary not found at {args.bin}")
+    if not args.target.is_file():
+        raise SystemExit(f"target GGUF not found at {args.target}")
+    draft = resolve_draft(args.draft) if args.draft.is_dir() else args.draft
+    if not draft.is_file():
+        raise SystemExit(f"draft safetensors not found at {args.draft}")
+
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer, trust_remote_code=True)
+    stop_ids = set()
+    for s in ("<|im_end|>", "<|endoftext|>"):
+        ids = tokenizer.encode(s, add_special_tokens=False)
+        if ids: stop_ids.add(ids[0])
+
+    app = build_app(args.target, draft, args.bin, args.budget, args.max_ctx,
+                    tokenizer, stop_ids)
+
+    import uvicorn
+    print(f"Luce DFlash OpenAI server (tool-aware) on http://{args.host}:{args.port}")
+    print(f"  target = {args.target}")
+    print(f"  draft  = {draft}")
+    print(f"  bin    = {args.bin}")
+    print(f"  budget = {args.budget}")
+    print(f"  max_ctx= {args.max_ctx}")
+    print(f"  tokenizer = {args.tokenizer}")
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/dflash/scripts/server_tools.py
+++ b/dflash/scripts/server_tools.py
@@ -358,8 +358,9 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
         # start in reasoning mode.
         started_in_thinking = bool(re.search(r"<think>\s*$", prompt))
         ids = tokenizer.encode(prompt, add_special_tokens=False)
-        tmp = Path(tempfile.mkstemp(suffix=".bin")[1])
-        with open(tmp, "wb") as f:
+        fd, path = tempfile.mkstemp(suffix=".bin")
+        tmp = Path(path)
+        with os.fdopen(fd, "wb") as f:
             for t in ids:
                 f.write(struct.pack("<i", int(t)))
         return tmp, started_in_thinking


### PR DESCRIPTION
What this PR does is that it extends scripts/server.py with the OpenAI Chat Completions fields that agent CLIs (OpenCode, Cline, Aider, Open WebUI, Hermes, etc.) require to work out of the box, and adds Blackwell consumer GPUs (RTX 5090, DGX Spark GB10) to the default build targets.

# Motivation
I managed to run Qwen3.6-27b on my DGX Spark (GB10) serving ~35token/s 
(Compared to vllm bf16 ~4tp/s, vllm bf16 + dflash 13.1 tp/s)

## Features
- Added Toolings Streaming & Non-streaming
- Reasoning Split
- Enable Thinking 
- stop sequences
- include usage

## Agent Demo

OpenCode
<img width="1471" height="728" alt="Screenshot 2026-04-23 at 7 56 58 PM" src="https://github.com/user-attachments/assets/a7ab44ff-257d-4e56-8bc4-2390f55756fb" />

Hermes
<img width="1167" height="525" alt="Screenshot 2026-04-23 at 7 57 59 PM" src="https://github.com/user-attachments/assets/18ec1071-ea32-436d-ad34-697593005e6e" />


