### PR TITLE
More Windows fixes

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# If we do not set this, ggml will output to bin and DLLs will not load
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
 endif()

--- a/dflash/examples/chat.py
+++ b/dflash/examples/chat.py
@@ -16,8 +16,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 TARGET = ROOT / "models" / "Qwen3.5-27B-Q4_K_M.gguf"
-DRAFT_SEARCH_ROOT = Path.home() / ".cache/huggingface/hub/models--z-lab--Qwen3.5-27B-DFlash/snapshots"
-BIN = ROOT / "build" / "test_dflash"
+DRAFT_ROOT = ROOT / "models" / "draft"
+BIN = ROOT / "build" / ("test_dflash.exe" if sys.platform == "win32" else "test_dflash")
 
 BUDGET = 22
 N_GEN  = 512
@@ -25,9 +25,14 @@ SYSTEM = "You are a concise, helpful assistant."
 
 
 def resolve_draft() -> Path:
-    for st in DRAFT_SEARCH_ROOT.rglob("model.safetensors"):
-        return st
-    sys.exit(f"draft weights not found under {DRAFT_SEARCH_ROOT}")
+    if DRAFT_ROOT.is_file():
+        return DRAFT_ROOT
+    if DRAFT_ROOT.is_dir():
+        for st in DRAFT_ROOT.rglob("model.safetensors"):
+            return st
+    sys.exit(
+        f"draft weights not found under {DRAFT_ROOT}. Download them as documented in the README."
+    )
 
 
 def tokenize(tok, text: str, path: Path) -> int:

