### PR TITLE
docs(hub): venv step for megakernel install + Blackwell callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Two projects today, more coming. Each one is a self-contained release with its o
 git clone https://github.com/Luce-Org/lucebox-hub && cd lucebox-hub/megakernel
 
 # 2. install (Python 3.10+, CUDA 12+, PyTorch 2.0+). Weights stream from HF on first run.
+python -m venv .venv && source .venv/bin/activate   # required on Ubuntu 24+ system Python (PEP 668)
 pip install -e .
 
 # 3. run the benchmark (prefill pp520 + decode tg128 vs llama.cpp BF16 + PyTorch HF)
@@ -58,6 +59,8 @@ python final_bench.py
 **What makes it work:** 82 blocks, 512 threads, one persistent kernel. No CPU round-trips between layers. Weights streamed straight from HuggingFace. Cooperative grid sync instead of ~100 kernel launches per token. Power ceiling hit before compute ceiling, so DVFS converts tight execution straight into saved watts.
 
 [Full writeup →](megakernel/README.md) · [Benchmarks →](megakernel/RESULTS.md) · [Blog post →](https://lucebox.com/blog/megakernel)
+
+> **Blackwell (RTX 5090, DGX Spark / GB10):** auto-detected by setup; NVFP4 decode path lands ~194 tok/s tg128 on GB10. See [megakernel/README.md#blackwell-sm_120--sm_121a](megakernel/README.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Two doc-only changes to the root README:

1. **Megakernel install fix.** Quickstart now wraps \`pip install -e .\` in a venv. Ubuntu 24+ system Python blocks pip via PEP 668, so the bare clone-and-go path was failing for fresh users on noble. Reported by chrisbward and others.
2. **Blackwell callout.** One-line mention under the megakernel section pointing Blackwell users (RTX 5090, DGX Spark / GB10) at the NVFP4 backend documented in PR #30. Same pattern as the Qwen3.6 callout under dflash.

## Why separate PR

PR #30 (cybernetic-physics:fork-parent-gb10) does not enable maintainerCanModify, so we cannot land this directly on that branch. Cherry-picked to its own branch off main; lands independently.

## Test plan

- [x] Diff is +3 lines, README only
- [ ] After PR #30 merges, verify the Blackwell anchor in megakernel/README.md actually exists (currently \`#blackwell-sm_120--sm_121a\`)

🧙 Built with [WOZCODE](https://wozcode.com)