### PR TITLE
fix(dflash): bake portable RPATH (closes #31 symbol lookup)

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # If we do not set this, ggml will output to bin and DLLs will not load
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+# Bake portable rpath into all executables so bundled libggml-cuda / libggml-base
+# are found regardless of LD_LIBRARY_PATH or stale /usr/local/lib (closes #31).
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH "$ORIGIN/deps/llama.cpp/ggml/src;$ORIGIN/deps/llama.cpp/ggml/src/ggml-cuda;$ORIGIN/../deps/llama.cpp/ggml/src;$ORIGIN/../deps/llama.cpp/ggml/src/ggml-cuda")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)


### PR DESCRIPTION
## Summary

- Closes #31 (the symbol-lookup half — `undefined symbol: ggml_gated_delta_net_tree_persist`).
- Sets `CMAKE_BUILD_WITH_INSTALL_RPATH` + an `$ORIGIN`-relative `CMAKE_INSTALL_RPATH` globally so all dflash build-tree binaries resolve the bundled `libggml-cuda.so.0` / `libggml-base.so.0` without `LD_LIBRARY_PATH`.
- 5-line patch in `dflash/CMakeLists.txt`, no behavior change for users who already had it working.

## Why

CMake's default rpath behavior varies by distro. On the reporter's system, no RUNPATH was baked into `test_dflash`, so the dynamic linker fell through to `/etc/ld.so.cache` and picked up an older `libggml-cuda.so.0` sitting in `/usr/local/lib` — that older lib lacks `ggml_gated_delta_net_tree_persist`, hence the crash. Workaround was a manual `export LD_LIBRARY_PATH=$PWD/build/deps/...`. This makes the binary self-locating instead.

The OOM half of #31 is a separate issue (Ada VMM allocator) and not addressed here.

## Test plan

- [x] `readelf -d build/test_dflash` shows the new `$ORIGIN`-relative RUNPATH on lucebox 3090
- [x] `env -i HOME=$HOME PATH=/usr/bin ./build/test_dflash --help` runs clean (no `LD_LIBRARY_PATH`)
- [x] No build regression (`cmake --build .` clean from scratch)
- [ ] Verify on the reporter's 4090 box that `python scripts/run.py` no longer needs `LD_LIBRARY_PATH`

🧙 Built with [WOZCODE](https://wozcode.com)