### PR TITLE
docs(dflash): bump long-context example from 128K to 256K

### DIFF
--- a/dflash/README.md
+++ b/dflash/README.md
@@ -132,12 +132,12 @@ python3 scripts/bench_llm.py                                 # HE + GSM8K + Math
 python3 scripts/bench_he.py --n-gen 256 --ddtree-budget 22   # minimal HE bench
 ```
 
-**128K context mode:**
+**Long-context mode (up to 256K):**
 ```bash
 DFLASH27B_KV_TQ3=1 DFLASH27B_PREFILL_UBATCH=16 \
   build/test_dflash models/Qwen3.5-27B-Q4_K_M.gguf \
   models/draft/model.safetensors /tmp/long_prompt.bin 64 /tmp/out.bin \
-  --fast-rollback --ddtree --ddtree-budget=16 --max-ctx=N   # N = align_up(prompt + n_gen + 64, 256); up to 131072
+  --fast-rollback --ddtree --ddtree-budget=16 --max-ctx=N   # N = align_up(prompt + n_gen + 64, 256); up to 262144
 ```
 
 **Requirements:** NVIDIA sm_86+ GPU (3090, A10, A40, 4090), CUDA 12+, 24 GB VRAM, ~80 GB disk.


### PR DESCRIPTION
## Summary
- Updates quickstart long-context example to reflect the 262K ceiling unlocked by TQ3_0 KV cache (merged in #21).
- Section header: `**128K context mode:**` → `**Long-context mode (up to 256K):**`
- Example comment: `up to 131072` → `up to 262144`

## Test plan
- [x] Text-only diff, 1 file, +2/-2
- [x] Confirm the 262K ceiling holds on RTX 3090 (relying on PR #1 author's claim; not re-verified locally)

🧙 Built with [WOZCODE](https://wozcode.com)