--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -219,9 +219,9 @@ def run_test_dflash(prompt_path: str, n_gen: int, fast_rollback: bool,
 
     # Parse output
     out = r.stdout
-    m_tps = re.search(r"→\s+(\d+\.\d+)\s+tok/s", out)
-    m_commit = re.search(r"avg commit/step=(\d+\.\d+)", out)
-    m_accept = re.search(r"accepted=(\d+)/(\d+) \((\d+\.\d+)%", out)
+    m_tps = re.search(r"(\d+(?:\.\d+)?)\s+tok/s", out)
+    m_commit = re.search(r"avg commit/step=(\d+(?:\.\d+)?)", out)
+    m_accept = re.search(r"accepted=(\d+)/(\d+) \((\d+(?:\.\d+)?)%", out)
     m_steps = re.search(r"(\d+) draft steps", out)
     if not (m_tps and m_commit and m_accept and m_steps):
         print("STDOUT tail:", out[-2000:])

--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -13,34 +13,25 @@ import re
 import struct
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent.parent
+BIN_SUFFIX = ".exe" if os.name == "nt" else ""
 TARGET = os.environ.get(
     "DFLASH_TARGET",
     str(ROOT / "models" / "Qwen3.5-27B-Q4_K_M.gguf"),
 )
-_DRAFT_DEFAULT_ROOT = (
-    Path.home() / ".cache/huggingface/hub"
-    / "models--z-lab--Qwen3.5-27B-DFlash" / "snapshots"
-)
-
-
-def _resolve_draft() -> str:
-    env = os.environ.get("DFLASH_DRAFT")
-    if env:
-        return env
-    for st in _DRAFT_DEFAULT_ROOT.rglob("model.safetensors"):
-        return str(st)
-    return str(_DRAFT_DEFAULT_ROOT / "model.safetensors")
-
-
-DRAFT = _resolve_draft()
+_LOCAL_DRAFT_FILE = ROOT / "models" / "draft" / "model.safetensors"
+_LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
+DRAFT = None
 TEST_DFLASH = os.environ.get(
     "DFLASH_BIN",
-    str(ROOT / "build" / "test_dflash"),
+    str(ROOT / "build" / f"test_dflash{BIN_SUFFIX}"),
 )
+TMPDIR = Path(tempfile.gettempdir()) / "dflash_bench"
+TMPDIR.mkdir(parents=True, exist_ok=True)
 
 PROMPTS = [
     # (name, source_code)
@@ -187,7 +178,46 @@ PROMPTS = [
 ]
 
 
-def tokenize_prompt(prompt: str, out_path: str, tokenizer) -> int:
+def _find_safetensors(root: Path) -> str | None:
+    if root.is_file():
+        return str(root)
+    if not root.is_dir():
+        return None
+    for st in root.rglob("model.safetensors"):
+        return str(st)
+    return None
+
+
+def _resolve_draft() -> str:
+    env = os.environ.get("DFLASH_DRAFT")
+    if env:
+        found = _find_safetensors(Path(env))
+        if found:
+            return found
+        raise FileNotFoundError(f"DFLASH_DRAFT does not point to model.safetensors: {env}")
+
+    for candidate in (_LOCAL_DRAFT_FILE, _LOCAL_DRAFT_ROOT):
+        found = _find_safetensors(candidate)
+        if found:
+            return found
+
+    raise FileNotFoundError(
+        "draft model.safetensors not found. Expected one of:\n"
+        f"  - {_LOCAL_DRAFT_FILE}\n"
+        "Download it as documented in the README, or set DFLASH_DRAFT to an explicit file or directory."
+    )
+
+
+def _require_file(path: str, label: str):
+    if not Path(path).is_file():
+        raise FileNotFoundError(f"{label} not found: {path}")
+
+
+def _prompt_path(i: int) -> Path:
+    return TMPDIR / f"he_prompt_{i:02d}.bin"
+
+
+def tokenize_prompt(prompt: str, out_path: Path, tokenizer) -> int:
     ids = tokenizer.encode(prompt, add_special_tokens=False)
     with open(out_path, "wb") as f:
         for tid in ids:
@@ -195,13 +225,13 @@ def tokenize_prompt(prompt: str, out_path: str, tokenizer) -> int:
     return len(ids)
 
 
-def run_test_dflash(prompt_path: str, n_gen: int, fast_rollback: bool,
+def run_test_dflash(prompt_path: Path, n_gen: int, fast_rollback: bool,
                     ddtree_budget: int | None = None,
                     ddtree_temp: float | None = None,
                     ddtree_no_chain_seed: bool = False) -> dict:
-    out_bin = "/tmp/he_bench_out.bin"
+    out_bin = TMPDIR / "he_bench_out.bin"
     cmd = [
-        TEST_DFLASH, TARGET, DRAFT, prompt_path, str(n_gen), out_bin,
+        TEST_DFLASH, TARGET, DRAFT, str(prompt_path), str(n_gen), str(out_bin),
     ]
     if fast_rollback:
         cmd.append("--fast-rollback")
@@ -237,6 +267,11 @@ def run_test_dflash(prompt_path: str, n_gen: int, fast_rollback: bool,
 
 
 def main():
+    global DRAFT
+    DRAFT = _resolve_draft()
+    _require_file(TARGET, "target GGUF")
+    _require_file(TEST_DFLASH, "test_dflash binary")
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--n-gen", type=int, default=128)
     ap.add_argument("--mode", choices=["fast", "batched"], default="fast")
@@ -249,16 +284,21 @@ def main():
                     help="Use paper's pure best-first (no chain pre-seed)")
     args = ap.parse_args()
 
+    print(f"[bench] target = {TARGET}")
+    print(f"[bench] draft  = {DRAFT}")
+    print(f"[bench] bin    = {TEST_DFLASH}")
+    print(f"[bench] tmp    = {TMPDIR}")
+
     if not args.skip_tokenize:
         print("[bench] tokenizing prompts via HF…")
         from transformers import AutoTokenizer
         tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B", trust_remote_code=True)
         for i, (name, p) in enumerate(PROMPTS):
-            path = f"/tmp/he_prompt_{i:02d}.bin"
+            path = _prompt_path(i)
             n = tokenize_prompt(p, path, tok)
             print(f"  [{i:02d}] {name:26s}  {n:4d} tokens")
     else:
-        print("[bench] skipping tokenize (reusing /tmp/he_prompt_NN.bin)")
+        print(f"[bench] skipping tokenize (reusing {_prompt_path(0).parent})")
 
     print(f"\n[bench] mode={args.mode}  n_gen={args.n_gen}")
     print(f"{'prompt':28s}  {'steps':>6s} {'AL':>6s} {'pct%':>6s} {'tok/s':>8s}")
@@ -266,7 +306,7 @@ def main():
 
     results = []
     for i, (name, _) in enumerate(PROMPTS):
-        path = f"/tmp/he_prompt_{i:02d}.bin"
+        path = _prompt_path(i)
         try:
             r = run_test_dflash(path, args.n_gen,
                                 fast_rollback=(args.mode == "fast"),

--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -9,56 +9,101 @@ Paths resolve from the repo root by default. Override with env vars:
     DFLASH_BIN      path to build/test_dflash
     DFLASH_BIN_AR   path to build/test_generate
 """
-import json, os, re, struct, subprocess
+import json
+import os
+import re
+import struct
+import subprocess
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+BIN_SUFFIX = ".exe" if os.name == "nt" else ""
 TARGET = os.environ.get(
     "DFLASH_TARGET",
     str(ROOT / "models" / "Qwen3.5-27B-Q4_K_M.gguf"),
 )
-_DRAFT_ROOT = (
-    Path.home() / ".cache/huggingface/hub"
-    / "models--z-lab--Qwen3.5-27B-DFlash" / "snapshots"
-)
-
-
-def _resolve_draft() -> str:
-    env = os.environ.get("DFLASH_DRAFT")
-    if env:
-        return env
-    for st in _DRAFT_ROOT.rglob("model.safetensors"):
-        return str(st)
-    return str(_DRAFT_ROOT / "model.safetensors")
-
-
-DRAFT = _resolve_draft()
-TEST_DFLASH   = os.environ.get("DFLASH_BIN",    str(ROOT / "build" / "test_dflash"))
-TEST_GENERATE = os.environ.get("DFLASH_BIN_AR", str(ROOT / "build" / "test_generate"))
+_LOCAL_DRAFT_FILE = ROOT / "models" / "draft" / "model.safetensors"
+_LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
+DRAFT = None
+TEST_DFLASH = os.environ.get("DFLASH_BIN", str(ROOT / "build" / f"test_dflash{BIN_SUFFIX}"))
+TEST_GENERATE = os.environ.get("DFLASH_BIN_AR", str(ROOT / "build" / f"test_generate{BIN_SUFFIX}"))
+TMPDIR = Path(tempfile.gettempdir()) / "dflash_bench"
+TMPDIR.mkdir(parents=True, exist_ok=True)
 
 N_GEN = 256
 BUDGET = 22
 N_SAMPLE = 10
 
 BENCHES = [
-    ("HumanEval", "openai_humaneval", None,   "test", lambda x: x["prompt"]),
-    ("GSM8K",     "gsm8k",            "main", "test", lambda x: f"Question: {x['question']}\nAnswer: "),
-    ("Math500",   "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: "),
+    ("HumanEval", "openai_humaneval", None, "test", lambda x: x["prompt"]),
+    ("GSM8K", "gsm8k", "main", "test", lambda x: f"Question: {x['question']}\nAnswer: "),
+    ("Math500", "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: "),
 ]
 
 
-def tokenize(tok, p, path):
+def _find_safetensors(root: Path) -> str | None:
+    if root.is_file():
+        return str(root)
+    if not root.is_dir():
+        return None
+    for st in root.rglob("model.safetensors"):
+        return str(st)
+    return None
+
+
+def _resolve_draft() -> str:
+    env = os.environ.get("DFLASH_DRAFT")
+    if env:
+        found = _find_safetensors(Path(env))
+        if found:
+            return found
+        raise FileNotFoundError(f"DFLASH_DRAFT does not point to model.safetensors: {env}")
+
+    for candidate in (_LOCAL_DRAFT_FILE, _LOCAL_DRAFT_ROOT):
+        found = _find_safetensors(candidate)
+        if found:
+            return found
+
+    raise FileNotFoundError(
+        "draft model.safetensors not found. Expected one of:\n"
+        f"  - {_LOCAL_DRAFT_FILE}\n"
+        "Download it as documented in the README, or set DFLASH_DRAFT to an explicit file or directory."
+    )
+
+
+def _require_file(path: str, label: str):
+    if not Path(path).is_file():
+        raise FileNotFoundError(f"{label} not found: {path}")
+
+
+def _run_checked(cmd, timeout: int, label: str) -> subprocess.CompletedProcess:
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if r.returncode != 0:
+        tail = (r.stderr or r.stdout or "<no output>").strip()[-2000:]
+        raise RuntimeError(f"{label} exited {r.returncode}: {tail}")
+    return r
+
+
+def tokenize(tok, p, path: Path):
     ids = tok.encode(p, add_special_tokens=False)
     with open(path, "wb") as f:
-        for t in ids: f.write(struct.pack("<i", int(t)))
+        for t in ids:
+            f.write(struct.pack("<i", int(t)))
     return len(ids)
 
 
-def run_ar(path):
-    r = subprocess.run([TEST_GENERATE, TARGET, path, str(N_GEN), "/tmp/ar_out.bin"],
-                       capture_output=True, text=True, timeout=300)
+def run_ar(path: Path):
+    out_bin = TMPDIR / "ar_out.bin"
+    r = _run_checked(
+        [TEST_GENERATE, TARGET, str(path), str(N_GEN), str(out_bin)],
+        timeout=300,
+        label="test_generate",
+    )
     m = re.search(r"(\d+\.\d+)\s+tok/s", r.stdout)
-    return float(m.group(1)) if m else 0.0
+    if not m:
+        raise RuntimeError(f"test_generate output parse failed: {r.stdout[-1000:]}")
+    return float(m.group(1))
 
 
 def _auto_max_ctx(n_prompt):
@@ -70,19 +115,44 @@ def _auto_max_ctx(n_prompt):
     return ((n_prompt + N_GEN + pad + 255) // 256) * 256
 
 
-def run_df(path, n_prompt):
+def run_df(path: Path, n_prompt):
     max_ctx = _auto_max_ctx(n_prompt)
-    r = subprocess.run([TEST_DFLASH, TARGET, DRAFT, path, str(N_GEN), "/tmp/df_out.bin",
-                        "--fast-rollback", "--ddtree", f"--ddtree-budget={BUDGET}",
-                        f"--max-ctx={max_ctx}"],
-                       capture_output=True, text=True, timeout=300)
-    tps = re.search(r"→\s+(\d+\.\d+)\s+tok/s", r.stdout)
-    al  = re.search(r"avg commit/step=(\d+\.\d+)", r.stdout)
-    return (float(tps.group(1)) if tps else 0.0,
-            float(al.group(1))  if al else 0.0)
+    out_bin = TMPDIR / "df_out.bin"
+    r = _run_checked(
+        [
+            TEST_DFLASH,
+            TARGET,
+            DRAFT,
+            str(path),
+            str(N_GEN),
+            str(out_bin),
+            "--fast-rollback",
+            "--ddtree",
+            f"--ddtree-budget={BUDGET}",
+            f"--max-ctx={max_ctx}",
+        ],
+        timeout=300,
+        label="test_dflash",
+    )
+    tps = re.search(r"(\d+(?:\.\d+)?)\s+tok/s", r.stdout)
+    al = re.search(r"avg commit/step=(\d+(?:\.\d+)?)", r.stdout)
+    if not (tps and al):
+        raise RuntimeError(f"test_dflash output parse failed: {r.stdout[-1500:]}")
+    return float(tps.group(1)), float(al.group(1))
 
 
 def main():
+    global DRAFT
+    DRAFT = _resolve_draft()
+    _require_file(TARGET, "target GGUF")
+    _require_file(TEST_DFLASH, "test_dflash binary")
+    _require_file(TEST_GENERATE, "test_generate binary")
+
+    print(f"[bench] target = {TARGET}", flush=True)
+    print(f"[bench] draft  = {DRAFT}", flush=True)
+    print(f"[bench] ar bin = {TEST_GENERATE}", flush=True)
+    print(f"[bench] df bin = {TEST_DFLASH}", flush=True)
+
     from datasets import load_dataset
     from transformers import AutoTokenizer
     tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B", trust_remote_code=True)
@@ -95,20 +165,27 @@ def main():
         ar_tps, df_tps, df_al = [], [], []
         for i, s in enumerate(ds):
             p = extract(s)
-            path = f"/tmp/b_{name}_{i:02d}.bin"
+            path = TMPDIR / f"b_{name}_{i:02d}.bin"
             n = tokenize(tok, p, path)
             if n == 0 or n > 3500:
                 continue
-            ar = run_ar(path)
-            df, al = run_df(path, n)
-            if ar > 0: ar_tps.append(ar)
-            if df > 0: df_tps.append(df); df_al.append(al)
+            try:
+                ar = run_ar(path)
+                df, al = run_df(path, n)
+            except Exception as e:
+                print(f"  [{i+1:02d}/{N_SAMPLE}] n_tok={n:4d}  FAILED: {e}", flush=True)
+                continue
+            if ar > 0:
+                ar_tps.append(ar)
+            if df > 0:
+                df_tps.append(df)
+                df_al.append(al)
             print(f"  [{i+1:02d}/{N_SAMPLE}] n_tok={n:4d}  AR={ar:6.2f}  DFlash={df:7.2f}  AL={al:5.2f}", flush=True)
-        ar_m = sum(ar_tps)/len(ar_tps) if ar_tps else 0
-        df_m = sum(df_tps)/len(df_tps) if df_tps else 0
-        al_m = sum(df_al)/len(df_al) if df_al else 0
+        ar_m = sum(ar_tps) / len(ar_tps) if ar_tps else 0
+        df_m = sum(df_tps) / len(df_tps) if df_tps else 0
+        al_m = sum(df_al) / len(df_al) if df_al else 0
         results[name] = {"ar": ar_m, "dflash": df_m, "al": al_m,
-                         "speedup": df_m/ar_m if ar_m else 0}
+                         "speedup": df_m / ar_m if ar_m else 0}
         print(f"  {name} mean: AR={ar_m:.2f}  DFlash={df_m:.2f}  AL={al_m:.2f}  {results[name]['speedup']:.2f}x", flush=True)
 
     print("\n[bench] === SUMMARY ===")
@@ -116,8 +193,10 @@ def main():
     for name, r in results.items():
         print(f"{name:12s}  {r['ar']:8.2f}  {r['dflash']:8.2f}  {r['al']:6.2f}  {r['speedup']:7.2f}x")
 
-    with open("/tmp/bench_llm_results.json", "w") as f:
+    out_json = TMPDIR / "bench_llm_results.json"
+    with open(out_json, "w") as f:
         json.dump(results, f, indent=2)
+    print(f"[bench] wrote {out_json}", flush=True)
 
 
 if __name__ == "__main__":

--- a/dflash/scripts/convert_dflash_to_gguf.py
+++ b/dflash/scripts/convert_dflash_to_gguf.py
@@ -22,7 +22,7 @@ name.
 
 Usage:
   PYTHONPATH=../../dflash27b_ggml/deps/llama.cpp/gguf-py python convert_dflash_to_gguf.py \
-    /home/lucebox/.cache/huggingface/hub/models--z-lab--Qwen3.5-27B-DFlash/snapshots/.../model.safetensors \
+    models/draft/model.safetensors \
     qwen3.5-27b-dflash-draft.gguf
 """
 

--- a/dflash/scripts/run.py
+++ b/dflash/scripts/run.py
@@ -26,13 +26,21 @@ def default_paths():
 
 def resolve_draft(draft_dir: str) -> str:
     if draft_dir.endswith(".safetensors"):
-        return draft_dir
+        p = Path(draft_dir)
+        if p.is_file():
+            return str(p)
+        raise FileNotFoundError(f"draft safetensors not found: {draft_dir}")
+
     p = Path(draft_dir)
     if p.is_file():
         return str(p)
-    for st in p.rglob("model.safetensors"):
-        return str(st)
-    raise FileNotFoundError(f"no model.safetensors under {draft_dir}")
+    if p.is_dir():
+        for st in p.rglob("model.safetensors"):
+            return str(st)
+
+    raise FileNotFoundError(
+        f"no model.safetensors under {draft_dir}. Download it as documented in the README, or pass --draft explicitly."
+    )
 
 
 def tokenize(tokenizer, text: str, out_path: str) -> int:

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -1859,7 +1859,7 @@ int main(int argc, char ** argv) {
                            + tt_accept + tt_restore + tt_replay_build + tt_replay_set + tt_replay_compute + tt_replay_logits);
     std::printf("  ----- sum     %.2f\n", sum_ms);
 
-    std::printf("\n[dflash] generated %d tokens in %.3f s  →  %.2f tok/s\n",
+    std::printf("\n[dflash] generated %d tokens in %.3f s  ->  %.2f tok/s\n",
                 n_generated, gen_s, tps);
     std::printf("[dflash] %d draft steps, accepted=%d/%d (%.1f%% per step), "
                 "avg commit/step=%.2f\n",

--- a/dflash/test/test_generate.cpp
+++ b/dflash/test/test_generate.cpp
@@ -243,7 +243,7 @@ int main(int argc, char ** argv) {
     // Also push the final next token so downstream sees it
     all_tokens.push_back(next);
 
-    std::printf("[gen] %d new tokens in %.3f s  →  %.2f tok/s\n", n_gen, secs, tps);
+    std::printf("[gen] %d new tokens in %.3f s  ->  %.2f tok/s\n", n_gen, secs, tps);
     std::printf("[gen] tokens: ");
     for (int i = 0; i < n_gen; i++) std::printf("%d ", all_tokens[prompt.size() + i]);
     std::printf("\n");


### PR DESCRIPTION
The benchmark now runs properly on Windows (ZOTAC RTX 3090 TRINITY OC):

```
C:\CodeBlocks\lucebox-hub\dflash>python scripts/bench_llm.py
[bench] target = C:\CodeBlocks\lucebox-hub\dflash\models\Qwen3.5-27B-Q4_K_M.gguf
[bench] draft  = C:\CodeBlocks\lucebox-hub\dflash\models\draft\model.safetensors
[bench] ar bin = C:\CodeBlocks\lucebox-hub\dflash\build\test_generate.exe
[bench] df bin = C:\CodeBlocks\lucebox-hub\dflash\build\test_dflash.exe

[bench] ==== HumanEval (n=10) ====
  [01/10] n_tok=  84  AR= 26.85  DFlash=  94.48  AL= 8.83
  [02/10] n_tok= 138  AR= 28.87  DFlash= 105.16  AL= 9.14
  [03/10] n_tok= 134  AR= 28.31  DFlash= 101.50  AL= 8.83
  [04/10] n_tok= 120  AR= 27.84  DFlash= 108.09  AL= 9.85
  [05/10] n_tok= 172  AR= 26.77  DFlash=  93.28  AL= 8.53
  [06/10] n_tok= 118  AR= 28.01  DFlash=  79.88  AL= 7.31
  [07/10] n_tok=  51  AR= 28.34  DFlash=  77.22  AL= 6.56
  [08/10] n_tok= 141  AR= 28.10  DFlash= 117.12  AL=10.24
  [09/10] n_tok= 125  AR= 27.64  DFlash=  95.03  AL= 8.26
  [10/10] n_tok=  95  AR= 27.56  DFlash=  65.15  AL= 5.57
  HumanEval mean: AR=27.83  DFlash=93.69  AL=8.31  3.37x

[bench] ==== GSM8K (n=10) ====
  [01/10] n_tok=  45  AR= 27.81  DFlash=  69.47  AL= 5.95
  [02/10] n_tok= 111  AR= 27.47  DFlash=  67.30  AL= 5.82
  [03/10] n_tok=  49  AR= 27.17  DFlash=  80.60  AL= 7.16
  [04/10] n_tok=  70  AR= 27.48  DFlash=  61.45  AL= 5.22
  [05/10] n_tok= 102  AR= 27.11  DFlash=  93.61  AL= 8.26
  [06/10] n_tok= 118  AR= 27.36  DFlash=  65.55  AL= 5.69
  [07/10] n_tok= 113  AR= 27.25  DFlash=  88.17  AL= 8.12
  [08/10] n_tok=  50  AR= 27.22  DFlash=  75.63  AL= 6.71
  [09/10] n_tok=  43  AR= 27.75  DFlash=  80.65  AL= 6.92
  [10/10] n_tok=  96  AR= 27.74  DFlash=  65.20  AL= 5.82
  GSM8K mean: AR=27.44  DFlash=74.76  AL=6.57  2.72x

[bench] ==== Math500 (n=10) ====
  [01/10] n_tok= 257  AR= 28.06  DFlash=  75.21  AL= 6.56
  [02/10] n_tok=  53  AR= 27.70  DFlash=  85.57  AL= 7.31
  [03/10] n_tok=  40  AR= 27.39  DFlash=  91.33  AL= 8.00
  [04/10] n_tok=  50  AR= 27.50  DFlash=  85.21  AL= 7.53
  [05/10] n_tok= 117  AR= 27.07  DFlash=  82.17  AL= 7.31
  [06/10] n_tok=  76  AR= 26.75  DFlash=  73.75  AL= 6.92
  [07/10] n_tok=  43  AR= 27.78  DFlash=  66.72  AL= 5.69
  [08/10] n_tok=  79  AR= 26.54  DFlash=  67.18  AL= 6.40
  [09/10] n_tok=  52  AR= 27.07  DFlash=  65.26  AL= 5.82
  [10/10] n_tok=  57  AR= 27.56  DFlash= 100.40  AL= 8.83
  Math500 mean: AR=27.34  DFlash=79.28  AL=7.04  2.90x

[bench] === SUMMARY ===
Task                AR    DFlash      AL   Speedup
HumanEval        27.83     93.69    8.31     3.37x
GSM8K            27.44     74.76    6.57     2.72x
Math500          27.34     79.28    7.04     2.90x
[bench] wrote C:\Users\Admin\AppData\Local\Temp\dflash_bench\bench_llm_results.json
```

I changed all the paths to be consistent with the README (downloaded to `models/`) instead of the huggingface cache.

Compilation was slightly annoying, here is the command I used (from a VS2022 x64 developer prompt):

```
cmake -B build -S . -DCMAKE_CUDA_ARCHITECTURES=86 -DCMAKE_BUILD_TYPE=Release --fresh -G Ninja -DCMAKE_ASM_COMPILER=ml64
cmake --build build
```

There is also no `requirements.txt` in the repo, I had to install the `dataset` package but I already had a bunch of other things installed so that is likely not the only thing.