### PR TITLE
megakernel: NVFP4 decode + hybrid prefill for Blackwell (DGX Spark / GB10)

### DIFF
--- a/megakernel/README.md
+++ b/megakernel/README.md
@@ -119,6 +119,12 @@ python final_bench.py    # runs pp520 tg128 (properly warmed), prints tok/s
 - PyTorch 2.0+
 - ~1.5 GB VRAM for BF16 weights
 
+**Blackwell (sm_120 / sm_121a):** runs on Blackwell consumer GPUs (RTX 5090)
+and the NVIDIA DGX Spark (GB10) via an NVFP4 decode path. The build
+auto-detects your GPU and `final_bench.py` dispatches to the right backend;
+use `--backend nvfp4` to force it. First DGX Spark numbers are in
+[RESULTS.md](RESULTS.md#nvidia-dgx-spark-gb10-sm_121a).
+
 **Optional:** Set a power limit to find your GPU's sweet spot:
 ```bash
 sudo nvidia-smi -pl 220    # or whatever your target wattage
@@ -132,10 +138,14 @@ sudo nvidia-smi -pl 220    # or whatever your target wattage
 | `prefill.cu` | Prefill (cuBLAS + standalone kernels) |
 | `torch_bindings.cpp` | PyTorch C++ bindings |
 | `model.py` | Weight loading + decoder |
-| `setup.py` | Build configuration |
+| `setup.py` | Build configuration (arch auto-detect, Blackwell gating) |
 | `final_bench.py` | Benchmark (prefill + decode, 10 warmup + 20 timed runs averaged — use this for published numbers) |
 | `bench_pp_tg.py` | Quick single-run benchmark with correctness check (not warmed, under-reports prefill) |
 | `RESULTS.md` | Full benchmark results and DVFS sweep |
+| `kernel_gb10_nvfp4.cu` | Blackwell-only: NVFP4 persistent decode megakernel |
+| `prefill_megakernel.cu` | Blackwell-only: single-dispatch prefill megakernel |
+| `model_nvfp4.py` | Blackwell-only: NVFP4 decoder driving the ops above |
+| `final_bench_nvfp4.py` / `bench_pp_tg_nvfp4.py` | Blackwell bench siblings dispatched by `--backend nvfp4` |
 
 ## Scope and limitations
 

--- a/megakernel/RESULTS.md
+++ b/megakernel/RESULTS.md
@@ -55,3 +55,45 @@ Sweet spot: 220W, 1.87 tok/J.
 - Models larger than 0.8B parameters
 - Multi-GPU or tensor-parallel setups
 - Total system power (CPU, RAM, PSU losses)
+
+## NVIDIA DGX Spark (GB10, sm_121a)
+
+First results for the megakernel on NVIDIA's DGX Spark (GB10). Decode runs
+through an NVFP4 persistent megakernel; prefill currently uses a single-dispatch
+kernel and is provisional — the tuned hybrid prefill path is next on deck.
+
+**Hardware:** NVIDIA GB10 Grace Blackwell Superchip (DGX Spark), compute cap
+12.1 (`sm_121a`), driver 580.126.09, CUDA 13.2, PyTorch 2.13.0a (cu13.2).
+
+### Decode (tg128)
+
+| Method | tg128 (tok/s) |
+|---|:---:|
+| **Megakernel NVFP4 decode** | **182** |
+| PyTorch HuggingFace (bf16) | 65 |
+
+**2.8× PyTorch HF on decode.** Output tokens match the PyTorch reference on
+the pp520 prompt from `final_bench.py`.
+
+### Prefill (pp520) — provisional
+
+| Method | pp520 (tok/s) |
+|---|:---:|
+| Megakernel (single-dispatch prefill) | 128 |
+| PyTorch HuggingFace (bf16) | 5584 |
+
+The single-dispatch prefill kernel is correct but not yet tuned on GB10. A
+tuned hybrid prefill (bf16 body + NVFP4 LM head) is tracked for a follow-up;
+until then the pp520 numbers here are preliminary. The value today is
+end-to-end correctness plus competitive decode throughput.
+
+### Run
+
+```bash
+# Auto-dispatches to the NVFP4 path on Blackwell
+python megakernel/final_bench.py
+
+# Or force a backend
+python megakernel/final_bench.py --backend nvfp4
+python megakernel/final_bench.py --backend bf16
+```

--- a/megakernel/RESULTS.md
+++ b/megakernel/RESULTS.md
@@ -59,33 +59,19 @@ Sweet spot: 220W, 1.87 tok/J.
 ## NVIDIA DGX Spark (GB10, sm_121a)
 
 First results for the megakernel on NVIDIA's DGX Spark (GB10). Decode runs
-through an NVFP4 persistent megakernel; prefill currently uses a single-dispatch
-kernel and is provisional — the tuned hybrid prefill path is next on deck.
+through a persistent NVFP4 megakernel; prefill uses a bf16 body with an
+NVFP4 LM head (the default "hybrid" prefill mode).
 
 **Hardware:** NVIDIA GB10 Grace Blackwell Superchip (DGX Spark), compute cap
 12.1 (`sm_121a`), driver 580.126.09, CUDA 13.2, PyTorch 2.13.0a (cu13.2).
 
-### Decode (tg128)
+| Method | Prefill pp520 (tok/s) | Decode tg128 (tok/s) |
+|---|:---:|:---:|
+| **Megakernel (NVFP4 decode, hybrid prefill)** | **20,639** | **181** |
+| PyTorch HuggingFace (bf16) | 5,649 | 65 |
 
-| Method | tg128 (tok/s) |
-|---|:---:|
-| **Megakernel NVFP4 decode** | **182** |
-| PyTorch HuggingFace (bf16) | 65 |
-
-**2.8× PyTorch HF on decode.** Output tokens match the PyTorch reference on
-the pp520 prompt from `final_bench.py`.
-
-### Prefill (pp520) — provisional
-
-| Method | pp520 (tok/s) |
-|---|:---:|
-| Megakernel (single-dispatch prefill) | 128 |
-| PyTorch HuggingFace (bf16) | 5584 |
-
-The single-dispatch prefill kernel is correct but not yet tuned on GB10. A
-tuned hybrid prefill (bf16 body + NVFP4 LM head) is tracked for a follow-up;
-until then the pp520 numbers here are preliminary. The value today is
-end-to-end correctness plus competitive decode throughput.
+**3.6× PyTorch HF on prefill, 2.8× on decode.** Output tokens match the
+PyTorch reference on the pp520 prompt from `final_bench.py`.
 
 ### Run
 
@@ -96,4 +82,7 @@ python megakernel/final_bench.py
 # Or force a backend
 python megakernel/final_bench.py --backend nvfp4
 python megakernel/final_bench.py --backend bf16
+
+# Switch prefill mode (default is "hybrid"; "raw" uses prefill_megakernel_nvfp4)
+MEGAKERNEL_PREFILL_MODE=raw python megakernel/final_bench.py --backend nvfp4
 ```

--- a/megakernel/bench_pp_tg.py
+++ b/megakernel/bench_pp_tg.py
@@ -3,7 +3,25 @@ Also tests end-to-end correctness (prefill → decode handoff).
 
 Scope: batch-size-1 single-stream decode, targeting local inference.
 All measurements use torch.cuda.synchronize() barriers + perf_counter.
-One warm-up run precedes each timed section."""
+One warm-up run precedes each timed section.
+
+Supports --backend {auto,bf16,nvfp4}. Default is auto: Blackwell (sm_12+)
+dispatches to bench_pp_tg_nvfp4.py; everything else runs the bf16 path
+below unchanged from upstream.
+"""
+import argparse as _argparse, os as _os, sys as _sys
+import torch as _torch
+
+_p = _argparse.ArgumentParser(add_help=False)
+_p.add_argument("--backend", default="auto", choices=("auto", "bf16", "nvfp4"))
+_a, _rest = _p.parse_known_args()
+_backend = _a.backend
+if _backend == "auto":
+    _backend = "nvfp4" if (_torch.cuda.is_available() and _torch.cuda.get_device_capability()[0] >= 12) else "bf16"
+if _backend == "nvfp4":
+    _here = _os.path.dirname(_os.path.abspath(__file__))
+    _os.execv(_sys.executable, [_sys.executable, _os.path.join(_here, "bench_pp_tg_nvfp4.py"), *_rest])
+
 import time, torch
 from model import Decoder, HIDDEN_SIZE, INTERMEDIATE_SIZE, FA_QPROJ_SIZE, FA_Q_SIZE, FA_KV_SIZE
 from model import DN_CONV_CHANNELS, DN_V_SIZE, DN_NUM_HEADS, MAX_SEQ_LEN

--- a/megakernel/bench_pp_tg_nvfp4.py
+++ b/megakernel/bench_pp_tg_nvfp4.py
@@ -1,0 +1,401 @@
+"""Benchmark pp512 / tg128 for the local Qwen3.5-0.8B megakernel backend.
+
+The default `all` mode runs each section in a fresh subprocess. This avoids
+carrying CUDA state from correctness checks into the timed benchmark sections.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+import torch
+from transformers import AutoTokenizer
+
+from model_nvfp4 import (
+    Decoder,
+    DN_CONV_CHANNELS,
+    DN_NUM_HEADS,
+    DN_V_SIZE,
+    FA_KV_SIZE,
+    FA_QPROJ_SIZE,
+    FA_Q_SIZE,
+    HIDDEN_SIZE,
+    INTERMEDIATE_SIZE,
+    PREFILL_PROJ_FUSED_SIZE,
+    PREFILL_PROJ_SCRATCH_SIZE,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark pp512 / tg128")
+    parser.add_argument("--model-name", default="Qwen/Qwen3.5-0.8B")
+    parser.add_argument("--backend", default="auto", choices=("auto", "bf16", "nvfp4"))
+    parser.add_argument("--prompt-tokens", type=int, default=512)
+    parser.add_argument("--gen-tokens", type=int, default=128)
+    parser.add_argument("--correctness-steps", type=int, default=30)
+    parser.add_argument("--warmup-runs", type=int, default=2)
+    parser.add_argument("--measure-runs", type=int, default=5)
+    parser.add_argument("--verbose-loader", action="store_true")
+    parser.add_argument(
+        "--section",
+        default="all",
+        choices=("all", "correctness", "pp", "tg"),
+    )
+    parser.add_argument("--json-result", action="store_true")
+    return parser.parse_args()
+
+
+def build_exact_prompt_ids(tokenizer, target_tokens):
+    seed = "Explain in great detail the history of artificial intelligence."
+    text = seed
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    while len(ids) < target_tokens:
+        text += " " + seed
+        ids = tokenizer.encode(text, add_special_tokens=False)
+    return ids[:target_tokens]
+
+
+def alloc_prefill_buffers(max_tokens):
+    bf16 = dict(dtype=torch.bfloat16, device="cuda")
+    f32 = dict(dtype=torch.float32, device="cuda")
+    i32 = dict(dtype=torch.int32, device="cuda")
+    return dict(
+        hidden=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+        residual=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+        normalized=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+        proj_buf=torch.empty(max_tokens * PREFILL_PROJ_FUSED_SIZE, **bf16),
+        proj_buf2=torch.empty(max_tokens * PREFILL_PROJ_SCRATCH_SIZE, **bf16),
+        attn_buf=torch.empty(max_tokens * max(FA_Q_SIZE, FA_KV_SIZE), **bf16),
+        mlp_buf=torch.empty(max_tokens * INTERMEDIATE_SIZE, **bf16),
+        dn_out_buf=torch.empty(max_tokens * DN_V_SIZE, **bf16),
+        beta_buf=torch.empty(max_tokens * DN_NUM_HEADS, **f32),
+        alpha_buf=torch.empty(max_tokens * DN_NUM_HEADS, **f32),
+        final_normed=torch.empty(HIDDEN_SIZE, **bf16),
+        hidden_bf16_out=torch.empty(HIDDEN_SIZE, **bf16),
+        lm_bmv=torch.empty(1024, **f32),
+        lm_bmi=torch.empty(1024, **i32),
+    )
+
+
+def get_prefill_op(decoder):
+    ops = torch.ops.qwen35_megakernel_bf16_C
+    if decoder.backend == "nvfp4":
+        return ops.prefill_megakernel_nvfp4
+    return ops.prefill_bf16
+
+
+def run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op):
+    decoder.reset()
+    if decoder.backend == "nvfp4":
+        return decoder.prefill_tokens(ids_t)
+    else:
+        prefill_op(
+            decoder._out_token,
+            ids_t,
+            decoder._embed_weight,
+            decoder._layer_weights_packed,
+            decoder._prefill_fused_weights_packed,
+            decoder._final_norm_weight,
+            decoder._lm_head_weight,
+            decoder._fa_k_cache,
+            decoder._fa_v_cache,
+            decoder._dn_states,
+            decoder._conv_bufs,
+            buffers["hidden"],
+            buffers["residual"],
+            buffers["normalized"],
+            buffers["proj_buf"],
+            buffers["proj_buf2"],
+            buffers["attn_buf"],
+            buffers["mlp_buf"],
+            buffers["dn_out_buf"],
+            buffers["beta_buf"],
+            buffers["alpha_buf"],
+            buffers["final_normed"],
+            buffers["hidden_bf16_out"],
+            buffers["lm_bmv"],
+            buffers["lm_bmi"],
+        )
+    decoder._hidden.copy_(buffers["hidden_bf16_out"])
+    decoder._position = prompt_len
+    return decoder._out_token.item()
+
+
+def decode_steps(decoder, first_token, num_steps, eos_token_id):
+    out = [first_token]
+    nid = first_token
+    for _ in range(num_steps):
+        nid = decoder.step(nid)
+        torch.cuda.synchronize()
+        if nid == eos_token_id:
+            break
+        out.append(nid)
+    return out
+
+
+def benchmark_prefill(decoder, ids_t, prompt_len, buffers, prefill_op, warmup_runs, measure_runs):
+    for _ in range(warmup_runs):
+        run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op)
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(measure_runs):
+        run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op)
+        torch.cuda.synchronize()
+    elapsed = (time.perf_counter() - t0) / measure_runs
+    return elapsed, prompt_len / elapsed
+
+
+def benchmark_decode(decoder, prompt_ids, gen_tokens, tokenizer, buffers, prefill_op):
+    ids_t = torch.tensor(prompt_ids, dtype=torch.int32, device="cuda")
+    first = run_prefill(decoder, ids_t, len(prompt_ids), buffers, prefill_op)
+
+    if decoder.backend == "nvfp4":
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        timed_ids_dev = decoder.step_many(first, gen_tokens)
+        torch.cuda.synchronize()
+        elapsed = time.perf_counter() - t0
+        timed_ids = timed_ids_dev.cpu().tolist()
+        if tokenizer.eos_token_id in timed_ids:
+            timed_ids = timed_ids[:timed_ids.index(tokenizer.eos_token_id)]
+        tps = (len(timed_ids) / elapsed) if timed_ids else 0.0
+        return first, elapsed, tps, timed_ids
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    nid = first
+    timed_ids = []
+    for _ in range(gen_tokens):
+        nid = decoder.step(nid)
+        torch.cuda.synchronize()
+        if nid == tokenizer.eos_token_id:
+            break
+        _ = tokenizer.decode([nid])
+        timed_ids.append(nid)
+
+    elapsed = time.perf_counter() - t0
+    tps = (len(timed_ids) / elapsed) if timed_ids else 0.0
+    return first, elapsed, tps, timed_ids
+
+
+def emit_result(result, json_result):
+    if json_result:
+        print(f"RESULT_JSON {json.dumps(result, sort_keys=True)}", flush=True)
+
+
+def run_correctness(args, tokenizer):
+    print(f"Loading decoder for {args.model_name}...", flush=True)
+    decoder = Decoder(
+        model_name=args.model_name,
+        backend=args.backend,
+        verbose=args.verbose_loader,
+    )
+    print(f"Backend: {decoder.backend_label}", flush=True)
+    if decoder.backend == "nvfp4":
+        print("Correctness mode: prefill/decode handoff smoke test", flush=True)
+
+    prefill_op = get_prefill_op(decoder)
+    prompt_ids = tokenizer.encode("The capital of France is", add_special_tokens=False)
+    buffers = alloc_prefill_buffers(max(32, len(prompt_ids)))
+
+    print("\n=== Correctness test ===", flush=True)
+    ids_t = torch.tensor(prompt_ids, dtype=torch.int32, device="cuda")
+    first = run_prefill(decoder, ids_t, len(prompt_ids), buffers, prefill_op)
+    print(f"Prefill -> first token: {first} = '{tokenizer.decode([first])}'", flush=True)
+
+    out = decode_steps(decoder, first, args.correctness_steps, tokenizer.eos_token_id)
+    text = tokenizer.decode(out, skip_special_tokens=True)
+    print(f"Prefill + decode: {text[:100]}", flush=True)
+
+    ok = bool(out)
+    if decoder.backend == "nvfp4":
+        if ok:
+            print("PASS: prefill completed and decode continued on NVFP4", flush=True)
+        else:
+            print("FAIL: no tokens produced after prefill on NVFP4", flush=True)
+    else:
+        print("PASS: BF16 correctness smoke test completed", flush=True)
+
+    result = {
+        "backend_label": decoder.backend_label,
+        "first_token": first,
+        "ok": ok,
+        "section": "correctness",
+    }
+    emit_result(result, args.json_result)
+    return result
+
+
+def run_pp(args, tokenizer):
+    print(f"Loading decoder for {args.model_name}...", flush=True)
+    decoder = Decoder(
+        model_name=args.model_name,
+        backend=args.backend,
+        verbose=args.verbose_loader,
+    )
+    prefill_op = get_prefill_op(decoder)
+    prompt_ids = build_exact_prompt_ids(tokenizer, args.prompt_tokens)
+    buffers = alloc_prefill_buffers(len(prompt_ids))
+    ids_t = torch.tensor(prompt_ids, dtype=torch.int32, device="cuda")
+
+    print("\n=== pp benchmark ===", flush=True)
+    print(f"Backend: {decoder.backend_label}", flush=True)
+    print(f"Prompt tokens: {len(prompt_ids)}", flush=True)
+    print(
+        f"Warming {args.warmup_runs}x and timing {args.measure_runs}x prompt-processing runs...",
+        flush=True,
+    )
+    pp_time, pp_tps = benchmark_prefill(
+        decoder,
+        ids_t,
+        len(prompt_ids),
+        buffers,
+        prefill_op,
+        args.warmup_runs,
+        args.measure_runs,
+    )
+    print(f"pp{len(prompt_ids)}: {pp_tps:.1f} tok/s ({pp_time * 1000:.1f}ms avg)", flush=True)
+
+    result = {
+        "backend_label": decoder.backend_label,
+        "pp_ms": pp_time * 1000.0,
+        "pp_tps": pp_tps,
+        "prompt_tokens": len(prompt_ids),
+        "section": "pp",
+    }
+    emit_result(result, args.json_result)
+    return result
+
+
+def run_tg(args, tokenizer):
+    print(f"Loading decoder for {args.model_name}...", flush=True)
+    decoder = Decoder(
+        model_name=args.model_name,
+        backend=args.backend,
+        verbose=args.verbose_loader,
+    )
+    prefill_op = get_prefill_op(decoder)
+    prompt_ids = tokenizer.encode("The capital of France is", add_special_tokens=False)
+    buffers = alloc_prefill_buffers(max(args.prompt_tokens, 32, len(prompt_ids)))
+
+    print("\n=== tg benchmark ===", flush=True)
+    print(f"Backend: {decoder.backend_label}", flush=True)
+    print(f"Timed decode steps: {args.gen_tokens}", flush=True)
+    first, tg_time, tg_tps, tg_ids = benchmark_decode(
+        decoder,
+        prompt_ids,
+        args.gen_tokens,
+        tokenizer,
+        buffers,
+        prefill_op,
+    )
+    print(f"Prefill seed token: {first} = '{tokenizer.decode([first])}'", flush=True)
+    print(f"tg{len(tg_ids)}: {tg_tps:.1f} tok/s ({tg_time * 1000:.1f}ms)", flush=True)
+
+    result = {
+        "backend_label": decoder.backend_label,
+        "first_token": first,
+        "gen_tokens": len(tg_ids),
+        "tg_ms": tg_time * 1000.0,
+        "tg_tps": tg_tps,
+        "section": "tg",
+    }
+    emit_result(result, args.json_result)
+    return result
+
+
+def build_child_cmd(args, section):
+    cmd = [
+        sys.executable,
+        __file__,
+        "--model-name",
+        args.model_name,
+        "--backend",
+        args.backend,
+        "--prompt-tokens",
+        str(args.prompt_tokens),
+        "--gen-tokens",
+        str(args.gen_tokens),
+        "--correctness-steps",
+        str(args.correctness_steps),
+        "--warmup-runs",
+        str(args.warmup_runs),
+        "--measure-runs",
+        str(args.measure_runs),
+        "--section",
+        section,
+        "--json-result",
+    ]
+    if args.verbose_loader:
+        cmd.append("--verbose-loader")
+    return cmd
+
+
+def filter_child_stderr(stderr_text):
+    keep = []
+    for line in stderr_text.splitlines():
+        if line.startswith("Loading weights:"):
+            continue
+        if line.startswith("[transformers] The fast path is not available"):
+            continue
+        if line.strip():
+            keep.append(line)
+    return "\n".join(keep)
+
+
+def run_child(args, section):
+    proc = subprocess.run(
+        build_child_cmd(args, section),
+        capture_output=True,
+        text=True,
+    )
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.returncode != 0:
+        if proc.stderr:
+            print(proc.stderr, end="", file=sys.stderr)
+        proc.check_returncode()
+    elif proc.stderr:
+        filtered = filter_child_stderr(proc.stderr)
+        if filtered:
+            print(filtered, file=sys.stderr, flush=True)
+
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT_JSON "):
+            result = json.loads(line[len("RESULT_JSON "):])
+    if result is None:
+        raise RuntimeError(f"missing RESULT_JSON for section {section}")
+    return result
+
+
+def main():
+    args = parse_args()
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+
+    if args.section == "correctness":
+        run_correctness(args, tokenizer)
+        return
+    if args.section == "pp":
+        run_pp(args, tokenizer)
+        return
+    if args.section == "tg":
+        run_tg(args, tokenizer)
+        return
+
+    correctness = run_child(args, "correctness")
+    pp = run_child(args, "pp")
+    tg = run_child(args, "tg")
+
+    print(f"\n=== Summary ({pp['backend_label']}, Qwen3.5-0.8B) ===", flush=True)
+    print(f"pp{pp['prompt_tokens']:>3d}: {pp['pp_tps']:>7.1f} tok/s", flush=True)
+    print(f"tg{tg['gen_tokens']:>3d}: {tg['tg_tps']:>7.1f} tok/s", flush=True)
+    if not correctness["ok"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/megakernel/final_bench.py
+++ b/megakernel/final_bench.py
@@ -1,5 +1,23 @@
 """Final benchmark: pp520 tg128 — Our megakernel vs PyTorch naive.
-Both properly warmed. Saves completions for verification."""
+Both properly warmed. Saves completions for verification.
+
+Supports --backend {auto,bf16,nvfp4}. Default is auto: Blackwell (sm_12+)
+dispatches to final_bench_nvfp4.py; everything else runs the bf16 path
+below unchanged from upstream.
+"""
+import argparse as _argparse, os as _os, sys as _sys
+import torch as _torch
+
+_p = _argparse.ArgumentParser(add_help=False)
+_p.add_argument("--backend", default="auto", choices=("auto", "bf16", "nvfp4"))
+_a, _rest = _p.parse_known_args()
+_backend = _a.backend
+if _backend == "auto":
+    _backend = "nvfp4" if (_torch.cuda.is_available() and _torch.cuda.get_device_capability()[0] >= 12) else "bf16"
+if _backend == "nvfp4":
+    _here = _os.path.dirname(_os.path.abspath(__file__))
+    _os.execv(_sys.executable, [_sys.executable, _os.path.join(_here, "final_bench_nvfp4.py"), *_rest])
+
 import time, torch
 from model import Decoder, HIDDEN_SIZE, INTERMEDIATE_SIZE, FA_QPROJ_SIZE, FA_Q_SIZE, FA_KV_SIZE
 from model import DN_CONV_CHANNELS, DN_V_SIZE, DN_NUM_HEADS, MAX_SEQ_LEN

--- a/megakernel/final_bench_nvfp4.py
+++ b/megakernel/final_bench_nvfp4.py
@@ -1,0 +1,389 @@
+"""Final benchmark for Qwen3.5-0.8B on local CUDA backends.
+
+This script compares:
+1. Megakernel prefill + decode
+2. Hugging Face eager baseline
+
+On GB10, the megakernel path may use BF16 prefill plus NVFP4 decode.
+The script is intentionally progress-heavy so long GPU runs do not look hung.
+"""
+
+import argparse
+import time
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from model_nvfp4 import (
+    Decoder,
+    DN_CONV_CHANNELS,
+    DN_NUM_HEADS,
+    DN_V_SIZE,
+    FA_KV_SIZE,
+    FA_QPROJ_SIZE,
+    FA_Q_SIZE,
+    HIDDEN_SIZE,
+    INTERMEDIATE_SIZE,
+    PREFILL_PROJ_FUSED_SIZE,
+    PREFILL_PROJ_SCRATCH_SIZE,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark megakernel vs HF baseline")
+    parser.add_argument("--model-name", default="Qwen/Qwen3.5-0.8B")
+    parser.add_argument("--backend", default="auto", choices=("auto", "bf16", "nvfp4"))
+    parser.add_argument("--prompt-tokens", type=int, default=520)
+    parser.add_argument("--gen-tokens", type=int, default=128)
+    parser.add_argument("--our-warmup-runs", type=int, default=3)
+    parser.add_argument("--our-pp-runs", type=int, default=5)
+    parser.add_argument("--hf-warmup-runs", type=int, default=2)
+    parser.add_argument("--hf-pp-runs", type=int, default=3)
+    parser.add_argument("--skip-hf", action="store_true")
+    parser.add_argument("--verbose-loader", action="store_true")
+    parser.add_argument("--prefill-mode", default="eager",
+                        choices=("eager", "mega"),
+                        help="'eager' = cuBLAS+launches prefill (prefill_bf16); "
+                             "'mega' = single-dispatch persistent megakernel "
+                             "(prefill_bf16_mega)")
+    return parser.parse_args()
+
+
+def build_exact_prompt_ids(tokenizer, target_tokens):
+    seed = (
+        "Explain in great detail the history of artificial intelligence, machine learning, "
+        "deep learning, and neural networks."
+    )
+    text = seed
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    while len(ids) < target_tokens:
+        text += " " + seed
+        ids = tokenizer.encode(text, add_special_tokens=False)
+    return ids[:target_tokens]
+
+
+def alloc_prefill_buffers(max_tokens):
+    bf16 = dict(dtype=torch.bfloat16, device="cuda")
+    f32 = dict(dtype=torch.float32, device="cuda")
+    i32 = dict(dtype=torch.int32, device="cuda")
+    return dict(
+        hidden=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+        residual=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+        normalized=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+        proj_buf=torch.empty(max_tokens * PREFILL_PROJ_FUSED_SIZE, **bf16),
+        proj_buf2=torch.empty(max_tokens * PREFILL_PROJ_SCRATCH_SIZE, **bf16),
+        attn_buf=torch.empty(max_tokens * max(FA_Q_SIZE, FA_KV_SIZE), **bf16),
+        mlp_buf=torch.empty(max_tokens * INTERMEDIATE_SIZE, **bf16),
+        dn_out_buf=torch.empty(max_tokens * DN_V_SIZE, **bf16),
+        beta_buf=torch.empty(max_tokens * DN_NUM_HEADS, **f32),
+        alpha_buf=torch.empty(max_tokens * DN_NUM_HEADS, **f32),
+        final_normed=torch.empty(HIDDEN_SIZE, **bf16),
+        hidden_bf16_out=torch.empty(HIDDEN_SIZE, **bf16),
+        lm_bmv=torch.empty(1024, **f32),
+        lm_bmi=torch.empty(1024, **i32),
+    )
+
+
+def get_prefill_op(decoder):
+    ops = torch.ops.qwen35_megakernel_bf16_C
+    if decoder.backend == "nvfp4":
+        return ops.prefill_megakernel_nvfp4
+    return ops.prefill_bf16
+
+
+def run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op, use_mega=False):
+    decoder.reset()
+    if decoder.backend == "nvfp4":
+        return decoder.prefill_tokens(ids_t)
+    elif use_mega:
+        prefill_op(
+            decoder._out_token,
+            ids_t,
+            decoder._embed_weight,
+            decoder._layer_weights_packed,
+            decoder._final_norm_weight,
+            decoder._lm_head_weight,
+            decoder._fa_k_cache,
+            decoder._fa_v_cache,
+            decoder._dn_states,
+            decoder._conv_bufs,
+            buffers["hidden"],
+            buffers["residual"],
+            buffers["normalized"],
+            buffers["proj_buf"],
+            buffers["proj_buf2"],
+            buffers["attn_buf"],
+            buffers["mlp_buf"],
+            buffers["dn_out_buf"],
+            buffers["beta_buf"],
+            buffers["alpha_buf"],
+            buffers["final_normed"],
+            buffers["hidden_bf16_out"],
+            buffers["lm_bmv"],
+            buffers["lm_bmi"],
+        )
+    else:
+        prefill_op(
+            decoder._out_token,
+            ids_t,
+            decoder._embed_weight,
+            decoder._layer_weights_packed,
+            decoder._prefill_fused_weights_packed,
+            decoder._final_norm_weight,
+            decoder._lm_head_weight,
+            decoder._fa_k_cache,
+            decoder._fa_v_cache,
+            decoder._dn_states,
+            decoder._conv_bufs,
+            buffers["hidden"],
+            buffers["residual"],
+            buffers["normalized"],
+            buffers["proj_buf"],
+            buffers["proj_buf2"],
+            buffers["attn_buf"],
+            buffers["mlp_buf"],
+            buffers["dn_out_buf"],
+            buffers["beta_buf"],
+            buffers["alpha_buf"],
+            buffers["final_normed"],
+            buffers["hidden_bf16_out"],
+            buffers["lm_bmv"],
+            buffers["lm_bmi"],
+        )
+    decoder._hidden.copy_(buffers["hidden_bf16_out"])
+    decoder._position = prompt_len
+    return decoder._out_token.item()
+
+
+def benchmark_megakernel(decoder, tokenizer, prompt_ids, args):
+    use_mega = getattr(args, "prefill_mode", "eager") == "mega" and decoder.backend != "nvfp4"
+    if use_mega:
+        prefill_op = torch.ops.qwen35_megakernel_bf16_C.prefill_bf16_mega
+    else:
+        prefill_op = get_prefill_op(decoder)
+    prompt_len = len(prompt_ids)
+    if use_mega:
+        padded_len = ((prompt_len + 31) // 32) * 32
+        ids_t = torch.zeros(padded_len, dtype=torch.int32, device="cuda")
+        ids_t[:prompt_len] = torch.tensor(prompt_ids, dtype=torch.int32, device="cuda")
+        ids_t = ids_t[:prompt_len]  # pass actual length; kernel reads only 0..prompt_len
+        buffers = alloc_prefill_buffers(padded_len)
+    else:
+        ids_t = torch.tensor(prompt_ids, dtype=torch.int32, device="cuda")
+        buffers = alloc_prefill_buffers(prompt_len)
+
+    print(f"Backend: {decoder.backend_label}", flush=True)
+    print(
+        f"Warming megakernel prefill {args.our_warmup_runs}x and timing {args.our_pp_runs}x...",
+        flush=True,
+    )
+
+    for _ in range(args.our_warmup_runs):
+        run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op, use_mega=use_mega)
+    torch.cuda.synchronize()
+
+    t0 = time.perf_counter()
+    for _ in range(args.our_pp_runs):
+        run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op, use_mega=use_mega)
+        torch.cuda.synchronize()
+    our_pp_ms = (time.perf_counter() - t0) / args.our_pp_runs * 1000.0
+    our_pp_tps = prompt_len / our_pp_ms * 1000.0
+
+    print(f"Running megakernel decode for {args.gen_tokens} timed steps...", flush=True)
+    del decoder
+    torch.cuda.empty_cache()
+    print("Reloading decoder for megakernel decode benchmark...", flush=True)
+    decoder = Decoder(
+        model_name=args.model_name,
+        backend=args.backend,
+        verbose=args.verbose_loader,
+    )
+    first = run_prefill(decoder, ids_t, prompt_len, buffers, prefill_op, use_mega=use_mega)
+    decoded_ids = [first]
+    eos = tokenizer.eos_token_id
+
+    if decoder.backend == "nvfp4":
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        timed_ids_dev = decoder.step_many(first, args.gen_tokens)
+        torch.cuda.synchronize()
+        our_tg_ms = (time.perf_counter() - t0) * 1000.0
+        timed_ids = timed_ids_dev.cpu().tolist()
+        if eos in timed_ids:
+            timed_ids = timed_ids[:timed_ids.index(eos)]
+    else:
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        nid = first
+        timed_ids = []
+        for _ in range(args.gen_tokens):
+            nid = decoder.step(nid)
+            if nid == eos:
+                break
+            timed_ids.append(nid)
+        torch.cuda.synchronize()
+        our_tg_ms = (time.perf_counter() - t0) * 1000.0
+
+    decoded_ids.extend(timed_ids)
+    our_tg_tps = (len(timed_ids) / our_tg_ms * 1000.0) if timed_ids else 0.0
+    our_text = tokenizer.decode(decoded_ids, skip_special_tokens=True)
+
+    return {
+        "pp_ms": our_pp_ms,
+        "pp_tps": our_pp_tps,
+        "tg_ms": our_tg_ms,
+        "tg_tps": our_tg_tps,
+        "tg_count": len(timed_ids),
+        "text": our_text,
+    }
+
+
+def benchmark_hf(model_name, tokenizer, prompt_ids, args):
+    print("\n=== PyTorch HuggingFace ===", flush=True)
+    print("Loading HF baseline model...", flush=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        dtype=torch.bfloat16,
+        device_map="cuda",
+    )
+    model.eval()
+    input_ids = torch.tensor([prompt_ids], device="cuda")
+
+    print(
+        f"Warming HF forward {args.hf_warmup_runs}x and timing {args.hf_pp_runs}x...",
+        flush=True,
+    )
+    with torch.inference_mode():
+        for _ in range(args.hf_warmup_runs):
+            _ = model(input_ids)
+            torch.cuda.synchronize()
+
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(args.hf_pp_runs):
+            _ = model(input_ids)
+            torch.cuda.synchronize()
+        pt_pp_ms = (time.perf_counter() - t0) / args.hf_pp_runs * 1000.0
+        pt_pp_tps = len(prompt_ids) / pt_pp_ms * 1000.0
+
+        print(f"Running HF decode for {args.gen_tokens} timed steps...", flush=True)
+        out = model(input_ids, use_cache=True)
+        past = out.past_key_values
+        next_id = out.logits[:, -1:].argmax(-1)
+        decoded_ids = [next_id.item()]
+
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        timed_ids = []
+        current = next_id
+        for _ in range(args.gen_tokens):
+            out = model(current, past_key_values=past, use_cache=True)
+            past = out.past_key_values
+            current = out.logits[:, -1:].argmax(-1)
+            token = current.item()
+            if token == tokenizer.eos_token_id:
+                break
+            timed_ids.append(token)
+        torch.cuda.synchronize()
+
+    decoded_ids.extend(timed_ids)
+    pt_tg_ms = (time.perf_counter() - t0) * 1000.0
+    pt_tg_tps = (len(timed_ids) / pt_tg_ms * 1000.0) if timed_ids else 0.0
+    pt_text = tokenizer.decode(decoded_ids, skip_special_tokens=True)
+
+    del model, input_ids, past, out
+    torch.cuda.empty_cache()
+
+    return {
+        "pp_ms": pt_pp_ms,
+        "pp_tps": pt_pp_tps,
+        "tg_ms": pt_tg_ms,
+        "tg_tps": pt_tg_tps,
+        "tg_count": len(timed_ids),
+        "text": pt_text,
+    }
+
+
+def main():
+    args = parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    print(f"Loading megakernel decoder for {args.model_name}...", flush=True)
+    decoder = Decoder(
+        model_name=args.model_name,
+        backend=args.backend,
+        verbose=args.verbose_loader,
+    )
+
+    prompt_ids = build_exact_prompt_ids(tokenizer, args.prompt_tokens)
+    print(f"Prompt: {len(prompt_ids)} tokens", flush=True)
+    backend_label = decoder.backend_label
+
+    print("\n=== Our Megakernel ===", flush=True)
+    our = benchmark_megakernel(decoder, tokenizer, prompt_ids, args)
+
+    print(
+        f"pp{len(prompt_ids)}: {our['pp_tps']:.0f} tok/s ({our['pp_ms']:.1f}ms avg)",
+        flush=True,
+    )
+    print(
+        f"tg{our['tg_count']}: {our['tg_tps']:.0f} tok/s ({our['tg_ms']:.1f}ms total)",
+        flush=True,
+    )
+    print(f"Completion: {our['text'][:120]}", flush=True)
+
+    del decoder
+    torch.cuda.empty_cache()
+
+    hf = None
+    if not args.skip_hf:
+        try:
+            hf = benchmark_hf(args.model_name, tokenizer, prompt_ids, args)
+            print(
+                f"pp{len(prompt_ids)}: {hf['pp_tps']:.0f} tok/s ({hf['pp_ms']:.1f}ms avg)",
+                flush=True,
+            )
+            print(
+                f"tg{hf['tg_count']}: {hf['tg_tps']:.0f} tok/s ({hf['tg_ms']:.1f}ms total)",
+                flush=True,
+            )
+            print(f"Completion: {hf['text'][:120]}", flush=True)
+        except Exception as exc:
+            hf = {"error": str(exc)}
+            print(f"HF baseline failed: {exc}", flush=True)
+
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"FINAL RESULTS — Qwen3.5-0.8B, {backend_label}", flush=True)
+    print(f"{'=' * 60}", flush=True)
+    print(f"{'Method':<25} {'pp'+str(len(prompt_ids)):>12} {'tg':>16}", flush=True)
+    print(f"{'-' * 55}", flush=True)
+    print(
+        f"{'Our megakernel':<25} {our['pp_tps']:>9.0f} t/s {our['tg_tps']:>9.0f} t/s",
+        flush=True,
+    )
+    if hf is None:
+        print(f"{'PyTorch HF':<25} {'(skipped)':>24}", flush=True)
+    elif "error" in hf:
+        print(f"{'PyTorch HF':<25} {'(failed)':>24}", flush=True)
+    else:
+        print(
+            f"{'PyTorch HF':<25} {hf['pp_tps']:>9.0f} t/s {hf['tg_tps']:>9.0f} t/s",
+            flush=True,
+        )
+    print(f"{'llama.cpp BF16':<25} {'(run separately)':>24}", flush=True)
+
+    if hf is not None and "error" not in hf:
+        print("", flush=True)
+        print(
+            f"Megakernel vs PyTorch:  pp {our['pp_tps'] / hf['pp_tps']:.1f}x  "
+            f"tg {our['tg_tps'] / hf['tg_tps']:.1f}x",
+            flush=True,
+        )
+        print("", flush=True)
+        print("=== Completions ===", flush=True)
+        print(f"Ours:    {our['text'][:100]}", flush=True)
+        print(f"PyTorch: {hf['text'][:100]}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/megakernel/kernel_gb10_nvfp4.cu
+++ b/megakernel/kernel_gb10_nvfp4.cu
@@ -1,0 +1,2257 @@
+/**
+ * GB10/Blackwell decode path: persistent CUDA megakernel with group-scaled fp4
+ * hot weights. Prefill stays on the existing bf16/cuBLAS path.
+ *
+ * Only compiled when building for Blackwell (sm_120/sm_121a). The RTX 3090
+ * (sm_86) build excludes this translation unit entirely; see setup.py.
+ */
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 1200
+#error "kernel_gb10_nvfp4.cu requires CUDA arch >= sm_120 (Blackwell)"
+#endif
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cublasLt.h>
+#include <cooperative_groups.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <stdint.h>
+
+namespace cg = cooperative_groups;
+
+constexpr int WARP_SIZE = 32;
+constexpr int HIDDEN_SIZE = 1024;
+constexpr int INTERMEDIATE_SIZE = 3584;
+constexpr int NUM_LAYERS = 24;
+constexpr float RMS_EPS = 1e-6f;
+constexpr int VOCAB_SIZE = 248320;
+constexpr int LM_HEAD_TC_N = 16;
+constexpr size_t LM_HEAD_MAX_WORKSPACE = 32ull * 1024ull * 1024ull;
+constexpr int LM_SCALE_ROWS_PER_TILE = 128;
+constexpr int LM_SCALE_COLS_PER_TILE = 4;
+constexpr int LM_SCALE_BLOCK_K = 16;
+constexpr int LM_SCALE_K_PER_TILE = LM_SCALE_COLS_PER_TILE * LM_SCALE_BLOCK_K;
+constexpr int LM_SCALE_THREADS = LM_SCALE_ROWS_PER_TILE * LM_SCALE_COLS_PER_TILE;
+constexpr size_t LM_HEAD_HIDDEN_SCALE_BYTES =
+    static_cast<size_t>((LM_HEAD_TC_N + LM_SCALE_ROWS_PER_TILE - 1) / LM_SCALE_ROWS_PER_TILE) *
+    static_cast<size_t>(HIDDEN_SIZE / LM_SCALE_K_PER_TILE) * 512ull;
+
+constexpr int FA_NUM_Q_HEADS = 8;
+constexpr int FA_NUM_KV_HEADS = 2;
+constexpr int FA_HEAD_DIM = 256;
+constexpr int FA_GQA_RATIO = FA_NUM_Q_HEADS / FA_NUM_KV_HEADS;
+constexpr int FA_Q_SIZE = FA_NUM_Q_HEADS * FA_HEAD_DIM;
+constexpr int FA_GATE_SIZE = FA_Q_SIZE;
+constexpr int FA_QPROJ_SIZE = FA_Q_SIZE + FA_GATE_SIZE;
+constexpr int FA_KV_SIZE = FA_NUM_KV_HEADS * FA_HEAD_DIM;
+constexpr int FA_ROTARY_DIM = 64;
+constexpr float FA_ROPE_THETA = 10000000.0f;
+
+constexpr int DN_NUM_HEADS = 16;
+constexpr int DN_KEY_DIM = 128;
+constexpr int DN_VALUE_DIM = 128;
+constexpr int DN_CONV_KERNEL = 4;
+constexpr int DN_QK_SIZE = DN_NUM_HEADS * DN_KEY_DIM;
+constexpr int DN_V_SIZE = DN_NUM_HEADS * DN_VALUE_DIM;
+constexpr int DN_CONV_CHANNELS = DN_QK_SIZE + DN_QK_SIZE + DN_V_SIZE;
+
+constexpr int MAX_ACT_DIM = (HIDDEN_SIZE > INTERMEDIATE_SIZE) ? HIDDEN_SIZE : INTERMEDIATE_SIZE;
+
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 512
+#endif
+
+constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
+
+#ifndef LM_BLOCK_SIZE
+#define LM_BLOCK_SIZE 256
+#endif
+
+__device__ __constant__ int LAYER_TYPE[NUM_LAYERS] = {
+    0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1
+};
+
+__device__ __constant__ float FP4_E2M1_LUT[16] = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+   -0.0f,-0.5f,-1.0f,-1.5f,-2.0f,-3.0f,-4.0f,-6.0f
+};
+
+__device__ __constant__ float ROPE_INV_FREQ[FA_ROTARY_DIM / 2] = {
+    1.000000000000000000e+00f,
+    6.042963902381328634e-01f,
+    3.651741272548377215e-01f,
+    2.206734069084589911e-01f,
+    1.333521432163324028e-01f,
+    8.058421877614818651e-02f,
+    4.869675251658631132e-02f,
+    2.942727176209281731e-02f,
+    1.778279410038922925e-02f,
+    1.074607828321317432e-02f,
+    6.493816315762112983e-03f,
+    3.924189758484536265e-03f,
+    2.371373705661655382e-03f,
+    1.433012570236962685e-03f,
+    8.659643233600653866e-04f,
+    5.232991146814947340e-04f,
+    3.162277660168379394e-04f,
+    1.910952974970440477e-04f,
+    1.154781984689458215e-04f,
+    6.978305848598663529e-05f,
+    4.216965034285822237e-05f,
+    2.548296747979346413e-05f,
+    1.539926526059491854e-05f,
+    9.305720409296990429e-06f,
+    5.623413251903491208e-06f,
+    3.398208328942559268e-06f,
+    2.053525026457146066e-06f,
+    1.240937760751719527e-06f,
+    7.498942093324558477e-07f,
+    4.531583637600817928e-07f,
+    2.738419634264361394e-07f,
+    1.654817099943181354e-07f
+};
+
+struct PackedMatrixNVFP4 {
+    const uint8_t *data;
+    const __half *scales;
+};
+
+struct FullAttnWeightsNVFP4 {
+    const __nv_bfloat16 *input_layernorm_weight;
+    PackedMatrixNVFP4 q_proj;
+    PackedMatrixNVFP4 k_proj;
+    PackedMatrixNVFP4 v_proj;
+    const __nv_bfloat16 *q_norm_weight;
+    const __nv_bfloat16 *k_norm_weight;
+    PackedMatrixNVFP4 o_proj;
+    const __nv_bfloat16 *post_attn_layernorm_weight;
+    PackedMatrixNVFP4 gate_proj;
+    PackedMatrixNVFP4 up_proj;
+    PackedMatrixNVFP4 down_proj;
+};
+
+struct DeltaNetWeightsNVFP4 {
+    const __nv_bfloat16 *input_layernorm_weight;
+    PackedMatrixNVFP4 qkv_proj;
+    PackedMatrixNVFP4 z_proj;
+    const __nv_bfloat16 *beta_proj_weight;
+    const __nv_bfloat16 *alpha_proj_weight;
+    const __nv_bfloat16 *conv1d_weight;
+    const __nv_bfloat16 *a_log;
+    const __nv_bfloat16 *dt_bias;
+    const __nv_bfloat16 *norm_weight;
+    PackedMatrixNVFP4 out_proj;
+    const __nv_bfloat16 *post_attn_layernorm_weight;
+    PackedMatrixNVFP4 gate_proj;
+    PackedMatrixNVFP4 up_proj;
+    PackedMatrixNVFP4 down_proj;
+};
+
+struct LayerWeightsNVFP4 {
+    int layer_type;
+    int group_size;
+    int _pad[2];
+    void *ptrs[24];
+};
+
+static __device__ __forceinline__ PackedMatrixNVFP4 make_packed_matrix(const LayerWeightsNVFP4 &w, int data_idx) {
+    return {
+        reinterpret_cast<const uint8_t *>(w.ptrs[data_idx]),
+        reinterpret_cast<const __half *>(w.ptrs[data_idx + 1]),
+    };
+}
+
+static __device__ __forceinline__ FullAttnWeightsNVFP4 make_full_attn_weights(const LayerWeightsNVFP4 &w) {
+    return {
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[0]),
+        make_packed_matrix(w, 1),
+        make_packed_matrix(w, 3),
+        make_packed_matrix(w, 5),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[7]),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[8]),
+        make_packed_matrix(w, 9),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[11]),
+        make_packed_matrix(w, 12),
+        make_packed_matrix(w, 14),
+        make_packed_matrix(w, 16),
+    };
+}
+
+static __device__ __forceinline__ DeltaNetWeightsNVFP4 make_deltanet_weights(const LayerWeightsNVFP4 &w) {
+    return {
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[0]),
+        make_packed_matrix(w, 1),
+        make_packed_matrix(w, 3),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[5]),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[6]),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[7]),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[8]),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[9]),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[10]),
+        make_packed_matrix(w, 11),
+        reinterpret_cast<const __nv_bfloat16 *>(w.ptrs[13]),
+        make_packed_matrix(w, 14),
+        make_packed_matrix(w, 16),
+        make_packed_matrix(w, 18),
+    };
+}
+
+struct AtomicGridSync {
+    __device__ __forceinline__ void sync() {
+        cg::this_grid().sync();
+    }
+};
+
+namespace {
+
+bool lm_debug_enabled() {
+    static int enabled = []() {
+        const char *value = std::getenv("MEGAKERNEL_DEBUG_LM");
+        return (value != nullptr && value[0] != '\0' && value[0] != '0') ? 1 : 0;
+    }();
+    return enabled != 0;
+}
+
+struct LmHeadCublasLtPlan {
+    bool initialized = false;
+    bool supported = false;
+    cublasLtHandle_t handle = nullptr;
+    cublasLtMatmulDesc_t op_desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr;
+    cublasLtMatrixLayout_t b_desc = nullptr;
+    cublasLtMatrixLayout_t c_desc = nullptr;
+    cublasLtMatrixLayout_t d_desc = nullptr;
+    cublasLtMatmulAlgo_t algo{};
+    void *dummy_a_scale = nullptr;
+    void *dummy_b_scale = nullptr;
+    void *workspace = nullptr;
+    size_t workspace_size = 0;
+};
+
+LmHeadCublasLtPlan &lm_head_plan() {
+    static LmHeadCublasLtPlan plan;
+    return plan;
+}
+
+void destroy_lm_head_plan(LmHeadCublasLtPlan &plan) {
+    if (plan.dummy_b_scale != nullptr) {
+        cudaFree(plan.dummy_b_scale);
+        plan.dummy_b_scale = nullptr;
+    }
+    if (plan.dummy_a_scale != nullptr) {
+        cudaFree(plan.dummy_a_scale);
+        plan.dummy_a_scale = nullptr;
+    }
+    if (plan.workspace != nullptr) {
+        cudaFree(plan.workspace);
+        plan.workspace = nullptr;
+    }
+    if (plan.d_desc != nullptr) {
+        cublasLtMatrixLayoutDestroy(plan.d_desc);
+        plan.d_desc = nullptr;
+    }
+    if (plan.c_desc != nullptr) {
+        cublasLtMatrixLayoutDestroy(plan.c_desc);
+        plan.c_desc = nullptr;
+    }
+    if (plan.b_desc != nullptr) {
+        cublasLtMatrixLayoutDestroy(plan.b_desc);
+        plan.b_desc = nullptr;
+    }
+    if (plan.a_desc != nullptr) {
+        cublasLtMatrixLayoutDestroy(plan.a_desc);
+        plan.a_desc = nullptr;
+    }
+    if (plan.op_desc != nullptr) {
+        cublasLtMatmulDescDestroy(plan.op_desc);
+        plan.op_desc = nullptr;
+    }
+    if (plan.handle != nullptr) {
+        cublasLtDestroy(plan.handle);
+        plan.handle = nullptr;
+    }
+    plan.initialized = false;
+    plan.supported = false;
+    plan.workspace_size = 0;
+}
+
+bool init_lm_head_plan() {
+    auto &plan = lm_head_plan();
+    if (plan.initialized) {
+        return plan.supported;
+    }
+    plan.initialized = true;
+
+    cublasOperation_t trans_a = CUBLAS_OP_T;
+    cublasOperation_t trans_b = CUBLAS_OP_N;
+    cublasLtMatmulMatrixScale_t a_scale_mode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+    cublasLtMatmulMatrixScale_t b_scale_mode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+    cublasLtOrder_t col_order = CUBLASLT_ORDER_COL;
+
+    if (cublasLtCreate(&plan.handle) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: cublasLtCreate failed\n");
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+    if (cublasLtMatmulDescCreate(&plan.op_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: MatmulDescCreate failed\n");
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+    if (cublasLtMatmulDescSetAttribute(plan.op_desc, CUBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(trans_a)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(plan.op_desc, CUBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(trans_b)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(plan.op_desc, CUBLASLT_MATMUL_DESC_A_SCALE_MODE, &a_scale_mode, sizeof(a_scale_mode)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(plan.op_desc, CUBLASLT_MATMUL_DESC_B_SCALE_MODE, &b_scale_mode, sizeof(b_scale_mode)) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: MatmulDescSetAttribute failed\n");
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+
+    if (cublasLtMatrixLayoutCreate(&plan.a_desc, CUDA_R_4F_E2M1, HIDDEN_SIZE, VOCAB_SIZE, HIDDEN_SIZE) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatrixLayoutCreate(&plan.b_desc, CUDA_R_4F_E2M1, HIDDEN_SIZE, LM_HEAD_TC_N, HIDDEN_SIZE) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatrixLayoutCreate(&plan.c_desc, CUDA_R_16F, VOCAB_SIZE, LM_HEAD_TC_N, VOCAB_SIZE) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatrixLayoutCreate(&plan.d_desc, CUDA_R_16F, VOCAB_SIZE, LM_HEAD_TC_N, VOCAB_SIZE) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: MatrixLayoutCreate failed\n");
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+
+    cublasLtMatrixLayoutSetAttribute(plan.a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+    cublasLtMatrixLayoutSetAttribute(plan.b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+    cublasLtMatrixLayoutSetAttribute(plan.c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+    cublasLtMatrixLayoutSetAttribute(plan.d_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+
+    if (cudaMalloc(&plan.dummy_a_scale, 4096) != cudaSuccess ||
+        cudaMalloc(&plan.dummy_b_scale, 4096) != cudaSuccess ||
+        cublasLtMatmulDescSetAttribute(
+            plan.op_desc,
+            CUBLASLT_MATMUL_DESC_A_SCALE_POINTER,
+            &plan.dummy_a_scale,
+            sizeof(plan.dummy_a_scale)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(
+            plan.op_desc,
+            CUBLASLT_MATMUL_DESC_B_SCALE_POINTER,
+            &plan.dummy_b_scale,
+            sizeof(plan.dummy_b_scale)) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: dummy scale setup failed\n");
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+
+    cublasLtMatmulPreference_t preference = nullptr;
+    cublasLtMatmulHeuristicResult_t heuristic{};
+    int returned_results = 0;
+    if (cublasLtMatmulPreferenceCreate(&preference) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: PreferenceCreate failed\n");
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+    cublasLtMatmulPreferenceSetAttribute(
+        preference,
+        CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &LM_HEAD_MAX_WORKSPACE,
+        sizeof(LM_HEAD_MAX_WORKSPACE));
+
+    cublasStatus_t heuristic_status = cublasLtMatmulAlgoGetHeuristic(
+        plan.handle,
+        plan.op_desc,
+        plan.a_desc,
+        plan.b_desc,
+        plan.c_desc,
+        plan.d_desc,
+        preference,
+        1,
+        &heuristic,
+        &returned_results);
+    cublasLtMatmulPreferenceDestroy(preference);
+
+    if (heuristic_status != CUBLAS_STATUS_SUCCESS || returned_results == 0) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr,
+                         "lm_head_cublaslt: heuristic failed status=%d returned=%d n=%d\n",
+                         int(heuristic_status), returned_results, LM_HEAD_TC_N);
+        }
+        destroy_lm_head_plan(plan);
+        return false;
+    }
+
+    plan.algo = heuristic.algo;
+    plan.workspace_size = heuristic.workspaceSize;
+    if (plan.workspace_size != 0) {
+        if (cudaMalloc(&plan.workspace, plan.workspace_size) != cudaSuccess) {
+            if (lm_debug_enabled()) {
+                std::fprintf(stderr,
+                             "lm_head_cublaslt: workspace alloc failed size=%zu\n",
+                             plan.workspace_size);
+            }
+            destroy_lm_head_plan(plan);
+            return false;
+        }
+    }
+
+    plan.supported = true;
+    if (lm_debug_enabled()) {
+        std::fprintf(stderr,
+                     "lm_head_cublaslt: plan ready workspace=%zu n=%d\n",
+                     plan.workspace_size, LM_HEAD_TC_N);
+    }
+    return true;
+}
+
+bool launch_lm_head_cublaslt(
+    const uint8_t *weight_packed,
+    const uint8_t *weight_scales,
+    const uint8_t *hidden_packed,
+    const uint8_t *hidden_scales,
+    __half *logits_f16,
+    cudaStream_t stream)
+{
+    auto &plan = lm_head_plan();
+    if (!plan.initialized && !init_lm_head_plan()) {
+        return false;
+    }
+    if (!plan.supported) {
+        return false;
+    }
+
+    if (cublasLtMatmulDescSetAttribute(
+            plan.op_desc,
+            CUBLASLT_MATMUL_DESC_A_SCALE_POINTER,
+            &weight_scales,
+            sizeof(weight_scales)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(
+            plan.op_desc,
+            CUBLASLT_MATMUL_DESC_B_SCALE_POINTER,
+            &hidden_scales,
+            sizeof(hidden_scales)) != CUBLAS_STATUS_SUCCESS) {
+        if (lm_debug_enabled()) {
+            std::fprintf(stderr, "lm_head_cublaslt: scale pointer set failed\n");
+        }
+        return false;
+    }
+
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    cudaGetLastError();
+    cublasStatus_t status = cublasLtMatmul(
+        plan.handle,
+        plan.op_desc,
+        &alpha,
+        weight_packed,
+        plan.a_desc,
+        hidden_packed,
+        plan.b_desc,
+        &beta,
+        logits_f16,
+        plan.c_desc,
+        logits_f16,
+        plan.d_desc,
+        &plan.algo,
+        plan.workspace,
+        plan.workspace_size,
+        stream);
+    cudaError_t last_error = cudaGetLastError();
+    if (lm_debug_enabled() && (status != CUBLAS_STATUS_SUCCESS || last_error != cudaSuccess)) {
+        std::fprintf(stderr,
+                     "lm_head_cublaslt: matmul status=%d cuda=%d (%s)\n",
+                     int(status),
+                     int(last_error),
+                     cudaGetErrorString(last_error));
+    }
+    return status == CUBLAS_STATUS_SUCCESS && last_error == cudaSuccess;
+}
+
+}  // namespace
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        val += __shfl_down_sync(0xffffffff, val, offset);
+    }
+    return val;
+}
+
+__device__ __forceinline__ float fast_exp(float x) {
+    float y;
+    asm volatile("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x * 1.44269504088896340736f));
+    return y;
+}
+
+__device__ __forceinline__ float fast_sigmoid(float x) {
+    float y;
+    asm volatile("rcp.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(1.0f + fast_exp(-x)));
+    return y;
+}
+
+__device__ __forceinline__ float fast_silu(float x) { return x * fast_sigmoid(x); }
+
+__device__ __forceinline__ uint4 load_128bit(const uint4 *ptr) {
+    uint4 out;
+    asm volatile("ld.global.L1::no_allocate.v4.b32 {%0, %1, %2, %3}, [%4];"
+                 : "=r"(out.x), "=r"(out.y), "=r"(out.z), "=r"(out.w) : "l"(ptr));
+    return out;
+}
+
+__device__ __forceinline__ uint32_t load_32bit(const uint32_t *ptr) {
+    uint32_t out;
+    asm volatile("ld.global.L1::no_allocate.b32 %0, [%1];" : "=r"(out) : "l"(ptr));
+    return out;
+}
+
+__device__ __forceinline__ float dot8_bf16(const uint4 &w_u4, const __nv_bfloat16 *act) {
+    const __nv_bfloat16 *w = reinterpret_cast<const __nv_bfloat16 *>(&w_u4);
+    float sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < 8; i++) {
+        sum += __bfloat162float(w[i]) * __bfloat162float(act[i]);
+    }
+    return sum;
+}
+
+__device__ __forceinline__ float fp4_value(unsigned int code) {
+    return FP4_E2M1_LUT[code & 0xf];
+}
+
+__device__ __forceinline__ float dot8_nvfp4_bf16(uint32_t packed, float scale, const __nv_bfloat16 *act) {
+    float sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        unsigned int byte = (packed >> (i * 8)) & 0xff;
+        sum += fp4_value(byte & 0xf) * __bfloat162float(act[i * 2 + 0]);
+        sum += fp4_value(byte >> 4) * __bfloat162float(act[i * 2 + 1]);
+    }
+    return sum * scale;
+}
+
+__device__ __forceinline__ float dot8_nvfp4_f32(uint32_t packed, float scale, const float *act) {
+    float sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        unsigned int byte = (packed >> (i * 8)) & 0xff;
+        sum += fp4_value(byte & 0xf) * act[i * 2 + 0];
+        sum += fp4_value(byte >> 4) * act[i * 2 + 1];
+    }
+    return sum * scale;
+}
+
+static __device__ void rmsnorm_redundant(
+    const __nv_bfloat16 *__restrict__ input,
+    const __nv_bfloat16 *__restrict__ weight,
+    __nv_bfloat16 *__restrict__ s_out,
+    __nv_bfloat16 *__restrict__ g_residual)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    __shared__ float smem_reduce[NUM_WARPS];
+
+    float local_sum_sq = 0.0f;
+    for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+        float v = __bfloat162float(__ldg(input + i));
+        s_out[i] = __float2bfloat16(v);
+        local_sum_sq += v * v;
+    }
+
+    if (block_id == 0) {
+        for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+            g_residual[i] = s_out[i];
+        }
+    }
+
+    local_sum_sq = warp_reduce_sum(local_sum_sq);
+    if (lane_id == 0) {
+        smem_reduce[warp_id] = local_sum_sq;
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float sum = (lane_id < NUM_WARPS) ? smem_reduce[lane_id] : 0.0f;
+        sum = warp_reduce_sum(sum);
+        if (lane_id == 0) {
+            smem_reduce[0] = rsqrtf(sum / float(HIDDEN_SIZE) + RMS_EPS);
+        }
+    }
+    __syncthreads();
+
+    float rstd = smem_reduce[0];
+    for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+        float w = __bfloat162float(__ldg(weight + i));
+        float v = __bfloat162float(s_out[i]);
+        s_out[i] = __float2bfloat16(v * rstd * (1.0f + w));
+    }
+    __syncthreads();
+}
+
+static __device__ void rmsnorm_from_bf16(
+    const __nv_bfloat16 *__restrict__ input,
+    const __nv_bfloat16 *__restrict__ weight,
+    __nv_bfloat16 *__restrict__ s_out,
+    __nv_bfloat16 *__restrict__ g_residual)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    __shared__ float smem_reduce[NUM_WARPS];
+
+    float local_sum_sq = 0.0f;
+    for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+        float v = __bfloat162float(input[i]);
+        s_out[i] = __float2bfloat16(v);
+        local_sum_sq += v * v;
+    }
+
+    if (block_id == 0) {
+        for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+            g_residual[i] = s_out[i];
+        }
+    }
+
+    local_sum_sq = warp_reduce_sum(local_sum_sq);
+    if (lane_id == 0) {
+        smem_reduce[warp_id] = local_sum_sq;
+    }
+    __syncthreads();
+
+    if (warp_id == 0) {
+        float sum = (lane_id < NUM_WARPS) ? smem_reduce[lane_id] : 0.0f;
+        sum = warp_reduce_sum(sum);
+        if (lane_id == 0) {
+            smem_reduce[0] = rsqrtf(sum / float(HIDDEN_SIZE) + RMS_EPS);
+        }
+    }
+    __syncthreads();
+
+    float rstd = smem_reduce[0];
+    for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+        float w = __bfloat162float(__ldg(weight + i));
+        float v = __bfloat162float(s_out[i]);
+        s_out[i] = __float2bfloat16(v * rstd * (1.0f + w));
+    }
+    __syncthreads();
+}
+
+static __device__ void matvec_bf16(
+    const __nv_bfloat16 *__restrict__ s_input,
+    const __nv_bfloat16 *__restrict__ weight,
+    float *__restrict__ output,
+    int in_dim, int out_dim, int num_blocks)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+
+    int rows_per_block = (out_dim + num_blocks - 1) / num_blocks;
+    int row_start = block_id * rows_per_block;
+    int row_end = min(row_start + rows_per_block, out_dim);
+
+    for (int m_base = row_start; m_base < row_end; m_base += NUM_WARPS) {
+        int m = m_base + warp_id;
+        if (m < row_end) {
+            const __nv_bfloat16 *w_row = weight + m * in_dim;
+            float sum = 0.0f;
+#pragma unroll 4
+            for (int k = lane_id * 8; k < in_dim; k += WARP_SIZE * 8) {
+                uint4 w_u4 = load_128bit(reinterpret_cast<const uint4 *>(w_row + k));
+                sum += dot8_bf16(w_u4, s_input + k);
+            }
+            sum = warp_reduce_sum(sum);
+            if (lane_id == 0) {
+                output[m] = sum;
+            }
+        }
+    }
+}
+
+static __device__ void matvec_nvfp4(
+    const __nv_bfloat16 *__restrict__ s_input,
+    PackedMatrixNVFP4 weight,
+    float *__restrict__ output,
+    int in_dim, int out_dim, int num_blocks, int group_size)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int rows_per_block = (out_dim + num_blocks - 1) / num_blocks;
+    int row_start = block_id * rows_per_block;
+    int row_end = min(row_start + rows_per_block, out_dim);
+    int row_bytes = in_dim / 2;
+    int row_scales = in_dim / group_size;
+
+    for (int m_base = row_start; m_base < row_end; m_base += NUM_WARPS) {
+        int m = m_base + warp_id;
+        if (m < row_end) {
+            const uint8_t *w_row = weight.data + m * row_bytes;
+            const __half *s_row = weight.scales + m * row_scales;
+            float sum = 0.0f;
+#pragma unroll 4
+            for (int k = lane_id * 8; k < in_dim; k += WARP_SIZE * 8) {
+                uint32_t packed = load_32bit(reinterpret_cast<const uint32_t *>(w_row + (k / 2)));
+                int scale_idx = k / group_size;
+                int scale_lane = lane_id & ~1;
+                float scale = 0.0f;
+                if (lane_id == scale_lane) {
+                    scale = __half2float(__ldg(s_row + scale_idx));
+                }
+                scale = __shfl_sync(0xffffffff, scale, scale_lane);
+                sum += dot8_nvfp4_bf16(packed, scale, s_input + k);
+            }
+            sum = warp_reduce_sum(sum);
+            if (lane_id == 0) {
+                output[m] = sum;
+            }
+        }
+    }
+}
+
+static __device__ void matvec_gate_up_silu_nvfp4(
+    const __nv_bfloat16 *__restrict__ s_input,
+    PackedMatrixNVFP4 gate_weight,
+    PackedMatrixNVFP4 up_weight,
+    float *__restrict__ output,
+    int in_dim, int out_dim, int num_blocks, int group_size)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int rows_per_block = (out_dim + num_blocks - 1) / num_blocks;
+    int row_start = block_id * rows_per_block;
+    int row_end = min(row_start + rows_per_block, out_dim);
+    int row_bytes = in_dim / 2;
+    int row_scales = in_dim / group_size;
+
+    for (int m_base = row_start; m_base < row_end; m_base += NUM_WARPS) {
+        int m = m_base + warp_id;
+        if (m < row_end) {
+            const uint8_t *g_row = gate_weight.data + m * row_bytes;
+            const __half *gs_row = gate_weight.scales + m * row_scales;
+            const uint8_t *u_row = up_weight.data + m * row_bytes;
+            const __half *us_row = up_weight.scales + m * row_scales;
+            float gate_sum = 0.0f;
+            float up_sum = 0.0f;
+#pragma unroll 4
+            for (int k = lane_id * 8; k < in_dim; k += WARP_SIZE * 8) {
+                uint32_t g_packed = load_32bit(reinterpret_cast<const uint32_t *>(g_row + (k / 2)));
+                uint32_t u_packed = load_32bit(reinterpret_cast<const uint32_t *>(u_row + (k / 2)));
+                int scale_idx = k / group_size;
+                int scale_lane = lane_id & ~1;
+                float g_scale = 0.0f;
+                float u_scale = 0.0f;
+                if (lane_id == scale_lane) {
+                    g_scale = __half2float(__ldg(gs_row + scale_idx));
+                    u_scale = __half2float(__ldg(us_row + scale_idx));
+                }
+                g_scale = __shfl_sync(0xffffffff, g_scale, scale_lane);
+                u_scale = __shfl_sync(0xffffffff, u_scale, scale_lane);
+                gate_sum += dot8_nvfp4_bf16(g_packed, g_scale, s_input + k);
+                up_sum += dot8_nvfp4_bf16(u_packed, u_scale, s_input + k);
+            }
+            gate_sum = warp_reduce_sum(gate_sum);
+            up_sum = warp_reduce_sum(up_sum);
+            if (lane_id == 0) {
+                output[m] = fast_silu(gate_sum) * up_sum;
+            }
+        }
+    }
+}
+
+static __device__ void matvec_down_residual_nvfp4(
+    const float *__restrict__ s_input,
+    PackedMatrixNVFP4 weight,
+    const __nv_bfloat16 *__restrict__ residual,
+    __nv_bfloat16 *__restrict__ hidden_out,
+    int in_dim, int out_dim, int num_blocks, int group_size)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int rows_per_block = (out_dim + num_blocks - 1) / num_blocks;
+    int row_start = block_id * rows_per_block;
+    int row_end = min(row_start + rows_per_block, out_dim);
+    int row_bytes = in_dim / 2;
+    int row_scales = in_dim / group_size;
+
+    for (int m_base = row_start; m_base < row_end; m_base += NUM_WARPS) {
+        int m = m_base + warp_id;
+        if (m < row_end) {
+            const uint8_t *w_row = weight.data + m * row_bytes;
+            const __half *s_row = weight.scales + m * row_scales;
+            float sum = 0.0f;
+#pragma unroll 4
+            for (int k = lane_id * 8; k < in_dim; k += WARP_SIZE * 8) {
+                uint32_t packed = load_32bit(reinterpret_cast<const uint32_t *>(w_row + (k / 2)));
+                int scale_idx = k / group_size;
+                int scale_lane = lane_id & ~1;
+                float scale = 0.0f;
+                if (lane_id == scale_lane) {
+                    scale = __half2float(__ldg(s_row + scale_idx));
+                }
+                scale = __shfl_sync(0xffffffff, scale, scale_lane);
+                sum += dot8_nvfp4_f32(packed, scale, s_input + k);
+            }
+            sum = warp_reduce_sum(sum);
+            if (lane_id == 0) {
+                hidden_out[m] = __float2bfloat16(sum + __bfloat162float(residual[m]));
+            }
+        }
+    }
+}
+
+static __device__ void matvec_o_residual_nvfp4(
+    const float *__restrict__ s_input,
+    PackedMatrixNVFP4 weight,
+    const __nv_bfloat16 *__restrict__ residual,
+    __nv_bfloat16 *__restrict__ hidden_out,
+    int in_dim, int out_dim, int num_blocks, int group_size)
+{
+    int block_id = blockIdx.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int rows_per_block = (out_dim + num_blocks - 1) / num_blocks;
+    int row_start = block_id * rows_per_block;
+    int row_end = min(row_start + rows_per_block, out_dim);
+    int row_bytes = in_dim / 2;
+    int row_scales = in_dim / group_size;
+
+    for (int m_base = row_start; m_base < row_end; m_base += NUM_WARPS) {
+        int m = m_base + warp_id;
+        if (m < row_end) {
+            const uint8_t *w_row = weight.data + m * row_bytes;
+            const __half *s_row = weight.scales + m * row_scales;
+            float sum = 0.0f;
+#pragma unroll 4
+            for (int k = lane_id * 8; k < in_dim; k += WARP_SIZE * 8) {
+                uint32_t packed = load_32bit(reinterpret_cast<const uint32_t *>(w_row + (k / 2)));
+                int scale_idx = k / group_size;
+                int scale_lane = lane_id & ~1;
+                float scale = 0.0f;
+                if (lane_id == scale_lane) {
+                    scale = __half2float(__ldg(s_row + scale_idx));
+                }
+                scale = __shfl_sync(0xffffffff, scale, scale_lane);
+                sum += dot8_nvfp4_f32(packed, scale, s_input + k);
+            }
+            sum = warp_reduce_sum(sum);
+            if (lane_id == 0) {
+                hidden_out[m] = __float2bfloat16(sum + __bfloat162float(residual[m]));
+            }
+        }
+    }
+}
+
+static __device__ void full_attention_layer_nvfp4(
+    AtomicGridSync &grid,
+    const FullAttnWeightsNVFP4 &w,
+    const __nv_bfloat16 *__restrict__ input,
+    __nv_bfloat16 *__restrict__ k_cache,
+    __nv_bfloat16 *__restrict__ v_cache,
+    __nv_bfloat16 *__restrict__ g_residual,
+    float *__restrict__ g_activations,
+    float *__restrict__ g_q,
+    float *__restrict__ g_kv,
+    float *__restrict__ g_attn_out,
+    float *__restrict__ g_mlp_inter,
+    __nv_bfloat16 *__restrict__ hidden_out,
+    int position, int max_seq_len,
+    int group_size,
+    __nv_bfloat16 *__restrict__ shmem)
+{
+    int block_id = blockIdx.x;
+    int num_blocks = gridDim.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    __shared__ float s_rope_cos[FA_ROTARY_DIM / 2];
+    __shared__ float s_rope_sin[FA_ROTARY_DIM / 2];
+    __shared__ float s_attn_partials[NUM_WARPS * FA_HEAD_DIM];
+
+    __nv_bfloat16 *s_norm = shmem;
+    rmsnorm_redundant(input, w.input_layernorm_weight, s_norm, g_residual);
+
+    matvec_nvfp4(s_norm, w.q_proj, g_q, HIDDEN_SIZE, FA_QPROJ_SIZE, num_blocks, group_size);
+    matvec_nvfp4(s_norm, w.k_proj, g_kv, HIDDEN_SIZE, FA_KV_SIZE, num_blocks, group_size);
+    matvec_nvfp4(s_norm, w.v_proj, g_kv + FA_KV_SIZE, HIDDEN_SIZE, FA_KV_SIZE, num_blocks, group_size);
+    grid.sync();
+
+    if (threadIdx.x < FA_ROTARY_DIM / 2) {
+        float angle = float(position) * ROPE_INV_FREQ[threadIdx.x];
+        __sincosf(angle, &s_rope_sin[threadIdx.x], &s_rope_cos[threadIdx.x]);
+    }
+    __syncthreads();
+
+    if (block_id == 0) {
+        float *k_buf = g_kv;
+        float *v_buf = g_kv + FA_KV_SIZE;
+        for (int h = warp_id; h < FA_NUM_KV_HEADS; h += NUM_WARPS) {
+            float *kh = k_buf + h * FA_HEAD_DIM;
+            float *vh = v_buf + h * FA_HEAD_DIM;
+            __nv_bfloat16 *kc = k_cache + h * max_seq_len * FA_HEAD_DIM + position * FA_HEAD_DIM;
+            __nv_bfloat16 *vc = v_cache + h * max_seq_len * FA_HEAD_DIM + position * FA_HEAD_DIM;
+            float ss = 0.0f;
+            for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) {
+                ss += kh[i] * kh[i];
+            }
+            ss = warp_reduce_sum(ss);
+            float sc = rsqrtf(ss / float(FA_HEAD_DIM) + RMS_EPS);
+            sc = __shfl_sync(0xffffffff, sc, 0);
+            for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) {
+                float wt = 1.0f + __bfloat162float(__ldg(w.k_norm_weight + i));
+                float normed = kh[i] * sc * wt;
+                if (i < FA_ROTARY_DIM) {
+                    int pair = i & ((FA_ROTARY_DIM / 2) - 1);
+                    int p = (i < FA_ROTARY_DIM / 2) ? i + FA_ROTARY_DIM / 2 : i - FA_ROTARY_DIM / 2;
+                    float pwt = 1.0f + __bfloat162float(__ldg(w.k_norm_weight + p));
+                    float pv = kh[p] * sc * pwt;
+                    float cv = s_rope_cos[pair];
+                    float sv = s_rope_sin[pair];
+                    float rotated = (i < FA_ROTARY_DIM / 2) ? (normed * cv - pv * sv) : (pv * sv + normed * cv);
+                    kc[i] = __float2bfloat16(rotated);
+                } else {
+                    kc[i] = __float2bfloat16(normed);
+                }
+                vc[i] = __float2bfloat16(vh[i]);
+            }
+        }
+    }
+
+    {
+        int hpb = (FA_NUM_Q_HEADS + num_blocks - 1) / num_blocks;
+        int hs = block_id * hpb;
+        int he = min(hs + hpb, FA_NUM_Q_HEADS);
+        for (int qh = hs; qh < he; qh++) {
+            float *qh_ptr = g_q + qh * FA_HEAD_DIM * 2;
+            if (warp_id == 0) {
+                float ss = 0.0f;
+                for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) {
+                    ss += qh_ptr[i] * qh_ptr[i];
+                }
+                ss = warp_reduce_sum(ss);
+                float sc = rsqrtf(ss / float(FA_HEAD_DIM) + RMS_EPS);
+                sc = __shfl_sync(0xffffffff, sc, 0);
+                for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) {
+                    float wt = 1.0f + __bfloat162float(__ldg(w.q_norm_weight + i));
+                    float normed = qh_ptr[i] * sc * wt;
+                    if (i < FA_ROTARY_DIM) {
+                        int pair = i & ((FA_ROTARY_DIM / 2) - 1);
+                        int p = (i < FA_ROTARY_DIM / 2) ? i + FA_ROTARY_DIM / 2 : i - FA_ROTARY_DIM / 2;
+                        float pwt = 1.0f + __bfloat162float(__ldg(w.q_norm_weight + p));
+                        float pv = qh_ptr[p] * sc * pwt;
+                        float cv = s_rope_cos[pair];
+                        float sv = s_rope_sin[pair];
+                        qh_ptr[i] = (i < FA_ROTARY_DIM / 2) ? (normed * cv - pv * sv) : (pv * sv + normed * cv);
+                    } else {
+                        qh_ptr[i] = normed;
+                    }
+                }
+            }
+        }
+    }
+    grid.sync();
+
+    {
+        int cache_len = position + 1;
+        float attn_scale = 1.0f / sqrtf(float(FA_HEAD_DIM));
+        int hpb = (FA_NUM_Q_HEADS + num_blocks - 1) / num_blocks;
+        int hs = block_id * hpb;
+        int he = min(hs + hpb, FA_NUM_Q_HEADS);
+        __shared__ float s_max_score[NUM_WARPS];
+        __shared__ float s_sum_exp[NUM_WARPS];
+        constexpr int EPL = FA_HEAD_DIM / WARP_SIZE;
+
+        for (int qh = hs; qh < he; qh++) {
+            int kvh = qh / FA_GQA_RATIO;
+            float *q_head = g_q + qh * FA_HEAD_DIM * 2;
+            float *out_head = g_attn_out + qh * FA_HEAD_DIM;
+            float max_score = -INFINITY;
+            float sum_exp = 0.0f;
+            float out_acc[EPL];
+            float q_local[EPL];
+            for (int e = 0; e < EPL; e++) {
+                out_acc[e] = 0.0f;
+                q_local[e] = q_head[lane_id * EPL + e];
+            }
+
+            for (int pos = warp_id; pos < cache_len; pos += NUM_WARPS) {
+                const __nv_bfloat16 *k_pos = k_cache + kvh * max_seq_len * FA_HEAD_DIM + pos * FA_HEAD_DIM;
+                const __nv_bfloat16 *v_pos = v_cache + kvh * max_seq_len * FA_HEAD_DIM + pos * FA_HEAD_DIM;
+                float score = 0.0f;
+                for (int e = 0; e < EPL; e++) {
+                    score += q_local[e] * __bfloat162float(__ldg(k_pos + lane_id * EPL + e));
+                }
+                score = warp_reduce_sum(score) * attn_scale;
+                score = __shfl_sync(0xffffffff, score, 0);
+                float old_max = max_score;
+                max_score = fmaxf(max_score, score);
+                float exp_diff = fast_exp(old_max - max_score);
+                sum_exp = sum_exp * exp_diff + fast_exp(score - max_score);
+                float wt = fast_exp(score - max_score);
+                for (int e = 0; e < EPL; e++) {
+                    out_acc[e] = out_acc[e] * exp_diff + wt * __bfloat162float(__ldg(v_pos + lane_id * EPL + e));
+                }
+            }
+            if (lane_id == 0) {
+                s_max_score[warp_id] = max_score;
+                s_sum_exp[warp_id] = sum_exp;
+            }
+            for (int e = 0; e < EPL; e++) {
+                s_attn_partials[warp_id * FA_HEAD_DIM + lane_id * EPL + e] = out_acc[e];
+            }
+            __syncthreads();
+
+            if (warp_id == 0) {
+                float gm = -INFINITY;
+                for (int ww = 0; ww < NUM_WARPS; ww++) {
+                    if (s_max_score[ww] > -INFINITY) {
+                        gm = fmaxf(gm, s_max_score[ww]);
+                    }
+                }
+                float ts = 0.0f;
+                float fo[EPL];
+                for (int e = 0; e < EPL; e++) {
+                    fo[e] = 0.0f;
+                }
+                for (int ww = 0; ww < NUM_WARPS; ww++) {
+                    if (s_max_score[ww] > -INFINITY) {
+                        float s = fast_exp(s_max_score[ww] - gm);
+                        ts += s_sum_exp[ww] * s;
+                        for (int e = 0; e < EPL; e++) {
+                            fo[e] += s_attn_partials[ww * FA_HEAD_DIM + lane_id * EPL + e] * s;
+                        }
+                    }
+                }
+                float *gate_ptr = q_head + FA_HEAD_DIM;
+                float rcp = 1.0f / ts;
+                for (int e = 0; e < EPL; e++) {
+                    int idx = lane_id * EPL + e;
+                    out_head[idx] = fo[e] * rcp * fast_sigmoid(gate_ptr[idx]);
+                }
+            }
+            __syncthreads();
+        }
+    }
+    grid.sync();
+
+    {
+        float *s_attn = reinterpret_cast<float *>(shmem);
+        for (int i = threadIdx.x; i < FA_Q_SIZE; i += BLOCK_SIZE) {
+            s_attn[i] = g_attn_out[i];
+        }
+        __syncthreads();
+        matvec_o_residual_nvfp4(s_attn, w.o_proj, g_residual, hidden_out, FA_Q_SIZE, HIDDEN_SIZE, num_blocks, group_size);
+    }
+    grid.sync();
+
+    __nv_bfloat16 *s_act = shmem;
+    rmsnorm_from_bf16(hidden_out, w.post_attn_layernorm_weight, s_act, g_residual);
+
+    matvec_gate_up_silu_nvfp4(
+        s_act, w.gate_proj, w.up_proj, g_mlp_inter,
+        HIDDEN_SIZE, INTERMEDIATE_SIZE, num_blocks, group_size);
+    grid.sync();
+
+    float *s_mlp = reinterpret_cast<float *>(shmem);
+    for (int i = threadIdx.x; i < INTERMEDIATE_SIZE; i += BLOCK_SIZE) {
+        s_mlp[i] = g_mlp_inter[i];
+    }
+    __syncthreads();
+
+    matvec_down_residual_nvfp4(
+        s_mlp, w.down_proj, g_residual, hidden_out,
+        INTERMEDIATE_SIZE, HIDDEN_SIZE, num_blocks, group_size);
+    grid.sync();
+}
+
+static __device__ void deltanet_layer_nvfp4(
+    AtomicGridSync &grid,
+    const DeltaNetWeightsNVFP4 &w,
+    const __nv_bfloat16 *__restrict__ input,
+    __nv_bfloat16 *__restrict__ g_residual,
+    float *__restrict__ g_activations,
+    float *__restrict__ g_qkv,
+    float *__restrict__ g_z,
+    float *__restrict__ g_beta,
+    float *__restrict__ g_alpha,
+    float *__restrict__ g_dn_out,
+    float *__restrict__ g_mlp_inter,
+    float *__restrict__ dn_state,
+    float *__restrict__ conv_buf,
+    __nv_bfloat16 *__restrict__ hidden_out,
+    int dn_layer_idx,
+    int group_size,
+    __nv_bfloat16 *__restrict__ shmem)
+{
+    int block_id = blockIdx.x;
+    int num_blocks = gridDim.x;
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+
+    __nv_bfloat16 *s_norm = shmem;
+    rmsnorm_redundant(input, w.input_layernorm_weight, s_norm, g_residual);
+
+    matvec_nvfp4(s_norm, w.qkv_proj, g_qkv, HIDDEN_SIZE, DN_CONV_CHANNELS, num_blocks, group_size);
+    matvec_nvfp4(s_norm, w.z_proj, g_z, HIDDEN_SIZE, DN_V_SIZE, num_blocks, group_size);
+    matvec_bf16(s_norm, w.beta_proj_weight, g_beta, HIDDEN_SIZE, DN_NUM_HEADS, num_blocks);
+    matvec_bf16(s_norm, w.alpha_proj_weight, g_alpha, HIDDEN_SIZE, DN_NUM_HEADS, num_blocks);
+    grid.sync();
+
+    if (block_id < DN_NUM_HEADS) {
+        int h = block_id;
+        float *layer_conv = conv_buf + dn_layer_idx * DN_CONV_CHANNELS * DN_CONV_KERNEL;
+
+        __shared__ float s_q[DN_KEY_DIM];
+        __shared__ float s_k[DN_KEY_DIM];
+        __shared__ float s_v[DN_VALUE_DIM];
+        int head_ch[3] = {h * DN_KEY_DIM, DN_QK_SIZE + h * DN_KEY_DIM, 2 * DN_QK_SIZE + h * DN_VALUE_DIM};
+        for (int region = 0; region < 3; region++) {
+            int ch_base = head_ch[region];
+            int ch_count = (region < 2) ? DN_KEY_DIM : DN_VALUE_DIM;
+            float *dst = (region == 0) ? s_q : (region == 1) ? s_k : s_v;
+            for (int c = threadIdx.x; c < ch_count; c += BLOCK_SIZE) {
+                int ch = ch_base + c;
+                float h0 = layer_conv[ch * DN_CONV_KERNEL + 1];
+                float h1 = layer_conv[ch * DN_CONV_KERNEL + 2];
+                float h2 = layer_conv[ch * DN_CONV_KERNEL + 3];
+                layer_conv[ch * DN_CONV_KERNEL + 0] = h0;
+                layer_conv[ch * DN_CONV_KERNEL + 1] = h1;
+                layer_conv[ch * DN_CONV_KERNEL + 2] = h2;
+                layer_conv[ch * DN_CONV_KERNEL + 3] = g_qkv[ch];
+                float co = 0.0f;
+                for (int t = 0; t < DN_CONV_KERNEL; t++) {
+                    co += layer_conv[ch * DN_CONV_KERNEL + t] * __bfloat162float(__ldg(w.conv1d_weight + ch * DN_CONV_KERNEL + t));
+                }
+                dst[c] = fast_silu(co);
+            }
+        }
+
+        if (threadIdx.x == 0) {
+            g_beta[h] = fast_sigmoid(g_beta[h]);
+            float a_log_val = __bfloat162float(__ldg(w.a_log + h));
+            float dt_b = __bfloat162float(__ldg(w.dt_bias + h));
+            float x = g_alpha[h] + dt_b;
+            float sp = (x > 20.0f) ? x : logf(1.0f + fast_exp(x));
+            g_alpha[h] = fast_exp(-fast_exp(a_log_val) * sp);
+        }
+        __syncthreads();
+
+        constexpr float Q_SCALE = 1.0f / 11.313708498984761f;
+        if (warp_id == 0) {
+            float sq = 0.0f;
+            for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) {
+                sq += s_q[i] * s_q[i];
+            }
+            sq = warp_reduce_sum(sq);
+            float n = rsqrtf(sq + 1e-6f) * Q_SCALE;
+            n = __shfl_sync(0xffffffff, n, 0);
+            for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) {
+                s_q[i] *= n;
+            }
+        }
+        if (warp_id == 1) {
+            float sq = 0.0f;
+            for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) {
+                sq += s_k[i] * s_k[i];
+            }
+            sq = warp_reduce_sum(sq);
+            float n = rsqrtf(sq + 1e-6f);
+            n = __shfl_sync(0xffffffff, n, 0);
+            for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) {
+                s_k[i] *= n;
+            }
+        }
+        __syncthreads();
+
+        float decay = g_alpha[h];
+        float beta = g_beta[h];
+
+        __shared__ float s_kq;
+        if (warp_id == 0) {
+            float kq = 0.0f;
+            for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) {
+                kq += s_k[i] * s_q[i];
+            }
+            kq = warp_reduce_sum(kq);
+            if (lane_id == 0) {
+                s_kq = kq;
+            }
+        }
+        __syncthreads();
+        float kq = s_kq;
+
+        float *state = dn_state + h * DN_KEY_DIM * DN_VALUE_DIM;
+        float *out_head = g_dn_out + h * DN_VALUE_DIM;
+
+        constexpr int J_PER_WARP = DN_VALUE_DIM / NUM_WARPS;
+        constexpr int I_PER_LANE = DN_KEY_DIM / WARP_SIZE;
+
+#pragma unroll
+        for (int jj = 0; jj < J_PER_WARP; jj++) {
+            int j = warp_id * J_PER_WARP + jj;
+            float s_regs[I_PER_LANE];
+            float stk = 0.0f;
+            float sqv = 0.0f;
+#pragma unroll
+            for (int ii = 0; ii < I_PER_LANE; ii++) {
+                int i = lane_id + ii * WARP_SIZE;
+                float sv = state[j * DN_KEY_DIM + i];
+                s_regs[ii] = sv;
+                stk += sv * s_k[i];
+                sqv += sv * s_q[i];
+            }
+            stk = warp_reduce_sum(stk);
+            sqv = warp_reduce_sum(sqv);
+            stk = __shfl_sync(0xffffffff, stk, 0);
+            sqv = __shfl_sync(0xffffffff, sqv, 0);
+            float error_j = (s_v[j] - stk) * beta;
+            float o_j = decay * sqv + error_j * kq;
+            if (lane_id == 0) {
+                out_head[j] = o_j;
+            }
+#pragma unroll
+            for (int ii = 0; ii < I_PER_LANE; ii++) {
+                int i = lane_id + ii * WARP_SIZE;
+                state[j * DN_KEY_DIM + i] = s_regs[ii] * decay + s_k[i] * error_j;
+            }
+        }
+
+        __syncthreads();
+        {
+            __shared__ float smem_gnorm[NUM_WARPS];
+            float sq = 0.0f;
+            for (int i = threadIdx.x; i < DN_VALUE_DIM; i += BLOCK_SIZE) {
+                sq += out_head[i] * out_head[i];
+            }
+            sq = warp_reduce_sum(sq);
+            if (lane_id == 0) {
+                smem_gnorm[warp_id] = sq;
+            }
+            __syncthreads();
+            if (warp_id == 0) {
+                float v = (lane_id < NUM_WARPS) ? smem_gnorm[lane_id] : 0.0f;
+                v = warp_reduce_sum(v);
+                if (lane_id == 0) {
+                    smem_gnorm[0] = rsqrtf(v / DN_VALUE_DIM + RMS_EPS);
+                }
+            }
+            __syncthreads();
+            float rstd = smem_gnorm[0];
+            for (int i = threadIdx.x; i < DN_VALUE_DIM; i += BLOCK_SIZE) {
+                float normed = out_head[i] * rstd * __bfloat162float(__ldg(w.norm_weight + i));
+                float gate = fast_silu(g_z[h * DN_VALUE_DIM + i]);
+                out_head[i] = normed * gate;
+            }
+        }
+    }
+    grid.sync();
+
+    {
+        float *s_dn = reinterpret_cast<float *>(shmem);
+        for (int i = threadIdx.x; i < DN_V_SIZE; i += BLOCK_SIZE) {
+            s_dn[i] = g_dn_out[i];
+        }
+        __syncthreads();
+        matvec_o_residual_nvfp4(s_dn, w.out_proj, g_residual, hidden_out, DN_V_SIZE, HIDDEN_SIZE, num_blocks, group_size);
+    }
+    grid.sync();
+
+    __nv_bfloat16 *s_act = shmem;
+    rmsnorm_from_bf16(hidden_out, w.post_attn_layernorm_weight, s_act, g_residual);
+
+    matvec_gate_up_silu_nvfp4(
+        s_act, w.gate_proj, w.up_proj, g_mlp_inter,
+        HIDDEN_SIZE, INTERMEDIATE_SIZE, num_blocks, group_size);
+    grid.sync();
+
+    float *s_mlp = reinterpret_cast<float *>(shmem);
+    for (int i = threadIdx.x; i < INTERMEDIATE_SIZE; i += BLOCK_SIZE) {
+        s_mlp[i] = g_mlp_inter[i];
+    }
+    __syncthreads();
+
+    matvec_down_residual_nvfp4(
+        s_mlp, w.down_proj, g_residual, hidden_out,
+        INTERMEDIATE_SIZE, HIDDEN_SIZE, num_blocks, group_size);
+    grid.sync();
+}
+
+__global__ void prepare_lm_hidden_bf16_kernel(
+    const float *__restrict__ hidden,
+    __nv_bfloat16 *__restrict__ lm_hidden)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = LM_HEAD_TC_N * HIDDEN_SIZE;
+    if (idx >= total) {
+        return;
+    }
+    int col = idx / HIDDEN_SIZE;
+    int k = idx % HIDDEN_SIZE;
+    float value = (col == 0) ? hidden[k] : 0.0f;
+    lm_hidden[idx] = __float2bfloat16(value);
+}
+
+__global__ void prepare_lm_hidden_bf16_from_bf16_kernel(
+    const __nv_bfloat16 *__restrict__ hidden,
+    __nv_bfloat16 *__restrict__ lm_hidden)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = LM_HEAD_TC_N * HIDDEN_SIZE;
+    if (idx >= total) {
+        return;
+    }
+    int row = idx / HIDDEN_SIZE;
+    int k = idx % HIDDEN_SIZE;
+    lm_hidden[idx] = (row == 0) ? hidden[k] : __float2bfloat16(0.0f);
+}
+
+__global__ void lm_head_argmax_half_kernel(
+    const __half *__restrict__ logits,
+    float *__restrict__ block_max_vals,
+    int *__restrict__ block_max_idxs)
+{
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int num_warps = LM_BLOCK_SIZE / WARP_SIZE;
+    int rows_per_block = (VOCAB_SIZE + gridDim.x - 1) / gridDim.x;
+    int row_start = blockIdx.x * rows_per_block;
+    int row_end = min(row_start + rows_per_block, VOCAB_SIZE);
+
+    float local_max = -INFINITY;
+    int local_idx = -1;
+    for (int row = row_start + warp_id; row < row_end; row += num_warps) {
+        float value = -INFINITY;
+        if (lane_id == 0) {
+            value = __half2float(logits[row]);
+        }
+        value = __shfl_sync(0xffffffff, value, 0);
+        if (lane_id == 0 && value > local_max) {
+            local_max = value;
+            local_idx = row;
+        }
+    }
+    local_max = __shfl_sync(0xffffffff, local_max, 0);
+    local_idx = __shfl_sync(0xffffffff, local_idx, 0);
+
+    __shared__ float warp_max[32];
+    __shared__ int warp_idx[32];
+    if (lane_id == 0) {
+        warp_max[warp_id] = local_max;
+        warp_idx[warp_id] = local_idx;
+    }
+    __syncthreads();
+    if (warp_id == 0) {
+        float max_value = (lane_id < num_warps) ? warp_max[lane_id] : -INFINITY;
+        int max_index = (lane_id < num_warps) ? warp_idx[lane_id] : -1;
+        for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+            float other_value = __shfl_down_sync(0xffffffff, max_value, offset);
+            int other_index = __shfl_down_sync(0xffffffff, max_index, offset);
+            if (other_value > max_value) {
+                max_value = other_value;
+                max_index = other_index;
+            }
+        }
+        if (lane_id == 0) {
+            block_max_vals[blockIdx.x] = max_value;
+            block_max_idxs[blockIdx.x] = max_index;
+        }
+    }
+}
+
+__global__ void __launch_bounds__(LM_SCALE_THREADS)
+quantize_nvfp4_lm_kernel(
+    const __nv_bfloat16 *__restrict__ weight,
+    uint8_t *__restrict__ packed,
+    uint8_t *__restrict__ scales,
+    int rows, int cols, int scale_tiles)
+{
+    int row_block = blockIdx.x;
+    int col_block = blockIdx.y;
+    int tid = threadIdx.x;
+    int tile_row = tid >> 2;
+    int tile_col = tid & 3;
+
+    int row = row_block * LM_SCALE_ROWS_PER_TILE + tile_row;
+    int scale_col = col_block * LM_SCALE_COLS_PER_TILE + tile_col;
+    int col_start = scale_col * LM_SCALE_BLOCK_K;
+
+    bool in_bounds = (row < rows) && (col_start + LM_SCALE_BLOCK_K <= cols);
+    const __nv_bfloat162 *weight_row = reinterpret_cast<const __nv_bfloat162 *>(weight + static_cast<size_t>(row) * cols);
+    __nv_bfloat162 vals[8];
+    float absmax = 0.0f;
+
+    if (in_bounds) {
+        const __nv_bfloat162 *src = weight_row + (col_start >> 1);
+#pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            vals[i] = src[i];
+            float2 v = __bfloat1622float2(vals[i]);
+            absmax = fmaxf(absmax, fmaxf(fabsf(v.x), fabsf(v.y)));
+        }
+    } else {
+#pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            vals[i] = __float2bfloat162_rn(0.0f);
+        }
+    }
+
+    float scale_f = fmaxf(absmax * (1.0f / 6.0f), 1.0f / float(1 << 28));
+    __nv_fp8_storage_t scale_fp8 = __nv_cvt_float_to_fp8(scale_f, __NV_SATFINITE, __NV_E4M3);
+    __half_raw scale_half_raw = __nv_cvt_fp8_to_halfraw(scale_fp8, __NV_E4M3);
+    float decoded_scale = __half2float(*reinterpret_cast<__half *>(&scale_half_raw));
+    float inv_scale = (decoded_scale > 0.0f) ? (1.0f / decoded_scale) : 0.0f;
+
+    uint64_t packed_u64 = 0;
+#pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        float2 v = __bfloat1622float2(vals[i]);
+        v.x *= inv_scale;
+        v.y *= inv_scale;
+        __nv_fp4x2_storage_t p = __nv_cvt_float2_to_fp4x2(v, __NV_E2M1, cudaRoundNearest);
+        packed_u64 |= static_cast<uint64_t>(static_cast<uint8_t>(p)) << (i * 8);
+    }
+
+    if (in_bounds) {
+        *reinterpret_cast<uint64_t *>(
+            packed + static_cast<size_t>(row) * (cols / 2) + (col_start >> 1)) = packed_u64;
+
+        int row_in_tile = row & 31;
+        int row_col_chunk = (row & (LM_SCALE_ROWS_PER_TILE - 1)) >> 5;
+        int scale_tile = row_block * scale_tiles + (scale_col >> 2);
+        int col_pos = scale_col & 3;
+        int swizzled_idx = scale_tile * 512 + row_in_tile * 16 + row_col_chunk * 4 + col_pos;
+        scales[swizzled_idx] = static_cast<uint8_t>(scale_fp8);
+    }
+}
+
+__device__ __forceinline__ float lm_swizzled_scale_value(
+    const uint8_t *__restrict__ scales,
+    int row,
+    int scale_idx)
+{
+    constexpr int scales_per_row = HIDDEN_SIZE / LM_SCALE_BLOCK_K;
+    constexpr int scale_tiles_per_row = scales_per_row / LM_SCALE_COLS_PER_TILE;
+    int row_block = row / LM_SCALE_ROWS_PER_TILE;
+    int row_in_block = row % LM_SCALE_ROWS_PER_TILE;
+    int row_in_tile = row_in_block & 31;
+    int row_chunk = row_in_block >> 5;
+    int tile = row_block * scale_tiles_per_row + (scale_idx >> 2);
+    int swizzled_idx = tile * 512 + row_in_tile * 16 + row_chunk * 4 + (scale_idx & 3);
+    __half_raw scale_half_raw = __nv_cvt_fp8_to_halfraw(
+        static_cast<__nv_fp8_storage_t>(scales[swizzled_idx]),
+        __NV_E4M3);
+    return __half2float(*reinterpret_cast<__half *>(&scale_half_raw));
+}
+
+__global__ void lm_head_kernel_nvfp4(
+    const float *__restrict__ hidden,
+    const uint8_t *__restrict__ weight,
+    const uint8_t *__restrict__ scales,
+    float *__restrict__ block_max_vals,
+    int *__restrict__ block_max_idxs,
+    int group_size)
+{
+    __shared__ float s_hidden[HIDDEN_SIZE];
+    for (int i = threadIdx.x; i < HIDDEN_SIZE; i += LM_BLOCK_SIZE) {
+        s_hidden[i] = hidden[i];
+    }
+    __syncthreads();
+
+    int warp_id = threadIdx.x / WARP_SIZE;
+    int lane_id = threadIdx.x % WARP_SIZE;
+    int num_warps = LM_BLOCK_SIZE / WARP_SIZE;
+    int rpb = (VOCAB_SIZE + gridDim.x - 1) / gridDim.x;
+    int rs = blockIdx.x * rpb;
+    int re = min(rs + rpb, VOCAB_SIZE);
+    int row_bytes = HIDDEN_SIZE / 2;
+    (void)group_size;
+
+    float local_max = -INFINITY;
+    int local_max_idx = -1;
+    for (int m = rs + warp_id; m < re; m += num_warps) {
+        const uint8_t *w_row = weight + m * row_bytes;
+        float sum = 0.0f;
+#pragma unroll 4
+        for (int k = lane_id * 8; k < HIDDEN_SIZE; k += WARP_SIZE * 8) {
+            uint32_t packed = load_32bit(reinterpret_cast<const uint32_t *>(w_row + (k / 2)));
+            int scale_idx = k / LM_SCALE_BLOCK_K;
+            int scale_lane = lane_id & ~1;
+            float scale = 0.0f;
+            if (lane_id == scale_lane) {
+                scale = lm_swizzled_scale_value(scales, m, scale_idx);
+            }
+            scale = __shfl_sync(0xffffffff, scale, scale_lane);
+            sum += dot8_nvfp4_f32(packed, scale, s_hidden + k);
+        }
+        sum = warp_reduce_sum(sum);
+        if (lane_id == 0 && sum > local_max) {
+            local_max = sum;
+            local_max_idx = m;
+        }
+    }
+    local_max = __shfl_sync(0xffffffff, local_max, 0);
+    local_max_idx = __shfl_sync(0xffffffff, local_max_idx, 0);
+
+    __shared__ float wm[32];
+    __shared__ int wi[32];
+    if (lane_id == 0) {
+        wm[warp_id] = local_max;
+        wi[warp_id] = local_max_idx;
+    }
+    __syncthreads();
+    if (warp_id == 0) {
+        float mv = (lane_id < num_warps) ? wm[lane_id] : -INFINITY;
+        int mi = (lane_id < num_warps) ? wi[lane_id] : -1;
+        for (int o = WARP_SIZE / 2; o > 0; o /= 2) {
+            float ov = __shfl_down_sync(0xffffffff, mv, o);
+            int oi = __shfl_down_sync(0xffffffff, mi, o);
+            if (ov > mv) {
+                mv = ov;
+                mi = oi;
+            }
+        }
+        if (lane_id == 0) {
+            block_max_vals[blockIdx.x] = mv;
+            block_max_idxs[blockIdx.x] = mi;
+        }
+    }
+}
+
+__global__ void lm_head_reduce_kernel(
+    const float *__restrict__ block_max_vals,
+    const int *__restrict__ block_max_idxs,
+    int *__restrict__ output_token,
+    int num_blocks)
+{
+    int tid = threadIdx.x;
+    float bv = -INFINITY;
+    int bi = -1;
+    for (int i = tid; i < num_blocks; i += blockDim.x) {
+        float v = block_max_vals[i];
+        if (v > bv) {
+            bv = v;
+            bi = block_max_idxs[i];
+        }
+    }
+
+    __shared__ float sv[LM_BLOCK_SIZE];
+    __shared__ int si[LM_BLOCK_SIZE];
+    sv[tid] = bv;
+    si[tid] = bi;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s && sv[tid + s] > sv[tid]) {
+            sv[tid] = sv[tid + s];
+            si[tid] = si[tid + s];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        *output_token = si[0];
+    }
+}
+
+__global__ void __launch_bounds__(BLOCK_SIZE, 1)
+decode_kernel_nvfp4(
+    const int *__restrict__ input_token_ptr,
+    const __nv_bfloat16 *__restrict__ embed_weight,
+    const __nv_bfloat16 *__restrict__ final_norm_weight,
+    const LayerWeightsNVFP4 *__restrict__ layer_weights,
+    __nv_bfloat16 *__restrict__ fa_k_cache,
+    __nv_bfloat16 *__restrict__ fa_v_cache,
+    float *__restrict__ dn_states,
+    float *__restrict__ conv_bufs,
+    __nv_bfloat16 *__restrict__ hidden_buffer,
+    float *__restrict__ g_activations,
+    __nv_bfloat16 *__restrict__ g_residual,
+    float *__restrict__ g_qkv_scratch,
+    float *__restrict__ g_kv_scratch,
+    float *__restrict__ g_attn_out,
+    float *__restrict__ g_mlp_inter,
+    float *__restrict__ g_z_scratch,
+    float *__restrict__ g_beta_scratch,
+    float *__restrict__ g_alpha_scratch,
+    float *__restrict__ g_normalized,
+    unsigned int *__restrict__ barrier_counter,
+    unsigned int *__restrict__ barrier_generation,
+    int position, int max_seq_len)
+{
+    int block_id = blockIdx.x;
+    int num_blocks = gridDim.x;
+    (void)barrier_counter;
+    (void)barrier_generation;
+
+    AtomicGridSync grid{};
+
+    __shared__ __align__(16) char shmem_raw[MAX_ACT_DIM * sizeof(float)];
+    __nv_bfloat16 *shmem_bf16 = reinterpret_cast<__nv_bfloat16 *>(shmem_raw);
+
+    int input_token_id = __ldg(input_token_ptr);
+    const __nv_bfloat16 *embed_row = embed_weight + input_token_id * HIDDEN_SIZE;
+    int fa_kv_stride = FA_NUM_KV_HEADS * max_seq_len * FA_HEAD_DIM;
+    int dn_state_stride = DN_NUM_HEADS * DN_KEY_DIM * DN_VALUE_DIM;
+
+    int dn_layer_idx = 0;
+    int fa_layer_idx = 0;
+
+    for (int layer = 0; layer < NUM_LAYERS; layer++) {
+        const __nv_bfloat16 *layer_input = (layer == 0) ? embed_row : hidden_buffer;
+        const LayerWeightsNVFP4 &weights = layer_weights[layer];
+
+        if (LAYER_TYPE[layer] == 0) {
+            DeltaNetWeightsNVFP4 dn_weights = make_deltanet_weights(weights);
+            deltanet_layer_nvfp4(
+                grid, dn_weights, layer_input,
+                g_residual, g_activations, g_qkv_scratch, g_z_scratch,
+                g_beta_scratch, g_alpha_scratch, g_attn_out, g_mlp_inter,
+                dn_states + dn_layer_idx * dn_state_stride,
+                conv_bufs, hidden_buffer, dn_layer_idx, weights.group_size, shmem_bf16);
+            dn_layer_idx++;
+        } else {
+            FullAttnWeightsNVFP4 fa_weights = make_full_attn_weights(weights);
+            full_attention_layer_nvfp4(
+                grid, fa_weights, layer_input,
+                fa_k_cache + fa_layer_idx * fa_kv_stride,
+                fa_v_cache + fa_layer_idx * fa_kv_stride,
+                g_residual, g_activations, g_qkv_scratch, g_kv_scratch,
+                g_attn_out, g_mlp_inter, hidden_buffer,
+                position, max_seq_len, weights.group_size, shmem_bf16);
+            fa_layer_idx++;
+        }
+    }
+
+    if (block_id == 0) {
+        __shared__ float smem_reduce[NUM_WARPS];
+        int warp_id = threadIdx.x / WARP_SIZE;
+        int lane_id = threadIdx.x % WARP_SIZE;
+        float local_sum_sq = 0.0f;
+        for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+            float v = __bfloat162float(hidden_buffer[i]);
+            local_sum_sq += v * v;
+        }
+        local_sum_sq = warp_reduce_sum(local_sum_sq);
+        if (lane_id == 0) {
+            smem_reduce[warp_id] = local_sum_sq;
+        }
+        __syncthreads();
+        if (warp_id == 0) {
+            float sum = (lane_id < NUM_WARPS) ? smem_reduce[lane_id] : 0.0f;
+            sum = warp_reduce_sum(sum);
+            if (lane_id == 0) {
+                smem_reduce[0] = rsqrtf(sum / HIDDEN_SIZE + RMS_EPS);
+            }
+        }
+        __syncthreads();
+        float rstd = smem_reduce[0];
+        for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+            float v = __bfloat162float(hidden_buffer[i]);
+            float wt = __bfloat162float(__ldg(final_norm_weight + i));
+            g_normalized[i] = v * rstd * (1.0f + wt);
+        }
+    }
+}
+
+__global__ void __launch_bounds__(BLOCK_SIZE, 1)
+prefill_kernel_nvfp4(
+    const int *__restrict__ token_ids,
+    int seq_len,
+    const __nv_bfloat16 *__restrict__ embed_weight,
+    const __nv_bfloat16 *__restrict__ final_norm_weight,
+    const LayerWeightsNVFP4 *__restrict__ layer_weights,
+    __nv_bfloat16 *__restrict__ fa_k_cache,
+    __nv_bfloat16 *__restrict__ fa_v_cache,
+    float *__restrict__ dn_states,
+    float *__restrict__ conv_bufs,
+    __nv_bfloat16 *__restrict__ hidden_buffer,
+    float *__restrict__ g_activations,
+    __nv_bfloat16 *__restrict__ g_residual,
+    float *__restrict__ g_qkv_scratch,
+    float *__restrict__ g_kv_scratch,
+    float *__restrict__ g_attn_out,
+    float *__restrict__ g_mlp_inter,
+    float *__restrict__ g_z_scratch,
+    float *__restrict__ g_beta_scratch,
+    float *__restrict__ g_alpha_scratch,
+    float *__restrict__ g_normalized,
+    int max_seq_len)
+{
+    int block_id = blockIdx.x;
+    AtomicGridSync grid{};
+
+    __shared__ __align__(16) char shmem_raw[MAX_ACT_DIM * sizeof(float)];
+    __nv_bfloat16 *shmem_bf16 = reinterpret_cast<__nv_bfloat16 *>(shmem_raw);
+
+    int fa_kv_stride = FA_NUM_KV_HEADS * max_seq_len * FA_HEAD_DIM;
+    int dn_state_stride = DN_NUM_HEADS * DN_KEY_DIM * DN_VALUE_DIM;
+
+    for (int position = 0; position < seq_len; ++position) {
+        int input_token_id = __ldg(token_ids + position);
+        const __nv_bfloat16 *embed_row = embed_weight + input_token_id * HIDDEN_SIZE;
+
+        int dn_layer_idx = 0;
+        int fa_layer_idx = 0;
+
+        for (int layer = 0; layer < NUM_LAYERS; layer++) {
+            const __nv_bfloat16 *layer_input = (layer == 0) ? embed_row : hidden_buffer;
+            const LayerWeightsNVFP4 &weights = layer_weights[layer];
+
+            if (LAYER_TYPE[layer] == 0) {
+                DeltaNetWeightsNVFP4 dn_weights = make_deltanet_weights(weights);
+                deltanet_layer_nvfp4(
+                    grid, dn_weights, layer_input,
+                    g_residual, g_activations, g_qkv_scratch, g_z_scratch,
+                    g_beta_scratch, g_alpha_scratch, g_attn_out, g_mlp_inter,
+                    dn_states + dn_layer_idx * dn_state_stride,
+                    conv_bufs, hidden_buffer, dn_layer_idx, weights.group_size, shmem_bf16);
+                dn_layer_idx++;
+            } else {
+                FullAttnWeightsNVFP4 fa_weights = make_full_attn_weights(weights);
+                full_attention_layer_nvfp4(
+                    grid, fa_weights, layer_input,
+                    fa_k_cache + fa_layer_idx * fa_kv_stride,
+                    fa_v_cache + fa_layer_idx * fa_kv_stride,
+                    g_residual, g_activations, g_qkv_scratch, g_kv_scratch,
+                    g_attn_out, g_mlp_inter, hidden_buffer,
+                    position, max_seq_len, weights.group_size, shmem_bf16);
+                fa_layer_idx++;
+            }
+        }
+    }
+
+    if (block_id == 0) {
+        __shared__ float smem_reduce[NUM_WARPS];
+        int warp_id = threadIdx.x / WARP_SIZE;
+        int lane_id = threadIdx.x % WARP_SIZE;
+        float local_sum_sq = 0.0f;
+        for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+            float v = __bfloat162float(hidden_buffer[i]);
+            local_sum_sq += v * v;
+        }
+        local_sum_sq = warp_reduce_sum(local_sum_sq);
+        if (lane_id == 0) {
+            smem_reduce[warp_id] = local_sum_sq;
+        }
+        __syncthreads();
+        if (warp_id == 0) {
+            float sum = (lane_id < NUM_WARPS) ? smem_reduce[lane_id] : 0.0f;
+            sum = warp_reduce_sum(sum);
+            if (lane_id == 0) {
+                smem_reduce[0] = rsqrtf(sum / HIDDEN_SIZE + RMS_EPS);
+            }
+        }
+        __syncthreads();
+        float rstd = smem_reduce[0];
+        for (int i = threadIdx.x; i < HIDDEN_SIZE; i += BLOCK_SIZE) {
+            float v = __bfloat162float(hidden_buffer[i]);
+            float wt = __bfloat162float(__ldg(final_norm_weight + i));
+            g_normalized[i] = v * rstd * (1.0f + wt);
+        }
+    }
+}
+
+__device__ __forceinline__ unsigned int quantize_fp4_code(float x) {
+    float ax = fabsf(x);
+    unsigned int mag = 0;
+    if (ax < 0.25f) mag = 0;
+    else if (ax < 0.75f) mag = 1;
+    else if (ax < 1.25f) mag = 2;
+    else if (ax < 1.75f) mag = 3;
+    else if (ax < 2.5f) mag = 4;
+    else if (ax < 3.5f) mag = 5;
+    else if (ax < 5.0f) mag = 6;
+    else mag = 7;
+    return (x < 0.0f) ? (mag | 0x8u) : mag;
+}
+
+__global__ void quantize_nvfp4_kernel(
+    const __nv_bfloat16 *__restrict__ weight,
+    uint8_t *__restrict__ packed,
+    __half *__restrict__ scales,
+    int rows, int cols, int group_size)
+{
+    int groups_per_row = cols / group_size;
+    int total_groups = rows * groups_per_row;
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= total_groups) {
+        return;
+    }
+
+    int row = gid / groups_per_row;
+    int group = gid % groups_per_row;
+    const __nv_bfloat16 *src = weight + row * cols + group * group_size;
+    uint8_t *dst = packed + row * (cols / 2) + group * (group_size / 2);
+
+    float amax = 0.0f;
+    for (int i = 0; i < group_size; ++i) {
+        amax = fmaxf(amax, fabsf(__bfloat162float(src[i])));
+    }
+
+    float scale = (amax > 0.0f) ? (amax / 6.0f) : 1.0f;
+    scales[row * groups_per_row + group] = __float2half(scale);
+
+    if (amax == 0.0f) {
+        for (int i = 0; i < group_size / 2; ++i) {
+            dst[i] = 0;
+        }
+        return;
+    }
+
+    float inv_scale = 1.0f / scale;
+    for (int i = 0; i < group_size; i += 2) {
+        unsigned int lo = quantize_fp4_code(__bfloat162float(src[i + 0]) * inv_scale);
+        unsigned int hi = quantize_fp4_code(__bfloat162float(src[i + 1]) * inv_scale);
+        dst[i / 2] = static_cast<uint8_t>(lo | (hi << 4));
+    }
+}
+
+static int decode_launch_blocks() {
+    if (const char *override_blocks = std::getenv("MEGAKERNEL_DECODE_BLOCKS")) {
+        int value = std::atoi(override_blocks);
+        if (value > 0) {
+            return value;
+        }
+    }
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, device);
+    int active_blocks = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&active_blocks, decode_kernel_nvfp4, BLOCK_SIZE, 0);
+    return std::max(1, active_blocks * prop.multiProcessorCount);
+}
+
+static int prefill_launch_blocks() {
+    if (const char *override_blocks = std::getenv("MEGAKERNEL_PREFILL_BLOCKS")) {
+        int value = std::atoi(override_blocks);
+        if (value > 0) {
+            return value;
+        }
+    }
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, device);
+    int active_blocks = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&active_blocks, prefill_kernel_nvfp4, BLOCK_SIZE, 0);
+    int resident = std::max(1, active_blocks * prop.multiProcessorCount);
+    return std::min(resident, 24);
+}
+
+static int lm_launch_blocks() {
+    if (const char *override_blocks = std::getenv("MEGAKERNEL_LM_BLOCKS")) {
+        int value = std::atoi(override_blocks);
+        if (value > 0) {
+            return value;
+        }
+    }
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, device);
+    int active_blocks = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&active_blocks, lm_head_kernel_nvfp4, LM_BLOCK_SIZE, 0);
+    int resident = std::max(1, active_blocks * prop.multiProcessorCount);
+    int target = std::max(resident, prop.multiProcessorCount * 8);
+    return std::min(1024, target);
+}
+
+extern "C" void launch_quantize_nvfp4_out(
+    const void *weight, int rows, int cols, int group_size,
+    void *packed_out, void *scales_out, cudaStream_t stream)
+{
+    int groups_per_row = cols / group_size;
+    int total_groups = rows * groups_per_row;
+    int threads = 256;
+    int blocks = (total_groups + threads - 1) / threads;
+    quantize_nvfp4_kernel<<<blocks, threads, 0, stream>>>(
+        (const __nv_bfloat16 *)weight,
+        (uint8_t *)packed_out,
+        (__half *)scales_out,
+        rows, cols, group_size);
+}
+
+extern "C" void launch_quantize_nvfp4_lm_out(
+    const void *weight, int rows, int cols,
+    void *packed_out, void *scales_out, cudaStream_t stream)
+{
+    int scale_tiles = cols / LM_SCALE_K_PER_TILE;
+    dim3 grid((rows + LM_SCALE_ROWS_PER_TILE - 1) / LM_SCALE_ROWS_PER_TILE, scale_tiles);
+    dim3 block(LM_SCALE_THREADS);
+    quantize_nvfp4_lm_kernel<<<grid, block, 0, stream>>>(
+        (const __nv_bfloat16 *)weight,
+        (uint8_t *)packed_out,
+        (uint8_t *)scales_out,
+        rows,
+        cols,
+        scale_tiles);
+}
+
+extern "C" bool launch_lm_head_cublaslt_bf16_top1(
+    const void *hidden_bf16,
+    const void *lm_head_weight_packed,
+    const void *lm_head_scales,
+    void *lm_hidden_bf16,
+    void *lm_hidden_packed,
+    void *lm_hidden_scales,
+    void *lm_logits_f16,
+    float *block_max_vals,
+    int *block_max_idxs,
+    int *output_token_id,
+    cudaStream_t stream)
+{
+    int prepare_threads = 256;
+    int prepare_blocks = (LM_HEAD_TC_N * HIDDEN_SIZE + prepare_threads - 1) / prepare_threads;
+    prepare_lm_hidden_bf16_from_bf16_kernel<<<prepare_blocks, prepare_threads, 0, stream>>>(
+        (const __nv_bfloat16 *)hidden_bf16,
+        (__nv_bfloat16 *)lm_hidden_bf16);
+    cudaMemsetAsync(lm_hidden_scales, 0, LM_HEAD_HIDDEN_SCALE_BYTES, stream);
+    launch_quantize_nvfp4_lm_out(
+        lm_hidden_bf16,
+        LM_HEAD_TC_N,
+        HIDDEN_SIZE,
+        lm_hidden_packed,
+        lm_hidden_scales,
+        stream);
+
+    bool used_cublaslt = launch_lm_head_cublaslt(
+        (const uint8_t *)lm_head_weight_packed,
+        (const uint8_t *)lm_head_scales,
+        (const uint8_t *)lm_hidden_packed,
+        (const uint8_t *)lm_hidden_scales,
+        (__half *)lm_logits_f16,
+        stream);
+    if (!used_cublaslt) {
+        return false;
+    }
+
+    int lm_blocks = lm_launch_blocks();
+    lm_head_argmax_half_kernel<<<lm_blocks, LM_BLOCK_SIZE, 0, stream>>>(
+        (const __half *)lm_logits_f16,
+        block_max_vals,
+        block_max_idxs);
+    lm_head_reduce_kernel<<<1, LM_BLOCK_SIZE, 0, stream>>>(
+        block_max_vals,
+        block_max_idxs,
+        output_token_id,
+        lm_blocks);
+    return true;
+}
+
+static void launch_lm_head_from_f32_normalized(
+    int lm_blocks,
+    const float *normalized,
+    int *output_token_id,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    float *block_max_vals, int *block_max_idxs,
+    int group_size,
+    cudaStream_t stream)
+{
+    int prepare_threads = 256;
+    int prepare_blocks = (LM_HEAD_TC_N * HIDDEN_SIZE + prepare_threads - 1) / prepare_threads;
+    prepare_lm_hidden_bf16_kernel<<<prepare_blocks, prepare_threads, 0, stream>>>(
+        normalized,
+        (__nv_bfloat16 *)lm_hidden_bf16);
+    cudaMemsetAsync(lm_hidden_scales, 0, LM_HEAD_HIDDEN_SCALE_BYTES, stream);
+    launch_quantize_nvfp4_lm_out(
+        lm_hidden_bf16,
+        LM_HEAD_TC_N,
+        HIDDEN_SIZE,
+        lm_hidden_packed,
+        lm_hidden_scales,
+        stream);
+
+    bool used_cublaslt = launch_lm_head_cublaslt(
+        (const uint8_t *)lm_head_weight_packed,
+        (const uint8_t *)lm_head_scales,
+        (const uint8_t *)lm_hidden_packed,
+        (const uint8_t *)lm_hidden_scales,
+        (__half *)lm_logits_f16,
+        stream);
+    if (lm_debug_enabled()) {
+        std::fprintf(stderr, "lm_head_cublaslt: used=%d\n", int(used_cublaslt));
+    }
+    if (used_cublaslt) {
+        lm_head_argmax_half_kernel<<<lm_blocks, LM_BLOCK_SIZE, 0, stream>>>(
+            (const __half *)lm_logits_f16,
+            block_max_vals,
+            block_max_idxs);
+    } else {
+        lm_head_kernel_nvfp4<<<lm_blocks, LM_BLOCK_SIZE, 0, stream>>>(
+            normalized,
+            (const uint8_t *)lm_head_weight_packed,
+            (const uint8_t *)lm_head_scales,
+            block_max_vals, block_max_idxs,
+            group_size);
+    }
+    lm_head_reduce_kernel<<<1, LM_BLOCK_SIZE, 0, stream>>>(
+        block_max_vals,
+        block_max_idxs,
+        output_token_id,
+        lm_blocks);
+}
+
+static void launch_decode_step_nvfp4(
+    int num_blocks, int lm_blocks,
+    const int *input_token_ptr, int *output_token_id,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int position, int max_seq_len, int group_size, cudaStream_t stream)
+{
+    void *decode_args[] = {
+        (void *)&input_token_ptr,
+        (void *)&embed_weight,
+        (void *)&final_norm_weight,
+        (void *)&layer_weights,
+        (void *)&fa_k_cache,
+        (void *)&fa_v_cache,
+        (void *)&dn_states,
+        (void *)&conv_bufs,
+        (void *)&hidden_buffer,
+        (void *)&g_activations,
+        (void *)&g_residual,
+        (void *)&g_qkv_scratch,
+        (void *)&g_kv_scratch,
+        (void *)&g_attn_out,
+        (void *)&g_mlp_inter,
+        (void *)&g_z_scratch,
+        (void *)&g_beta_scratch,
+        (void *)&g_alpha_scratch,
+        (void *)&g_normalized,
+        (void *)&barrier_counter,
+        (void *)&barrier_generation,
+        (void *)&position,
+        (void *)&max_seq_len,
+    };
+    cudaLaunchCooperativeKernel(
+        (void *)decode_kernel_nvfp4,
+        dim3(num_blocks),
+        dim3(BLOCK_SIZE),
+        decode_args,
+        0,
+        stream);
+    launch_lm_head_from_f32_normalized(
+        lm_blocks,
+        (const float *)g_normalized,
+        output_token_id,
+        lm_head_weight_packed, lm_head_scales,
+        lm_hidden_bf16, lm_hidden_packed, lm_hidden_scales, lm_logits_f16,
+        block_max_vals, block_max_idxs,
+        group_size,
+        stream);
+    (void)lm_sync_counter;
+}
+
+extern "C" void launch_decode_nvfp4(
+    const int *input_token_ptr, int *output_token_id,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int position, int max_seq_len, int group_size, cudaStream_t stream)
+{
+    int num_blocks = decode_launch_blocks();
+    int lm_blocks = lm_launch_blocks();
+    launch_decode_step_nvfp4(
+        num_blocks,
+        lm_blocks,
+        input_token_ptr,
+        output_token_id,
+        embed_weight,
+        layer_weights,
+        final_norm_weight,
+        lm_head_weight_packed,
+        lm_head_scales,
+        lm_hidden_bf16,
+        lm_hidden_packed,
+        lm_hidden_scales,
+        lm_logits_f16,
+        fa_k_cache,
+        fa_v_cache,
+        dn_states,
+        conv_bufs,
+        hidden_buffer,
+        g_activations,
+        g_residual,
+        g_qkv_scratch,
+        g_kv_scratch,
+        g_attn_out,
+        g_mlp_inter,
+        g_z_scratch,
+        g_beta_scratch,
+        g_alpha_scratch,
+        g_normalized,
+        barrier_counter,
+        barrier_generation,
+        block_max_vals,
+        block_max_idxs,
+        lm_sync_counter,
+        position,
+        max_seq_len,
+        group_size,
+        stream);
+}
+
+extern "C" void launch_prefill_megakernel_nvfp4(
+    const int *token_ids, int seq_len, int *output_token_id,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int max_seq_len, int group_size, cudaStream_t stream)
+{
+    (void)barrier_counter;
+    (void)barrier_generation;
+    (void)lm_sync_counter;
+
+    int num_blocks = prefill_launch_blocks();
+    int lm_blocks = lm_launch_blocks();
+    void *prefill_args[] = {
+        (void *)&token_ids,
+        (void *)&seq_len,
+        (void *)&embed_weight,
+        (void *)&final_norm_weight,
+        (void *)&layer_weights,
+        (void *)&fa_k_cache,
+        (void *)&fa_v_cache,
+        (void *)&dn_states,
+        (void *)&conv_bufs,
+        (void *)&hidden_buffer,
+        (void *)&g_activations,
+        (void *)&g_residual,
+        (void *)&g_qkv_scratch,
+        (void *)&g_kv_scratch,
+        (void *)&g_attn_out,
+        (void *)&g_mlp_inter,
+        (void *)&g_z_scratch,
+        (void *)&g_beta_scratch,
+        (void *)&g_alpha_scratch,
+        (void *)&g_normalized,
+        (void *)&max_seq_len,
+    };
+    cudaLaunchCooperativeKernel(
+        (void *)prefill_kernel_nvfp4,
+        dim3(num_blocks),
+        dim3(BLOCK_SIZE),
+        prefill_args,
+        0,
+        stream);
+
+    launch_lm_head_from_f32_normalized(
+        lm_blocks,
+        (const float *)g_normalized,
+        output_token_id,
+        lm_head_weight_packed, lm_head_scales,
+        lm_hidden_bf16, lm_hidden_packed, lm_hidden_scales, lm_logits_f16,
+        block_max_vals, block_max_idxs,
+        group_size,
+        stream);
+}
+
+extern "C" void launch_decode_many_nvfp4(
+    int *token_buffer, int *output_tokens, int steps,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int position, int max_seq_len, int group_size, cudaStream_t stream)
+{
+    int num_blocks = decode_launch_blocks();
+    int lm_blocks = lm_launch_blocks();
+    for (int step = 0; step < steps; ++step) {
+        launch_decode_step_nvfp4(
+            num_blocks,
+            lm_blocks,
+            token_buffer,
+            token_buffer,
+            embed_weight,
+            layer_weights,
+            final_norm_weight,
+            lm_head_weight_packed,
+            lm_head_scales,
+            lm_hidden_bf16,
+            lm_hidden_packed,
+            lm_hidden_scales,
+            lm_logits_f16,
+            fa_k_cache,
+            fa_v_cache,
+            dn_states,
+            conv_bufs,
+            hidden_buffer,
+            g_activations,
+            g_residual,
+            g_qkv_scratch,
+            g_kv_scratch,
+            g_attn_out,
+            g_mlp_inter,
+            g_z_scratch,
+            g_beta_scratch,
+            g_alpha_scratch,
+            g_normalized,
+            barrier_counter,
+            barrier_generation,
+            block_max_vals,
+            block_max_idxs,
+            lm_sync_counter,
+            position + step,
+            max_seq_len,
+            group_size,
+            stream);
+        cudaMemcpyAsync(
+            output_tokens + step,
+            token_buffer,
+            sizeof(int),
+            cudaMemcpyDeviceToDevice,
+            stream);
+    }
+}

--- a/megakernel/model_nvfp4.py
+++ b/megakernel/model_nvfp4.py
@@ -100,16 +100,15 @@ def _resolve_backend(backend):
 
 
 def _resolve_prefill_mode():
-    # On fork-parent-gb10 only the "raw" mode is wired up: prefill runs via
-    # launch_prefill_megakernel_nvfp4 from prefill_megakernel.cu. The "hybrid"
-    # mode from the upstream gb10 branch would dispatch to prefill_bf16_nvfp4_lm,
-    # which requires the vectorized prefill.cu rewrite that is deferred to a
-    # future PR.
-    mode = os.environ.get("MEGAKERNEL_PREFILL_MODE", "raw")
-    if mode != "raw":
+    # 'hybrid' (default) = bf16 body + NVFP4 LM head via prefill_bf16_nvfp4_lm
+    #   from prefill_bw.cu (Blackwell-only, anonymous-namespaced so it does
+    #   not collide with upstream prefill.cu).
+    # 'raw' = single-dispatch persistent prefill_megakernel_nvfp4 from
+    #   prefill_megakernel.cu.
+    mode = os.environ.get("MEGAKERNEL_PREFILL_MODE", "hybrid")
+    if mode not in ("hybrid", "raw"):
         raise ValueError(
-            f"MEGAKERNEL_PREFILL_MODE={mode!r} is not available in this build; "
-            "only 'raw' (prefill_megakernel_nvfp4) is wired up."
+            f"MEGAKERNEL_PREFILL_MODE={mode!r} is not supported; expected 'hybrid' or 'raw'."
         )
     return mode
 

--- a/megakernel/model_nvfp4.py
+++ b/megakernel/model_nvfp4.py
@@ -1,0 +1,844 @@
+"""Qwen3.5-0.8B Blackwell NVFP4 decode API.
+
+Companion to model.py. The upstream bf16 decoder stays in model.py, unmodified
+from the RTX 3090 reference build; this module is the Blackwell (sm_120 /
+sm_121a DGX Spark) NVFP4 path, dispatching through the decode_nvfp4 and
+prefill_megakernel_nvfp4 torch ops added alongside kernel_gb10_nvfp4.cu and
+prefill_megakernel.cu.
+
+Only importable on Blackwell-class GPUs; only supports backend='nvfp4'.
+"""
+
+import os
+import struct
+import torch
+
+if not torch.cuda.is_available():
+    raise RuntimeError("model_nvfp4 requires CUDA")
+_cap_major, _cap_minor = torch.cuda.get_device_capability()
+if _cap_major < 12:
+    raise RuntimeError(
+        f"model_nvfp4 requires Blackwell (sm_120/sm_121a); detected "
+        f"sm_{_cap_major}{_cap_minor}. Use megakernel.model for sm_86 and earlier."
+    )
+
+
+NUM_LAYERS = 24
+HIDDEN_SIZE = 1024
+INTERMEDIATE_SIZE = 3584
+VOCAB_SIZE = 248320
+MAX_SEQ_LEN = 2048
+
+FA_NUM_Q_HEADS = 8
+FA_NUM_KV_HEADS = 2
+FA_HEAD_DIM = 256
+FA_Q_SIZE = FA_NUM_Q_HEADS * FA_HEAD_DIM
+FA_QPROJ_SIZE = FA_Q_SIZE * 2
+FA_KV_SIZE = FA_NUM_KV_HEADS * FA_HEAD_DIM
+
+DN_NUM_HEADS = 16
+DN_KEY_DIM = 128
+DN_VALUE_DIM = 128
+DN_QK_SIZE = DN_NUM_HEADS * DN_KEY_DIM
+DN_V_SIZE = DN_NUM_HEADS * DN_VALUE_DIM
+DN_CONV_CHANNELS = DN_QK_SIZE * 2 + DN_V_SIZE
+DN_BETA_ALPHA_SIZE = DN_NUM_HEADS * 2
+DN_CONV_KERNEL = 4
+DN_PROJ_FUSED_SIZE = DN_CONV_CHANNELS + DN_V_SIZE + DN_BETA_ALPHA_SIZE
+DN_PROJ_FUSED_PADDED_SIZE = ((DN_PROJ_FUSED_SIZE + 127) // 128) * 128
+PREFILL_PROJ_FUSED_SIZE = max(DN_PROJ_FUSED_PADDED_SIZE, FA_QPROJ_SIZE + 2 * FA_KV_SIZE, INTERMEDIATE_SIZE * 2)
+PREFILL_PROJ_SCRATCH_SIZE = max(DN_CONV_CHANNELS, FA_QPROJ_SIZE, INTERMEDIATE_SIZE)
+NVFP4_TC_ROWS_PER_TILE = 128
+NVFP4_TC_COLS_PER_TILE = 4
+NVFP4_TC_BLOCK_K = 16
+NVFP4_TC_K_PER_TILE = NVFP4_TC_COLS_PER_TILE * NVFP4_TC_BLOCK_K
+
+LAYER_TYPE = [0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1]
+NVFP4_GROUP_SIZE = 32
+NVFP4_LM_GROUP_SIZE = 16
+LM_HEAD_TENSORCORE_N = 16
+LM_HEAD_TENSORCORE_PACKED_BYTES = LM_HEAD_TENSORCORE_N * (HIDDEN_SIZE // 2)
+LM_HEAD_TENSORCORE_SCALE_BYTES = ((LM_HEAD_TENSORCORE_N + 127) // 128) * (HIDDEN_SIZE // 64) * 512
+
+_decode = None
+_decode_nvfp4 = None
+_decode_many_nvfp4 = None
+_prefill_bf16 = None
+_prefill_bf16_nvfp4_lm = None
+_prefill_megakernel_nvfp4 = None
+_quantize_nvfp4_out = None
+_quantize_nvfp4_lm_out = None
+
+
+def _load_op():
+    global _decode, _decode_nvfp4, _decode_many_nvfp4
+    global _prefill_bf16, _prefill_bf16_nvfp4_lm, _prefill_megakernel_nvfp4
+    global _quantize_nvfp4_out, _quantize_nvfp4_lm_out
+    if _decode is None:
+        import qwen35_megakernel_bf16_C
+        ops = torch.ops.qwen35_megakernel_bf16_C
+        _decode = ops.decode
+        _decode_nvfp4 = ops.decode_nvfp4
+        _decode_many_nvfp4 = ops.decode_many_nvfp4
+        _prefill_bf16 = ops.prefill_bf16
+        try:
+            _prefill_bf16_nvfp4_lm = ops.prefill_bf16_nvfp4_lm
+        except AttributeError:
+            _prefill_bf16_nvfp4_lm = None
+        _prefill_megakernel_nvfp4 = ops.prefill_megakernel_nvfp4
+        _quantize_nvfp4_out = ops.quantize_nvfp4_out
+        _quantize_nvfp4_lm_out = ops.quantize_nvfp4_lm_out
+
+
+def _resolve_backend(backend):
+    if backend in (None, "auto", "nvfp4"):
+        return "nvfp4"
+    raise ValueError(
+        f"model_nvfp4 only supports backend='nvfp4' (got {backend!r}); "
+        "use megakernel.model for bf16."
+    )
+
+
+def _resolve_prefill_mode():
+    # On fork-parent-gb10 only the "raw" mode is wired up: prefill runs via
+    # launch_prefill_megakernel_nvfp4 from prefill_megakernel.cu. The "hybrid"
+    # mode from the upstream gb10 branch would dispatch to prefill_bf16_nvfp4_lm,
+    # which requires the vectorized prefill.cu rewrite that is deferred to a
+    # future PR.
+    mode = os.environ.get("MEGAKERNEL_PREFILL_MODE", "raw")
+    if mode != "raw":
+        raise ValueError(
+            f"MEGAKERNEL_PREFILL_MODE={mode!r} is not available in this build; "
+            "only 'raw' (prefill_megakernel_nvfp4) is wired up."
+        )
+    return mode
+
+
+def _resolve_prefill_graph():
+    value = os.environ.get("MEGAKERNEL_PREFILL_GRAPH", "1").strip().lower()
+    return value not in ("0", "false", "no", "off")
+
+
+def _resolve_prefill_tc():
+    value = os.environ.get("MEGAKERNEL_PREFILL_TC", "0").strip().lower()
+    return value not in ("0", "false", "no", "off")
+
+
+def _quantize_matrix_nvfp4(weight, group_size):
+    _load_op()
+    if weight.dtype != torch.bfloat16:
+        raise TypeError(f"expected bfloat16 weight, got {weight.dtype}")
+    if weight.dim() != 2:
+        raise ValueError(f"expected 2D weight, got shape {tuple(weight.shape)}")
+
+    rows, cols = weight.shape
+    if cols % 2 != 0 or cols % group_size != 0:
+        raise ValueError(f"in_dim {cols} must be divisible by 2 and group_size {group_size}")
+
+    packed = torch.empty((rows, cols // 2), dtype=torch.uint8, device=weight.device)
+    scales = torch.empty((rows, cols // group_size), dtype=torch.float16, device=weight.device)
+    _quantize_nvfp4_out(packed, scales, weight.contiguous(), group_size)
+    return {"packed": packed, "scales": scales}
+
+
+def _quantize_matrix_nvfp4_lm(weight):
+    _load_op()
+    if weight.dtype != torch.bfloat16:
+        raise TypeError(f"expected bfloat16 weight, got {weight.dtype}")
+    if weight.dim() != 2:
+        raise ValueError(f"expected 2D weight, got shape {tuple(weight.shape)}")
+
+    rows, cols = weight.shape
+    if rows % 128 != 0:
+        raise ValueError(f"lm_head out_dim {rows} must be divisible by 128")
+    if cols % 64 != 0:
+        raise ValueError(f"lm_head in_dim {cols} must be divisible by 64")
+
+    scale_tiles = cols // 64
+    packed = torch.empty((rows, cols // 2), dtype=torch.uint8, device=weight.device)
+    scales = torch.empty((rows // 128) * scale_tiles * 512, dtype=torch.uint8, device=weight.device)
+    _quantize_nvfp4_lm_out(packed, scales, weight.contiguous())
+    return {"packed": packed, "scales": scales}
+
+
+def _quantize_matrix_nvfp4_tc(weight, padded_rows=None):
+    _load_op()
+    if weight.dtype != torch.bfloat16:
+        raise TypeError(f"expected bfloat16 weight, got {weight.dtype}")
+    if weight.dim() != 2:
+        raise ValueError(f"expected 2D weight, got shape {tuple(weight.shape)}")
+
+    rows, cols = weight.shape
+    if cols % NVFP4_TC_K_PER_TILE != 0:
+        raise ValueError(f"in_dim {cols} must be divisible by {NVFP4_TC_K_PER_TILE}")
+
+    if padded_rows is None:
+        padded_rows = ((rows + NVFP4_TC_ROWS_PER_TILE - 1) // NVFP4_TC_ROWS_PER_TILE) * NVFP4_TC_ROWS_PER_TILE
+    if padded_rows < rows:
+        raise ValueError(f"padded_rows {padded_rows} must be >= rows {rows}")
+
+    if padded_rows != rows:
+        padded = torch.zeros((padded_rows, cols), dtype=weight.dtype, device=weight.device)
+        padded[:rows].copy_(weight)
+        source = padded
+    else:
+        source = weight.contiguous()
+
+    packed = torch.empty((padded_rows, cols // 2), dtype=torch.uint8, device=weight.device)
+    scale_tiles = cols // NVFP4_TC_K_PER_TILE
+    scales = torch.zeros(
+        ((padded_rows + NVFP4_TC_ROWS_PER_TILE - 1) // NVFP4_TC_ROWS_PER_TILE) * scale_tiles * 512,
+        dtype=torch.uint8,
+        device=weight.device,
+    )
+    _quantize_nvfp4_lm_out(packed, scales, source)
+    return {"packed": packed, "scales": scales, "rows": rows, "padded_rows": padded_rows}
+
+
+def _attach_prefill_fused_weights(weights):
+    if "prefill_fused_layer_data" in weights:
+        return
+
+    fused_layer_data = []
+    for ld in weights["layer_data"]:
+        ptrs = ld["ptrs"]
+        if ld["type"] == 1:
+            proj_weight = torch.cat([ptrs[1], ptrs[2], ptrs[3]], dim=0).contiguous()
+            gate_up_weight = torch.cat([ptrs[8], ptrs[9]], dim=0).contiguous()
+        else:
+            proj_weight = torch.cat([ptrs[1], ptrs[2], ptrs[3], ptrs[4]], dim=0).contiguous()
+            gate_up_weight = torch.cat([ptrs[11], ptrs[12]], dim=0).contiguous()
+        fused_layer_data.append({
+            "proj_weight": proj_weight,
+            "gate_up_weight": gate_up_weight,
+        })
+
+    weights["prefill_fused_layer_data"] = fused_layer_data
+
+
+def _attach_prefill_nvfp4_weights(weights, verbose=True):
+    _attach_prefill_fused_weights(weights)
+
+    fused_layer_data = weights["prefill_fused_layer_data"]
+    if fused_layer_data and "proj_weight_packed" in fused_layer_data[0]:
+        return
+
+    if verbose:
+        print("Quantizing prompt fused weights to NVFP4 tensor-core format...")
+
+    packed_bytes = 0
+    scale_bytes = 0
+    for i, ld in enumerate(weights["layer_data"]):
+        fused = fused_layer_data[i]
+        proj_padded_rows = DN_PROJ_FUSED_PADDED_SIZE if ld["type"] == 0 else fused["proj_weight"].shape[0]
+        proj_q = _quantize_matrix_nvfp4_tc(fused["proj_weight"], padded_rows=proj_padded_rows)
+        gate_up_q = _quantize_matrix_nvfp4_tc(fused["gate_up_weight"])
+        fused["proj_weight_packed"] = proj_q["packed"]
+        fused["proj_weight_scales"] = proj_q["scales"]
+        fused["gate_up_weight_packed"] = gate_up_q["packed"]
+        fused["gate_up_weight_scales"] = gate_up_q["scales"]
+        packed_bytes += proj_q["packed"].numel() + gate_up_q["packed"].numel()
+        scale_bytes += proj_q["scales"].numel() + gate_up_q["scales"].numel()
+
+    if verbose:
+        print(
+            f"NVFP4 prompt fused weights: {packed_bytes/1e6:.0f} MB packed + "
+            f"{scale_bytes/1e6:.0f} MB scales ({(packed_bytes + scale_bytes)/1e6:.0f} MB total)"
+        )
+
+
+def _attach_nvfp4_weights(weights, group_size=NVFP4_GROUP_SIZE, verbose=True):
+    if (
+        "nvfp4" in weights
+        and weights["nvfp4"]["group_size"] == group_size
+        and weights["nvfp4"].get("lm_group_size") == NVFP4_LM_GROUP_SIZE
+    ):
+        return weights
+
+    if verbose:
+        print(f"Quantizing decode hot weights to NVFP4 (group_size={group_size})...")
+
+    layer_data_nvfp4 = []
+    packed_bytes = 0
+    scale_bytes = 0
+
+    for ld in weights["layer_data"]:
+        if ld["type"] == 1:
+            q_proj = _quantize_matrix_nvfp4(ld["ptrs"][1], group_size)
+            k_proj = _quantize_matrix_nvfp4(ld["ptrs"][2], group_size)
+            v_proj = _quantize_matrix_nvfp4(ld["ptrs"][3], group_size)
+            o_proj = _quantize_matrix_nvfp4(ld["ptrs"][6], group_size)
+            gate_proj = _quantize_matrix_nvfp4(ld["ptrs"][8], group_size)
+            up_proj = _quantize_matrix_nvfp4(ld["ptrs"][9], group_size)
+            down_proj = _quantize_matrix_nvfp4(ld["ptrs"][10], group_size)
+            qptrs = [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+            layer_data_nvfp4.append({
+                "type": 1,
+                "ptrs": [
+                    ld["ptrs"][0],
+                    q_proj["packed"], q_proj["scales"],
+                    k_proj["packed"], k_proj["scales"],
+                    v_proj["packed"], v_proj["scales"],
+                    ld["ptrs"][4], ld["ptrs"][5],
+                    o_proj["packed"], o_proj["scales"],
+                    ld["ptrs"][7],
+                    gate_proj["packed"], gate_proj["scales"],
+                    up_proj["packed"], up_proj["scales"],
+                    down_proj["packed"], down_proj["scales"],
+                ],
+                "quantized": qptrs,
+            })
+        else:
+            qkv_proj = _quantize_matrix_nvfp4(ld["ptrs"][1], group_size)
+            z_proj = _quantize_matrix_nvfp4(ld["ptrs"][2], group_size)
+            out_proj = _quantize_matrix_nvfp4(ld["ptrs"][9], group_size)
+            gate_proj = _quantize_matrix_nvfp4(ld["ptrs"][11], group_size)
+            up_proj = _quantize_matrix_nvfp4(ld["ptrs"][12], group_size)
+            down_proj = _quantize_matrix_nvfp4(ld["ptrs"][13], group_size)
+            qptrs = [qkv_proj, z_proj, out_proj, gate_proj, up_proj, down_proj]
+            layer_data_nvfp4.append({
+                "type": 0,
+                "ptrs": [
+                    ld["ptrs"][0],
+                    qkv_proj["packed"], qkv_proj["scales"],
+                    z_proj["packed"], z_proj["scales"],
+                    ld["ptrs"][3], ld["ptrs"][4], ld["ptrs"][5], ld["ptrs"][6], ld["ptrs"][7], ld["ptrs"][8],
+                    out_proj["packed"], out_proj["scales"],
+                    ld["ptrs"][10],
+                    gate_proj["packed"], gate_proj["scales"],
+                    up_proj["packed"], up_proj["scales"],
+                    down_proj["packed"], down_proj["scales"],
+                ],
+                "quantized": qptrs,
+            })
+
+        for q in qptrs:
+            packed_bytes += q["packed"].numel() * q["packed"].element_size()
+            scale_bytes += q["scales"].numel() * q["scales"].element_size()
+
+    lm_head_nvfp4 = _quantize_matrix_nvfp4_lm(weights["lm_head_weight"])
+    packed_bytes += lm_head_nvfp4["packed"].numel() * lm_head_nvfp4["packed"].element_size()
+    scale_bytes += lm_head_nvfp4["scales"].numel() * lm_head_nvfp4["scales"].element_size()
+
+    weights["nvfp4"] = {
+        "group_size": group_size,
+        "lm_group_size": NVFP4_LM_GROUP_SIZE,
+        "layer_data": layer_data_nvfp4,
+        "lm_head_weight_packed": lm_head_nvfp4["packed"],
+        "lm_head_scales": lm_head_nvfp4["scales"],
+    }
+
+    if verbose:
+        total_mb = (packed_bytes + scale_bytes) / 1e6
+        print(
+            f"NVFP4 decode weights: {packed_bytes/1e6:.0f} MB packed + "
+            f"{scale_bytes/1e6:.0f} MB scales ({total_mb:.0f} MB total)"
+        )
+
+    return weights
+
+
+def load_weights(
+    model_name="Qwen/Qwen3.5-0.8B",
+    verbose=True,
+    backend="bf16",
+    nvfp4_group_size=NVFP4_GROUP_SIZE,
+):
+    """Load Qwen3.5-0.8B weights and optional GB10 NVFP4 decode weights."""
+    if not verbose:
+        os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+        os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    resolved_backend = _resolve_backend(backend)
+
+    if verbose:
+        print(f"Loading {model_name} (bf16)...")
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name, dtype=torch.bfloat16, device_map="cuda"
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    state = model.state_dict()
+
+    layer_data = []
+    for i in range(NUM_LAYERS):
+        p = f"model.layers.{i}."
+        lt = LAYER_TYPE[i]
+
+        if lt == 1:
+            # Full Attention: 11 pointers (all bf16)
+            layer_data.append({
+                "type": 1,
+                "ptrs": [
+                    state[p + "input_layernorm.weight"].contiguous(),
+                    state[p + "self_attn.q_proj.weight"].contiguous(),
+                    state[p + "self_attn.k_proj.weight"].contiguous(),
+                    state[p + "self_attn.v_proj.weight"].contiguous(),
+                    state[p + "self_attn.q_norm.weight"].contiguous(),
+                    state[p + "self_attn.k_norm.weight"].contiguous(),
+                    state[p + "self_attn.o_proj.weight"].contiguous(),
+                    state[p + "post_attention_layernorm.weight"].contiguous(),
+                    state[p + "mlp.gate_proj.weight"].contiguous(),
+                    state[p + "mlp.up_proj.weight"].contiguous(),
+                    state[p + "mlp.down_proj.weight"].contiguous(),
+                ]
+            })
+        else:
+            # DeltaNet: 14 pointers (all bf16)
+            layer_data.append({
+                "type": 0,
+                "ptrs": [
+                    state[p + "input_layernorm.weight"].contiguous(),
+                    state[p + "linear_attn.in_proj_qkv.weight"].contiguous(),
+                    state[p + "linear_attn.in_proj_z.weight"].contiguous(),
+                    state[p + "linear_attn.in_proj_b.weight"].contiguous(),
+                    state[p + "linear_attn.in_proj_a.weight"].contiguous(),
+                    state[p + "linear_attn.conv1d.weight"].contiguous(),
+                    state[p + "linear_attn.A_log"].contiguous(),
+                    state[p + "linear_attn.dt_bias"].contiguous(),
+                    state[p + "linear_attn.norm.weight"].contiguous(),
+                    state[p + "linear_attn.out_proj.weight"].contiguous(),
+                    state[p + "post_attention_layernorm.weight"].contiguous(),
+                    state[p + "mlp.gate_proj.weight"].contiguous(),
+                    state[p + "mlp.up_proj.weight"].contiguous(),
+                    state[p + "mlp.down_proj.weight"].contiguous(),
+                ]
+            })
+
+    embed_weight = state["model.embed_tokens.weight"].contiguous()
+    final_norm_weight = state["model.norm.weight"].contiguous()
+    lm_head = state.get("lm_head.weight", embed_weight).contiguous()
+
+    weights = {
+        "embed_weight": embed_weight,
+        "final_norm_weight": final_norm_weight,
+        "lm_head_weight": lm_head,
+        "layer_data": layer_data,
+    }
+
+    del model
+    torch.cuda.empty_cache()
+
+    if verbose:
+        total = sum(sum(t.numel() for t in ld["ptrs"]) for ld in layer_data) + lm_head.numel()
+        print(f"BF16 weights: {total/1e6:.1f}M params ({total*2/1e6:.0f} MB)")
+
+    _attach_prefill_fused_weights(weights)
+
+    if resolved_backend == "nvfp4":
+        _attach_nvfp4_weights(weights, group_size=nvfp4_group_size, verbose=verbose)
+        if _resolve_prefill_tc():
+            _attach_prefill_nvfp4_weights(weights, verbose=verbose)
+
+    return weights, tokenizer
+
+
+def _pack_layer_weights(layer_data):
+    """Pack layer weights into device blob matching LayerWeights struct."""
+    ptr_size = 8
+    max_ptrs = 14
+    header_size = 16
+    struct_size = header_size + max_ptrs * ptr_size  # 128
+
+    buf = bytearray(NUM_LAYERS * struct_size)
+    for i in range(NUM_LAYERS):
+        ld = layer_data[i]
+        offset = i * struct_size
+        struct.pack_into("iiii", buf, offset, ld["type"], 0, 0, 0)
+        for j, tensor in enumerate(ld["ptrs"]):
+            struct.pack_into("Q", buf, offset + header_size + j * ptr_size, tensor.data_ptr())
+        for j in range(len(ld["ptrs"]), max_ptrs):
+            struct.pack_into("Q", buf, offset + header_size + j * ptr_size, 0)
+
+    return torch.frombuffer(buf, dtype=torch.uint8).cuda()
+
+
+def _pack_layer_weights_nvfp4(layer_data, group_size):
+    """Pack layer weights into device blob matching LayerWeightsNVFP4 struct."""
+    ptr_size = 8
+    max_ptrs = 24
+    header_size = 16
+    struct_size = header_size + max_ptrs * ptr_size
+
+    buf = bytearray(NUM_LAYERS * struct_size)
+    for i in range(NUM_LAYERS):
+        ld = layer_data[i]
+        offset = i * struct_size
+        struct.pack_into("iiii", buf, offset, ld["type"], group_size, 0, 0)
+        for j, tensor in enumerate(ld["ptrs"]):
+            struct.pack_into("Q", buf, offset + header_size + j * ptr_size, tensor.data_ptr())
+        for j in range(len(ld["ptrs"]), max_ptrs):
+            struct.pack_into("Q", buf, offset + header_size + j * ptr_size, 0)
+
+    return torch.frombuffer(buf, dtype=torch.uint8).cuda()
+
+
+def _pack_prefill_fused_layer_weights(fused_layer_data):
+    ptr_size = 8
+    fields = 6
+    struct_size = ptr_size * fields
+
+    buf = bytearray(NUM_LAYERS * struct_size)
+    for i in range(NUM_LAYERS):
+        ld = fused_layer_data[i]
+        offset = i * struct_size
+        proj_weight_packed = ld.get("proj_weight_packed")
+        proj_weight_scales = ld.get("proj_weight_scales")
+        gate_up_weight_packed = ld.get("gate_up_weight_packed")
+        gate_up_weight_scales = ld.get("gate_up_weight_scales")
+        struct.pack_into("Q", buf, offset, ld["proj_weight"].data_ptr())
+        struct.pack_into("Q", buf, offset + ptr_size, ld["gate_up_weight"].data_ptr())
+        struct.pack_into("Q", buf, offset + 2 * ptr_size, proj_weight_packed.data_ptr() if proj_weight_packed is not None else 0)
+        struct.pack_into("Q", buf, offset + 3 * ptr_size, proj_weight_scales.data_ptr() if proj_weight_scales is not None else 0)
+        struct.pack_into("Q", buf, offset + 4 * ptr_size, gate_up_weight_packed.data_ptr() if gate_up_weight_packed is not None else 0)
+        struct.pack_into("Q", buf, offset + 5 * ptr_size, gate_up_weight_scales.data_ptr() if gate_up_weight_scales is not None else 0)
+
+    return torch.frombuffer(buf, dtype=torch.uint8).cuda()
+
+
+class Decoder:
+    """Stateful decoder for Qwen3.5-0.8B megakernel backends."""
+
+    def __init__(
+        self,
+        weights=None,
+        tokenizer=None,
+        model_name="Qwen/Qwen3.5-0.8B",
+        backend="auto",
+        nvfp4_group_size=NVFP4_GROUP_SIZE,
+        verbose=True,
+    ):
+        _load_op()
+        self.backend = _resolve_backend(backend)
+        self.backend_label = "NVFP4 decode" if self.backend == "nvfp4" else "BF16"
+        self._nvfp4_group_size = nvfp4_group_size
+        self._prefill_mode = _resolve_prefill_mode()
+        self._prefill_graph_enabled = (
+            self.backend == "nvfp4"
+            and self._prefill_mode == "hybrid"
+            and _resolve_prefill_graph()
+        )
+
+        if weights is None:
+            weights, tokenizer = load_weights(
+                model_name,
+                verbose=verbose,
+                backend=self.backend,
+                nvfp4_group_size=nvfp4_group_size,
+            )
+        elif self.backend == "nvfp4":
+            _attach_nvfp4_weights(weights, group_size=nvfp4_group_size, verbose=verbose)
+            if _resolve_prefill_tc():
+                _attach_prefill_nvfp4_weights(weights, verbose=verbose)
+        _attach_prefill_fused_weights(weights)
+        self.tokenizer = tokenizer
+        self._position = 0
+        self._weights = weights
+        self._embed_weight = weights["embed_weight"]
+        self._final_norm_weight = weights["final_norm_weight"]
+        self._lm_head_weight = weights["lm_head_weight"]
+        self._layer_weights_packed = _pack_layer_weights(weights["layer_data"])
+        self._prefill_fused_weights_packed = _pack_prefill_fused_layer_weights(
+            weights["prefill_fused_layer_data"]
+        )
+        self._layer_weights_packed_nvfp4 = None
+        self._lm_head_weight_packed = None
+        self._lm_head_scales = None
+        if self.backend == "nvfp4":
+            nvfp4 = weights["nvfp4"]
+            self._layer_weights_packed_nvfp4 = _pack_layer_weights_nvfp4(
+                nvfp4["layer_data"], nvfp4["group_size"])
+            self._lm_head_weight_packed = nvfp4["lm_head_weight_packed"]
+            self._lm_head_scales = nvfp4["lm_head_scales"]
+
+        bf16 = dict(dtype=torch.bfloat16, device="cuda")
+        f16 = dict(dtype=torch.float16, device="cuda")
+        f32 = dict(dtype=torch.float32, device="cuda")
+        i32 = dict(dtype=torch.int32, device="cuda")
+        u32 = dict(dtype=torch.uint32, device="cuda")
+
+        n_fa = sum(1 for t in LAYER_TYPE if t == 1)
+        self._fa_k_cache = torch.zeros(n_fa, FA_NUM_KV_HEADS, MAX_SEQ_LEN, FA_HEAD_DIM, **bf16)
+        self._fa_v_cache = torch.zeros_like(self._fa_k_cache)
+
+        n_dn = sum(1 for t in LAYER_TYPE if t == 0)
+        self._dn_states = torch.zeros(n_dn, DN_NUM_HEADS, DN_KEY_DIM, DN_VALUE_DIM, **f32)
+        self._conv_bufs = torch.zeros(n_dn, DN_CONV_CHANNELS, DN_CONV_KERNEL, **f32)
+
+        self._hidden = torch.empty(HIDDEN_SIZE, **bf16)
+        max_scratch = max(FA_QPROJ_SIZE, DN_CONV_CHANNELS, HIDDEN_SIZE * 8 + INTERMEDIATE_SIZE)
+        self._activations = torch.empty(max_scratch, **f32)
+        self._residual = torch.empty(HIDDEN_SIZE, **bf16)
+        self._qkv_scratch = torch.empty(max(FA_QPROJ_SIZE, DN_CONV_CHANNELS), **f32)
+        self._kv_scratch = torch.empty(FA_KV_SIZE * 2, **f32)
+        self._attn_out = torch.empty(max(FA_Q_SIZE, DN_V_SIZE), **f32)
+        self._mlp_inter = torch.empty(INTERMEDIATE_SIZE, **f32)
+        self._z_scratch = torch.empty(DN_V_SIZE, **f32)
+        self._beta_scratch = torch.empty(DN_NUM_HEADS, **f32)
+        self._alpha_scratch = torch.empty(DN_NUM_HEADS, **f32)
+        self._normalized = torch.empty(HIDDEN_SIZE, **f32)
+        self._lm_hidden_bf16 = torch.empty((LM_HEAD_TENSORCORE_N, HIDDEN_SIZE), **bf16)
+        self._lm_hidden_packed = torch.empty(LM_HEAD_TENSORCORE_PACKED_BYTES, dtype=torch.uint8, device="cuda")
+        self._lm_hidden_scales = torch.empty(LM_HEAD_TENSORCORE_SCALE_BYTES, dtype=torch.uint8, device="cuda")
+        self._lm_logits_f16 = torch.empty((LM_HEAD_TENSORCORE_N, VOCAB_SIZE), **f16)
+
+        self._barrier_counter = torch.zeros(1, **u32)
+        self._barrier_generation = torch.zeros(1, **u32)
+        self._block_max_vals = torch.empty(1024, **f32)
+        self._block_max_idxs = torch.empty(1024, **i32)
+        self._lm_sync_counter = torch.zeros(1, **u32)
+        self._out_token = torch.empty(1, **i32)
+        self._prefill_buffers = None
+        self._prefill_buffer_tokens = 0
+        self._prefill_graph_cache = {}
+
+    def _ensure_prefill_buffers(self, max_tokens: int):
+        if self._prefill_buffers is not None and self._prefill_buffer_tokens >= max_tokens:
+            return self._prefill_buffers
+
+        bf16 = dict(dtype=torch.bfloat16, device="cuda")
+        f32 = dict(dtype=torch.float32, device="cuda")
+        i32 = dict(dtype=torch.int32, device="cuda")
+        self._prefill_buffers = dict(
+            hidden=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+            residual=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+            normalized=torch.empty(max_tokens * HIDDEN_SIZE, **bf16),
+            proj_buf=torch.empty(max_tokens * PREFILL_PROJ_FUSED_SIZE, **bf16),
+            proj_buf2=torch.empty(max_tokens * PREFILL_PROJ_SCRATCH_SIZE, **bf16),
+            proj_buf_half=torch.empty(max_tokens * PREFILL_PROJ_FUSED_SIZE, dtype=torch.float16, device="cuda"),
+            proj_act_packed=torch.empty(max_tokens * (HIDDEN_SIZE // 2), dtype=torch.uint8, device="cuda"),
+            proj_act_scales=torch.empty(
+                ((max_tokens + NVFP4_TC_ROWS_PER_TILE - 1) // NVFP4_TC_ROWS_PER_TILE)
+                * (HIDDEN_SIZE // NVFP4_TC_K_PER_TILE)
+                * 512,
+                dtype=torch.uint8,
+                device="cuda",
+            ),
+            attn_buf=torch.empty(max_tokens * max(FA_Q_SIZE, FA_KV_SIZE), **bf16),
+            mlp_buf=torch.empty(max_tokens * INTERMEDIATE_SIZE, **bf16),
+            dn_out_buf=torch.empty(max_tokens * DN_V_SIZE, **bf16),
+            beta_buf=torch.empty(max_tokens * DN_NUM_HEADS, **f32),
+            alpha_buf=torch.empty(max_tokens * DN_NUM_HEADS, **f32),
+            final_normed=torch.empty(HIDDEN_SIZE, **bf16),
+            hidden_bf16_out=torch.empty(HIDDEN_SIZE, **bf16),
+            lm_bmv=torch.empty(1024, **f32),
+            lm_bmi=torch.empty(1024, **i32),
+        )
+        self._prefill_buffer_tokens = max_tokens
+        return self._prefill_buffers
+
+    def _reset_runtime_state(self):
+        self._position = 0
+        self._fa_k_cache.zero_()
+        self._fa_v_cache.zero_()
+        self._dn_states.zero_()
+        self._conv_bufs.zero_()
+
+    def _run_prefill_bf16_nvfp4_lm(self, token_ids: torch.Tensor, buffers):
+        _prefill_bf16_nvfp4_lm(
+            self._out_token,
+            token_ids,
+            self._embed_weight,
+            self._layer_weights_packed,
+            self._prefill_fused_weights_packed,
+            self._final_norm_weight,
+            self._lm_head_weight,
+            self._lm_head_weight_packed,
+            self._lm_head_scales,
+            self._fa_k_cache,
+            self._fa_v_cache,
+            self._dn_states,
+            self._conv_bufs,
+            buffers["hidden"],
+            buffers["residual"],
+            buffers["normalized"],
+            buffers["proj_buf"],
+            buffers["proj_buf2"],
+            buffers["proj_buf_half"],
+            buffers["proj_act_packed"],
+            buffers["proj_act_scales"],
+            buffers["attn_buf"],
+            buffers["mlp_buf"],
+            buffers["dn_out_buf"],
+            buffers["beta_buf"],
+            buffers["alpha_buf"],
+            buffers["final_normed"],
+            buffers["hidden_bf16_out"],
+            buffers["lm_bmv"],
+            buffers["lm_bmi"],
+            self._lm_hidden_bf16,
+            self._lm_hidden_packed,
+            self._lm_hidden_scales,
+            self._lm_logits_f16,
+        )
+        self._hidden.copy_(buffers["hidden_bf16_out"])
+
+    def _build_prefill_graph(self, prompt_len: int):
+        buffers = self._ensure_prefill_buffers(prompt_len)
+        static_ids = torch.empty(prompt_len, dtype=torch.int32, device="cuda")
+        warmup_stream = torch.cuda.Stream()
+        graph = torch.cuda.CUDAGraph()
+
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            self._reset_runtime_state()
+            static_ids.zero_()
+            self._run_prefill_bf16_nvfp4_lm(static_ids, buffers)
+        warmup_stream.synchronize()
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+
+        with torch.cuda.graph(graph):
+            self._reset_runtime_state()
+            self._run_prefill_bf16_nvfp4_lm(static_ids, buffers)
+
+        state = {"graph": graph, "token_ids": static_ids, "buffers": buffers}
+        self._prefill_graph_cache[prompt_len] = state
+        return state
+
+    def _prefill_graph_state(self, prompt_len: int):
+        state = self._prefill_graph_cache.get(prompt_len)
+        if state is None:
+            state = self._build_prefill_graph(prompt_len)
+        return state
+
+    def step(self, token_id: int) -> int:
+        """Decode one token. Returns next token id."""
+        if self.backend == "nvfp4":
+            _decode_nvfp4(
+                self._out_token, token_id,
+                self._embed_weight, self._layer_weights_packed_nvfp4,
+                self._final_norm_weight, self._lm_head_weight_packed, self._lm_head_scales,
+                self._lm_hidden_bf16, self._lm_hidden_packed, self._lm_hidden_scales, self._lm_logits_f16,
+                self._fa_k_cache, self._fa_v_cache,
+                self._dn_states, self._conv_bufs,
+                self._hidden, self._activations, self._residual,
+                self._qkv_scratch, self._kv_scratch, self._attn_out,
+                self._mlp_inter, self._z_scratch, self._beta_scratch,
+                self._alpha_scratch, self._normalized,
+                self._barrier_counter, self._barrier_generation,
+                self._block_max_vals, self._block_max_idxs,
+                self._lm_sync_counter,
+                self._position, MAX_SEQ_LEN, self._nvfp4_group_size,
+            )
+        else:
+            _decode(
+                self._out_token, token_id,
+                self._embed_weight, self._layer_weights_packed,
+                self._final_norm_weight, self._lm_head_weight,
+                self._fa_k_cache, self._fa_v_cache,
+                self._dn_states, self._conv_bufs,
+                self._hidden, self._activations, self._residual,
+                self._qkv_scratch, self._kv_scratch, self._attn_out,
+                self._mlp_inter, self._z_scratch, self._beta_scratch,
+                self._alpha_scratch, self._normalized,
+                self._barrier_counter, self._barrier_generation,
+                self._block_max_vals, self._block_max_idxs,
+                self._lm_sync_counter,
+                self._position, MAX_SEQ_LEN,
+            )
+        self._position += 1
+        return self._out_token.item()
+
+    def step_many(self, token_id: int, num_steps: int) -> torch.Tensor:
+        """Decode multiple NVFP4 steps without per-token host/device synchronization."""
+        if self.backend != "nvfp4":
+            raise RuntimeError("step_many is only available for the NVFP4 backend")
+        if num_steps < 0:
+            raise ValueError("num_steps must be non-negative")
+        if num_steps == 0:
+            return torch.empty(0, dtype=torch.int32, device="cuda")
+
+        output_tokens = torch.empty(num_steps, dtype=torch.int32, device="cuda")
+        _decode_many_nvfp4(
+            output_tokens, self._out_token, token_id,
+            self._embed_weight, self._layer_weights_packed_nvfp4,
+            self._final_norm_weight, self._lm_head_weight_packed, self._lm_head_scales,
+            self._lm_hidden_bf16, self._lm_hidden_packed, self._lm_hidden_scales, self._lm_logits_f16,
+            self._fa_k_cache, self._fa_v_cache,
+            self._dn_states, self._conv_bufs,
+            self._hidden, self._activations, self._residual,
+            self._qkv_scratch, self._kv_scratch, self._attn_out,
+            self._mlp_inter, self._z_scratch, self._beta_scratch,
+            self._alpha_scratch, self._normalized,
+            self._barrier_counter, self._barrier_generation,
+            self._block_max_vals, self._block_max_idxs,
+            self._lm_sync_counter,
+            self._position, MAX_SEQ_LEN, self._nvfp4_group_size,
+        )
+        self._position += num_steps
+        return output_tokens
+
+    def prefill_tokens(self, token_ids: torch.Tensor) -> int:
+        """Run prompt prefill and return the first generated token id."""
+        if token_ids.device.type != "cuda" or token_ids.dtype != torch.int32 or token_ids.dim() != 1:
+            raise TypeError("token_ids must be a 1D CUDA int32 tensor")
+        prompt_len = int(token_ids.numel())
+        if self.backend == "nvfp4" and self._prefill_mode == "raw":
+            self.reset()
+            _prefill_megakernel_nvfp4(
+                self._out_token,
+                token_ids,
+                self._embed_weight,
+                self._layer_weights_packed_nvfp4,
+                self._final_norm_weight,
+                self._lm_head_weight_packed,
+                self._lm_head_scales,
+                self._lm_hidden_bf16,
+                self._lm_hidden_packed,
+                self._lm_hidden_scales,
+                self._lm_logits_f16,
+                self._fa_k_cache,
+                self._fa_v_cache,
+                self._dn_states,
+                self._conv_bufs,
+                self._hidden,
+                self._activations,
+                self._residual,
+                self._qkv_scratch,
+                self._kv_scratch,
+                self._attn_out,
+                self._mlp_inter,
+                self._z_scratch,
+                self._beta_scratch,
+                self._alpha_scratch,
+                self._normalized,
+                self._barrier_counter,
+                self._barrier_generation,
+                self._block_max_vals,
+                self._block_max_idxs,
+                self._lm_sync_counter,
+                MAX_SEQ_LEN,
+                self._nvfp4_group_size,
+            )
+        elif self.backend == "nvfp4":
+            if self._prefill_graph_enabled:
+                state = self._prefill_graph_state(prompt_len)
+                state["token_ids"].copy_(token_ids)
+                state["graph"].replay()
+            else:
+                self.reset()
+                buffers = self._ensure_prefill_buffers(prompt_len)
+                self._run_prefill_bf16_nvfp4_lm(token_ids, buffers)
+        else:
+            raise RuntimeError("prefill_tokens megakernel path is only implemented for the NVFP4 backend")
+        self._position = prompt_len
+        return self._out_token.item()
+
+    def reset(self):
+        self._reset_runtime_state()
+
+    def generate(self, prompt: str, max_tokens: int = 100) -> str:
+        self.reset()
+        ids = self.tokenizer.encode(prompt, add_special_tokens=True)
+        for tid in ids[:-1]:
+            self.step(tid)
+        out = []
+        next_id = ids[-1]
+        eos = self.tokenizer.eos_token_id
+        for _ in range(max_tokens):
+            next_id = self.step(next_id)
+            if next_id == eos:
+                break
+            out.append(next_id)
+        return self.tokenizer.decode(out, skip_special_tokens=True)

--- a/megakernel/prefill_bw.cu
+++ b/megakernel/prefill_bw.cu
@@ -1,0 +1,1521 @@
+/**
+ * BF16 prefill (Blackwell-only) — vectorized bf16 kernels + bf16 body
+ * with optional NVFP4 LM head. Companion to upstream prefill.cu, which is
+ * compiled and exposed unchanged on every arch. This file is only compiled
+ * for sm_120+ (see setup.py) so its symbols never reach the sm_86 build.
+ *
+ * Internal helpers and __global__ kernels live in an anonymous namespace
+ * so their names (pf_rmsnorm, pf_attention, ...) coexist with upstream's
+ * versions in the same .so without ODR violation. Only the new
+ * launch_prefill_bf16_nvfp4_lm entry point is exposed with extern "C" linkage.
+ */
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 1200
+#error "prefill_bw.cu requires CUDA arch >= sm_120 (Blackwell)"
+#endif
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#ifndef PREFILL_DN_BLOCK_SIZE
+#define PREFILL_DN_BLOCK_SIZE 128
+#endif
+
+#ifndef PREFILL_DN_BLOCKS_PER_HEAD
+#define PREFILL_DN_BLOCKS_PER_HEAD 8
+#endif
+
+#ifndef PREFILL_FA_BLOCK_SIZE
+#define PREFILL_FA_BLOCK_SIZE 256
+#endif
+
+
+// ===== Cross-TU forward declarations — defined in kernel_gb10_nvfp4.cu =====
+
+extern "C" bool launch_lm_head_cublaslt_bf16_top1(
+    const void *hidden_bf16,
+    const void *lm_head_weight_packed,
+    const void *lm_head_scales,
+    void *lm_hidden_bf16,
+    void *lm_hidden_packed,
+    void *lm_hidden_scales,
+    void *lm_logits_f16,
+    float *block_max_vals,
+    int *block_max_idxs,
+    int *output_token_id,
+    cudaStream_t stream);
+
+extern "C" void launch_quantize_nvfp4_lm_out(
+    const void *weight, int rows, int cols,
+    void *packed_out, void *scales_out, cudaStream_t stream);
+
+namespace {
+
+constexpr int HIDDEN = 1024;
+constexpr int INTER = 3584;
+constexpr int VOCAB = 248320;
+constexpr float RMS_EPS = 1e-6f;
+
+constexpr int FA_Q_HEADS = 8;
+constexpr int FA_KV_HEADS = 2;
+constexpr int FA_HEAD_DIM = 256;
+constexpr int FA_GQA = FA_Q_HEADS / FA_KV_HEADS;
+constexpr int FA_Q_SIZE = FA_Q_HEADS * FA_HEAD_DIM;
+constexpr int FA_QPROJ_SIZE = FA_Q_SIZE * 2;
+constexpr int FA_KV_SIZE = FA_KV_HEADS * FA_HEAD_DIM;
+constexpr int FA_ROT_DIM = 64;
+constexpr float FA_ROPE_THETA = 10000000.0f;
+constexpr int FA_ROT_PAIRS = FA_ROT_DIM / 2;
+
+constexpr int DN_HEADS = 16;
+constexpr int DN_KEY = 128;
+constexpr int DN_VAL = 128;
+constexpr int DN_CONV_K = 4;
+constexpr int DN_QK_SIZE = DN_HEADS * DN_KEY;
+constexpr int DN_V_SIZE = DN_HEADS * DN_VAL;
+constexpr int DN_CONV_CH = DN_QK_SIZE * 2 + DN_V_SIZE;
+constexpr int DN_Z_OFFSET = DN_CONV_CH;
+constexpr int DN_BETA_OFFSET = DN_Z_OFFSET + DN_V_SIZE;
+constexpr int DN_ALPHA_OFFSET = DN_BETA_OFFSET + DN_HEADS;
+constexpr int DN_PROJ_FUSED = DN_ALPHA_OFFSET + DN_HEADS;
+constexpr int DN_PROJ_FUSED_PADDED = ((DN_PROJ_FUSED + 127) / 128) * 128;
+constexpr int FA_QKV_FUSED = FA_QPROJ_SIZE + 2 * FA_KV_SIZE;
+constexpr int MLP_GATE_UP_FUSED = INTER * 2;
+constexpr int NVFP4_TC_ROWS_PER_TILE = 128;
+constexpr int NVFP4_TC_COLS_PER_TILE = 4;
+constexpr int NVFP4_TC_BLOCK_K = 16;
+constexpr int NVFP4_TC_K_PER_TILE = NVFP4_TC_COLS_PER_TILE * NVFP4_TC_BLOCK_K;
+constexpr size_t PREFILL_TC_MAX_WORKSPACE = 32ull * 1024ull * 1024ull;
+
+constexpr int NUM_LAYERS = 24;
+constexpr int LAYER_TYPE[24] = {0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1};
+
+struct PFLayerWeights { int layer_type; int _pad[3]; void *ptrs[14]; };
+struct PFFusedLayerWeights {
+    void *proj_weight;
+    void *gate_up_weight;
+    void *proj_weight_packed;
+    void *proj_weight_scales;
+    void *gate_up_weight_packed;
+    void *gate_up_weight_scales;
+};
+
+
+__device__ __constant__ float PF_ROPE_INV_FREQ[FA_ROT_PAIRS] = {
+    1.000000000000000000e+00f, 6.042963902381328634e-01f,
+    3.651741272548377215e-01f, 2.206734069084589911e-01f,
+    1.333521432163324028e-01f, 8.058421877614818651e-02f,
+    4.869675251658631132e-02f, 2.942727176209281731e-02f,
+    1.778279410038922925e-02f, 1.074607828321317432e-02f,
+    6.493816315762112983e-03f, 3.924189758484536265e-03f,
+    2.371373705661655382e-03f, 1.433012570236962685e-03f,
+    8.659643233600653866e-04f, 5.232991146814947340e-04f,
+    3.162277660168379394e-04f, 1.910952974970440477e-04f,
+    1.154781984689458215e-04f, 6.978305848598663529e-05f,
+    4.216965034285822237e-05f, 2.548296747979346413e-05f,
+    1.539926526059491854e-05f, 9.305720409296990429e-06f,
+    5.623413251903491208e-06f, 3.398208328942559268e-06f,
+    2.053525026457146066e-06f, 1.240937760751719527e-06f,
+    7.498942093324558477e-07f, 4.531583637600817928e-07f,
+    2.738419634264361394e-07f, 1.654817099943181354e-07f
+};
+
+__device__ __forceinline__ float pf_warp_sum(float v) {
+    for (int o = 16; o > 0; o >>= 1) v += __shfl_down_sync(0xffffffff, v, o); return v;
+}
+__device__ __forceinline__ float pf_sigmoid(float x) { return 1.0f / (1.0f + __expf(-x)); }
+__device__ __forceinline__ float pf_silu(float x) { return x * pf_sigmoid(x); }
+
+// Embedding
+__global__ void pf_embed(const int *ids, const __nv_bfloat16 *embed, __nv_bfloat16 *out, int S) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= S * HIDDEN) return;
+    out[idx] = embed[ids[idx / HIDDEN] * HIDDEN + idx % HIDDEN];
+}
+
+// Batched RMSNorm: bf16 in → bf16 out, saves bf16 residual
+__global__ void pf_rmsnorm(const __nv_bfloat16 *in, const __nv_bfloat16 *w,
+    __nv_bfloat16 *out, __nv_bfloat16 *res, int S, int D) {
+    int s = blockIdx.x; if (s >= S) return;
+    int tid = threadIdx.x, wid = tid/32, lid = tid%32;
+    __shared__ float smem[8];
+    const __nv_bfloat16 *ri = in + s*D;
+    __nv_bfloat16 *ro = out + s*D, *rr = res + s*D;
+    const __nv_bfloat162 *ri2 = reinterpret_cast<const __nv_bfloat162 *>(ri);
+    const __nv_bfloat162 *w2 = reinterpret_cast<const __nv_bfloat162 *>(w);
+    __nv_bfloat162 *ro2 = reinterpret_cast<__nv_bfloat162 *>(ro);
+    __nv_bfloat162 *rr2 = reinterpret_cast<__nv_bfloat162 *>(rr);
+    int D2 = D / 2;
+    float sq = 0;
+    for (int i2 = tid; i2 < D2; i2 += blockDim.x) {
+        __nv_bfloat162 rv2 = ri2[i2];
+        float2 rv = __bfloat1622float2(rv2);
+        rr2[i2] = rv2;
+        sq += rv.x * rv.x + rv.y * rv.y;
+    }
+    if ((D & 1) && tid == 0) {
+        float v = __bfloat162float(ri[D - 1]);
+        rr[D - 1] = ri[D - 1];
+        sq += v * v;
+    }
+    sq = pf_warp_sum(sq); if(lid==0) smem[wid]=sq; __syncthreads();
+    if(wid==0){float v=(lid<blockDim.x/32)?smem[lid]:0;v=pf_warp_sum(v);if(lid==0)smem[0]=rsqrtf(v/D+RMS_EPS);}
+    __syncthreads(); float rstd = smem[0];
+    for (int i2 = tid; i2 < D2; i2 += blockDim.x) {
+        float2 rv = __bfloat1622float2(ri2[i2]);
+        float2 wv = __bfloat1622float2(w2[i2]);
+        ro2[i2] = __floats2bfloat162_rn(
+            rv.x * rstd * (1.0f + wv.x),
+            rv.y * rstd * (1.0f + wv.y));
+    }
+    if ((D & 1) && tid == 0) {
+        float v = __bfloat162float(ri[D - 1]) * rstd * (1.0f + __bfloat162float(w[D - 1]));
+        ro[D - 1] = __float2bfloat16(v);
+    }
+}
+
+// bf16 matvec for tiny projections (beta/alpha)
+__global__ void pf_bf16_matvec(const __nv_bfloat16 *in, const __nv_bfloat16 *w, float *out, int S, int K, int N) {
+    int idx = blockIdx.x; if (idx >= S * N) return;
+    int s = idx / N, n = idx % N, lid = threadIdx.x;
+    const __nv_bfloat16 *ir = in + s*K, *wr = w + n*K;
+    float sum = 0;
+    for (int k = lid; k < K; k += 32) sum += __bfloat162float(ir[k]) * __bfloat162float(wr[k]);
+    sum = pf_warp_sum(sum);
+    if (lid == 0) out[idx] = sum;
+}
+
+// bf16 result + bf16 residual → bf16 output
+__global__ void pf_add_residual_bf16(const __nv_bfloat16 *a, const __nv_bfloat16 *b, __nv_bfloat16 *out, int N) {
+    int pair = blockIdx.x * blockDim.x + threadIdx.x;
+    int pairs = N / 2;
+    if (pair < pairs) {
+        const __nv_bfloat162 *a2 = reinterpret_cast<const __nv_bfloat162 *>(a);
+        const __nv_bfloat162 *b2 = reinterpret_cast<const __nv_bfloat162 *>(b);
+        __nv_bfloat162 *out2 = reinterpret_cast<__nv_bfloat162 *>(out);
+        float2 av = __bfloat1622float2(a2[pair]);
+        float2 bv = __bfloat1622float2(b2[pair]);
+        out2[pair] = __floats2bfloat162_rn(av.x + bv.x, av.y + bv.y);
+    }
+    if ((N & 1) && pair == 0) {
+        out[N - 1] = __float2bfloat16(__bfloat162float(a[N - 1]) + __bfloat162float(b[N - 1]));
+    }
+}
+
+// Fuse residual add with the immediately following RMSNorm. This avoids
+// round-tripping the post-add hidden row through global memory before the MLP.
+__global__ void pf_add_residual_rmsnorm_bf16(
+    const __nv_bfloat16 *a,
+    const __nv_bfloat16 *b,
+    const __nv_bfloat16 *w,
+    __nv_bfloat16 *hidden_out,
+    __nv_bfloat16 *norm_out,
+    __nv_bfloat16 *residual_out,
+    int S, int D)
+{
+    int s = blockIdx.x;
+    if (s >= S) return;
+
+    int tid = threadIdx.x, wid = tid / 32, lid = tid % 32;
+    __shared__ float smem[8];
+    __shared__ __align__(16) __nv_bfloat162 s_sum[HIDDEN / 2];
+
+    const __nv_bfloat16 *ar = a + s * D;
+    const __nv_bfloat16 *br = b + s * D;
+    __nv_bfloat16 *ho = hidden_out + s * D;
+    __nv_bfloat16 *no = norm_out + s * D;
+    __nv_bfloat16 *ro = residual_out + s * D;
+
+    const __nv_bfloat162 *a2 = reinterpret_cast<const __nv_bfloat162 *>(ar);
+    const __nv_bfloat162 *b2 = reinterpret_cast<const __nv_bfloat162 *>(br);
+    const __nv_bfloat162 *w2 = reinterpret_cast<const __nv_bfloat162 *>(w);
+    __nv_bfloat162 *ho2 = reinterpret_cast<__nv_bfloat162 *>(ho);
+    __nv_bfloat162 *no2 = reinterpret_cast<__nv_bfloat162 *>(no);
+    __nv_bfloat162 *ro2 = reinterpret_cast<__nv_bfloat162 *>(ro);
+    int D2 = D / 2;
+
+    float sq = 0.0f;
+    for (int i2 = tid; i2 < D2; i2 += blockDim.x) {
+        float2 av = __bfloat1622float2(a2[i2]);
+        float2 bv = __bfloat1622float2(b2[i2]);
+        float2 sv = make_float2(av.x + bv.x, av.y + bv.y);
+        s_sum[i2] = __floats2bfloat162_rn(sv.x, sv.y);
+        sq += sv.x * sv.x + sv.y * sv.y;
+    }
+
+    if ((D & 1) && tid == 0) {
+        float sv = __bfloat162float(ar[D - 1]) + __bfloat162float(br[D - 1]);
+        reinterpret_cast<__nv_bfloat16 *>(s_sum)[D - 1] = __float2bfloat16(sv);
+        sq += sv * sv;
+    }
+
+    sq = pf_warp_sum(sq);
+    if (lid == 0) smem[wid] = sq;
+    __syncthreads();
+    if (wid == 0) {
+        float v = (lid < blockDim.x / 32) ? smem[lid] : 0.0f;
+        v = pf_warp_sum(v);
+        if (lid == 0) smem[0] = rsqrtf(v / D + RMS_EPS);
+    }
+    __syncthreads();
+    float rstd = smem[0];
+
+    for (int i2 = tid; i2 < D2; i2 += blockDim.x) {
+        __nv_bfloat162 sum2 = s_sum[i2];
+        float2 sv = __bfloat1622float2(sum2);
+        float2 wv = __bfloat1622float2(w2[i2]);
+        ho2[i2] = sum2;
+        ro2[i2] = sum2;
+        no2[i2] = __floats2bfloat162_rn(
+            sv.x * rstd * (1.0f + wv.x),
+            sv.y * rstd * (1.0f + wv.y));
+    }
+
+    if ((D & 1) && tid == 0) {
+        __nv_bfloat16 sumv = reinterpret_cast<__nv_bfloat16 *>(s_sum)[D - 1];
+        float sv = __bfloat162float(sumv);
+        ho[D - 1] = sumv;
+        ro[D - 1] = sumv;
+        no[D - 1] = __float2bfloat16(sv * rstd * (1.0f + __bfloat162float(w[D - 1])));
+    }
+}
+
+// SiLU(gate) * up — bf16 inputs → bf16 output
+__global__ void pf_silu_mul_bf16(const __nv_bfloat16 *gate, const __nv_bfloat16 *up, __nv_bfloat16 *out, int N) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N) { float g = __bfloat162float(gate[i]); out[i] = __float2bfloat16(pf_silu(g) * __bfloat162float(up[i])); }
+}
+
+// SiLU(gate) * up from a fused [rows, 2 * cols] row-major buffer.
+__global__ void pf_silu_mul_fused_bf16(const __nv_bfloat16 *gate_up, __nv_bfloat16 *out, int rows, int cols) {
+    int pair = blockIdx.x * blockDim.x + threadIdx.x;
+    int col_pairs = cols / 2;
+    int total_pairs = rows * col_pairs;
+    if (pair >= total_pairs) return;
+
+    int row = pair / col_pairs;
+    int col_pair = pair - row * col_pairs;
+    const __nv_bfloat162 *gate_up2 =
+        reinterpret_cast<const __nv_bfloat162 *>(gate_up + row * (cols * 2));
+    __nv_bfloat162 *out2 = reinterpret_cast<__nv_bfloat162 *>(out + row * cols);
+    float2 gate = __bfloat1622float2(gate_up2[col_pair]);
+    float2 up = __bfloat1622float2(gate_up2[col_pairs + col_pair]);
+    out2[col_pair] = __floats2bfloat162_rn(
+        pf_silu(gate.x) * up.x,
+        pf_silu(gate.y) * up.y);
+}
+
+__global__ void pf_half_to_bf16(const __half *in, __nv_bfloat16 *out, int N) {
+    int pair = blockIdx.x * blockDim.x + threadIdx.x;
+    int pairs = N / 2;
+    if (pair < pairs) {
+        const __half2 *in2 = reinterpret_cast<const __half2 *>(in);
+        __nv_bfloat162 *out2 = reinterpret_cast<__nv_bfloat162 *>(out);
+        float2 fv = __half22float2(in2[pair]);
+        out2[pair] = __floats2bfloat162_rn(fv.x, fv.y);
+    }
+    if ((N & 1) && pair == 0) {
+        out[N - 1] = __float2bfloat16(__half2float(in[N - 1]));
+    }
+}
+
+// Precompute DeltaNet q/k once per head so the tiled recurrence no longer
+// repeats the q/k conv and normalization work across every value tile.
+template <int BLOCK_THREADS>
+__global__ void __launch_bounds__(BLOCK_THREADS, 1)
+pf_deltanet_prepare_qk(
+    const __nv_bfloat16 *__restrict__ qkv_proj,
+    int qkv_stride,
+    const __nv_bfloat16 *__restrict__ conv_w,
+    float *__restrict__ conv_buf,
+    __nv_bfloat16 *__restrict__ qk_out,
+    int qk_stride,
+    int S)
+{
+    constexpr float Q_SCALE = 1.0f / 11.313708498984761f;
+    constexpr int QK_CHANNELS = DN_KEY + DN_KEY;
+    constexpr int HALF_WARPS = DN_KEY / 32;
+    static_assert(BLOCK_THREADS % 32 == 0, "DeltaNet qk precompute block size must be warp-aligned");
+    static_assert(BLOCK_THREADS == QK_CHANNELS, "DeltaNet qk precompute expects one thread per q/k channel");
+
+    int h = blockIdx.x;
+    if (h >= DN_HEADS) return;
+
+    int tid = threadIdx.x, wid = tid / 32, lid = tid % 32;
+    const int q_base = h * DN_KEY;
+    const int k_base = DN_QK_SIZE + h * DN_KEY;
+    const bool is_q = tid < DN_KEY;
+    const int local_c = is_q ? tid : (tid - DN_KEY);
+    const int global_ch = (is_q ? q_base : k_base) + local_c;
+
+    __shared__ float s_partials[QK_CHANNELS / 32];
+    __shared__ float s_norms[2];
+
+    float4 hist = reinterpret_cast<const float4 *>(conv_buf + global_ch * DN_CONV_K)[0];
+    const __nv_bfloat16 *weight_ptr = conv_w + global_ch * DN_CONV_K;
+    float4 weight = make_float4(
+        __bfloat162float(weight_ptr[0]),
+        __bfloat162float(weight_ptr[1]),
+        __bfloat162float(weight_ptr[2]),
+        __bfloat162float(weight_ptr[3]));
+
+    for (int t = 0; t < S; t++) {
+        const __nv_bfloat16 *qkv_t = qkv_proj + t * qkv_stride;
+        float in_val = is_q
+            ? __bfloat162float(qkv_t[q_base + local_c])
+            : __bfloat162float(qkv_t[k_base + local_c]);
+        hist.x = hist.y;
+        hist.y = hist.z;
+        hist.z = hist.w;
+        hist.w = in_val;
+        float act = pf_silu(fmaf(hist.x, weight.x, fmaf(hist.y, weight.y, fmaf(hist.z, weight.z, hist.w * weight.w))));
+
+        float sq = pf_warp_sum(act * act);
+        if (lid == 0) {
+            s_partials[wid] = sq;
+        }
+        __syncthreads();
+
+        if (wid == 0 || wid == HALF_WARPS) {
+            int partial_base = (wid == 0) ? 0 : HALF_WARPS;
+            float total = (lid < HALF_WARPS) ? s_partials[partial_base + lid] : 0.0f;
+            total = pf_warp_sum(total);
+            if (lid == 0) {
+                s_norms[wid == 0 ? 0 : 1] = rsqrtf(total + 1e-6f) * ((wid == 0) ? Q_SCALE : 1.0f);
+            }
+        }
+        __syncthreads();
+
+        __nv_bfloat16 *qk_t = qk_out + t * qk_stride + h * QK_CHANNELS;
+        qk_t[is_q ? local_c : (DN_KEY + local_c)] = __float2bfloat16(act * s_norms[is_q ? 0 : 1]);
+    }
+
+    reinterpret_cast<float4 *>(conv_buf + global_ch * DN_CONV_K)[0] = hist;
+}
+
+// ===== Standalone DeltaNet recurrence tiled over value channels =====
+template <int BLOCK_THREADS, int BLOCKS_PER_HEAD, bool SEPARATE_CTRL>
+__global__ void __launch_bounds__(BLOCK_THREADS, 1)
+pf_deltanet_recurrence_tiled(
+    const __nv_bfloat16 *__restrict__ qkv_proj,
+    int qkv_stride,
+    const __nv_bfloat16 *__restrict__ qk_norm,
+    int qk_stride,
+    const __nv_bfloat16 *__restrict__ beta_proj,
+    const __nv_bfloat16 *__restrict__ alpha_proj,
+    int ctrl_stride,
+    const __nv_bfloat16 *__restrict__ conv_w, const __nv_bfloat16 *__restrict__ a_log,
+    const __nv_bfloat16 *__restrict__ dt_bias,
+    float *__restrict__ state, float *__restrict__ conv_buf, __nv_bfloat16 *__restrict__ output, int S)
+{
+    constexpr int NWARPS = BLOCK_THREADS / 32;
+    constexpr int VAL_TILE = DN_VAL / BLOCKS_PER_HEAD;
+    static_assert(BLOCK_THREADS % 32 == 0, "DeltaNet prefill block size must be warp-aligned");
+    static_assert(DN_VAL % BLOCKS_PER_HEAD == 0, "DeltaNet value width must divide the tile count");
+    static_assert(VAL_TILE % NWARPS == 0, "DeltaNet value tile must divide the warp count");
+    static_assert(DN_KEY == DN_VAL, "DeltaNet prefill kernel assumes equal key/value widths");
+
+    int block = blockIdx.x;
+    int h = block / BLOCKS_PER_HEAD;
+    if (h >= DN_HEADS) return;
+    int tile = block % BLOCKS_PER_HEAD;
+    int val_offset = tile * VAL_TILE;
+
+    int tid = threadIdx.x, wid = tid/32, lid = tid%32;
+    float a_log_val = __bfloat162float(a_log[h]);
+    float a_scale = __expf(a_log_val);
+    float dt_b = __bfloat162float(dt_bias[h]);
+
+    __shared__ float s_beta, s_decay;
+
+    float *my_state = state + h * DN_KEY * DN_VAL + val_offset * DN_KEY;
+    const int v_base = 2 * DN_QK_SIZE + h * DN_VAL + val_offset;
+
+    constexpr int CPW = VAL_TILE / NWARPS;
+    constexpr int RPL = DN_KEY / 32;
+    static_assert(CPW <= 32, "DeltaNet value channels per warp must fit in one warp");
+    float sreg[CPW * RPL];
+    float4 v_hist_reg = make_float4(0.f, 0.f, 0.f, 0.f);
+    float4 v_weight_reg = make_float4(0.f, 0.f, 0.f, 0.f);
+
+#pragma unroll
+    for (int jj = 0; jj < CPW; jj++) {
+        int j = wid * CPW + jj;
+        for (int ii = 0; ii < RPL; ii++) {
+            sreg[jj * RPL + ii] = my_state[j * DN_KEY + lid + ii * 32];
+        }
+    }
+    if (lid < CPW) {
+        int j = wid * CPW + lid;
+        int global_ch = v_base + j;
+        const float *conv_ptr = conv_buf + global_ch * DN_CONV_K;
+        const __nv_bfloat16 *weight_ptr = conv_w + global_ch * DN_CONV_K;
+        v_hist_reg = make_float4(conv_ptr[0], conv_ptr[1], conv_ptr[2], conv_ptr[3]);
+        v_weight_reg = make_float4(
+            __bfloat162float(weight_ptr[0]),
+            __bfloat162float(weight_ptr[1]),
+            __bfloat162float(weight_ptr[2]),
+            __bfloat162float(weight_ptr[3]));
+    }
+
+    for (int t = 0; t < S; t++) {
+        const __nv_bfloat16 *qkv_t = qkv_proj + t * qkv_stride;
+        const __nv_bfloat16 *qk_t = qk_norm + t * qk_stride + h * (DN_KEY * 2);
+        float beta_proj_val;
+        float alpha_proj_val;
+        if constexpr (SEPARATE_CTRL) {
+            const __nv_bfloat16 *beta_t = beta_proj + t * ctrl_stride;
+            const __nv_bfloat16 *alpha_t = alpha_proj + t * ctrl_stride;
+            beta_proj_val = __bfloat162float(beta_t[h]);
+            alpha_proj_val = __bfloat162float(alpha_t[h]);
+        } else {
+            beta_proj_val = __bfloat162float(qkv_t[DN_BETA_OFFSET + h]);
+            alpha_proj_val = __bfloat162float(qkv_t[DN_ALPHA_OFFSET + h]);
+        }
+
+        float v_lane = 0.0f;
+        if (lid < CPW) {
+            int j = wid * CPW + lid;
+            float4 hist = v_hist_reg;
+            float4 weight = v_weight_reg;
+            hist.x = hist.y;
+            hist.y = hist.z;
+            hist.z = hist.w;
+            hist.w = __bfloat162float(qkv_t[v_base + j]);
+            v_hist_reg = hist;
+            float co = fmaf(hist.x, weight.x, fmaf(hist.y, weight.y, fmaf(hist.z, weight.z, hist.w * weight.w)));
+            v_lane = pf_silu(co);
+        }
+
+        float v_reg[CPW];
+#pragma unroll
+        for (int jj = 0; jj < CPW; jj++) {
+            v_reg[jj] = __shfl_sync(0xffffffff, v_lane, jj);
+        }
+
+        float q_reg[RPL];
+        float k_reg[RPL];
+#pragma unroll
+        for (int ii = 0; ii < RPL; ii++) {
+            int key_idx = lid + ii * 32;
+            q_reg[ii] = __bfloat162float(qk_t[key_idx]);
+            k_reg[ii] = __bfloat162float(qk_t[DN_KEY + key_idx]);
+        }
+        if (tid == 0) {
+            s_beta = pf_sigmoid(beta_proj_val);
+            float x = alpha_proj_val + dt_b;
+            float sp = (x > 20.0f) ? x : log1pf(__expf(x));
+            s_decay = __expf(-a_scale * sp);
+        }
+        __syncthreads();
+
+        float beta = s_beta;
+        float decay = s_decay;
+
+        __nv_bfloat16 *out_h = output + t * DN_V_SIZE + h * DN_VAL + val_offset;
+
+#pragma unroll
+        for (int jj = 0; jj < CPW; jj++) {
+            int j = wid * CPW + jj;
+            float kv = 0.0f;
+#pragma unroll
+            for (int ii = 0; ii < RPL; ii++) {
+                kv = fmaf(sreg[jj * RPL + ii], k_reg[ii], kv);
+            }
+            kv = pf_warp_sum(kv);
+            kv = __shfl_sync(0xffffffff, kv, 0);
+            float delta = (v_reg[jj] - decay * kv) * beta;
+            float attn = 0.0f;
+#pragma unroll
+            for (int ii = 0; ii < RPL; ii++) {
+                float new_state = fmaf(k_reg[ii], delta, decay * sreg[jj * RPL + ii]);
+                sreg[jj * RPL + ii] = new_state;
+                attn = fmaf(new_state, q_reg[ii], attn);
+            }
+            attn = pf_warp_sum(attn);
+            if (lid == 0) out_h[j] = __float2bfloat16(attn);
+        }
+    }
+
+    if (lid < CPW) {
+        int j = wid * CPW + lid;
+        float *conv_ptr = conv_buf + (v_base + j) * DN_CONV_K;
+        conv_ptr[0] = v_hist_reg.x;
+        conv_ptr[1] = v_hist_reg.y;
+        conv_ptr[2] = v_hist_reg.z;
+        conv_ptr[3] = v_hist_reg.w;
+    }
+
+#pragma unroll
+    for (int jj = 0; jj < CPW; jj++) {
+        int j = wid * CPW + jj;
+        for (int ii = 0; ii < RPL; ii++) {
+            my_state[j * DN_KEY + lid + ii * 32] = sreg[jj * RPL + ii];
+        }
+    }
+}
+
+__global__ void pf_deltanet_finalize(
+    __nv_bfloat16 *attn_out, const __nv_bfloat16 *proj,
+    int proj_stride, int z_offset,
+    const __nv_bfloat16 *norm_w, int S)
+{
+    int idx = blockIdx.x;
+    if (idx >= S * DN_HEADS) return;
+    int t = idx / DN_HEADS;
+    int h = idx % DN_HEADS;
+    int tid = threadIdx.x;
+    int wid = tid / 32;
+    int lid = tid % 32;
+
+    __shared__ float smem[4];
+    __nv_bfloat16 *row = attn_out + t * DN_V_SIZE + h * DN_VAL;
+    const __nv_bfloat16 *z_h = proj + t * proj_stride + z_offset + h * DN_VAL;
+    const __nv_bfloat162 *row2 = reinterpret_cast<const __nv_bfloat162 *>(row);
+    const __nv_bfloat162 *z2 = reinterpret_cast<const __nv_bfloat162 *>(z_h);
+    const __nv_bfloat162 *norm2 = reinterpret_cast<const __nv_bfloat162 *>(norm_w);
+    __nv_bfloat162 *out2 = reinterpret_cast<__nv_bfloat162 *>(row);
+
+    float sq = 0.0f;
+    for (int i2 = tid; i2 < DN_VAL / 2; i2 += blockDim.x) {
+        float2 v = __bfloat1622float2(row2[i2]);
+        sq += v.x * v.x + v.y * v.y;
+    }
+    sq = pf_warp_sum(sq);
+    if (lid == 0) {
+        smem[wid] = sq;
+    }
+    __syncthreads();
+    if (wid == 0) {
+        float v = (lid < blockDim.x / 32) ? smem[lid] : 0.0f;
+        v = pf_warp_sum(v);
+        if (lid == 0) {
+            smem[0] = rsqrtf(v / DN_VAL + RMS_EPS);
+        }
+    }
+    __syncthreads();
+    float rstd = smem[0];
+    for (int i2 = tid; i2 < DN_VAL / 2; i2 += blockDim.x) {
+        float2 rv = __bfloat1622float2(row2[i2]);
+        float2 zv = __bfloat1622float2(z2[i2]);
+        float2 nw = __bfloat1622float2(norm2[i2]);
+        out2[i2] = __floats2bfloat162_rn(
+            rv.x * rstd * nw.x * pf_silu(zv.x),
+            rv.y * rstd * nw.y * pf_silu(zv.y));
+    }
+}
+
+// ===== QK norm + RoPE + KV cache =====
+__global__ void pf_qk_norm_rope(
+    __nv_bfloat16 *qkv, int qkv_stride,
+    const __nv_bfloat16 *qnw, const __nv_bfloat16 *knw,
+    __nv_bfloat16 *k_cache, __nv_bfloat16 *v_cache, int S, int max_seq)
+{
+    constexpr int HALF_DIM = FA_HEAD_DIM / 2;
+    constexpr int ROT_HALF = FA_ROT_DIM / 2;
+    int idx = blockIdx.x * (blockDim.x / 32) + threadIdx.x / 32;
+    int lid = threadIdx.x % 32;
+    int total_q = S * FA_Q_HEADS, total_k = S * FA_KV_HEADS;
+    if (idx < total_q) {
+        int pos = idx / FA_Q_HEADS, head = idx % FA_Q_HEADS;
+        __nv_bfloat16 *qh = qkv + pos * qkv_stride + head * FA_HEAD_DIM * 2;
+        const __nv_bfloat162 *qh2 = reinterpret_cast<const __nv_bfloat162 *>(qh);
+        const __nv_bfloat162 *qnw2 = reinterpret_cast<const __nv_bfloat162 *>(qnw);
+        __nv_bfloat162 *qh2_out = reinterpret_cast<__nv_bfloat162 *>(qh);
+        float ss = 0;
+        for (int i2 = lid; i2 < HALF_DIM; i2 += 32) {
+            float2 v = __bfloat1622float2(qh2[i2]);
+            ss += v.x * v.x + v.y * v.y;
+        }
+        ss = pf_warp_sum(ss);
+        float sc = rsqrtf(ss / FA_HEAD_DIM + RMS_EPS);
+        sc = __shfl_sync(0xffffffff, sc, 0);
+
+        for (int pair = lid; pair < FA_ROT_PAIRS; pair += 32) {
+            int lo = pair;
+            int hi = pair + FA_ROT_PAIRS;
+            float lo_norm = __bfloat162float(qh[lo]) * sc * (1.f + __bfloat162float(qnw[lo]));
+            float hi_norm = __bfloat162float(qh[hi]) * sc * (1.f + __bfloat162float(qnw[hi]));
+            float angle = float(pos) * PF_ROPE_INV_FREQ[pair];
+            float sv, cv;
+            __sincosf(angle, &sv, &cv);
+            qh[lo] = __float2bfloat16(lo_norm * cv - hi_norm * sv);
+            qh[hi] = __float2bfloat16(hi_norm * cv + lo_norm * sv);
+        }
+        for (int i2 = lid + ROT_HALF; i2 < HALF_DIM; i2 += 32) {
+            float2 rv = __bfloat1622float2(qh2[i2]);
+            float2 wv = __bfloat1622float2(qnw2[i2]);
+            qh2_out[i2] = __floats2bfloat162_rn(
+                rv.x * sc * (1.f + wv.x),
+                rv.y * sc * (1.f + wv.y));
+        }
+    }
+    int kidx = idx - total_q;
+    if (idx >= total_q && kidx < total_k) {
+        int pos = kidx / FA_KV_HEADS, head = kidx % FA_KV_HEADS;
+        __nv_bfloat16 *kh = qkv + pos * qkv_stride + FA_QPROJ_SIZE + head * FA_HEAD_DIM;
+        const __nv_bfloat16 *vh = qkv + pos * qkv_stride + FA_QPROJ_SIZE + FA_KV_SIZE + head * FA_HEAD_DIM;
+        __nv_bfloat16 *kc = k_cache + head*max_seq*FA_HEAD_DIM + pos*FA_HEAD_DIM;
+        __nv_bfloat16 *vc = v_cache + head*max_seq*FA_HEAD_DIM + pos*FA_HEAD_DIM;
+        const __nv_bfloat162 *kh2 = reinterpret_cast<const __nv_bfloat162 *>(kh);
+        const __nv_bfloat162 *vh2 = reinterpret_cast<const __nv_bfloat162 *>(vh);
+        const __nv_bfloat162 *knw2 = reinterpret_cast<const __nv_bfloat162 *>(knw);
+        __nv_bfloat162 *kh2_out = reinterpret_cast<__nv_bfloat162 *>(kh);
+        __nv_bfloat162 *kc2 = reinterpret_cast<__nv_bfloat162 *>(kc);
+        __nv_bfloat162 *vc2 = reinterpret_cast<__nv_bfloat162 *>(vc);
+        float ss = 0;
+        for (int i2 = lid; i2 < HALF_DIM; i2 += 32) {
+            float2 v = __bfloat1622float2(kh2[i2]);
+            ss += v.x * v.x + v.y * v.y;
+        }
+        ss = pf_warp_sum(ss);
+        float sc = rsqrtf(ss / FA_HEAD_DIM + RMS_EPS);
+        sc = __shfl_sync(0xffffffff, sc, 0);
+
+        for (int pair = lid; pair < FA_ROT_PAIRS; pair += 32) {
+            int lo = pair;
+            int hi = pair + FA_ROT_PAIRS;
+            float lo_norm = __bfloat162float(kh[lo]) * sc * (1.f + __bfloat162float(knw[lo]));
+            float hi_norm = __bfloat162float(kh[hi]) * sc * (1.f + __bfloat162float(knw[hi]));
+            float angle = float(pos) * PF_ROPE_INV_FREQ[pair];
+            float sv, cv;
+            __sincosf(angle, &sv, &cv);
+            __nv_bfloat16 lo_out = __float2bfloat16(lo_norm * cv - hi_norm * sv);
+            __nv_bfloat16 hi_out = __float2bfloat16(hi_norm * cv + lo_norm * sv);
+            kh[lo] = lo_out;
+            kh[hi] = hi_out;
+            kc[lo] = lo_out;
+            kc[hi] = hi_out;
+            vc[lo] = vh[lo];
+            vc[hi] = vh[hi];
+        }
+        for (int i2 = lid + ROT_HALF; i2 < HALF_DIM; i2 += 32) {
+            float2 kv = __bfloat1622float2(kh2[i2]);
+            float2 wv = __bfloat1622float2(knw2[i2]);
+            __nv_bfloat162 out2 = __floats2bfloat162_rn(
+                kv.x * sc * (1.f + wv.x),
+                kv.y * sc * (1.f + wv.y));
+            kh2_out[i2] = out2;
+            kc2[i2] = out2;
+            vc2[i2] = vh2[i2];
+        }
+    }
+}
+
+// ===== Causal attention (bf16 Q/K/V, f32 accumulation, bf16 output) =====
+__global__ void pf_causal_attn_generic(
+    const __nv_bfloat16 *__restrict__ qkv,
+    int qkv_stride,
+    __nv_bfloat16 *__restrict__ out,
+    int S)
+{
+    int idx = blockIdx.x * (blockDim.x / 32) + threadIdx.x / 32;
+    int lid = threadIdx.x % 32;
+    if (idx >= S * FA_Q_HEADS) return;
+    int pos = idx / FA_Q_HEADS, qh = idx % FA_Q_HEADS, kvh = qh / FA_GQA;
+    float scale = 1.0f / sqrtf(float(FA_HEAD_DIM));
+    constexpr int EPL = FA_HEAD_DIM / 32;
+    constexpr int PAIRS = EPL / 2;
+    const __nv_bfloat16 *qv = qkv + pos * qkv_stride + qh * FA_HEAD_DIM * 2;
+    const __nv_bfloat16 *gv = qv + FA_HEAD_DIM;
+    __nv_bfloat16 *ov = out + pos*FA_Q_SIZE + qh*FA_HEAD_DIM;
+    const __nv_bfloat162 *qv2 = reinterpret_cast<const __nv_bfloat162 *>(qv + lid * EPL);
+    const __nv_bfloat162 *gv2 = reinterpret_cast<const __nv_bfloat162 *>(gv + lid * EPL);
+    float2 ql[PAIRS];
+    float2 oa[PAIRS];
+#pragma unroll
+    for (int p = 0; p < PAIRS; ++p) {
+        ql[p] = __bfloat1622float2(qv2[p]);
+        oa[p] = make_float2(0.0f, 0.0f);
+    }
+    float mx=-1e30f, se=0;
+    for (int kp = 0; kp <= pos; kp++) {
+        const __nv_bfloat16 *kv = qkv + kp * qkv_stride + FA_QPROJ_SIZE + kvh * FA_HEAD_DIM;
+        const __nv_bfloat16 *vv = qkv + kp * qkv_stride + FA_QPROJ_SIZE + FA_KV_SIZE + kvh * FA_HEAD_DIM;
+        const __nv_bfloat162 *kv2 = reinterpret_cast<const __nv_bfloat162 *>(kv + lid * EPL);
+        const __nv_bfloat162 *vv2 = reinterpret_cast<const __nv_bfloat162 *>(vv + lid * EPL);
+        float sc = 0.0f;
+#pragma unroll
+        for (int p = 0; p < PAIRS; ++p) {
+            float2 kf = __bfloat1622float2(kv2[p]);
+            sc += ql[p].x * kf.x + ql[p].y * kf.y;
+        }
+        sc=pf_warp_sum(sc)*scale; sc=__shfl_sync(0xffffffff,sc,0);
+        float om=mx; mx=fmaxf(mx,sc); float ed=__expf(om-mx); float wexp=__expf(sc-mx); se=se*ed+wexp;
+        float wt=wexp;
+#pragma unroll
+        for (int p = 0; p < PAIRS; ++p) {
+            float2 vf = __bfloat1622float2(vv2[p]);
+            oa[p].x = oa[p].x * ed + wt * vf.x;
+            oa[p].y = oa[p].y * ed + wt * vf.y;
+        }
+    }
+    float rs=1.f/se;
+#pragma unroll
+    for (int p = 0; p < PAIRS; ++p) {
+        int i = lid * EPL + p * 2;
+        float2 gf = __bfloat1622float2(gv2[p]);
+        ov[i] = __float2bfloat16(oa[p].x * rs * pf_sigmoid(gf.x));
+        ov[i + 1] = __float2bfloat16(oa[p].y * rs * pf_sigmoid(gf.y));
+    }
+}
+
+template <int TILE_POS>
+__global__ void pf_causal_attn_posblock(
+    const __nv_bfloat16 *__restrict__ qkv,
+    int qkv_stride,
+    __nv_bfloat16 *__restrict__ out,
+    int S)
+{
+    static_assert(FA_Q_HEADS == 8, "optimized prefill attention assumes 8 Q heads");
+    static_assert(FA_KV_HEADS == 2, "optimized prefill attention assumes 2 KV heads");
+
+    int pos = blockIdx.x;
+    if (pos >= S) return;
+
+    int warp_id = threadIdx.x / 32;
+    int lid = threadIdx.x % 32;
+    int qh = warp_id;
+    int kvh = qh / FA_GQA;
+
+    constexpr int EPL = FA_HEAD_DIM / 32;
+    constexpr int PAIRS = EPL / 2;
+    constexpr int HALF_DIM = FA_HEAD_DIM / 2;
+    constexpr float SCALE = 1.0f / 16.0f;
+
+    __shared__ __align__(16) __nv_bfloat162 s_k_tile[TILE_POS * FA_KV_HEADS * HALF_DIM];
+    __shared__ __align__(16) __nv_bfloat162 s_v_tile[TILE_POS * FA_KV_HEADS * HALF_DIM];
+
+    const __nv_bfloat16 *qv = qkv + pos * qkv_stride + qh * FA_HEAD_DIM * 2;
+    const __nv_bfloat16 *gv = qv + FA_HEAD_DIM;
+    __nv_bfloat16 *ov = out + pos * FA_Q_SIZE + qh * FA_HEAD_DIM;
+    const __nv_bfloat162 *qv2 = reinterpret_cast<const __nv_bfloat162 *>(qv + lid * EPL);
+    const __nv_bfloat162 *gv2 = reinterpret_cast<const __nv_bfloat162 *>(gv + lid * EPL);
+
+    float2 ql[PAIRS];
+    float2 oa[PAIRS];
+#pragma unroll
+    for (int p = 0; p < PAIRS; ++p) {
+        ql[p] = __bfloat1622float2(qv2[p]);
+        oa[p] = make_float2(0.0f, 0.0f);
+    }
+
+    float mx = -1e30f;
+    float se = 0.0f;
+
+    for (int base = 0; base <= pos; base += TILE_POS) {
+        int tile = min(TILE_POS, pos - base + 1);
+        int tile_pairs = tile * FA_KV_HEADS * HALF_DIM;
+        for (int idx = threadIdx.x; idx < tile_pairs; idx += blockDim.x) {
+            int pair = idx % HALF_DIM;
+            int tmp = idx / HALF_DIM;
+            int head = tmp % FA_KV_HEADS;
+            int t = tmp / FA_KV_HEADS;
+            const __nv_bfloat16 *k_ptr = qkv + (base + t) * qkv_stride + FA_QPROJ_SIZE + head * FA_HEAD_DIM;
+            const __nv_bfloat16 *v_ptr = qkv + (base + t) * qkv_stride + FA_QPROJ_SIZE + FA_KV_SIZE + head * FA_HEAD_DIM;
+            const __nv_bfloat162 *k_ptr2 = reinterpret_cast<const __nv_bfloat162 *>(k_ptr);
+            const __nv_bfloat162 *v_ptr2 = reinterpret_cast<const __nv_bfloat162 *>(v_ptr);
+            int tile_idx = (t * FA_KV_HEADS + head) * HALF_DIM + pair;
+            s_k_tile[tile_idx] = k_ptr2[pair];
+            s_v_tile[tile_idx] = v_ptr2[pair];
+        }
+        __syncthreads();
+
+        for (int t = 0; t < tile; ++t) {
+            int tile_idx = (t * FA_KV_HEADS + kvh) * HALF_DIM + lid * PAIRS;
+            const __nv_bfloat162 *kv2 = s_k_tile + tile_idx;
+            const __nv_bfloat162 *vv2 = s_v_tile + tile_idx;
+            float sc = 0.0f;
+#pragma unroll
+            for (int p = 0; p < PAIRS; ++p) {
+                float2 kf = __bfloat1622float2(kv2[p]);
+                sc += ql[p].x * kf.x + ql[p].y * kf.y;
+            }
+            sc = pf_warp_sum(sc) * SCALE;
+            sc = __shfl_sync(0xffffffff, sc, 0);
+            float old_mx = mx;
+            mx = fmaxf(mx, sc);
+            float ed = __expf(old_mx - mx);
+            float wexp = __expf(sc - mx);
+            se = se * ed + wexp;
+#pragma unroll
+            for (int p = 0; p < PAIRS; ++p) {
+                float2 vf = __bfloat1622float2(vv2[p]);
+                oa[p].x = oa[p].x * ed + wexp * vf.x;
+                oa[p].y = oa[p].y * ed + wexp * vf.y;
+            }
+        }
+        __syncthreads();
+    }
+
+    float rs = 1.0f / se;
+#pragma unroll
+    for (int p = 0; p < PAIRS; ++p) {
+        int i = lid * EPL + p * 2;
+        float2 gf = __bfloat1622float2(gv2[p]);
+        ov[i] = __float2bfloat16(oa[p].x * rs * pf_sigmoid(gf.x));
+        ov[i + 1] = __float2bfloat16(oa[p].y * rs * pf_sigmoid(gf.y));
+    }
+}
+
+// Final norm
+__global__ void pf_final_norm(const __nv_bfloat16 *hidden, const __nv_bfloat16 *w,
+    __nv_bfloat16 *normed, __nv_bfloat16 *hidden_out, int S) {
+    int tid=threadIdx.x, wid=tid/32, lid=tid%32;
+    __shared__ float smem[16];
+    const __nv_bfloat16 *row = hidden + (S-1)*HIDDEN;
+    float sq=0; for(int i=tid;i<HIDDEN;i+=blockDim.x){float v=__bfloat162float(row[i]);sq+=v*v;}
+    sq=pf_warp_sum(sq);if(lid==0)smem[wid]=sq;__syncthreads();
+    if(wid==0){float v=(lid<blockDim.x/32)?smem[lid]:0;v=pf_warp_sum(v);if(lid==0)smem[0]=rsqrtf(v/HIDDEN+RMS_EPS);}
+    __syncthreads();float rstd=smem[0];
+    for(int i=tid;i<HIDDEN;i+=blockDim.x){
+        float v=__bfloat162float(row[i]);
+        normed[i]=__float2bfloat16(v*rstd*(1.f+__bfloat162float(w[i])));
+        hidden_out[i]=row[i];
+    }
+}
+
+// LM head: bf16 weight × bf16 hidden
+__global__ void pf_lm_head(const __nv_bfloat16 *hidden, const __nv_bfloat16 *w,
+    float *bmv, int *bmi, int N) {
+    __shared__ __nv_bfloat16 s_h[HIDDEN];
+    for(int i=threadIdx.x;i<HIDDEN;i+=blockDim.x) s_h[i]=hidden[i];
+    __syncthreads();
+    int wid=threadIdx.x/32, lid=threadIdx.x%32, nw=blockDim.x/32;
+    int rpb=(N+gridDim.x-1)/gridDim.x, rs=blockIdx.x*rpb, re=min(rs+rpb,N);
+    float lm=-1e30f; int li=-1;
+    for(int m=rs+wid;m<re;m+=nw){const __nv_bfloat16 *wr=w+m*HIDDEN;float s=0;
+        for(int k=lid*8;k<HIDDEN;k+=32*8){for(int i=0;i<8;i++)s+=__bfloat162float(wr[k+i])*__bfloat162float(s_h[k+i]);}
+        s=pf_warp_sum(s);if(lid==0&&s>lm){lm=s;li=m;}}
+    lm=__shfl_sync(0xffffffff,lm,0);li=__shfl_sync(0xffffffff,li,0);
+    __shared__ float wm[32]; __shared__ int wi[32];
+    if(lid==0){wm[wid]=lm;wi[wid]=li;}__syncthreads();
+    if(wid==0){float mv=(lid<nw)?wm[lid]:-1e30f;int mi=(lid<nw)?wi[lid]:-1;
+        for(int o=16;o>0;o>>=1){float ov=__shfl_down_sync(0xffffffff,mv,o);int oi=__shfl_down_sync(0xffffffff,mi,o);if(ov>mv){mv=ov;mi=oi;}}
+        if(lid==0){bmv[blockIdx.x]=mv;bmi[blockIdx.x]=mi;}}
+}
+__global__ void pf_lm_reduce(const float *bmv, const int *bmi, int *out, int nb) {
+    int tid=threadIdx.x; float best=-1e30f; int bi=-1;
+    for(int i=tid;i<nb;i+=blockDim.x){float v=bmv[i];if(v>best){best=v;bi=bmi[i];}}
+    __shared__ float sv[256]; __shared__ int si[256];
+    sv[tid]=best;si[tid]=bi;__syncthreads();
+    for(int s=blockDim.x/2;s>0;s>>=1){if(tid<s&&sv[tid+s]>sv[tid]){sv[tid]=sv[tid+s];si[tid]=si[tid+s];}__syncthreads();}
+    if(tid==0)*out=si[0];
+}
+
+// ===== cuBLAS bf16 GEMM =====
+static void cublas_bf16_gemm(cublasHandle_t h,
+    const __nv_bfloat16 *A, const __nv_bfloat16 *B, __nv_bfloat16 *C,
+    int S, int N, int K) {
+    float alpha = 1.0f, beta_val = 0.0f;
+    cublasGemmEx(h, CUBLAS_OP_T, CUBLAS_OP_N, N, S, K,
+        &alpha, B, CUDA_R_16BF, K, A, CUDA_R_16BF, K,
+        &beta_val, C, CUDA_R_16BF, N,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+}
+
+static bool prefill_tc_debug_enabled() {
+    static int enabled = []() {
+        const char *value = std::getenv("MEGAKERNEL_DEBUG_PREFILL_TC");
+        return (value != nullptr && value[0] != '\0' && value[0] != '0') ? 1 : 0;
+    }();
+    return enabled != 0;
+}
+
+static bool prefill_tc_compare_enabled() {
+    static int enabled = []() {
+        const char *value = std::getenv("MEGAKERNEL_DEBUG_PREFILL_TC_COMPARE");
+        return (value != nullptr && value[0] != '\0' && value[0] != '0') ? 1 : 0;
+    }();
+    return enabled != 0;
+}
+
+static bool prefill_tc_proj_enabled() {
+    static int enabled = []() {
+        const char *master = std::getenv("MEGAKERNEL_PREFILL_TC");
+        if (master == nullptr || master[0] == '\0' || master[0] == '0') {
+            return 0;
+        }
+        const char *value = std::getenv("MEGAKERNEL_PREFILL_TC_PROJ");
+        return (value == nullptr || value[0] == '\0' || value[0] != '0') ? 1 : 0;
+    }();
+    return enabled != 0;
+}
+
+static bool prefill_tc_gate_up_enabled() {
+    static int enabled = []() {
+        const char *master = std::getenv("MEGAKERNEL_PREFILL_TC");
+        if (master == nullptr || master[0] == '\0' || master[0] == '0') {
+            return 0;
+        }
+        const char *value = std::getenv("MEGAKERNEL_PREFILL_TC_GATE_UP");
+        return (value != nullptr && value[0] != '\0' && value[0] != '0') ? 1 : 0;
+    }();
+    return enabled != 0;
+}
+
+static size_t nvfp4_tc_scale_bytes(int rows, int cols) {
+    return static_cast<size_t>((rows + NVFP4_TC_ROWS_PER_TILE - 1) / NVFP4_TC_ROWS_PER_TILE) *
+           static_cast<size_t>(cols / NVFP4_TC_K_PER_TILE) * 512ull;
+}
+
+static void debug_compare_prefill_tc_proj(
+    cublasHandle_t cublas,
+    const __nv_bfloat16 *normalized,
+    const __nv_bfloat16 *weight_bf16,
+    const __nv_bfloat16 *tc_out,
+    int seq_len,
+    int logical_rows,
+    int out_stride,
+    int k,
+    const char *tag)
+{
+    static int already_dumped = 0;
+    if (!prefill_tc_compare_enabled() || already_dumped) {
+        return;
+    }
+
+    __nv_bfloat16 *ref = nullptr;
+    if (cudaMalloc(&ref, static_cast<size_t>(seq_len) * logical_rows * sizeof(__nv_bfloat16)) != cudaSuccess) {
+        return;
+    }
+
+    cudaStream_t stream = nullptr;
+    cublasGetStream(cublas, &stream);
+    cublas_bf16_gemm(cublas, normalized, weight_bf16, ref, seq_len, logical_rows, k);
+    cudaStreamSynchronize(stream);
+
+    int ref_count = seq_len * logical_rows;
+    int tc_count = seq_len * out_stride;
+    std::vector<__nv_bfloat16> tc_host(tc_count);
+    std::vector<__nv_bfloat16> ref_host(ref_count);
+    cudaMemcpy(tc_host.data(), tc_out, static_cast<size_t>(tc_count) * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost);
+    cudaMemcpy(ref_host.data(), ref, static_cast<size_t>(ref_count) * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost);
+
+    auto tc_at = [&](int row, int col) { return __bfloat162float(tc_host[row * out_stride + col]); };
+    auto bf16_at = [&](int row, int col) { return __bfloat162float(ref_host[row * logical_rows + col]); };
+
+    float max_row_major = 0.0f;
+    float sum_row_major = 0.0f;
+    int finite_row = 0;
+    int total = seq_len * logical_rows;
+    for (int s = 0; s < seq_len; ++s) {
+        for (int n = 0; n < logical_rows; ++n) {
+            float ref_v = bf16_at(s, n);
+            float row_v = tc_at(s, n);
+            float diff_row = fabsf(row_v - ref_v);
+            max_row_major = fmaxf(max_row_major, diff_row);
+            sum_row_major += diff_row;
+            finite_row += int(isfinite(row_v));
+        }
+    }
+
+    std::fprintf(
+        stderr,
+        "prefill_tc_compare[%s]: seq=%d logical=%d stride=%d k=%d row_max=%.6f row_mean=%.6f row_finite=%d/%d ref0=%.6f row0=%.6f\n",
+        tag,
+        seq_len,
+        logical_rows,
+        out_stride,
+        k,
+        max_row_major,
+        sum_row_major / total,
+        finite_row,
+        total,
+        bf16_at(0, 0),
+        tc_at(0, 0));
+
+    already_dumped = 1;
+    cudaFree(ref);
+}
+
+static bool cublaslt_nvfp4_bf16_gemm(
+    const uint8_t *weight_packed,
+    const uint8_t *weight_scales,
+    const uint8_t *act_packed,
+    const uint8_t *act_scales,
+    __nv_bfloat16 *out,
+    int out_rows,
+    int seq_len,
+    int k,
+    cudaStream_t stream)
+{
+    if (!weight_packed || !weight_scales || !act_packed || !act_scales || !out) {
+        return false;
+    }
+
+    static cublasLtHandle_t handle = nullptr;
+    static void *workspace = nullptr;
+    static size_t workspace_size = 0;
+    if (!handle && cublasLtCreate(&handle) != CUBLAS_STATUS_SUCCESS) {
+        return false;
+    }
+    if (workspace == nullptr) {
+        if (cudaMalloc(&workspace, PREFILL_TC_MAX_WORKSPACE) != cudaSuccess) {
+            workspace = nullptr;
+            workspace_size = 0;
+            return false;
+        }
+        workspace_size = PREFILL_TC_MAX_WORKSPACE;
+    }
+
+    cublasLtMatmulDesc_t op_desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr;
+    cublasLtMatrixLayout_t b_desc = nullptr;
+    cublasLtMatrixLayout_t c_desc = nullptr;
+    cublasLtMatrixLayout_t d_desc = nullptr;
+    cublasLtMatmulPreference_t preference = nullptr;
+    bool ok = false;
+    cublasLtMatmulAlgo_t algo{};
+    cublasLtMatmulHeuristicResult_t heuristic{};
+    int returned_results = 0;
+    cublasStatus_t heuristic_status = CUBLAS_STATUS_SUCCESS;
+
+    cublasOperation_t trans_a = CUBLAS_OP_T;
+    cublasOperation_t trans_b = CUBLAS_OP_N;
+    cublasLtMatmulMatrixScale_t a_scale_mode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+    cublasLtMatmulMatrixScale_t b_scale_mode = CUBLASLT_MATMUL_MATRIX_SCALE_VEC16_UE4M3;
+    cublasLtOrder_t col_order = CUBLASLT_ORDER_COL;
+
+    if (cublasLtMatmulDescCreate(&op_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F) != CUBLAS_STATUS_SUCCESS) {
+        goto cleanup;
+    }
+    if (cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(trans_a)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(trans_b)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_A_SCALE_MODE, &a_scale_mode, sizeof(a_scale_mode)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_B_SCALE_MODE, &b_scale_mode, sizeof(b_scale_mode)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, &weight_scales, sizeof(weight_scales)) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatmulDescSetAttribute(op_desc, CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, &act_scales, sizeof(act_scales)) != CUBLAS_STATUS_SUCCESS) {
+        goto cleanup;
+    }
+
+    if (cublasLtMatrixLayoutCreate(&a_desc, CUDA_R_4F_E2M1, k, out_rows, k) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatrixLayoutCreate(&b_desc, CUDA_R_4F_E2M1, k, seq_len, k) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatrixLayoutCreate(&c_desc, CUDA_R_16BF, out_rows, seq_len, out_rows) != CUBLAS_STATUS_SUCCESS ||
+        cublasLtMatrixLayoutCreate(&d_desc, CUDA_R_16BF, out_rows, seq_len, out_rows) != CUBLAS_STATUS_SUCCESS) {
+        goto cleanup;
+    }
+
+    cublasLtMatrixLayoutSetAttribute(a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+    cublasLtMatrixLayoutSetAttribute(b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+    cublasLtMatrixLayoutSetAttribute(c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+    cublasLtMatrixLayoutSetAttribute(d_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &col_order, sizeof(col_order));
+
+    if (cublasLtMatmulPreferenceCreate(&preference) != CUBLAS_STATUS_SUCCESS) {
+        goto cleanup;
+    }
+    cublasLtMatmulPreferenceSetAttribute(
+        preference,
+        CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &workspace_size,
+        sizeof(workspace_size));
+
+    heuristic_status = cublasLtMatmulAlgoGetHeuristic(
+        handle,
+        op_desc,
+        a_desc,
+        b_desc,
+        c_desc,
+        d_desc,
+        preference,
+        1,
+        &heuristic,
+        &returned_results);
+    if (heuristic_status != CUBLAS_STATUS_SUCCESS || returned_results == 0 || heuristic.workspaceSize > workspace_size) {
+        goto cleanup;
+    }
+    algo = heuristic.algo;
+
+    {
+        const float alpha = 1.0f;
+        const float beta = 0.0f;
+        cudaGetLastError();
+        cublasStatus_t status = cublasLtMatmul(
+            handle,
+            op_desc,
+            &alpha,
+            weight_packed,
+            a_desc,
+            act_packed,
+            b_desc,
+            &beta,
+            out,
+            c_desc,
+            out,
+            d_desc,
+            &algo,
+            workspace,
+            heuristic.workspaceSize,
+            stream);
+        cudaError_t last_error = cudaGetLastError();
+        ok = (status == CUBLAS_STATUS_SUCCESS && last_error == cudaSuccess);
+        if (prefill_tc_debug_enabled() && !ok) {
+            std::fprintf(stderr,
+                         "prefill_tc_cublaslt: status=%d cuda=%d m=%d n=%d k=%d\n",
+                         int(status), int(last_error), out_rows, seq_len, k);
+        }
+    }
+
+cleanup:
+    if (preference) cublasLtMatmulPreferenceDestroy(preference);
+    if (d_desc) cublasLtMatrixLayoutDestroy(d_desc);
+    if (c_desc) cublasLtMatrixLayoutDestroy(c_desc);
+    if (b_desc) cublasLtMatrixLayoutDestroy(b_desc);
+    if (a_desc) cublasLtMatrixLayoutDestroy(a_desc);
+    if (op_desc) cublasLtMatmulDescDestroy(op_desc);
+    return ok;
+}
+
+// ===== Main orchestrator =====
+static void launch_prefill_bf16_impl(
+    const int *token_ids, int seq_len, int *output_token,
+    const __nv_bfloat16 *embed_weight, const PFLayerWeights *layers,
+    const PFFusedLayerWeights *fused_layers,
+    const __nv_bfloat16 *final_norm_w, const __nv_bfloat16 *lm_head_w,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    __nv_bfloat16 *fa_k_cache, __nv_bfloat16 *fa_v_cache,
+    float *dn_states, float *conv_bufs,
+    // Scratch (ALL bf16 except state/conv which are f32)
+    __nv_bfloat16 *hidden, __nv_bfloat16 *residual, __nv_bfloat16 *normalized,
+    __nv_bfloat16 *proj_buf, __nv_bfloat16 *proj_buf2, __half *proj_buf_half,
+    uint8_t *proj_act_packed, uint8_t *proj_act_scales,
+    __nv_bfloat16 *attn_buf, __nv_bfloat16 *mlp_buf,
+    __nv_bfloat16 *dn_out_buf,
+    float *beta_buf, float *alpha_buf,
+    __nv_bfloat16 *final_normed, __nv_bfloat16 *hidden_bf16_out,
+    float *lm_bmv, int *lm_bmi,
+    __nv_bfloat16 *lm_hidden_bf16, uint8_t *lm_hidden_packed,
+    uint8_t *lm_hidden_scales, __half *lm_logits_f16,
+    cudaStream_t stream)
+{
+    static cublasHandle_t cublas = nullptr;
+    if (!cublas) cublasCreate(&cublas);
+    cublasSetStream(cublas, stream);
+
+    static PFLayerWeights hl[NUM_LAYERS];
+    static const PFLayerWeights *cached_layers = nullptr;
+    if (layers != cached_layers) {
+        cudaMemcpy(hl, layers, NUM_LAYERS * sizeof(PFLayerWeights), cudaMemcpyDeviceToHost);
+        cached_layers = layers;
+    }
+
+    static PFFusedLayerWeights hfl[NUM_LAYERS];
+    static const PFFusedLayerWeights *cached_fused_layers = nullptr;
+    if (fused_layers != cached_fused_layers) {
+        cudaMemcpy(hfl, fused_layers, NUM_LAYERS * sizeof(PFFusedLayerWeights), cudaMemcpyDeviceToHost);
+        cached_fused_layers = fused_layers;
+    }
+
+    int S = seq_len;
+    int bk = (S*HIDDEN+255)/256;
+    int res_bk = (S*HIDDEN + 511) / 512;
+
+    pf_embed<<<bk, 256, 0, stream>>>(token_ids, embed_weight, hidden, S);
+
+    int fa_stride = FA_KV_HEADS * 2048 * FA_HEAD_DIM;
+    int dn_stride = DN_HEADS * DN_KEY * DN_VAL;
+    int fa_idx = 0, dn_idx = 0;
+
+    for (int li = 0; li < NUM_LAYERS; li++) {
+        const PFLayerWeights &lw = hl[li];
+        const PFFusedLayerWeights &fw = hfl[li];
+        int lt = LAYER_TYPE[li];
+        bool use_tc_weights = (
+            fw.proj_weight_packed != nullptr &&
+            fw.proj_weight_scales != nullptr &&
+            fw.gate_up_weight_packed != nullptr &&
+            fw.gate_up_weight_scales != nullptr &&
+            proj_act_packed != nullptr &&
+            proj_act_scales != nullptr);
+        bool use_tc_proj = use_tc_weights && prefill_tc_proj_enabled();
+        bool use_tc_gate_up = use_tc_weights && prefill_tc_gate_up_enabled();
+
+        const __nv_bfloat16 *norm_w = (const __nv_bfloat16 *)lw.ptrs[0];
+        pf_rmsnorm<<<S, 256, 0, stream>>>(hidden, norm_w, normalized, residual, S, HIDDEN);
+        if (use_tc_proj) {
+            cudaMemsetAsync(proj_act_scales, 0, nvfp4_tc_scale_bytes(S, HIDDEN), stream);
+            launch_quantize_nvfp4_lm_out(
+                normalized,
+                S,
+                HIDDEN,
+                proj_act_packed,
+                proj_act_scales,
+                stream);
+        }
+
+        if (lt == 0) {
+            // DeltaNet
+            constexpr int DN_QK_PRECOMP_STRIDE = DN_HEADS * DN_KEY * 2;
+            constexpr int DN_CTRL_STRIDE = DN_HEADS;
+            const __nv_bfloat16 *conv_w=(const __nv_bfloat16*)lw.ptrs[5];
+            const __nv_bfloat16 *a_log=(const __nv_bfloat16*)lw.ptrs[6];
+            const __nv_bfloat16 *dt_bias=(const __nv_bfloat16*)lw.ptrs[7];
+            const __nv_bfloat16 *dn_norm=(const __nv_bfloat16*)lw.ptrs[8];
+            const __nv_bfloat16 *out_w=(const __nv_bfloat16*)lw.ptrs[9];
+            const __nv_bfloat16 *post_norm=(const __nv_bfloat16*)lw.ptrs[10];
+            const __nv_bfloat16 *beta_w=(const __nv_bfloat16*)lw.ptrs[3];
+            const __nv_bfloat16 *alpha_w=(const __nv_bfloat16*)lw.ptrs[4];
+            const __nv_bfloat16 *down_w=(const __nv_bfloat16*)lw.ptrs[13];
+            const __nv_bfloat16 *proj_fused_w = (const __nv_bfloat16*)fw.proj_weight;
+            const __nv_bfloat16 *gate_up_fused_w = (const __nv_bfloat16*)fw.gate_up_weight;
+            int dn_proj_stride = DN_PROJ_FUSED;
+            __nv_bfloat16 *beta_proj_bf16 = nullptr;
+            __nv_bfloat16 *alpha_proj_bf16 = nullptr;
+
+            bool used_tc = use_tc_proj && cublaslt_nvfp4_bf16_gemm(
+                (const uint8_t *)fw.proj_weight_packed,
+                (const uint8_t *)fw.proj_weight_scales,
+                proj_act_packed,
+                proj_act_scales,
+                proj_buf,
+                DN_PROJ_FUSED_PADDED,
+                S,
+                HIDDEN,
+                stream);
+            if (used_tc) {
+                dn_proj_stride = DN_PROJ_FUSED_PADDED;
+                beta_proj_bf16 = reinterpret_cast<__nv_bfloat16 *>(beta_buf);
+                alpha_proj_bf16 = reinterpret_cast<__nv_bfloat16 *>(alpha_buf);
+                cublas_bf16_gemm(cublas, normalized, beta_w, beta_proj_bf16, S, DN_HEADS, HIDDEN);
+                cublas_bf16_gemm(cublas, normalized, alpha_w, alpha_proj_bf16, S, DN_HEADS, HIDDEN);
+                debug_compare_prefill_tc_proj(
+                    cublas,
+                    normalized,
+                    proj_fused_w,
+                    proj_buf,
+                    S,
+                    DN_PROJ_FUSED,
+                    DN_PROJ_FUSED_PADDED,
+                    HIDDEN,
+                    "dn_proj");
+            } else {
+                cublas_bf16_gemm(cublas, normalized, proj_fused_w, proj_buf, S, DN_PROJ_FUSED, HIDDEN);
+            }
+            pf_deltanet_prepare_qk<256><<<DN_HEADS, 256, 0, stream>>>(
+                proj_buf, dn_proj_stride,
+                conv_w,
+                conv_bufs + dn_idx * DN_CONV_CH * DN_CONV_K,
+                proj_buf2,
+                DN_QK_PRECOMP_STRIDE,
+                S);
+
+            // Standalone recurrence
+            if (beta_proj_bf16 != nullptr && alpha_proj_bf16 != nullptr) {
+                pf_deltanet_recurrence_tiled<PREFILL_DN_BLOCK_SIZE, PREFILL_DN_BLOCKS_PER_HEAD, true>
+                    <<<DN_HEADS * PREFILL_DN_BLOCKS_PER_HEAD, PREFILL_DN_BLOCK_SIZE, 0, stream>>>(
+                    proj_buf, dn_proj_stride,
+                    proj_buf2, DN_QK_PRECOMP_STRIDE,
+                    beta_proj_bf16, alpha_proj_bf16, DN_CTRL_STRIDE,
+                    conv_w, a_log, dt_bias,
+                    dn_states + dn_idx*dn_stride,
+                    conv_bufs + dn_idx*DN_CONV_CH*DN_CONV_K,
+                    dn_out_buf, S);
+            } else {
+                pf_deltanet_recurrence_tiled<PREFILL_DN_BLOCK_SIZE, PREFILL_DN_BLOCKS_PER_HEAD, false>
+                    <<<DN_HEADS * PREFILL_DN_BLOCKS_PER_HEAD, PREFILL_DN_BLOCK_SIZE, 0, stream>>>(
+                    proj_buf, dn_proj_stride,
+                    proj_buf2, DN_QK_PRECOMP_STRIDE,
+                    nullptr, nullptr, DN_CTRL_STRIDE,
+                    conv_w, a_log, dt_bias,
+                    dn_states + dn_idx*dn_stride,
+                    conv_bufs + dn_idx*DN_CONV_CH*DN_CONV_K,
+                    dn_out_buf, S);
+            }
+            pf_deltanet_finalize<<<S * DN_HEADS, 64, 0, stream>>>(
+                dn_out_buf,
+                proj_buf,
+                dn_proj_stride,
+                DN_CONV_CH,
+                dn_norm,
+                S);
+
+            // Out projection + residual
+            cublas_bf16_gemm(cublas, dn_out_buf, out_w, proj_buf2, S, HIDDEN, DN_V_SIZE);
+            pf_add_residual_rmsnorm_bf16<<<S, 256, 0, stream>>>(
+                proj_buf2, residual, post_norm, hidden, normalized, residual, S, HIDDEN);
+
+            // MLP
+            int mlp_bk = (S*INTER + 511) / 512;
+            if (use_tc_gate_up) {
+                cudaMemsetAsync(proj_act_scales, 0, nvfp4_tc_scale_bytes(S, HIDDEN), stream);
+                launch_quantize_nvfp4_lm_out(
+                    normalized,
+                    S,
+                    HIDDEN,
+                    proj_act_packed,
+                    proj_act_scales,
+                    stream);
+            }
+            used_tc = use_tc_gate_up && cublaslt_nvfp4_bf16_gemm(
+                (const uint8_t *)fw.gate_up_weight_packed,
+                (const uint8_t *)fw.gate_up_weight_scales,
+                proj_act_packed,
+                proj_act_scales,
+                proj_buf,
+                MLP_GATE_UP_FUSED,
+                S,
+                HIDDEN,
+                stream);
+            if (!used_tc) {
+                cublas_bf16_gemm(cublas, normalized, gate_up_fused_w, proj_buf, S, MLP_GATE_UP_FUSED, HIDDEN);
+            }
+            pf_silu_mul_fused_bf16<<<mlp_bk, 256, 0, stream>>>(proj_buf, mlp_buf, S, INTER);
+            cublas_bf16_gemm(cublas, mlp_buf, down_w, proj_buf2, S, HIDDEN, INTER);
+            pf_add_residual_bf16<<<res_bk, 256, 0, stream>>>(proj_buf2, residual, hidden, S*HIDDEN);
+
+            dn_idx++;
+        } else {
+            // Full Attention
+            const __nv_bfloat16 *q_nw=(const __nv_bfloat16*)lw.ptrs[4];
+            const __nv_bfloat16 *k_nw=(const __nv_bfloat16*)lw.ptrs[5];
+            const __nv_bfloat16 *o_w=(const __nv_bfloat16*)lw.ptrs[6];
+            const __nv_bfloat16 *post_norm=(const __nv_bfloat16*)lw.ptrs[7];
+            const __nv_bfloat16 *down_w=(const __nv_bfloat16*)lw.ptrs[10];
+            const __nv_bfloat16 *proj_fused_w = (const __nv_bfloat16*)fw.proj_weight;
+            const __nv_bfloat16 *gate_up_fused_w = (const __nv_bfloat16*)fw.gate_up_weight;
+
+            bool used_tc = use_tc_proj && cublaslt_nvfp4_bf16_gemm(
+                (const uint8_t *)fw.proj_weight_packed,
+                (const uint8_t *)fw.proj_weight_scales,
+                proj_act_packed,
+                proj_act_scales,
+                proj_buf,
+                FA_QKV_FUSED,
+                S,
+                HIDDEN,
+                stream);
+            if (used_tc) {
+                debug_compare_prefill_tc_proj(
+                    cublas,
+                    normalized,
+                    proj_fused_w,
+                    proj_buf,
+                    S,
+                    FA_QKV_FUSED,
+                    FA_QKV_FUSED,
+                    HIDDEN,
+                    "fa_proj");
+            } else {
+                cublas_bf16_gemm(cublas, normalized, proj_fused_w, proj_buf, S, FA_QKV_FUSED, HIDDEN);
+            }
+
+            constexpr int PREFILL_FA_WARPS = PREFILL_FA_BLOCK_SIZE / 32;
+            int total_heads = S*(FA_Q_HEADS+FA_KV_HEADS);
+            pf_qk_norm_rope<<<(total_heads + PREFILL_FA_WARPS - 1) / PREFILL_FA_WARPS, PREFILL_FA_BLOCK_SIZE, 0, stream>>>(
+                proj_buf, FA_QKV_FUSED, q_nw, k_nw,
+                fa_k_cache + fa_idx*fa_stride, fa_v_cache + fa_idx*fa_stride, S, 2048);
+
+            if constexpr (PREFILL_FA_BLOCK_SIZE == FA_Q_HEADS * 32) {
+                pf_causal_attn_posblock<8><<<S, PREFILL_FA_BLOCK_SIZE, 0, stream>>>(
+                    proj_buf, FA_QKV_FUSED, dn_out_buf, S);
+            } else {
+                pf_causal_attn_generic<<<(S * FA_Q_HEADS + PREFILL_FA_WARPS - 1) / PREFILL_FA_WARPS, PREFILL_FA_BLOCK_SIZE, 0, stream>>>(
+                    proj_buf, FA_QKV_FUSED, dn_out_buf, S);
+            }
+
+            cublas_bf16_gemm(cublas, dn_out_buf, o_w, proj_buf2, S, HIDDEN, FA_Q_SIZE);
+            pf_add_residual_rmsnorm_bf16<<<S, 256, 0, stream>>>(
+                proj_buf2, residual, post_norm, hidden, normalized, residual, S, HIDDEN);
+
+            // MLP
+            int mlp_bk = (S*INTER + 511) / 512;
+            if (use_tc_gate_up) {
+                cudaMemsetAsync(proj_act_scales, 0, nvfp4_tc_scale_bytes(S, HIDDEN), stream);
+                launch_quantize_nvfp4_lm_out(
+                    normalized,
+                    S,
+                    HIDDEN,
+                    proj_act_packed,
+                    proj_act_scales,
+                    stream);
+            }
+            used_tc = use_tc_gate_up && cublaslt_nvfp4_bf16_gemm(
+                (const uint8_t *)fw.gate_up_weight_packed,
+                (const uint8_t *)fw.gate_up_weight_scales,
+                proj_act_packed,
+                proj_act_scales,
+                proj_buf,
+                MLP_GATE_UP_FUSED,
+                S,
+                HIDDEN,
+                stream);
+            if (!used_tc) {
+                cublas_bf16_gemm(cublas, normalized, gate_up_fused_w, proj_buf, S, MLP_GATE_UP_FUSED, HIDDEN);
+            }
+            pf_silu_mul_fused_bf16<<<mlp_bk, 256, 0, stream>>>(proj_buf, mlp_buf, S, INTER);
+            cublas_bf16_gemm(cublas, mlp_buf, down_w, proj_buf2, S, HIDDEN, INTER);
+            pf_add_residual_bf16<<<res_bk, 256, 0, stream>>>(proj_buf2, residual, hidden, S*HIDDEN);
+
+            fa_idx++;
+        }
+    }
+
+    pf_final_norm<<<1, 512, 0, stream>>>(hidden, final_norm_w, final_normed, hidden_bf16_out, S);
+
+    bool used_nvfp4_lm = false;
+    if (lm_head_weight_packed && lm_head_scales && lm_hidden_bf16 && lm_hidden_packed &&
+        lm_hidden_scales && lm_logits_f16) {
+        used_nvfp4_lm = launch_lm_head_cublaslt_bf16_top1(
+            final_normed,
+            lm_head_weight_packed,
+            lm_head_scales,
+            lm_hidden_bf16,
+            lm_hidden_packed,
+            lm_hidden_scales,
+            lm_logits_f16,
+            lm_bmv,
+            lm_bmi,
+            output_token,
+            stream);
+    }
+    if (!used_nvfp4_lm) {
+        int lm_blocks = 512;
+        pf_lm_head<<<lm_blocks, 256, 0, stream>>>(final_normed, lm_head_w, lm_bmv, lm_bmi, VOCAB);
+        pf_lm_reduce<<<1, 256, 0, stream>>>(lm_bmv, lm_bmi, output_token, lm_blocks);
+    }
+}
+
+}  // anonymous namespace
+
+// ===== Public entry point =====
+
+extern "C" void launch_prefill_bf16_nvfp4_lm(
+    const int *token_ids, int seq_len, int *output_token,
+    const void *embed_weight, const PFLayerWeights *layers,
+    const PFFusedLayerWeights *fused_layers,
+    const void *final_norm_w, const void *lm_head_w,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *fa_k_cache, void *fa_v_cache, void *dn_states, void *conv_bufs,
+    void *hidden, void *residual, void *normalized,
+    void *proj_buf, void *proj_buf2, void *proj_buf_half, void *proj_act_packed, void *proj_act_scales,
+    void *attn_buf, void *mlp_buf,
+    void *dn_out_buf, void *beta_buf, void *alpha_buf,
+    void *final_normed, void *hidden_bf16_out,
+    void *lm_bmv, void *lm_bmi,
+    void *lm_hidden_bf16, void *lm_hidden_packed,
+    void *lm_hidden_scales, void *lm_logits_f16,
+    cudaStream_t stream)
+{
+    launch_prefill_bf16_impl(
+        token_ids, seq_len, output_token,
+        (const __nv_bfloat16 *)embed_weight, layers, fused_layers,
+        (const __nv_bfloat16 *)final_norm_w, (const __nv_bfloat16 *)lm_head_w,
+        lm_head_weight_packed, lm_head_scales,
+        (__nv_bfloat16 *)fa_k_cache, (__nv_bfloat16 *)fa_v_cache,
+        (float *)dn_states, (float *)conv_bufs,
+        (__nv_bfloat16 *)hidden, (__nv_bfloat16 *)residual, (__nv_bfloat16 *)normalized,
+        (__nv_bfloat16 *)proj_buf, (__nv_bfloat16 *)proj_buf2, (__half *)proj_buf_half,
+        (uint8_t *)proj_act_packed, (uint8_t *)proj_act_scales,
+        (__nv_bfloat16 *)attn_buf, (__nv_bfloat16 *)mlp_buf,
+        (__nv_bfloat16 *)dn_out_buf,
+        (float *)beta_buf, (float *)alpha_buf,
+        (__nv_bfloat16 *)final_normed, (__nv_bfloat16 *)hidden_bf16_out,
+        (float *)lm_bmv, (int *)lm_bmi,
+        (__nv_bfloat16 *)lm_hidden_bf16, (uint8_t *)lm_hidden_packed,
+        (uint8_t *)lm_hidden_scales, (__half *)lm_logits_f16,
+        stream);
+}

--- a/megakernel/prefill_megakernel.cu
+++ b/megakernel/prefill_megakernel.cu
@@ -1,0 +1,1085 @@
+/**
+ * BF16 Prefill Megakernel for NVIDIA B200 (sm_100).
+ *
+ * One `cudaLaunchCooperativeKernel` dispatch. All 24 layers, all S tokens,
+ * processed in a single persistent kernel with `cg::this_grid().sync()`
+ * between phases. No cuBLAS, no intermediate launches, no host round-trips.
+ *
+ * Matmuls use WMMA (wraps `mma.sync` under the hood) with bf16 operands and
+ * f32 accumulate. Block tile [BTM=32, BTN=128]; warp grid 2×8. Work is
+ * distributed across the 148 persistent blocks via cyclic tile assignment.
+ *
+ * The DeltaNet recurrence keeps its 16-block-per-layer structure from the
+ * pre-mega version (hard serial dep over t) but sits inside the persistent
+ * kernel so there's no per-layer relaunch.
+ *
+ * Assumes S is a multiple of 32 (caller pads).
+ *
+ * Only compiled for Blackwell (sm_120/sm_121a). Excluded from the sm_86
+ * RTX 3090 build; see setup.py.
+ */
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 1200
+#error "prefill_megakernel.cu requires CUDA arch >= sm_120 (Blackwell)"
+#endif
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cooperative_groups.h>
+#include <mma.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+
+namespace cg = cooperative_groups;
+using namespace nvcuda;
+
+// ===== Model constants =====
+constexpr int HIDDEN = 1024;
+constexpr int INTER = 3584;
+constexpr int VOCAB = 248320;
+constexpr int NUM_LAYERS = 24;
+constexpr float RMS_EPS = 1e-6f;
+constexpr int MAX_SEQ = 2048;
+
+constexpr int FA_Q_HEADS = 8;
+constexpr int FA_KV_HEADS = 2;
+constexpr int FA_HEAD_DIM = 256;
+constexpr int FA_GQA = FA_Q_HEADS / FA_KV_HEADS;
+constexpr int FA_Q_SIZE = FA_Q_HEADS * FA_HEAD_DIM;
+constexpr int FA_QPROJ_SIZE = FA_Q_SIZE * 2;
+constexpr int FA_KV_SIZE = FA_KV_HEADS * FA_HEAD_DIM;
+constexpr int FA_ROT_DIM = 64;
+constexpr float FA_ROPE_THETA = 10000000.0f;
+
+constexpr int DN_HEADS = 16;
+constexpr int DN_KEY = 128;
+constexpr int DN_VAL = 128;
+constexpr int DN_CONV_K = 4;
+constexpr int DN_QK_SIZE = DN_HEADS * DN_KEY;
+constexpr int DN_V_SIZE = DN_HEADS * DN_VAL;
+constexpr int DN_CONV_CH = DN_QK_SIZE * 2 + DN_V_SIZE;  // 6144
+
+__device__ __constant__ int MEGA_LAYER_TYPE[NUM_LAYERS] = {
+    0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1
+};
+
+struct MegaLayerWeights {
+    int layer_type;
+    int _pad[3];
+    void *ptrs[14];
+};
+
+// ===== Kernel tile sizes =====
+#define MEGA_BLOCK_SIZE 512
+constexpr int MEGA_WARPS = MEGA_BLOCK_SIZE / 32;
+
+constexpr int WM = 16;
+constexpr int WN = 16;
+constexpr int WK = 16;
+// Block tile [32, 128] with 2×8 warp grid; each warp produces a [16, 16]
+// output. K is processed in BTK=64 chunks, double-buffered in shared
+// memory via cp.async so the next chunk streams in while we MMA on the
+// current one. This keeps parallelism high for small-N matmuls (down,
+// out, z projections) while letting the async loader hide global latency.
+constexpr int BTM = 32;
+constexpr int BTN = 128;
+constexpr int BTK = 64;                // k-chunk size (double buffered)
+constexpr int N_PER_WARP = 1;          // 16-col WMMA tile per warp
+constexpr int WARPS_M = 2;
+constexpr int WARPS_N = 8;
+static_assert(WARPS_M * WARPS_N == MEGA_WARPS, "warp grid must match block");
+static_assert(WARPS_N * WN * N_PER_WARP == BTN, "warp N coverage mismatch");
+static_assert(WARPS_M * WM == BTM, "warp M coverage mismatch");
+
+constexpr int LM_BLOCKS_MEGA = 1024;
+
+// ===== Small helpers =====
+__device__ __forceinline__ float mega_warp_sum(float v) {
+    for (int o = 16; o > 0; o >>= 1) v += __shfl_down_sync(0xffffffff, v, o);
+    return v;
+}
+__device__ __forceinline__ float mega_silu(float x) { return x / (1.0f + expf(-x)); }
+
+// cp.async.cg: copy 16 bytes global → shared, bypassing L1 (goes through L2).
+// The copy is asynchronous; producer threads must issue cp.async.commit_group
+// and consumers must cp.async.wait_group before reading shared.
+__device__ __forceinline__ void cp_async_16(void *dst_smem, const void *src_gmem) {
+    unsigned int smem_int = __cvta_generic_to_shared(dst_smem);
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n"
+                 :: "r"(smem_int), "l"(src_gmem));
+}
+
+__device__ __forceinline__ void cp_async_commit() {
+    asm volatile("cp.async.commit_group;\n");
+}
+
+template <int N>
+__device__ __forceinline__ void cp_async_wait_group() {
+    asm volatile("cp.async.wait_group %0;\n" :: "n"(N));
+}
+
+__device__ __forceinline__ void cp_async_wait_all() {
+    asm volatile("cp.async.wait_all;\n");
+}
+
+// ===== Phase: Embedding =====
+// hidden[s*H + i] = embed[ids[s]*H + i]
+__device__ void phase_embed(const int *ids, const __nv_bfloat16 *embed,
+                            __nv_bfloat16 *hidden, int S) {
+    int total = S * HIDDEN;
+    int stride = gridDim.x * blockDim.x;
+    for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < total; idx += stride) {
+        int s = idx / HIDDEN;
+        int i = idx - s * HIDDEN;
+        hidden[idx] = embed[ids[s] * HIDDEN + i];
+    }
+}
+
+// ===== Phase: RMSNorm =====
+// normalized[s, :] = (input[s, :] * rsqrt(mean(input[s, :]^2) + eps) * (1 + w)
+// Also copies input -> residual.
+// Rows distributed cyclically across blocks.
+__device__ void phase_rmsnorm(const __nv_bfloat16 *input, const __nv_bfloat16 *w,
+                              __nv_bfloat16 *output, __nv_bfloat16 *residual,
+                              int S, int D) {
+    int tid = threadIdx.x, wid = tid / 32, lid = tid % 32;
+    __shared__ float smem[MEGA_WARPS];
+
+    for (int s = blockIdx.x; s < S; s += gridDim.x) {
+        const __nv_bfloat16 *ri = input + s * D;
+        __nv_bfloat16 *ro = output + s * D;
+        __nv_bfloat16 *rr = residual + s * D;
+
+        float sq = 0;
+        for (int i = tid; i < D; i += blockDim.x) {
+            float v = __bfloat162float(ri[i]);
+            rr[i] = ri[i];
+            sq += v * v;
+        }
+        sq = mega_warp_sum(sq);
+        if (lid == 0) smem[wid] = sq;
+        __syncthreads();
+        if (wid == 0) {
+            float v = (lid < MEGA_WARPS) ? smem[lid] : 0;
+            v = mega_warp_sum(v);
+            if (lid == 0) smem[0] = rsqrtf(v / D + RMS_EPS);
+        }
+        __syncthreads();
+        float rstd = smem[0];
+        for (int i = tid; i < D; i += blockDim.x) {
+            float v = __bfloat162float(ri[i]) * rstd * (1.0f + __bfloat162float(w[i]));
+            ro[i] = __float2bfloat16(v);
+        }
+        __syncthreads();
+    }
+}
+
+// ===== Phase: bf16 matmul C[M, N] = A[M, K] @ W[N, K]^T =====
+// Requires M and N multiples of BTM and BTN respectively, K multiple of WK.
+// Each block owns a [BTM, BTN] output tile; warps within a block tile
+// [WARPS_M, WARPS_N]×[WM, WN].
+// ===== Pipelined double-buffered BF16 GEMM =====
+//
+// C[M, N] = A[M, K] × W[N, K]^T  (W stored row-major as [N, K]).
+//
+// Per block:
+//   Block tile   : [BTM=32, BTN=256]
+//   Warp grid    : 2 × 8
+//   Per-warp out : [16, 32] via 2× WMMA m16n16k16 accumulators
+//   K-chunk      : BTK=64 (double-buffered with cp.async)
+//
+// Shared memory layout (dynamic):
+//   sA[2][BTM][BTK]  : double-buffered A staging         (2*32*64*2 =  8 KB)
+//   sB[2][BTN][BTK]  : double-buffered B staging         (2*256*64*2= 64 KB)
+//   sC[BTM][BTN]     : f32 output accumulator staging    (32*256*4 = 32 KB)
+// Total: 104 KB dynamic shared per block (B200 carveout = 228 KB, ok).
+//
+// Threads-per-tile work:
+//   - A chunk is BTM*BTK = 32*64 = 2048 bf16 = 4 KB per buffer.
+//     Each thread copies 8 bf16 (16 B) per cp.async, so 2048/8 = 256 copies
+//     across 512 threads = ½ pass. Threads >= 256 skip the A load.
+//   - B chunk is BTN*BTK = 256*64 = 16384 bf16 = 32 KB per buffer.
+//     512 threads × 8 bf16 = 4096 bf16 per pass → 4 passes.
+
+__device__ void phase_matmul_bf16(const __nv_bfloat16 *A, const __nv_bfloat16 *W,
+                                  __nv_bfloat16 *C, int M, int N, int K) {
+    extern __shared__ __align__(16) char smem_raw[];
+    __nv_bfloat16 *sA = reinterpret_cast<__nv_bfloat16 *>(smem_raw);
+    __nv_bfloat16 *sB = sA + 2 * BTM * BTK;
+    float *tile_f32 = reinterpret_cast<float *>(sB + 2 * BTN * BTK);
+
+    int tid = threadIdx.x;
+    int warp_id = tid >> 5;
+    int wm = warp_id / WARPS_N;
+    int wn = warp_id % WARPS_N;
+
+    int num_m_tiles = (M + BTM - 1) / BTM;
+    int num_n_tiles = (N + BTN - 1) / BTN;
+    int total_tiles = num_m_tiles * num_n_tiles;
+
+    // K must be a multiple of BTK for the pipeline to work cleanly.
+    // All our Ks (1024, 2048, 3584) satisfy K % 64 == 0.
+    int num_k_chunks = K / BTK;
+
+    // Lambda: asynchronously stage one (BM, BTK) tile of A or B from global
+    // into the `buf`-th shared buffer, using cp.async.cg (bypasses L1).
+    auto issue_a_chunk = [&] (int buf, int m_start, int k_start) {
+        const __nv_bfloat16 *src_base = A + m_start * K + k_start;
+        __nv_bfloat16 *dst_base = sA + buf * BTM * BTK;
+        // 2048 bf16 elements = 256 cp.async calls at 8 bf16 each.
+        // Use 256 threads (half the block). Each thread does 1 call.
+        if (tid < 256) {
+            int r = tid >> 3;            // 0..31 rows
+            int c = (tid & 7) * 8;        // col start within BTK
+            cp_async_16(dst_base + r * BTK + c,
+                         src_base + r * K + c);
+        }
+    };
+
+    auto issue_b_chunk = [&] (int buf, int n_start, int k_start) {
+        // W is [N, K] row-major; our tile is rows [n_start, n_start+BTN)
+        // and cols [k_start, k_start+BTK). In shared we lay it out as
+        // [BTN, BTK] so WMMA col_major loads get the correct N-fragment.
+        const __nv_bfloat16 *src_base = W + n_start * K + k_start;
+        __nv_bfloat16 *dst_base = sB + buf * BTN * BTK;
+        // BTN * BTK / 8 = 128*64/8 = 1024 cp.async calls; 512 threads × 2.
+        #pragma unroll
+        for (int it = 0; it < 2; it++) {
+            int idx = tid + it * blockDim.x;
+            int r = idx >> 3;         // 0..127 rows
+            int c = (idx & 7) * 8;     // col start within BTK
+            if (r < BTN) {
+                cp_async_16(dst_base + r * BTK + c,
+                             src_base + r * K + c);
+            }
+        }
+    };
+
+    for (int tile = blockIdx.x; tile < total_tiles; tile += gridDim.x) {
+        int mt = tile / num_n_tiles;
+        int nt = tile % num_n_tiles;
+        int m_start = mt * BTM;
+        int n_start = nt * BTN;
+        bool m_in_bounds = (m_start < M);
+        bool n_in_bounds = (n_start < N);
+
+        // Per-warp accumulators: 2 × [16×16] f32 WMMA fragments.
+        wmma::fragment<wmma::accumulator, WM, WN, WK, float> c_frag[N_PER_WARP];
+        #pragma unroll
+        for (int n = 0; n < N_PER_WARP; n++) wmma::fill_fragment(c_frag[n], 0.0f);
+
+        // Prefetch chunk 0 into buffer 0.
+        if (m_in_bounds && n_in_bounds) {
+            issue_a_chunk(0, m_start, 0);
+            issue_b_chunk(0, n_start, 0);
+        }
+        cp_async_commit();
+
+        int warp_row_in_block = wm * WM;
+        int warp_col_in_block = wn * WN * N_PER_WARP;
+
+        for (int ck = 0; ck < num_k_chunks; ck++) {
+            int cur = ck & 1;
+            int nxt = cur ^ 1;
+
+            // Prefetch next chunk
+            if (ck + 1 < num_k_chunks) {
+                if (m_in_bounds && n_in_bounds) {
+                    issue_a_chunk(nxt, m_start, (ck + 1) * BTK);
+                    issue_b_chunk(nxt, n_start, (ck + 1) * BTK);
+                }
+                cp_async_commit();
+                cp_async_wait_group<1>();
+            } else {
+                cp_async_wait_group<0>();
+            }
+            __syncthreads();
+
+            if (m_in_bounds && n_in_bounds) {
+                const __nv_bfloat16 *sA_buf = sA + cur * BTM * BTK;
+                const __nv_bfloat16 *sB_buf = sB + cur * BTN * BTK;
+
+                // MMA over this chunk: BTK/WK = 4 k-steps, each with 1 A load
+                // + N_PER_WARP B loads + N_PER_WARP MMAs.
+                #pragma unroll
+                for (int ki = 0; ki < BTK; ki += WK) {
+                    wmma::fragment<wmma::matrix_a, WM, WN, WK, __nv_bfloat16, wmma::row_major> a_frag;
+                    wmma::load_matrix_sync(a_frag, sA_buf + warp_row_in_block * BTK + ki, BTK);
+
+                    #pragma unroll
+                    for (int n = 0; n < N_PER_WARP; n++) {
+                        int col_in_block = warp_col_in_block + n * WN;
+                        wmma::fragment<wmma::matrix_b, WM, WN, WK, __nv_bfloat16, wmma::col_major> b_frag;
+                        wmma::load_matrix_sync(b_frag, sB_buf + col_in_block * BTK + ki, BTK);
+                        wmma::mma_sync(c_frag[n], a_frag, b_frag, c_frag[n]);
+                    }
+                }
+            }
+        }
+
+        // Epilogue: store each accumulator to its slot in the f32 tile.
+        if (m_in_bounds && n_in_bounds) {
+            #pragma unroll
+            for (int n = 0; n < N_PER_WARP; n++) {
+                int col_in_block = warp_col_in_block + n * WN;
+                wmma::store_matrix_sync(
+                    tile_f32 + warp_row_in_block * BTN + col_in_block,
+                    c_frag[n], BTN, wmma::mem_row_major);
+            }
+        }
+        __syncthreads();
+
+        // f32 → bf16 cast and write to global, respecting M/N bounds.
+        if (m_in_bounds && n_in_bounds) {
+            for (int i = threadIdx.x; i < BTM * BTN; i += blockDim.x) {
+                int mi = i / BTN, ni = i % BTN;
+                int gm = m_start + mi, gn = n_start + ni;
+                if (gm < M && gn < N) {
+                    C[gm * N + gn] = __float2bfloat16(tile_f32[i]);
+                }
+            }
+        }
+        __syncthreads();
+    }
+}
+
+// Same as above but output is f32 (for beta/alpha which feed the recurrence as f32).
+// (unused in the current layer schedule — beta/alpha are done via
+// phase_matvec_small_to_f32 below since N=16 which doesn't fit WMMA 16×16
+// output fragments cleanly without padding.)
+
+// ===== Phase: tiny matvec for beta/alpha (N=16) =====
+// Output is f32.
+__device__ void phase_matvec_small_to_f32(const __nv_bfloat16 *in, const __nv_bfloat16 *w,
+                                          float *out, int S, int K, int N) {
+    // One (s, n) per warp, cyclic assignment.
+    int warps_per_block = blockDim.x / 32;
+    int global_warp = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    int total_warps = gridDim.x * warps_per_block;
+    int total = S * N;
+    int lid = threadIdx.x & 31;
+
+    for (int idx = global_warp; idx < total; idx += total_warps) {
+        int s = idx / N, n = idx - s * N;
+        const __nv_bfloat16 *ir = in + s * K;
+        const __nv_bfloat16 *wr = w + n * K;
+        float sum = 0;
+        for (int k = lid; k < K; k += 32) {
+            sum += __bfloat162float(ir[k]) * __bfloat162float(wr[k]);
+        }
+        sum = mega_warp_sum(sum);
+        if (lid == 0) out[idx] = sum;
+    }
+}
+
+// ===== Phase: elementwise bf16 residual add =====
+__device__ void phase_add_residual(const __nv_bfloat16 *a, const __nv_bfloat16 *b,
+                                   __nv_bfloat16 *out, int total) {
+    int stride = gridDim.x * blockDim.x;
+    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < total; i += stride) {
+        out[i] = __float2bfloat16(__bfloat162float(a[i]) + __bfloat162float(b[i]));
+    }
+}
+
+// ===== Phase: SiLU(gate) * up =====
+__device__ void phase_silu_mul(const __nv_bfloat16 *gate, const __nv_bfloat16 *up,
+                               __nv_bfloat16 *out, int total) {
+    int stride = gridDim.x * blockDim.x;
+    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < total; i += stride) {
+        float g = __bfloat162float(gate[i]);
+        out[i] = __float2bfloat16(mega_silu(g) * __bfloat162float(up[i]));
+    }
+}
+
+// ===== Phase: DeltaNet recurrence (16 heads, each on its own block) =====
+// Reuses the optimized B200 per-head inner loop: conv ring-buffer in shared,
+// conv weights in shared, s_out in shared, norm_w in shared.
+__device__ void phase_deltanet_recurrence(
+    const __nv_bfloat16 *qkv_proj,   // [S, DN_CONV_CH]
+    const __nv_bfloat16 *z_proj,     // [S, DN_V_SIZE]
+    const float *beta_proj,          // [S, DN_HEADS]
+    const float *alpha_proj,         // [S, DN_HEADS]
+    const __nv_bfloat16 *conv_w,     // [DN_CONV_CH, DN_CONV_K]
+    const __nv_bfloat16 *a_log,      // [DN_HEADS]
+    const __nv_bfloat16 *dt_bias,    // [DN_HEADS]
+    const __nv_bfloat16 *norm_w,     // [DN_VAL]
+    float *state,                    // [DN_HEADS, DN_KEY, DN_VAL]
+    float *conv_buf,                 // [DN_CONV_CH, DN_CONV_K]
+    __nv_bfloat16 *output,           // [S, DN_V_SIZE]
+    int S)
+{
+    int h = blockIdx.x;
+    if (h >= DN_HEADS) return;  // extra blocks stay idle this phase
+
+    int tid = threadIdx.x, wid = tid / 32, lid = tid % 32;
+    constexpr int NWARPS = 16;
+    constexpr float Q_SCALE = 1.0f / 11.313708498984761f;
+    constexpr int QKV_CH = 2 * DN_KEY + DN_VAL;
+
+    float a_log_val = __bfloat162float(a_log[h]);
+    float dt_b = __bfloat162float(dt_bias[h]);
+
+    __shared__ float s_q[DN_KEY], s_k[DN_KEY], s_v[DN_VAL];
+    __shared__ float s_beta, s_decay;
+    __shared__ float s_gnorm[NWARPS];
+    __shared__ float s_conv[QKV_CH * DN_CONV_K];
+    __shared__ float s_conv_w[QKV_CH * DN_CONV_K];
+    __shared__ float s_z[DN_VAL];
+    __shared__ float s_out[DN_VAL];
+    __shared__ float s_norm_w[DN_VAL];
+
+    float *my_state = state + h * DN_KEY * DN_VAL;
+
+    constexpr int CPW = DN_VAL / NWARPS;   // 8
+    constexpr int RPL = DN_KEY / 32;       // 4
+    float sreg[CPW * RPL];
+
+    for (int jj = 0; jj < CPW; jj++) {
+        int j = wid * CPW + jj;
+        for (int ii = 0; ii < RPL; ii++) {
+            sreg[jj * RPL + ii] = my_state[j * DN_KEY + lid + ii * 32];
+        }
+    }
+
+    auto ch_global = [&] (int c) -> int {
+        if (c < DN_KEY) return h * DN_KEY + c;
+        if (c < 2 * DN_KEY) return DN_QK_SIZE + h * DN_KEY + (c - DN_KEY);
+        return 2 * DN_QK_SIZE + h * DN_VAL + (c - 2 * DN_KEY);
+    };
+
+    for (int c = tid; c < QKV_CH; c += blockDim.x) {
+        int gch = ch_global(c);
+        const float *src_state = conv_buf + gch * DN_CONV_K;
+        const __nv_bfloat16 *src_w = conv_w + gch * DN_CONV_K;
+        float *dst_state = s_conv + c * DN_CONV_K;
+        float *dst_w = s_conv_w + c * DN_CONV_K;
+        #pragma unroll
+        for (int k = 0; k < DN_CONV_K; k++) {
+            dst_state[k] = src_state[k];
+            dst_w[k] = __bfloat162float(src_w[k]);
+        }
+    }
+    for (int i = tid; i < DN_VAL; i += blockDim.x) {
+        s_norm_w[i] = __bfloat162float(norm_w[i]);
+    }
+    __syncthreads();
+
+    for (int t = 0; t < S; t++) {
+        // Fused conv1d+SiLU for all 384 per-head channels.
+        for (int c = tid; c < QKV_CH; c += blockDim.x) {
+            int gch = ch_global(c);
+            float *cs = s_conv + c * DN_CONV_K;
+            const float *cw = s_conv_w + c * DN_CONV_K;
+            float new_x = __bfloat162float(qkv_proj[t * DN_CONV_CH + gch]);
+            float h0 = cs[1], h1 = cs[2], h2 = cs[3];
+            cs[0] = h0; cs[1] = h1; cs[2] = h2; cs[3] = new_x;
+            float co = h0 * cw[0] + h1 * cw[1] + h2 * cw[2] + new_x * cw[3];
+            float silu_out = mega_silu(co);
+            if (c < DN_KEY)           s_q[c] = silu_out;
+            else if (c < 2 * DN_KEY)  s_k[c - DN_KEY] = silu_out;
+            else                       s_v[c - 2 * DN_KEY] = silu_out;
+        }
+        // Prefetch z-row in parallel.
+        {
+            const __nv_bfloat16 *z_h_bf = z_proj + t * DN_V_SIZE + h * DN_VAL;
+            for (int i = tid; i < DN_VAL; i += blockDim.x) {
+                s_z[i] = __bfloat162float(z_h_bf[i]);
+            }
+        }
+        __syncthreads();
+
+        // L2 normalize q (warp 0), L2 normalize k (warp 1), beta/decay
+        // scalars (warp 2 lane 0) — all disjoint targets, one sync fences
+        // the three in parallel (saves one sync per step vs the old
+        // two-phase normalize→beta/decay sequence).
+        if (wid == 0) {
+            float sq = 0; for (int i = lid; i < DN_KEY; i += 32) sq += s_q[i] * s_q[i];
+            sq = mega_warp_sum(sq);
+            float n = rsqrtf(sq + 1e-6f) * Q_SCALE;
+            n = __shfl_sync(0xffffffff, n, 0);
+            for (int i = lid; i < DN_KEY; i += 32) s_q[i] *= n;
+        }
+        if (wid == 1) {
+            float sq = 0; for (int i = lid; i < DN_KEY; i += 32) sq += s_k[i] * s_k[i];
+            sq = mega_warp_sum(sq);
+            float n = rsqrtf(sq + 1e-6f);
+            n = __shfl_sync(0xffffffff, n, 0);
+            for (int i = lid; i < DN_KEY; i += 32) s_k[i] *= n;
+        }
+        if (wid == 2 && lid == 0) {
+            s_beta = 1.f / (1.f + expf(-beta_proj[t * DN_HEADS + h]));
+            float x = alpha_proj[t * DN_HEADS + h] + dt_b;
+            float sp = (x > 20.f) ? x : logf(1.f + expf(x));
+            s_decay = expf(-expf(a_log_val) * sp);
+        }
+        __syncthreads();
+
+        float beta = s_beta, decay = s_decay;
+        __nv_bfloat16 *out_h = output + t * DN_V_SIZE + h * DN_VAL;
+
+        // Cache per-lane s_k / s_q into registers once per step so the
+        // CPW=8 inner-loop iterations read from registers instead of
+        // shared memory.
+        float sk_cache[RPL];
+        float sq_cache[RPL];
+        #pragma unroll
+        for (int ii = 0; ii < RPL; ii++) {
+            sk_cache[ii] = s_k[lid + ii * 32];
+            sq_cache[ii] = s_q[lid + ii * 32];
+        }
+
+        #pragma unroll
+        for (int jj = 0; jj < CPW; jj++) {
+            int j = wid * CPW + jj;
+            float kv = 0;
+            #pragma unroll
+            for (int ii = 0; ii < RPL; ii++) kv += sreg[jj * RPL + ii] * sk_cache[ii];
+            kv = mega_warp_sum(kv);
+            kv = __shfl_sync(0xffffffff, kv, 0);
+            float delta = (s_v[j] - decay * kv) * beta;
+            float attn = 0;
+            #pragma unroll
+            for (int ii = 0; ii < RPL; ii++) {
+                sreg[jj * RPL + ii] = decay * sreg[jj * RPL + ii] + sk_cache[ii] * delta;
+                attn += sreg[jj * RPL + ii] * sq_cache[ii];
+            }
+            attn = mega_warp_sum(attn);
+            if (lid == 0) s_out[j] = attn;
+        }
+        __syncthreads();
+
+        // Gated RMSNorm.
+        //
+        // After writing per-warp partials to s_gnorm[wid] and syncing, EVERY
+        // thread reads all 16 warp partials and computes rstd locally — no
+        // second "warp 0 reduces then everyone syncs to pick up rstd" round
+        // trip through shared memory. Saves one __syncthreads per step
+        // (×520 steps ×18 layers = ~9k syncs removed per prefill).
+        float sq2 = 0;
+        for (int i = tid; i < DN_VAL; i += blockDim.x) { float v = s_out[i]; sq2 += v * v; }
+        sq2 = mega_warp_sum(sq2);
+        if (lid == 0) s_gnorm[wid] = sq2;
+        __syncthreads();
+
+        float total = 0;
+        #pragma unroll
+        for (int w = 0; w < NWARPS; w++) total += s_gnorm[w];
+        float rstd = rsqrtf(total / DN_VAL + RMS_EPS);
+
+        for (int i = tid; i < DN_VAL; i += blockDim.x) {
+            float n = s_out[i] * rstd * s_norm_w[i];
+            out_h[i] = __float2bfloat16(n * mega_silu(s_z[i]));
+        }
+        // No end-of-iter sync: each thread's writes to shared in the next
+        // iteration's conv+z phase target its own slot (stride = blockDim.x)
+        // and the first cross-warp read is fenced by the existing sync
+        // inside that phase.
+    }
+
+    // State writeback
+    for (int jj = 0; jj < CPW; jj++) {
+        int j = wid * CPW + jj;
+        for (int ii = 0; ii < RPL; ii++) {
+            my_state[j * DN_KEY + lid + ii * 32] = sreg[jj * RPL + ii];
+        }
+    }
+    __syncthreads();
+    for (int c = tid; c < QKV_CH; c += blockDim.x) {
+        int gch = ch_global(c);
+        float *dst_state = conv_buf + gch * DN_CONV_K;
+        const float *src_state = s_conv + c * DN_CONV_K;
+        #pragma unroll
+        for (int k = 0; k < DN_CONV_K; k++) {
+            dst_state[k] = src_state[k];
+        }
+    }
+}
+
+// ===== Phase: QK norm + RoPE + KV cache write =====
+// One warp per (s, head) for q, and for k/v in sequence.
+__device__ void phase_qk_norm_rope(
+    __nv_bfloat16 *q,               // [S, FA_QPROJ_SIZE] (in-place)
+    __nv_bfloat16 *k,               // [S, FA_KV_SIZE]    (in-place)
+    const __nv_bfloat16 *v,          // [S, FA_KV_SIZE]
+    const __nv_bfloat16 *qnw, const __nv_bfloat16 *knw,
+    __nv_bfloat16 *k_cache,          // [FA_KV_HEADS, MAX_SEQ, FA_HEAD_DIM]
+    __nv_bfloat16 *v_cache,
+    int S)
+{
+    int warps_per_block = blockDim.x / 32;
+    int global_warp = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    int total_warps = gridDim.x * warps_per_block;
+    int lid = threadIdx.x & 31;
+
+    int total_q = S * FA_Q_HEADS;
+    int total_k = S * FA_KV_HEADS;
+    int total = total_q + total_k;
+
+    for (int idx = global_warp; idx < total; idx += total_warps) {
+        if (idx < total_q) {
+            int pos = idx / FA_Q_HEADS, head = idx - pos * FA_Q_HEADS;
+            __nv_bfloat16 *qh = q + pos * FA_QPROJ_SIZE + head * FA_HEAD_DIM * 2;
+            float ss = 0;
+            for (int i = lid; i < FA_HEAD_DIM; i += 32) {
+                float v = __bfloat162float(qh[i]); ss += v * v;
+            }
+            ss = mega_warp_sum(ss);
+            float sc = rsqrtf(ss / FA_HEAD_DIM + RMS_EPS);
+            sc = __shfl_sync(0xffffffff, sc, 0);
+            for (int i = lid; i < FA_HEAD_DIM; i += 32) {
+                float normed = __bfloat162float(qh[i]) * sc * (1.f + __bfloat162float(qnw[i]));
+                if (i < FA_ROT_DIM) {
+                    float fe = float(2 * (i % (FA_ROT_DIM / 2))) / FA_ROT_DIM;
+                    float freq = float(pos) / powf(FA_ROPE_THETA, fe);
+                    float cv = cosf(freq), sv = sinf(freq);
+                    int p = (i < FA_ROT_DIM / 2) ? i + FA_ROT_DIM / 2 : i - FA_ROT_DIM / 2;
+                    float pv = __bfloat162float(qh[p]) * sc * (1.f + __bfloat162float(qnw[p]));
+                    qh[i] = __float2bfloat16((i < FA_ROT_DIM / 2)
+                                              ? (normed * cv - pv * sv)
+                                              : (pv * sv + normed * cv));
+                } else {
+                    qh[i] = __float2bfloat16(normed);
+                }
+            }
+        } else {
+            int kidx = idx - total_q;
+            int pos = kidx / FA_KV_HEADS, head = kidx - pos * FA_KV_HEADS;
+            __nv_bfloat16 *kh = k + pos * FA_KV_SIZE + head * FA_HEAD_DIM;
+            const __nv_bfloat16 *vh = v + pos * FA_KV_SIZE + head * FA_HEAD_DIM;
+            __nv_bfloat16 *kc = k_cache + head * MAX_SEQ * FA_HEAD_DIM + pos * FA_HEAD_DIM;
+            __nv_bfloat16 *vc = v_cache + head * MAX_SEQ * FA_HEAD_DIM + pos * FA_HEAD_DIM;
+            float ss = 0;
+            for (int i = lid; i < FA_HEAD_DIM; i += 32) {
+                float v = __bfloat162float(kh[i]); ss += v * v;
+            }
+            ss = mega_warp_sum(ss);
+            float sc = rsqrtf(ss / FA_HEAD_DIM + RMS_EPS);
+            sc = __shfl_sync(0xffffffff, sc, 0);
+            for (int i = lid; i < FA_HEAD_DIM; i += 32) {
+                float normed = __bfloat162float(kh[i]) * sc * (1.f + __bfloat162float(knw[i]));
+                float fk;
+                if (i < FA_ROT_DIM) {
+                    float fe = float(2 * (i % (FA_ROT_DIM / 2))) / FA_ROT_DIM;
+                    float freq = float(pos) / powf(FA_ROPE_THETA, fe);
+                    float cv = cosf(freq), sv = sinf(freq);
+                    int p = (i < FA_ROT_DIM / 2) ? i + FA_ROT_DIM / 2 : i - FA_ROT_DIM / 2;
+                    float pv = __bfloat162float(kh[p]) * sc * (1.f + __bfloat162float(knw[p]));
+                    fk = (i < FA_ROT_DIM / 2) ? (normed * cv - pv * sv) : (pv * sv + normed * cv);
+                } else {
+                    fk = normed;
+                }
+                kh[i] = __float2bfloat16(fk);
+                kc[i] = __float2bfloat16(fk);
+                vc[i] = vh[i];
+            }
+        }
+    }
+}
+
+// ===== Phase: causal attention (per (s, q_head), single-warp online softmax) =====
+__device__ void phase_causal_attn(const __nv_bfloat16 *q, const __nv_bfloat16 *k,
+                                  const __nv_bfloat16 *v, __nv_bfloat16 *out, int S)
+{
+    int warps_per_block = blockDim.x / 32;
+    int global_warp = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    int total_warps = gridDim.x * warps_per_block;
+    int lid = threadIdx.x & 31;
+
+    int total = S * FA_Q_HEADS;
+    float scale = 1.0f / sqrtf(float(FA_HEAD_DIM));
+    constexpr int EPL = FA_HEAD_DIM / 32;
+
+    for (int idx = global_warp; idx < total; idx += total_warps) {
+        int pos = idx / FA_Q_HEADS, qh = idx - pos * FA_Q_HEADS;
+        int kvh = qh / FA_GQA;
+
+        const __nv_bfloat16 *qv = q + pos * FA_QPROJ_SIZE + qh * FA_HEAD_DIM * 2;
+        const __nv_bfloat16 *gv = qv + FA_HEAD_DIM;
+        __nv_bfloat16 *ov = out + pos * FA_Q_SIZE + qh * FA_HEAD_DIM;
+
+        float ql[EPL];
+        for (int e = 0; e < EPL; e++) ql[e] = __bfloat162float(qv[lid * EPL + e]);
+        float oa[EPL] = {};
+        float mx = -1e30f, se = 0;
+
+        for (int kp = 0; kp <= pos; kp++) {
+            const __nv_bfloat16 *kv_ptr = k + kp * FA_KV_SIZE + kvh * FA_HEAD_DIM;
+            const __nv_bfloat16 *vv = v + kp * FA_KV_SIZE + kvh * FA_HEAD_DIM;
+            float sc = 0;
+            for (int e = 0; e < EPL; e++) sc += ql[e] * __bfloat162float(kv_ptr[lid * EPL + e]);
+            sc = mega_warp_sum(sc) * scale;
+            sc = __shfl_sync(0xffffffff, sc, 0);
+            float om = mx;
+            mx = fmaxf(mx, sc);
+            float ed = expf(om - mx);
+            se = se * ed + expf(sc - mx);
+            float wt = expf(sc - mx);
+            for (int e = 0; e < EPL; e++) {
+                oa[e] = oa[e] * ed + wt * __bfloat162float(vv[lid * EPL + e]);
+            }
+        }
+        float rs = 1.f / se;
+        for (int e = 0; e < EPL; e++) {
+            int i = lid * EPL + e;
+            float g = 1.f / (1.f + expf(-__bfloat162float(gv[i])));
+            ov[i] = __float2bfloat16(oa[e] * rs * g);
+        }
+    }
+}
+
+// ===== Phase: final norm (just last row) =====
+// Only block 0 works. hidden_out is embedded residual, final_normed is the
+// rmsnorm'd row used by the LM head.
+__device__ void phase_final_norm(const __nv_bfloat16 *hidden,
+                                 const __nv_bfloat16 *w,
+                                 __nv_bfloat16 *final_normed,
+                                 __nv_bfloat16 *hidden_bf16_out,
+                                 int S)
+{
+    if (blockIdx.x != 0) return;
+    int tid = threadIdx.x, wid = tid / 32, lid = tid % 32;
+    __shared__ float smem[MEGA_WARPS];
+
+    const __nv_bfloat16 *row = hidden + (S - 1) * HIDDEN;
+    float sq = 0;
+    for (int i = tid; i < HIDDEN; i += blockDim.x) {
+        float v = __bfloat162float(row[i]); sq += v * v;
+    }
+    sq = mega_warp_sum(sq);
+    if (lid == 0) smem[wid] = sq;
+    __syncthreads();
+    if (wid == 0) {
+        float v = (lid < MEGA_WARPS) ? smem[lid] : 0;
+        v = mega_warp_sum(v);
+        if (lid == 0) smem[0] = rsqrtf(v / HIDDEN + RMS_EPS);
+    }
+    __syncthreads();
+    float rstd = smem[0];
+    for (int i = tid; i < HIDDEN; i += blockDim.x) {
+        float v = __bfloat162float(row[i]);
+        final_normed[i] = __float2bfloat16(v * rstd * (1.f + __bfloat162float(w[i])));
+        hidden_bf16_out[i] = row[i];
+    }
+}
+
+// ===== Phase: LM head (bf16 matvec over full vocab) =====
+// Each block computes part of the vocab and writes (max_val, argmax) pair.
+// A final reduce picks the global argmax.
+__device__ void phase_lm_head(const __nv_bfloat16 *hidden,
+                              const __nv_bfloat16 *weight,
+                              float *block_max_vals,
+                              int *block_max_idxs)
+{
+    __shared__ float s_hidden[HIDDEN];
+    for (int i = threadIdx.x; i < HIDDEN; i += blockDim.x) {
+        s_hidden[i] = __bfloat162float(hidden[i]);
+    }
+    __syncthreads();
+
+    int warp_id = threadIdx.x / 32;
+    int lid = threadIdx.x & 31;
+    int num_warps = blockDim.x / 32;
+    int total_blocks = gridDim.x;
+    int rpb = (VOCAB + total_blocks - 1) / total_blocks;
+    int rs = blockIdx.x * rpb;
+    int re = min(rs + rpb, VOCAB);
+
+    float local_max = -INFINITY;
+    int local_max_idx = -1;
+    for (int m = rs + warp_id; m < re; m += num_warps) {
+        const __nv_bfloat16 *wr = weight + m * HIDDEN;
+        float sum = 0;
+        for (int k = lid; k < HIDDEN; k += 32) {
+            sum += __bfloat162float(wr[k]) * s_hidden[k];
+        }
+        sum = mega_warp_sum(sum);
+        if (lid == 0 && sum > local_max) { local_max = sum; local_max_idx = m; }
+    }
+    local_max = __shfl_sync(0xffffffff, local_max, 0);
+    local_max_idx = __shfl_sync(0xffffffff, local_max_idx, 0);
+
+    __shared__ float wm[32]; __shared__ int wi[32];
+    if (lid == 0) { wm[warp_id] = local_max; wi[warp_id] = local_max_idx; }
+    __syncthreads();
+    if (warp_id == 0) {
+        float mv = (lid < num_warps) ? wm[lid] : -INFINITY;
+        int mi = (lid < num_warps) ? wi[lid] : -1;
+        for (int o = 16; o > 0; o /= 2) {
+            float ov = __shfl_down_sync(0xffffffff, mv, o);
+            int oi = __shfl_down_sync(0xffffffff, mi, o);
+            if (ov > mv) { mv = ov; mi = oi; }
+        }
+        if (lid == 0) {
+            block_max_vals[blockIdx.x] = mv;
+            block_max_idxs[blockIdx.x] = mi;
+        }
+    }
+}
+
+// ===== Phase: LM reduce (block 0 only) =====
+__device__ void phase_lm_reduce(const float *block_max_vals,
+                                const int *block_max_idxs,
+                                int *output_token, int num_blocks)
+{
+    if (blockIdx.x != 0) return;
+    int tid = threadIdx.x;
+    __shared__ float sv[MEGA_BLOCK_SIZE];
+    __shared__ int si[MEGA_BLOCK_SIZE];
+    float bv = -INFINITY; int bi = -1;
+    for (int i = tid; i < num_blocks; i += blockDim.x) {
+        float v = block_max_vals[i];
+        if (v > bv) { bv = v; bi = block_max_idxs[i]; }
+    }
+    sv[tid] = bv; si[tid] = bi;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s && sv[tid + s] > sv[tid]) { sv[tid] = sv[tid + s]; si[tid] = si[tid + s]; }
+        __syncthreads();
+    }
+    if (tid == 0) *output_token = si[0];
+}
+
+// ==========================================================================
+// Main megakernel. All device work for a prefill lives in this one dispatch.
+// ==========================================================================
+__global__ void __launch_bounds__(MEGA_BLOCK_SIZE, 1)
+prefill_megakernel(
+    const int *token_ids, int S, int *output_token,
+    const __nv_bfloat16 *embed_weight, const MegaLayerWeights *layers,
+    const __nv_bfloat16 *final_norm_w, const __nv_bfloat16 *lm_head_w,
+    __nv_bfloat16 *fa_k_cache, __nv_bfloat16 *fa_v_cache,
+    float *dn_states, float *conv_bufs,
+    __nv_bfloat16 *hidden, __nv_bfloat16 *residual, __nv_bfloat16 *normalized,
+    __nv_bfloat16 *proj_buf, __nv_bfloat16 *proj_buf2,
+    __nv_bfloat16 *attn_buf, __nv_bfloat16 *mlp_buf,
+    __nv_bfloat16 *dn_out_buf,
+    float *beta_buf, float *alpha_buf,
+    __nv_bfloat16 *final_normed, __nv_bfloat16 *hidden_bf16_out,
+    float *lm_bmv, int *lm_bmi)
+{
+    cg::grid_group grid = cg::this_grid();
+
+    // Pad S up to the matmul block-tile multiple so WMMA fragments always
+    // land inside allocated scratch. Padding rows are computed through every
+    // matmul but never influence sequential phases (DN recurrence, RoPE,
+    // causal attn, final norm), which use S directly.
+    int S_pad = ((S + BTM - 1) / BTM) * BTM;
+
+    int fa_stride = FA_KV_HEADS * MAX_SEQ * FA_HEAD_DIM;
+    int dn_stride = DN_HEADS * DN_KEY * DN_VAL;
+
+    // Phase 0: Embedding for real tokens; zero-fill padding rows so matmuls
+    // never read uninitialised memory.
+    phase_embed(token_ids, embed_weight, hidden, S);
+    // Zero the padding tail of hidden.
+    {
+        int stride = gridDim.x * blockDim.x;
+        int start = S * HIDDEN;
+        int end = S_pad * HIDDEN;
+        for (int i = start + blockIdx.x * blockDim.x + threadIdx.x; i < end; i += stride) {
+            hidden[i] = __float2bfloat16(0.0f);
+        }
+    }
+    grid.sync();
+
+    int fa_idx = 0, dn_idx = 0;
+
+    for (int li = 0; li < NUM_LAYERS; li++) {
+        const MegaLayerWeights &lw = layers[li];
+        int lt = MEGA_LAYER_TYPE[li];
+
+        const __nv_bfloat16 *inp_norm_w = (const __nv_bfloat16 *)lw.ptrs[0];
+        phase_rmsnorm(hidden, inp_norm_w, normalized, residual, S_pad, HIDDEN);
+        grid.sync();
+
+        if (lt == 0) {
+            // DeltaNet
+            const __nv_bfloat16 *qkv_w = (const __nv_bfloat16 *)lw.ptrs[1];
+            const __nv_bfloat16 *z_w   = (const __nv_bfloat16 *)lw.ptrs[2];
+            const __nv_bfloat16 *beta_w = (const __nv_bfloat16 *)lw.ptrs[3];
+            const __nv_bfloat16 *alpha_w= (const __nv_bfloat16 *)lw.ptrs[4];
+            const __nv_bfloat16 *conv_w = (const __nv_bfloat16 *)lw.ptrs[5];
+            const __nv_bfloat16 *a_log  = (const __nv_bfloat16 *)lw.ptrs[6];
+            const __nv_bfloat16 *dt_bias= (const __nv_bfloat16 *)lw.ptrs[7];
+            const __nv_bfloat16 *dn_norm= (const __nv_bfloat16 *)lw.ptrs[8];
+            const __nv_bfloat16 *out_w  = (const __nv_bfloat16 *)lw.ptrs[9];
+            const __nv_bfloat16 *post_norm = (const __nv_bfloat16 *)lw.ptrs[10];
+            const __nv_bfloat16 *gate_w = (const __nv_bfloat16 *)lw.ptrs[11];
+            const __nv_bfloat16 *up_w   = (const __nv_bfloat16 *)lw.ptrs[12];
+            const __nv_bfloat16 *down_w = (const __nv_bfloat16 *)lw.ptrs[13];
+
+            phase_matmul_bf16(normalized, qkv_w, proj_buf, S_pad, DN_CONV_CH, HIDDEN);
+            phase_matmul_bf16(normalized, z_w,   proj_buf2, S_pad, DN_V_SIZE, HIDDEN);
+            phase_matvec_small_to_f32(normalized, beta_w,  beta_buf,  S, HIDDEN, DN_HEADS);
+            phase_matvec_small_to_f32(normalized, alpha_w, alpha_buf, S, HIDDEN, DN_HEADS);
+            grid.sync();
+
+            phase_deltanet_recurrence(proj_buf, proj_buf2, beta_buf, alpha_buf,
+                                      conv_w, a_log, dt_bias, dn_norm,
+                                      dn_states + dn_idx * dn_stride,
+                                      conv_bufs + dn_idx * DN_CONV_CH * DN_CONV_K,
+                                      dn_out_buf, S);
+            grid.sync();
+
+            phase_matmul_bf16(dn_out_buf, out_w, proj_buf, S_pad, HIDDEN, DN_V_SIZE);
+            grid.sync();
+            phase_add_residual(proj_buf, residual, hidden, S_pad * HIDDEN);
+            grid.sync();
+
+            // MLP
+            phase_rmsnorm(hidden, post_norm, normalized, residual, S_pad, HIDDEN);
+            grid.sync();
+            phase_matmul_bf16(normalized, gate_w, proj_buf, S_pad, INTER, HIDDEN);
+            phase_matmul_bf16(normalized, up_w,   proj_buf2, S_pad, INTER, HIDDEN);
+            grid.sync();
+            phase_silu_mul(proj_buf, proj_buf2, mlp_buf, S_pad * INTER);
+            grid.sync();
+            phase_matmul_bf16(mlp_buf, down_w, proj_buf, S_pad, HIDDEN, INTER);
+            grid.sync();
+            phase_add_residual(proj_buf, residual, hidden, S_pad * HIDDEN);
+            grid.sync();
+
+            dn_idx++;
+        } else {
+            // Full Attention
+            const __nv_bfloat16 *q_w = (const __nv_bfloat16 *)lw.ptrs[1];
+            const __nv_bfloat16 *k_w = (const __nv_bfloat16 *)lw.ptrs[2];
+            const __nv_bfloat16 *v_w = (const __nv_bfloat16 *)lw.ptrs[3];
+            const __nv_bfloat16 *q_nw = (const __nv_bfloat16 *)lw.ptrs[4];
+            const __nv_bfloat16 *k_nw = (const __nv_bfloat16 *)lw.ptrs[5];
+            const __nv_bfloat16 *o_w = (const __nv_bfloat16 *)lw.ptrs[6];
+            const __nv_bfloat16 *post_norm = (const __nv_bfloat16 *)lw.ptrs[7];
+            const __nv_bfloat16 *gate_w = (const __nv_bfloat16 *)lw.ptrs[8];
+            const __nv_bfloat16 *up_w   = (const __nv_bfloat16 *)lw.ptrs[9];
+            const __nv_bfloat16 *down_w = (const __nv_bfloat16 *)lw.ptrs[10];
+
+            phase_matmul_bf16(normalized, q_w, proj_buf, S_pad, FA_QPROJ_SIZE, HIDDEN);
+            phase_matmul_bf16(normalized, k_w, proj_buf2, S_pad, FA_KV_SIZE, HIDDEN);
+            phase_matmul_bf16(normalized, v_w, attn_buf, S_pad, FA_KV_SIZE, HIDDEN);
+            grid.sync();
+
+            phase_qk_norm_rope(proj_buf, proj_buf2, attn_buf, q_nw, k_nw,
+                               fa_k_cache + fa_idx * fa_stride,
+                               fa_v_cache + fa_idx * fa_stride, S);
+            grid.sync();
+
+            phase_causal_attn(proj_buf, proj_buf2, attn_buf, dn_out_buf, S);
+            grid.sync();
+
+            phase_matmul_bf16(dn_out_buf, o_w, proj_buf, S_pad, HIDDEN, FA_Q_SIZE);
+            grid.sync();
+            phase_add_residual(proj_buf, residual, hidden, S_pad * HIDDEN);
+            grid.sync();
+
+            phase_rmsnorm(hidden, post_norm, normalized, residual, S_pad, HIDDEN);
+            grid.sync();
+            phase_matmul_bf16(normalized, gate_w, proj_buf, S_pad, INTER, HIDDEN);
+            phase_matmul_bf16(normalized, up_w,   proj_buf2, S_pad, INTER, HIDDEN);
+            grid.sync();
+            phase_silu_mul(proj_buf, proj_buf2, mlp_buf, S_pad * INTER);
+            grid.sync();
+            phase_matmul_bf16(mlp_buf, down_w, proj_buf, S_pad, HIDDEN, INTER);
+            grid.sync();
+            phase_add_residual(proj_buf, residual, hidden, S_pad * HIDDEN);
+            grid.sync();
+
+            fa_idx++;
+        }
+    }
+
+    // Final RMSNorm (last row only) + LM head
+    phase_final_norm(hidden, final_norm_w, final_normed, hidden_bf16_out, S);
+    grid.sync();
+    phase_lm_head(final_normed, lm_head_w, lm_bmv, lm_bmi);
+    grid.sync();
+    phase_lm_reduce(lm_bmv, lm_bmi, output_token, gridDim.x);
+}
+
+// ===== Launcher =====
+// Dynamic shared memory = double-buffered A+B staging + f32 output tile.
+//   sA: 2 × BTM × BTK × 2 B  =  8 KB
+//   sB: 2 × BTN × BTK × 2 B  = 64 KB
+//   sC: BTM × BTN × 4 B      = 32 KB
+//   total                    = 104 KB
+// B200 per-block dynamic shared max is 227 KB (228 KB carveout - driver).
+constexpr int MEGA_SHMEM_BYTES =
+    2 * BTM * BTK * 2   // sA
+  + 2 * BTN * BTK * 2   // sB
+  + BTM * BTN * 4;      // sC
+
+static int mega_launch_blocks() {
+    if (const char *override_blocks = std::getenv("MEGAKERNEL_PREFILL_MEGA_BLOCKS")) {
+        int v = std::atoi(override_blocks);
+        if (v > 0) return v;
+    }
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, device);
+    // Raise per-block dynamic shared limit (sm_100 default caps lower).
+    cudaFuncSetAttribute(prefill_megakernel,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         MEGA_SHMEM_BYTES);
+    int active = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &active, prefill_megakernel, MEGA_BLOCK_SIZE, MEGA_SHMEM_BYTES);
+    return std::max(1, active * prop.multiProcessorCount);
+}
+
+extern "C" void launch_prefill_bf16_mega(
+    const int *token_ids, int seq_len, int *output_token,
+    const __nv_bfloat16 *embed_weight, const MegaLayerWeights *layers,
+    const __nv_bfloat16 *final_norm_w, const __nv_bfloat16 *lm_head_w,
+    __nv_bfloat16 *fa_k_cache, __nv_bfloat16 *fa_v_cache,
+    float *dn_states, float *conv_bufs,
+    __nv_bfloat16 *hidden, __nv_bfloat16 *residual, __nv_bfloat16 *normalized,
+    __nv_bfloat16 *proj_buf, __nv_bfloat16 *proj_buf2,
+    __nv_bfloat16 *attn_buf, __nv_bfloat16 *mlp_buf,
+    __nv_bfloat16 *dn_out_buf,
+    float *beta_buf, float *alpha_buf,
+    __nv_bfloat16 *final_normed, __nv_bfloat16 *hidden_bf16_out,
+    float *lm_bmv, int *lm_bmi,
+    cudaStream_t stream)
+{
+    static int cached_blocks = 0;
+    if (cached_blocks == 0) cached_blocks = mega_launch_blocks();
+
+    const int *token_ids_arg = token_ids;
+    int seq_len_arg = seq_len;
+    int *output_token_arg = output_token;
+    const __nv_bfloat16 *embed_arg = embed_weight;
+    const MegaLayerWeights *layers_arg = layers;
+    const __nv_bfloat16 *fn_arg = final_norm_w;
+    const __nv_bfloat16 *lm_arg = lm_head_w;
+    __nv_bfloat16 *fk_arg = fa_k_cache; __nv_bfloat16 *fv_arg = fa_v_cache;
+    float *ds_arg = dn_states; float *cb_arg = conv_bufs;
+    __nv_bfloat16 *h_arg = hidden; __nv_bfloat16 *r_arg = residual; __nv_bfloat16 *n_arg = normalized;
+    __nv_bfloat16 *p1 = proj_buf; __nv_bfloat16 *p2 = proj_buf2;
+    __nv_bfloat16 *a_arg = attn_buf; __nv_bfloat16 *m_arg = mlp_buf;
+    __nv_bfloat16 *dn_out_arg = dn_out_buf;
+    float *bb = beta_buf; float *ab = alpha_buf;
+    __nv_bfloat16 *fnrm = final_normed; __nv_bfloat16 *hout = hidden_bf16_out;
+    float *lv = lm_bmv; int *li_ = lm_bmi;
+
+    void *args[] = {
+        (void *)&token_ids_arg, (void *)&seq_len_arg, (void *)&output_token_arg,
+        (void *)&embed_arg, (void *)&layers_arg,
+        (void *)&fn_arg, (void *)&lm_arg,
+        (void *)&fk_arg, (void *)&fv_arg,
+        (void *)&ds_arg, (void *)&cb_arg,
+        (void *)&h_arg, (void *)&r_arg, (void *)&n_arg,
+        (void *)&p1, (void *)&p2,
+        (void *)&a_arg, (void *)&m_arg,
+        (void *)&dn_out_arg,
+        (void *)&bb, (void *)&ab,
+        (void *)&fnrm, (void *)&hout,
+        (void *)&lv, (void *)&li_,
+    };
+    cudaLaunchCooperativeKernel(
+        (void *)prefill_megakernel,
+        dim3(cached_blocks),
+        dim3(MEGA_BLOCK_SIZE),
+        args, MEGA_SHMEM_BYTES, stream);
+}

--- a/megakernel/setup.py
+++ b/megakernel/setup.py
@@ -1,5 +1,34 @@
+import os
+
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+
+def _detect_arch():
+    arch = os.environ.get("MEGAKERNEL_CUDA_ARCH")
+    if arch:
+        return arch
+    try:
+        import torch
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability()
+            if major == 12 and minor in (0, 1):
+                return f"sm_{major}{minor}a"
+            return f"sm_{major}{minor}"
+    except Exception:
+        pass
+    return "sm_86"
+
+
+def _int_env(name, default):
+    return str(int(os.environ.get(name, default)))
+
+
+arch = _detect_arch()
+num_blocks = _int_env("MEGAKERNEL_NUM_BLOCKS", 82)
+block_size = _int_env("MEGAKERNEL_BLOCK_SIZE", 512)
+lm_num_blocks = _int_env("MEGAKERNEL_LM_NUM_BLOCKS", 512)
+lm_block_size = _int_env("MEGAKERNEL_LM_BLOCK_SIZE", 256)
 
 setup(
     name="qwen35_megakernel_bf16",
@@ -15,13 +44,13 @@ setup(
                 "cxx": ["-O3"],
                 "nvcc": [
                     "-O3",
-                    "-arch=sm_86",
+                    f"-arch={arch}",
                     "--use_fast_math",
                     "-std=c++17",
-                    "-DNUM_BLOCKS=82",
-                    "-DBLOCK_SIZE=512",
-                    "-DLM_NUM_BLOCKS=512",
-                    "-DLM_BLOCK_SIZE=256",
+                    f"-DNUM_BLOCKS={num_blocks}",
+                    f"-DBLOCK_SIZE={block_size}",
+                    f"-DLM_NUM_BLOCKS={lm_num_blocks}",
+                    f"-DLM_BLOCK_SIZE={lm_block_size}",
                 ],
             },
             libraries=["cublas"],

--- a/megakernel/setup.py
+++ b/megakernel/setup.py
@@ -51,10 +51,12 @@ nvcc_args = [
 
 if is_blackwell:
     sources.append("kernel_gb10_nvfp4.cu")
+    sources.append("prefill_megakernel.cu")
     # Exposed to both nvcc (for the Blackwell .cu files) and the host
     # compiler (so torch_bindings.cpp registers the NVFP4 ops).
     cxx_args.append("-DMEGAKERNEL_HAS_NVFP4")
     nvcc_args.append("-DMEGAKERNEL_HAS_NVFP4")
+    nvcc_args.append("-DMEGAKERNEL_HAS_PREFILL_MEGA")
     libraries.append("cublasLt")
 
 setup(

--- a/megakernel/setup.py
+++ b/megakernel/setup.py
@@ -52,6 +52,7 @@ nvcc_args = [
 if is_blackwell:
     sources.append("kernel_gb10_nvfp4.cu")
     sources.append("prefill_megakernel.cu")
+    sources.append("prefill_bw.cu")
     # Exposed to both nvcc (for the Blackwell .cu files) and the host
     # compiler (so torch_bindings.cpp registers the NVFP4 ops).
     cxx_args.append("-DMEGAKERNEL_HAS_NVFP4")

--- a/megakernel/setup.py
+++ b/megakernel/setup.py
@@ -25,35 +25,49 @@ def _int_env(name, default):
 
 
 arch = _detect_arch()
+is_blackwell = arch.startswith("sm_12")
 num_blocks = _int_env("MEGAKERNEL_NUM_BLOCKS", 82)
 block_size = _int_env("MEGAKERNEL_BLOCK_SIZE", 512)
 lm_num_blocks = _int_env("MEGAKERNEL_LM_NUM_BLOCKS", 512)
 lm_block_size = _int_env("MEGAKERNEL_LM_BLOCK_SIZE", 256)
+
+sources = [
+    "torch_bindings.cpp",
+    "kernel.cu",
+    "prefill.cu",
+]
+libraries = ["cublas"]
+cxx_args = ["-O3"]
+nvcc_args = [
+    "-O3",
+    f"-arch={arch}",
+    "--use_fast_math",
+    "-std=c++17",
+    f"-DNUM_BLOCKS={num_blocks}",
+    f"-DBLOCK_SIZE={block_size}",
+    f"-DLM_NUM_BLOCKS={lm_num_blocks}",
+    f"-DLM_BLOCK_SIZE={lm_block_size}",
+]
+
+if is_blackwell:
+    sources.append("kernel_gb10_nvfp4.cu")
+    # Exposed to both nvcc (for the Blackwell .cu files) and the host
+    # compiler (so torch_bindings.cpp registers the NVFP4 ops).
+    cxx_args.append("-DMEGAKERNEL_HAS_NVFP4")
+    nvcc_args.append("-DMEGAKERNEL_HAS_NVFP4")
+    libraries.append("cublasLt")
 
 setup(
     name="qwen35_megakernel_bf16",
     ext_modules=[
         CUDAExtension(
             name="qwen35_megakernel_bf16_C",
-            sources=[
-                "torch_bindings.cpp",
-                "kernel.cu",
-                "prefill.cu",
-            ],
+            sources=sources,
             extra_compile_args={
-                "cxx": ["-O3"],
-                "nvcc": [
-                    "-O3",
-                    f"-arch={arch}",
-                    "--use_fast_math",
-                    "-std=c++17",
-                    f"-DNUM_BLOCKS={num_blocks}",
-                    f"-DBLOCK_SIZE={block_size}",
-                    f"-DLM_NUM_BLOCKS={lm_num_blocks}",
-                    f"-DLM_BLOCK_SIZE={lm_block_size}",
-                ],
+                "cxx": cxx_args,
+                "nvcc": nvcc_args,
             },
-            libraries=["cublas"],
+            libraries=libraries,
         ),
     ],
     cmdclass={"build_ext": BuildExtension},

--- a/megakernel/torch_bindings.cpp
+++ b/megakernel/torch_bindings.cpp
@@ -1,5 +1,10 @@
 /**
  * PyTorch bindings for Qwen3.5-0.8B bf16 megakernel — decode.
+ *
+ * Blackwell-only bindings (NVFP4 decode, bf16 prefill megakernel, prefill
+ * megakernel NVFP4) are gated behind MEGAKERNEL_HAS_NVFP4, which is only
+ * defined by setup.py for sm_12+ builds. On sm_86 the symbol set is
+ * identical to the original upstream build.
  */
 
 #include <Python.h>
@@ -28,6 +33,15 @@ struct LayerWeights {
     void *ptrs[14];  // max(11 FA, 14 DN) pointers — all bf16, no scales
 };
 
+#ifdef MEGAKERNEL_HAS_NVFP4
+struct LayerWeightsNVFP4 {
+    int layer_type;
+    int group_size;
+    int _pad[2];
+    void *ptrs[24];  // hot decode weights become packed fp4 + per-group scales
+};
+#endif
+
 extern "C" void launch_decode(
     int input_token_id, int *output_token_id,
     const void *embed_weight, const LayerWeights *layer_weights,
@@ -42,6 +56,78 @@ extern "C" void launch_decode(
     float *block_max_vals, int *block_max_idxs,
     unsigned int *lm_sync_counter,
     int position, int max_seq_len, cudaStream_t stream);
+
+#ifdef MEGAKERNEL_HAS_NVFP4
+extern "C" void launch_decode_nvfp4(
+    const int *input_token_ptr, int *output_token_id,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int position, int max_seq_len, int group_size, cudaStream_t stream);
+
+extern "C" void launch_decode_many_nvfp4(
+    int *token_buffer, int *output_tokens, int steps,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int position, int max_seq_len, int group_size, cudaStream_t stream);
+
+extern "C" void launch_quantize_nvfp4_out(
+    const void *weight, int rows, int cols, int group_size,
+    void *packed_out, void *scales_out, cudaStream_t stream);
+
+extern "C" void launch_quantize_nvfp4_lm_out(
+    const void *weight, int rows, int cols,
+    void *packed_out, void *scales_out, cudaStream_t stream);
+
+extern "C" void launch_prefill_megakernel_nvfp4(
+    const int *token_ids, int seq_len, int *output_token_id,
+    const void *embed_weight, const LayerWeightsNVFP4 *layer_weights,
+    const void *final_norm_weight,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *lm_hidden_bf16, void *lm_hidden_packed, void *lm_hidden_scales, void *lm_logits_f16,
+    void *fa_k_cache, void *fa_v_cache,
+    void *dn_states, void *conv_bufs,
+    void *hidden_buffer, void *g_activations, void *g_residual,
+    void *g_qkv_scratch, void *g_kv_scratch, void *g_attn_out,
+    void *g_mlp_inter, void *g_z_scratch, void *g_beta_scratch,
+    void *g_alpha_scratch, void *g_normalized,
+    unsigned int *barrier_counter, unsigned int *barrier_generation,
+    float *block_max_vals, int *block_max_idxs,
+    unsigned int *lm_sync_counter,
+    int max_seq_len, int group_size, cudaStream_t stream);
+
+static void seed_token_buffer(torch::Tensor token_buffer, int token_id) {
+    auto stream = c10::cuda::getCurrentCUDAStream().stream();
+    cudaError_t err = cudaMemcpyAsync(
+        token_buffer.data_ptr(),
+        &token_id,
+        sizeof(token_id),
+        cudaMemcpyHostToDevice,
+        stream);
+    TORCH_CHECK(err == cudaSuccess, "cudaMemcpyAsync(token_buffer) failed: ", cudaGetErrorString(err));
+}
+#endif  // MEGAKERNEL_HAS_NVFP4
 
 void decode(
     torch::Tensor output_token, int64_t input_token_id,
@@ -74,6 +160,165 @@ void decode(
         (int)position, (int)max_seq_len,
         c10::cuda::getCurrentCUDAStream().stream());
 }
+
+#ifdef MEGAKERNEL_HAS_NVFP4
+void decode_nvfp4(
+    torch::Tensor output_token, int64_t input_token_id,
+    torch::Tensor embed_weight, torch::Tensor layer_weights_packed,
+    torch::Tensor final_norm_weight,
+    torch::Tensor lm_head_weight_packed, torch::Tensor lm_head_scales,
+    torch::Tensor lm_hidden_bf16, torch::Tensor lm_hidden_packed, torch::Tensor lm_hidden_scales, torch::Tensor lm_logits_f16,
+    torch::Tensor fa_k_cache, torch::Tensor fa_v_cache,
+    torch::Tensor dn_states, torch::Tensor conv_bufs,
+    torch::Tensor hidden_buffer, torch::Tensor activations, torch::Tensor residual,
+    torch::Tensor qkv_scratch, torch::Tensor kv_scratch, torch::Tensor attn_out,
+    torch::Tensor mlp_inter, torch::Tensor z_scratch, torch::Tensor beta_scratch,
+    torch::Tensor alpha_scratch, torch::Tensor normalized,
+    torch::Tensor barrier_counter, torch::Tensor barrier_generation,
+    torch::Tensor block_max_vals, torch::Tensor block_max_idxs,
+    torch::Tensor lm_sync_counter, int64_t position, int64_t max_seq_len,
+    int64_t group_size)
+{
+    seed_token_buffer(output_token, (int)input_token_id);
+    launch_decode_nvfp4(
+        (const int*)output_token.data_ptr(),
+        (int*)output_token.data_ptr(),
+        embed_weight.data_ptr(),
+        reinterpret_cast<const LayerWeightsNVFP4*>(layer_weights_packed.data_ptr()),
+        final_norm_weight.data_ptr(),
+        lm_head_weight_packed.data_ptr(), lm_head_scales.data_ptr(),
+        lm_hidden_bf16.data_ptr(), lm_hidden_packed.data_ptr(), lm_hidden_scales.data_ptr(), lm_logits_f16.data_ptr(),
+        fa_k_cache.data_ptr(), fa_v_cache.data_ptr(),
+        dn_states.data_ptr(), conv_bufs.data_ptr(),
+        hidden_buffer.data_ptr(), activations.data_ptr(), residual.data_ptr(),
+        qkv_scratch.data_ptr(), kv_scratch.data_ptr(), attn_out.data_ptr(),
+        mlp_inter.data_ptr(), z_scratch.data_ptr(), beta_scratch.data_ptr(),
+        alpha_scratch.data_ptr(), normalized.data_ptr(),
+        (unsigned int*)barrier_counter.data_ptr(), (unsigned int*)barrier_generation.data_ptr(),
+        (float*)block_max_vals.data_ptr(), (int*)block_max_idxs.data_ptr(),
+        (unsigned int*)lm_sync_counter.data_ptr(),
+        (int)position, (int)max_seq_len, (int)group_size,
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+
+void decode_many_nvfp4(
+    torch::Tensor output_tokens,
+    torch::Tensor token_buffer,
+    int64_t input_token_id,
+    torch::Tensor embed_weight, torch::Tensor layer_weights_packed,
+    torch::Tensor final_norm_weight,
+    torch::Tensor lm_head_weight_packed, torch::Tensor lm_head_scales,
+    torch::Tensor lm_hidden_bf16, torch::Tensor lm_hidden_packed, torch::Tensor lm_hidden_scales, torch::Tensor lm_logits_f16,
+    torch::Tensor fa_k_cache, torch::Tensor fa_v_cache,
+    torch::Tensor dn_states, torch::Tensor conv_bufs,
+    torch::Tensor hidden_buffer, torch::Tensor activations, torch::Tensor residual,
+    torch::Tensor qkv_scratch, torch::Tensor kv_scratch, torch::Tensor attn_out,
+    torch::Tensor mlp_inter, torch::Tensor z_scratch, torch::Tensor beta_scratch,
+    torch::Tensor alpha_scratch, torch::Tensor normalized,
+    torch::Tensor barrier_counter, torch::Tensor barrier_generation,
+    torch::Tensor block_max_vals, torch::Tensor block_max_idxs,
+    torch::Tensor lm_sync_counter, int64_t position, int64_t max_seq_len,
+    int64_t group_size)
+{
+    TORCH_CHECK(output_tokens.is_cuda(), "output_tokens must be CUDA");
+    TORCH_CHECK(output_tokens.is_contiguous(), "output_tokens must be contiguous");
+    TORCH_CHECK(output_tokens.scalar_type() == torch::kInt32, "output_tokens must be int32");
+    TORCH_CHECK(output_tokens.dim() == 1, "output_tokens must be 1D");
+    TORCH_CHECK(token_buffer.is_cuda(), "token_buffer must be CUDA");
+    TORCH_CHECK(token_buffer.is_contiguous(), "token_buffer must be contiguous");
+    TORCH_CHECK(token_buffer.scalar_type() == torch::kInt32, "token_buffer must be int32");
+    TORCH_CHECK(token_buffer.numel() == 1, "token_buffer must contain exactly one int32 token");
+
+    seed_token_buffer(token_buffer, (int)input_token_id);
+    launch_decode_many_nvfp4(
+        (int*)token_buffer.data_ptr(),
+        (int*)output_tokens.data_ptr(),
+        (int)output_tokens.numel(),
+        embed_weight.data_ptr(),
+        reinterpret_cast<const LayerWeightsNVFP4*>(layer_weights_packed.data_ptr()),
+        final_norm_weight.data_ptr(),
+        lm_head_weight_packed.data_ptr(), lm_head_scales.data_ptr(),
+        lm_hidden_bf16.data_ptr(), lm_hidden_packed.data_ptr(), lm_hidden_scales.data_ptr(), lm_logits_f16.data_ptr(),
+        fa_k_cache.data_ptr(), fa_v_cache.data_ptr(),
+        dn_states.data_ptr(), conv_bufs.data_ptr(),
+        hidden_buffer.data_ptr(), activations.data_ptr(), residual.data_ptr(),
+        qkv_scratch.data_ptr(), kv_scratch.data_ptr(), attn_out.data_ptr(),
+        mlp_inter.data_ptr(), z_scratch.data_ptr(), beta_scratch.data_ptr(),
+        alpha_scratch.data_ptr(), normalized.data_ptr(),
+        (unsigned int*)barrier_counter.data_ptr(), (unsigned int*)barrier_generation.data_ptr(),
+        (float*)block_max_vals.data_ptr(), (int*)block_max_idxs.data_ptr(),
+        (unsigned int*)lm_sync_counter.data_ptr(),
+        (int)position, (int)max_seq_len, (int)group_size,
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+
+void quantize_nvfp4_out(
+    torch::Tensor packed_out,
+    torch::Tensor scales_out,
+    torch::Tensor weight,
+    int64_t group_size)
+{
+    TORCH_CHECK(weight.is_cuda(), "weight must be CUDA");
+    TORCH_CHECK(weight.is_contiguous(), "weight must be contiguous");
+    TORCH_CHECK(weight.dim() == 2, "weight must be a 2D [out_dim, in_dim] tensor");
+    TORCH_CHECK(weight.scalar_type() == torch::kBFloat16, "weight must be bfloat16");
+    TORCH_CHECK(group_size > 0 && (group_size % 2) == 0, "group_size must be a positive even integer");
+
+    auto rows = static_cast<int>(weight.size(0));
+    auto cols = static_cast<int>(weight.size(1));
+    TORCH_CHECK((cols % 2) == 0, "in_dim must be divisible by 2 for packed fp4 output");
+    TORCH_CHECK((cols % group_size) == 0, "in_dim must be divisible by group_size");
+    TORCH_CHECK(packed_out.is_cuda() && packed_out.is_contiguous(), "packed_out must be contiguous CUDA");
+    TORCH_CHECK(scales_out.is_cuda() && scales_out.is_contiguous(), "scales_out must be contiguous CUDA");
+    TORCH_CHECK(packed_out.scalar_type() == torch::kUInt8, "packed_out must be uint8");
+    TORCH_CHECK(scales_out.scalar_type() == torch::kFloat16, "scales_out must be float16");
+    TORCH_CHECK(
+        packed_out.numel() == (int64_t)rows * (cols / 2),
+        "packed_out has the wrong size");
+    TORCH_CHECK(
+        scales_out.numel() == (int64_t)rows * (cols / group_size),
+        "scales_out has the wrong size");
+
+    launch_quantize_nvfp4_out(
+        weight.data_ptr(), rows, cols, (int)group_size,
+        packed_out.data_ptr(), scales_out.data_ptr(),
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+
+void quantize_nvfp4_lm_out(
+    torch::Tensor packed_out,
+    torch::Tensor scales_out,
+    torch::Tensor weight)
+{
+    TORCH_CHECK(weight.is_cuda(), "weight must be CUDA");
+    TORCH_CHECK(weight.is_contiguous(), "weight must be contiguous");
+    TORCH_CHECK(weight.dim() == 2, "weight must be a 2D [out_dim, in_dim] tensor");
+    TORCH_CHECK(weight.scalar_type() == torch::kBFloat16, "weight must be bfloat16");
+
+    auto rows = static_cast<int>(weight.size(0));
+    auto cols = static_cast<int>(weight.size(1));
+    TORCH_CHECK((rows % 128) == 0, "out_dim must be divisible by 128");
+    TORCH_CHECK((cols % 64) == 0, "in_dim must be divisible by 64");
+    TORCH_CHECK(packed_out.is_cuda() && packed_out.is_contiguous(), "packed_out must be contiguous CUDA");
+    TORCH_CHECK(scales_out.is_cuda() && scales_out.is_contiguous(), "scales_out must be contiguous CUDA");
+    TORCH_CHECK(packed_out.scalar_type() == torch::kUInt8, "packed_out must be uint8");
+    TORCH_CHECK(scales_out.scalar_type() == torch::kUInt8, "scales_out must be uint8");
+    TORCH_CHECK(
+        packed_out.numel() == (int64_t)rows * (cols / 2),
+        "packed_out has the wrong size");
+
+    int scale_tiles = cols / 64;
+    int expected_scales = (rows / 128) * scale_tiles * 512;
+    TORCH_CHECK(
+        scales_out.numel() == expected_scales,
+        "scales_out has the wrong size");
+
+    launch_quantize_nvfp4_lm_out(
+        weight.data_ptr(), rows, cols,
+        packed_out.data_ptr(), scales_out.data_ptr(),
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+#endif  // MEGAKERNEL_HAS_NVFP4
 
 // ===== Prefill BF16 =====
 
@@ -119,6 +364,109 @@ void prefill_bf16(
         c10::cuda::getCurrentCUDAStream().stream());
 }
 
+#ifdef MEGAKERNEL_HAS_NVFP4
+extern "C" void launch_prefill_bf16_mega(
+    const int *token_ids, int seq_len, int *output_token,
+    const void *embed_weight, const LayerWeights *layers,
+    const void *final_norm_w, const void *lm_head_w,
+    void *fa_k_cache, void *fa_v_cache, void *dn_states, void *conv_bufs,
+    void *hidden, void *residual, void *normalized,
+    void *proj_buf, void *proj_buf2, void *attn_buf, void *mlp_buf,
+    void *dn_out_buf, void *beta_buf, void *alpha_buf,
+    void *final_normed, void *hidden_bf16_out,
+    void *lm_bmv, void *lm_bmi,
+    cudaStream_t stream);
+
+void prefill_bf16_mega(
+    torch::Tensor output_token, torch::Tensor token_ids,
+    torch::Tensor embed_weight, torch::Tensor layer_weights_packed,
+    torch::Tensor final_norm_weight, torch::Tensor lm_head_weight,
+    torch::Tensor fa_k_cache, torch::Tensor fa_v_cache,
+    torch::Tensor dn_states, torch::Tensor conv_bufs,
+    torch::Tensor hidden, torch::Tensor residual, torch::Tensor normalized,
+    torch::Tensor proj_buf, torch::Tensor proj_buf2,
+    torch::Tensor attn_buf, torch::Tensor mlp_buf,
+    torch::Tensor dn_out_buf, torch::Tensor beta_buf, torch::Tensor alpha_buf,
+    torch::Tensor final_normed, torch::Tensor hidden_bf16_out,
+    torch::Tensor lm_bmv, torch::Tensor lm_bmi)
+{
+    launch_prefill_bf16_mega(
+        (const int*)token_ids.data_ptr(), token_ids.size(0),
+        (int*)output_token.data_ptr(),
+        embed_weight.data_ptr(),
+        reinterpret_cast<const LayerWeights*>(layer_weights_packed.data_ptr()),
+        final_norm_weight.data_ptr(), lm_head_weight.data_ptr(),
+        fa_k_cache.data_ptr(), fa_v_cache.data_ptr(),
+        dn_states.data_ptr(), conv_bufs.data_ptr(),
+        hidden.data_ptr(), residual.data_ptr(), normalized.data_ptr(),
+        proj_buf.data_ptr(), proj_buf2.data_ptr(),
+        attn_buf.data_ptr(), mlp_buf.data_ptr(),
+        dn_out_buf.data_ptr(), beta_buf.data_ptr(), alpha_buf.data_ptr(),
+        final_normed.data_ptr(), hidden_bf16_out.data_ptr(),
+        lm_bmv.data_ptr(), lm_bmi.data_ptr(),
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+
+void prefill_megakernel_nvfp4(
+    torch::Tensor output_token, torch::Tensor token_ids,
+    torch::Tensor embed_weight, torch::Tensor layer_weights_packed,
+    torch::Tensor final_norm_weight,
+    torch::Tensor lm_head_weight_packed, torch::Tensor lm_head_scales,
+    torch::Tensor lm_hidden_bf16, torch::Tensor lm_hidden_packed, torch::Tensor lm_hidden_scales, torch::Tensor lm_logits_f16,
+    torch::Tensor fa_k_cache, torch::Tensor fa_v_cache,
+    torch::Tensor dn_states, torch::Tensor conv_bufs,
+    torch::Tensor hidden_buffer, torch::Tensor activations, torch::Tensor residual,
+    torch::Tensor qkv_scratch, torch::Tensor kv_scratch, torch::Tensor attn_out,
+    torch::Tensor mlp_inter, torch::Tensor z_scratch, torch::Tensor beta_scratch,
+    torch::Tensor alpha_scratch, torch::Tensor normalized,
+    torch::Tensor barrier_counter, torch::Tensor barrier_generation,
+    torch::Tensor block_max_vals, torch::Tensor block_max_idxs,
+    torch::Tensor lm_sync_counter, int64_t max_seq_len, int64_t group_size)
+{
+    TORCH_CHECK(token_ids.is_cuda(), "token_ids must be CUDA");
+    TORCH_CHECK(token_ids.is_contiguous(), "token_ids must be contiguous");
+    TORCH_CHECK(token_ids.scalar_type() == torch::kInt32, "token_ids must be int32");
+    TORCH_CHECK(token_ids.dim() == 1, "token_ids must be 1D");
+
+    launch_prefill_megakernel_nvfp4(
+        (const int *)token_ids.data_ptr(),
+        static_cast<int>(token_ids.numel()),
+        (int *)output_token.data_ptr(),
+        embed_weight.data_ptr(),
+        reinterpret_cast<const LayerWeightsNVFP4 *>(layer_weights_packed.data_ptr()),
+        final_norm_weight.data_ptr(),
+        lm_head_weight_packed.data_ptr(),
+        lm_head_scales.data_ptr(),
+        lm_hidden_bf16.data_ptr(),
+        lm_hidden_packed.data_ptr(),
+        lm_hidden_scales.data_ptr(),
+        lm_logits_f16.data_ptr(),
+        fa_k_cache.data_ptr(),
+        fa_v_cache.data_ptr(),
+        dn_states.data_ptr(),
+        conv_bufs.data_ptr(),
+        hidden_buffer.data_ptr(),
+        activations.data_ptr(),
+        residual.data_ptr(),
+        qkv_scratch.data_ptr(),
+        kv_scratch.data_ptr(),
+        attn_out.data_ptr(),
+        mlp_inter.data_ptr(),
+        z_scratch.data_ptr(),
+        beta_scratch.data_ptr(),
+        alpha_scratch.data_ptr(),
+        normalized.data_ptr(),
+        (unsigned int *)barrier_counter.data_ptr(),
+        (unsigned int *)barrier_generation.data_ptr(),
+        (float *)block_max_vals.data_ptr(),
+        (int *)block_max_idxs.data_ptr(),
+        (unsigned int *)lm_sync_counter.data_ptr(),
+        (int)max_seq_len,
+        (int)group_size,
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+#endif  // MEGAKERNEL_HAS_NVFP4
+
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
     ops.def("decode(Tensor output_token, int input_token_id, "
             "Tensor embed_weight, Tensor layer_weights_packed, "
@@ -143,6 +491,67 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor final_normed, Tensor hidden_bf16_out, "
             "Tensor lm_bmv, Tensor lm_bmi) -> ()");
     ops.impl("prefill_bf16", torch::kCUDA, &prefill_bf16);
+
+#ifdef MEGAKERNEL_HAS_NVFP4
+    ops.def("decode_nvfp4(Tensor output_token, int input_token_id, "
+            "Tensor embed_weight, Tensor layer_weights_packed, "
+            "Tensor final_norm_weight, Tensor lm_head_weight_packed, Tensor lm_head_scales, "
+            "Tensor lm_hidden_bf16, Tensor lm_hidden_packed, Tensor lm_hidden_scales, Tensor lm_logits_f16, "
+            "Tensor fa_k_cache, Tensor fa_v_cache, Tensor dn_states, Tensor conv_bufs, "
+            "Tensor hidden_buffer, Tensor activations, Tensor residual, "
+            "Tensor qkv_scratch, Tensor kv_scratch, Tensor attn_out, "
+            "Tensor mlp_inter, Tensor z_scratch, Tensor beta_scratch, "
+            "Tensor alpha_scratch, Tensor normalized, "
+            "Tensor barrier_counter, Tensor barrier_generation, "
+            "Tensor block_max_vals, Tensor block_max_idxs, Tensor lm_sync_counter, "
+            "int position, int max_seq_len, int group_size) -> ()");
+    ops.impl("decode_nvfp4", torch::kCUDA, &decode_nvfp4);
+
+    ops.def("decode_many_nvfp4(Tensor output_tokens, Tensor token_buffer, int input_token_id, "
+            "Tensor embed_weight, Tensor layer_weights_packed, "
+            "Tensor final_norm_weight, Tensor lm_head_weight_packed, Tensor lm_head_scales, "
+            "Tensor lm_hidden_bf16, Tensor lm_hidden_packed, Tensor lm_hidden_scales, Tensor lm_logits_f16, "
+            "Tensor fa_k_cache, Tensor fa_v_cache, Tensor dn_states, Tensor conv_bufs, "
+            "Tensor hidden_buffer, Tensor activations, Tensor residual, "
+            "Tensor qkv_scratch, Tensor kv_scratch, Tensor attn_out, "
+            "Tensor mlp_inter, Tensor z_scratch, Tensor beta_scratch, "
+            "Tensor alpha_scratch, Tensor normalized, "
+            "Tensor barrier_counter, Tensor barrier_generation, "
+            "Tensor block_max_vals, Tensor block_max_idxs, Tensor lm_sync_counter, "
+            "int position, int max_seq_len, int group_size) -> ()");
+    ops.impl("decode_many_nvfp4", torch::kCUDA, &decode_many_nvfp4);
+
+    ops.def("prefill_bf16_mega(Tensor output_token, Tensor token_ids, "
+            "Tensor embed_weight, Tensor layer_weights_packed, "
+            "Tensor final_norm_weight, Tensor lm_head_weight, "
+            "Tensor fa_k_cache, Tensor fa_v_cache, Tensor dn_states, Tensor conv_bufs, "
+            "Tensor hidden, Tensor residual, Tensor normalized, "
+            "Tensor proj_buf, Tensor proj_buf2, Tensor attn_buf, Tensor mlp_buf, "
+            "Tensor dn_out_buf, Tensor beta_buf, Tensor alpha_buf, "
+            "Tensor final_normed, Tensor hidden_bf16_out, "
+            "Tensor lm_bmv, Tensor lm_bmi) -> ()");
+    ops.impl("prefill_bf16_mega", torch::kCUDA, &prefill_bf16_mega);
+
+    ops.def("prefill_megakernel_nvfp4(Tensor output_token, Tensor token_ids, "
+            "Tensor embed_weight, Tensor layer_weights_packed, "
+            "Tensor final_norm_weight, Tensor lm_head_weight_packed, Tensor lm_head_scales, "
+            "Tensor lm_hidden_bf16, Tensor lm_hidden_packed, Tensor lm_hidden_scales, Tensor lm_logits_f16, "
+            "Tensor fa_k_cache, Tensor fa_v_cache, Tensor dn_states, Tensor conv_bufs, "
+            "Tensor hidden_buffer, Tensor activations, Tensor residual, "
+            "Tensor qkv_scratch, Tensor kv_scratch, Tensor attn_out, "
+            "Tensor mlp_inter, Tensor z_scratch, Tensor beta_scratch, "
+            "Tensor alpha_scratch, Tensor normalized, "
+            "Tensor barrier_counter, Tensor barrier_generation, "
+            "Tensor block_max_vals, Tensor block_max_idxs, Tensor lm_sync_counter, "
+            "int max_seq_len, int group_size) -> ()");
+    ops.impl("prefill_megakernel_nvfp4", torch::kCUDA, &prefill_megakernel_nvfp4);
+
+    ops.def("quantize_nvfp4_out(Tensor packed_out, Tensor scales_out, Tensor weight, int group_size) -> ()");
+    ops.impl("quantize_nvfp4_out", torch::kCUDA, &quantize_nvfp4_out);
+
+    ops.def("quantize_nvfp4_lm_out(Tensor packed_out, Tensor scales_out, Tensor weight) -> ()");
+    ops.impl("quantize_nvfp4_lm_out", torch::kCUDA, &quantize_nvfp4_lm_out);
+#endif  // MEGAKERNEL_HAS_NVFP4
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/megakernel/torch_bindings.cpp
+++ b/megakernel/torch_bindings.cpp
@@ -40,6 +40,17 @@ struct LayerWeightsNVFP4 {
     int _pad[2];
     void *ptrs[24];  // hot decode weights become packed fp4 + per-group scales
 };
+
+// Layout-compatible with PFFusedLayerWeights in prefill_bw.cu — used by the
+// hybrid bf16 prefill + NVFP4 LM head path (launch_prefill_bf16_nvfp4_lm).
+struct PrefillFusedLayerWeights {
+    void *proj_weight;
+    void *gate_up_weight;
+    void *proj_weight_packed;
+    void *proj_weight_scales;
+    void *gate_up_weight_packed;
+    void *gate_up_weight_scales;
+};
 #endif
 
 extern "C" void launch_decode(
@@ -407,6 +418,63 @@ void prefill_bf16_mega(
         c10::cuda::getCurrentCUDAStream().stream());
 }
 
+extern "C" void launch_prefill_bf16_nvfp4_lm(
+    const int *token_ids, int seq_len, int *output_token,
+    const void *embed_weight, const LayerWeights *layers,
+    const PrefillFusedLayerWeights *fused_layers,
+    const void *final_norm_w, const void *lm_head_w,
+    const void *lm_head_weight_packed, const void *lm_head_scales,
+    void *fa_k_cache, void *fa_v_cache, void *dn_states, void *conv_bufs,
+    void *hidden, void *residual, void *normalized,
+    void *proj_buf, void *proj_buf2, void *proj_buf_half, void *proj_act_packed, void *proj_act_scales,
+    void *attn_buf, void *mlp_buf,
+    void *dn_out_buf, void *beta_buf, void *alpha_buf,
+    void *final_normed, void *hidden_bf16_out,
+    void *lm_bmv, void *lm_bmi,
+    void *lm_hidden_bf16, void *lm_hidden_packed,
+    void *lm_hidden_scales, void *lm_logits_f16,
+    cudaStream_t stream);
+
+void prefill_bf16_nvfp4_lm(
+    torch::Tensor output_token, torch::Tensor token_ids,
+    torch::Tensor embed_weight, torch::Tensor layer_weights_packed,
+    torch::Tensor prefill_fused_weights_packed,
+    torch::Tensor final_norm_weight, torch::Tensor lm_head_weight,
+    torch::Tensor lm_head_weight_packed, torch::Tensor lm_head_scales,
+    torch::Tensor fa_k_cache, torch::Tensor fa_v_cache,
+    torch::Tensor dn_states, torch::Tensor conv_bufs,
+    torch::Tensor hidden, torch::Tensor residual, torch::Tensor normalized,
+    torch::Tensor proj_buf, torch::Tensor proj_buf2, torch::Tensor proj_buf_half,
+    torch::Tensor proj_act_packed, torch::Tensor proj_act_scales,
+    torch::Tensor attn_buf, torch::Tensor mlp_buf,
+    torch::Tensor dn_out_buf, torch::Tensor beta_buf, torch::Tensor alpha_buf,
+    torch::Tensor final_normed, torch::Tensor hidden_bf16_out,
+    torch::Tensor lm_bmv, torch::Tensor lm_bmi,
+    torch::Tensor lm_hidden_bf16, torch::Tensor lm_hidden_packed,
+    torch::Tensor lm_hidden_scales, torch::Tensor lm_logits_f16)
+{
+    launch_prefill_bf16_nvfp4_lm(
+        (const int*)token_ids.data_ptr(), token_ids.size(0),
+        (int*)output_token.data_ptr(),
+        embed_weight.data_ptr(),
+        reinterpret_cast<const LayerWeights*>(layer_weights_packed.data_ptr()),
+        reinterpret_cast<const PrefillFusedLayerWeights*>(prefill_fused_weights_packed.data_ptr()),
+        final_norm_weight.data_ptr(), lm_head_weight.data_ptr(),
+        lm_head_weight_packed.data_ptr(), lm_head_scales.data_ptr(),
+        fa_k_cache.data_ptr(), fa_v_cache.data_ptr(),
+        dn_states.data_ptr(), conv_bufs.data_ptr(),
+        hidden.data_ptr(), residual.data_ptr(), normalized.data_ptr(),
+        proj_buf.data_ptr(), proj_buf2.data_ptr(), proj_buf_half.data_ptr(),
+        proj_act_packed.data_ptr(), proj_act_scales.data_ptr(),
+        attn_buf.data_ptr(), mlp_buf.data_ptr(),
+        dn_out_buf.data_ptr(), beta_buf.data_ptr(), alpha_buf.data_ptr(),
+        final_normed.data_ptr(), hidden_bf16_out.data_ptr(),
+        lm_bmv.data_ptr(), lm_bmi.data_ptr(),
+        lm_hidden_bf16.data_ptr(), lm_hidden_packed.data_ptr(),
+        lm_hidden_scales.data_ptr(), lm_logits_f16.data_ptr(),
+        c10::cuda::getCurrentCUDAStream().stream());
+}
+
 void prefill_megakernel_nvfp4(
     torch::Tensor output_token, torch::Tensor token_ids,
     torch::Tensor embed_weight, torch::Tensor layer_weights_packed,
@@ -545,6 +613,20 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor block_max_vals, Tensor block_max_idxs, Tensor lm_sync_counter, "
             "int max_seq_len, int group_size) -> ()");
     ops.impl("prefill_megakernel_nvfp4", torch::kCUDA, &prefill_megakernel_nvfp4);
+
+    ops.def("prefill_bf16_nvfp4_lm(Tensor output_token, Tensor token_ids, "
+            "Tensor embed_weight, Tensor layer_weights_packed, Tensor prefill_fused_weights_packed, "
+            "Tensor final_norm_weight, Tensor lm_head_weight, "
+            "Tensor lm_head_weight_packed, Tensor lm_head_scales, "
+            "Tensor fa_k_cache, Tensor fa_v_cache, Tensor dn_states, Tensor conv_bufs, "
+            "Tensor hidden, Tensor residual, Tensor normalized, "
+            "Tensor proj_buf, Tensor proj_buf2, Tensor proj_buf_half, Tensor proj_act_packed, Tensor proj_act_scales, "
+            "Tensor attn_buf, Tensor mlp_buf, "
+            "Tensor dn_out_buf, Tensor beta_buf, Tensor alpha_buf, "
+            "Tensor final_normed, Tensor hidden_bf16_out, "
+            "Tensor lm_bmv, Tensor lm_bmi, "
+            "Tensor lm_hidden_bf16, Tensor lm_hidden_packed, Tensor lm_hidden_scales, Tensor lm_logits_f16) -> ()");
+    ops.impl("prefill_bf16_nvfp4_lm", torch::kCUDA, &prefill_bf16_nvfp4_lm);
 
     ops.def("quantize_nvfp4_out(Tensor packed_out, Tensor scales_out, Tensor weight, int group_size) -> ()");
     ops.impl("quantize_nvfp4_out", torch::kCUDA, &quantize_nvfp4_out);


### PR DESCRIPTION
Closes #12. Companion to #18 — extends `megakernel/` with Blackwell support without touching the RTX 3090 reference path.
                                                                                                                                                                                             
  ## What this changes                                                                                                                                                                       
                                                                                                                                                                                             
  Blackwell support is purely additive — new files compiled only when the target arch starts with `sm_12`:                                                                                   
                                                                                                                                                                                             
  - `kernel_gb10_nvfp4.cu` — persistent NVFP4 decode megakernel (group-scaled fp4 hot weights + cuBLASLt NVFP4 LM head)
  - `prefill_megakernel.cu` — single-dispatch persistent bf16 prefill kernel                                                                                                                 
  - `prefill_bw.cu` — vectorized bf16 prefill body + NVFP4 LM head ("hybrid" mode); kernels live in an anonymous namespace so they coexist with upstream `prefill.cu` symbols in the same
  `.so`                                                                                                                                                                                      
  - `model_nvfp4.py` — Blackwell-only `Decoder`; raises at import on sm < 120                              
  - `final_bench_nvfp4.py` / `bench_pp_tg_nvfp4.py` — companion benches                                                                                                                      
                                                                                                                                                                                             
  `final_bench.py` / `bench_pp_tg.py` grow `--backend {auto,bf16,nvfp4}` (auto-detects on Blackwell, re-execs into the NVFP4 variant). `setup.py` auto-detects arch and gates the Blackwell  
  sources/defines/lib (cuBLASLt) under `if is_blackwell`. `torch_bindings.cpp` registers the NVFP4 ops behind `#ifdef MEGAKERNEL_HAS_NVFP4`.                                                 
                                                                                                                                                                                             
  ## sm_86 path is byte-identical to upstream                                                                                                                                                
                                                                                                                                                                                             
  ```                                                                                                                                                                                        
  git diff fork-parent HEAD -- megakernel/kernel.cu megakernel/prefill.cu megakernel/model.py              
  → 0                                         
  ```                                         
                                                                                                                                                                                             
  `torch_bindings.cpp` differs only in a 5-line file-header comment after stripping the `#ifdef MEGAKERNEL_HAS_NVFP4` blocks. `setup.py` produces byte-identical nvcc args on sm_86          
  (`-arch=sm_86 -DNUM_BLOCKS=82 -DBLOCK_SIZE=512 -DLM_NUM_BLOCKS=512 -DLM_BLOCK_SIZE=256`, `-lcublas`, sources `[torch_bindings.cpp, kernel.cu, prefill.cu]`). Empirical verification on the 
  same vast.ai 3090: pp520 8742 → 8639 (−1.2%, noise), tg128 419 → 418.                                                                                                                      
                                                                                                                                                                                             
  ## Build / run                                                                                                                                                                             
                            
  ```bash                                                                                                                                                                                    
  pip install -e megakernel/                              # auto-detects arch                              
  MEGAKERNEL_CUDA_ARCH=sm_121a pip install -e megakernel/ # explicit DGX Spark
  python megakernel/final_bench.py                        # auto-dispatches
  python megakernel/final_bench.py --backend nvfp4
  ```                                                                                                                                                                                        
                                                                                                                                                                                             
  ## Wide-shape sweep (Qwen3.5-0.8B)                                                                                                                                                         
                                                                                                                                                                                             
  ### GB10 / DGX Spark (sm_121a)                                                                                                                                                             
                                                                                                                                                                                             
  Prefill (tok/s):                                                                                                                                                                           
                                              
  | pp | Ours (NVFP4 hybrid) | llama.cpp BF16 | PyTorch HF |                                                                                                                                 
  |---:|---:|---:|---:|                                                                                    
  | 127 | **10,457** | 7,311 | 1,647 |                                                                                                                                                       
  | 512 | **19,727** | 13,532 | 5,361 |                                                                    
  | 1024 | **18,034** | 13,308 | 7,054 |                                                                                                                                                     
  | 2048 | **14,838** | 13,201 | 7,078 |                                                                                                                                                     
  | 3000 | **13,220** | 12,752 | 6,661 |                                                                                                                                                     
  | 4096 | 11,950 | **9,087** | 6,629 |                                                                                                                                                      
  | 8192 | 8,694 | **10,518** | 6,202 |                                                                                                                                                      
  | 16384 | 5,329 | **8,264** | 5,937 |                                                                                                                                                      
  | 32768 | 2,886 | **5,786** | 5,405 |                                                                                                                                                      
                                                                                                                                                                                             
  Decode (tok/s):                                                                                                                                                                            
                                                                                                                                                                                             
  | tg | Ours (NVFP4) | llama.cpp BF16 | PyTorch HF |                                                                                                                                        
  |---:|---:|---:|---:|                                                                                    
  | 31 | **193.8** | 129.8 | 57.8 |                                                                                                                                                          
  | 128 | **193.7** | 131.3 | 62.8 |                                                                       
  | 512 | **189.2** | 130.6 | 64.4 |                                                                                                                                                         
  | 1024 | **181.8** | 130.0 | 64.6 |         
                                                                                                                                                                                             
  ### RTX 3090 (sm_86, vast.ai)                                                                                                                                                              
                                                                                                                                                                                             
  Prefill (tok/s):                                                                                                                                                                           
                                                                                                                                                                                             
  | pp | Ours (BF16 = upstream) | llama.cpp BF16 | PyTorch HF |                                                                                                                              
  |---:|---:|---:|---:|                                                                                    
  | 127 | 7,296 | **11,924** | 270 |                                                                                                                                                         
  | 512 | 8,523 | **18,392** | 1,743 |        
  | 1024 | 8,446 | **18,561** | 3,384 |                                                                                                                                                      
  | 2048 | 7,931 | **18,519** | 4,857 |                                                                                                                                                      
  | 4096 | 6,638 | **13,441** | 7,571 |                                                                                                                                                      
  | 8192 | 5,022 | **16,586** | 7,693 |                                                                                                                                                      
  | 16384 | 3,346 | **14,582** | 7,578 |                                                                                                                                                     
  | 32768 | 1,974 | **11,254** | n/a |                                                                                                                                                       
                                                                                                                                                                                             
  Decode (tok/s):                                                                                                                                                                            
                                                                                                                                                                                             
  | tg | Ours (BF16) | llama.cpp BF16 | PyTorch HF |                                                                                                                                         
  |---:|---:|---:|---:|                                                                                                                                                                      
  | 31 | **441.9** | 293.8 | 34.6 |                                                                        
  | 128 | **441.4** | 299.3 | 39.1 |          
  | 1024 | **418.3** | 295.7 | 38.7 |                                                                                                                                                        
  | 4096 | **352.7** | 290.3 | 40.1 |         
  | 8192 | 290.8 | **284.1** | 41.0 |                                                                                                                                                        
  | 16384 | 215.6 | **271.2** | 42.0 |                                                                     
  | 32768 | 141.8 | **239.4** | 40.3 |                                                                                                                                                       
                                                                                                           
  vast's 3090 measures lower than the published reference (37,800 pp520) for *both* the upstream baseline and our build not a regression. We don't change `kernel.cu` / `prefill.cu` / `model.py` on sm_86, so the 3090 number is whatever upstream's is.                                                                               
                                                                                                                                                                                             
  ## Hardware                                                                                                                                                                                
                                                                                                                                                                                             
  - DGX Spark / GB10 — sm_121a, driver 580.126.09, CUDA 13.2, PyTorch 2.13.0a (cu13.2)
  - RTX 3090 (verification) — sm_86, vast.ai, CUDA 12.4, PyTorch 2.5.1+cu124                                                                                                                 
  - llama.cpp build commit `0d0764d` on both boxes                                                         
                                              
  ## Out of scope (deferred)                                                                                                                                                                 
                                                                                                                                                                                             
  - Vectorized rewrites of upstream `prefill.cu` / `kernel.cu` (the same kernels that ship to RTX 3090). The Blackwell-only equivalents live in namespace-isolated `prefill_bw.cu` instead,  
  so the perf wins are realised on Blackwell without putting sm_86 at risk.                                                                                                                  
  - Long-context decode (≥ 8k) where attention is O(N) per step and llama.cpp's flash-attention pulls ahead. Real FA integration is a future PR.                                             
  - Long-context prefill (≥ 4k on GB10) where the bf16 attention body in hybrid prefill is O(N²) — same FA-integration work.
                                                                                                                                                                                             
  ## Commits                                                                                               
                                                                                                                                                                                             
  ```                                                                                                                                                                                        
  ba6a402 megakernel: hybrid bf16+NVFP4-LM prefill for Blackwell                                                                                                                             
  b00f9b8 megakernel: document Blackwell / GB10 support                                                                                                                                      
  47bf4d3 megakernel: --backend dispatch in bench scripts, add NVFP4 variants                              
  2763acd megakernel: add model_nvfp4.py for Blackwell NVFP4 decode                                                                                                                          
  addbb5a megakernel: add NVFP4 torch bindings behind MEGAKERNEL_HAS_NVFP4                                                                                                                   
  02042e4 megakernel: add prefill megakernel for Blackwell                                                                                                                                   
  0b0678e megakernel: add NVFP4 decode kernel for Blackwell (sm_120/sm_121a)                                                                                                                 
  0d90fb9 megakernel: detect CUDA arch and allow env overrides                                                                                                                               
  ```                                                                               