### PR TITLE
fix: support OpenAI content blocks in /v1/chat/completions

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -91,7 +91,7 @@ def _tokenizer_id_from_gguf(gguf_path: Path) -> str:
 
 class ChatMessage(BaseModel):
     role: str
-    content: str
+    content: str | list[dict]
 
 
 class ChatRequest(BaseModel):
@@ -160,7 +160,9 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
         }
 
     def _tokenize_prompt(req: ChatRequest) -> Path:
-        msgs = [m.model_dump() for m in req.messages]
+        msgs = [{"role": m.role, "content": _anthropic_text_from_content(m.content)
+                 if isinstance(m.content, list) else m.content}
+                for m in req.messages]
         prompt = tokenizer.apply_chat_template(
             msgs, tokenize=False, add_generation_prompt=True)
         ids = tokenizer.encode(prompt, add_special_tokens=False)


### PR DESCRIPTION
## Summary

- The OpenAI spec allows `message.content` to be either a plain `string` or an array of content blocks (`[{"type":"text","text":"..."}]`)
- Clients like opencode and Claude Code send the block form, causing `ChatMessage` to silently receive empty content (Pydantic can't coerce a list to `str`)
- The Anthropic handler in the same file already handles this correctly via `_anthropic_text_from_content` — this fix mirrors that for the OpenAI endpoint

## Changes

- `ChatMessage.content: str` → `str | list[dict]`
- `_tokenize_prompt` flattens list content using the existing `_anthropic_text_from_content` helper

## Test plan

- [ ] Send a request with `content` as a plain string — works as before
- [ ] Send a request with `content` as a block array (e.g. from opencode or Claude Code) — prompt is no longer silently empty

🤖 Generated with [Claude Code](https://claude.ai/claude-code)