### PR TITLE
fix(megakernel): restore decode parity + safer grid sync (closes #28)

### DIFF
--- a/megakernel/README.md
+++ b/megakernel/README.md
@@ -76,7 +76,7 @@ A single persistent CUDA kernel processes the entire Qwen 3.5-0.8B forward pass 
 **Architecture:** Qwen 3.5-0.8B is a hybrid model, 18 DeltaNet layers (linear attention with learned recurrence) and 6 full attention layers, in a 3:1 ratio. DeltaNet scales linearly with context length vs. quadratic for standard attention. It's an emerging pattern in next-gen models (Qwen3-Next, Kimi Linear), but no framework had optimized kernels for it.
 
 **Kernel specs:**
-- 82 blocks, 512 threads, all SMs on the RTX 3090 kept occupied
+- 82 blocks, 512 threads, all SMs on the RTX 3090 kept occupied; launch count is clamped to the resident-block ceiling on smaller GPUs to avoid grid-sync deadlock
 - BF16 weights and activations, FP32 accumulation where it matters
 - DeltaNet recurrence via warp-cooperative state updates in F32 registers
 - Full attention with online softmax (fused QKV, RoPE, causal mask, output projection)

--- a/megakernel/bench_pp_tg.py
+++ b/megakernel/bench_pp_tg.py
@@ -66,7 +66,7 @@ def prefill(ids):
         bufs['attn_buf'], bufs['mlp_buf'],
         bufs['dn_out_buf'], bufs['beta_buf'], bufs['alpha_buf'],
         bufs['final_normed'], bufs['hidden_bf16_out'],
-        bufs['lm_bmv'], bufs['lm_bmi'])
+        bufs['lm_bmv'], bufs['lm_bmi'], dec.max_seq_len)
     # Handoff: copy hidden state for decode kernel
     dec._hidden.copy_(bufs['hidden_bf16_out'])
     dec._position = len(ids)

--- a/megakernel/final_bench.py
+++ b/megakernel/final_bench.py
@@ -66,7 +66,8 @@ def our_prefill():
         b['hidden'], b['residual'], b['normalized'],
         b['proj_buf'], b['proj_buf2'], b['attn_buf'], b['mlp_buf'],
         b['dn_out_buf'], b['beta_buf'], b['alpha_buf'],
-        b['final_normed'], b['hidden_bf16_out'], b['lm_bmv'], b['lm_bmi'])
+        b['final_normed'], b['hidden_bf16_out'], b['lm_bmv'], b['lm_bmi'],
+        dec.max_seq_len)
     dec._hidden.copy_(b['hidden_bf16_out'])
     dec._position = len(prompt_ids)
     return dec._out_token.item()

--- a/megakernel/kernel.cu
+++ b/megakernel/kernel.cu
@@ -60,6 +60,8 @@ constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
 #define LM_BLOCK_SIZE 256
 #endif
 
+static int g_decode_blocks_override = 0;
+
 __device__ __constant__ int LAYER_TYPE[NUM_LAYERS] = {
     0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1
 };
@@ -695,7 +697,7 @@ __device__ void deltanet_layer(
             }
             stk = warp_reduce_sum(stk); sqv = warp_reduce_sum(sqv);
             stk = __shfl_sync(0xffffffff,stk,0); sqv = __shfl_sync(0xffffffff,sqv,0);
-            float error_j = (s_v[j] - stk) * beta;
+            float error_j = (s_v[j] - decay * stk) * beta;
             float o_j = decay * sqv + error_j * kq;
             if (lane_id == 0) out_head[j] = o_j;
 #pragma unroll
@@ -759,7 +761,9 @@ __global__ void lm_head_kernel(
     float *__restrict__ block_max_vals,
     int *__restrict__ block_max_idxs,
     int *__restrict__ output_token,
-    unsigned int *__restrict__ sync_counter)
+    unsigned int *__restrict__ sync_counter,
+    const float *__restrict__ seen_token_mask,
+    float repetition_penalty)
 {
     __shared__ float s_hidden[HIDDEN_SIZE];
     for (int i = threadIdx.x; i < HIDDEN_SIZE; i += LM_BLOCK_SIZE) s_hidden[i] = hidden[i];
@@ -781,6 +785,9 @@ __global__ void lm_head_kernel(
             for (int i = 0; i < 8; i++) sum += __bfloat162float(wp[i]) * s_hidden[k+i];
         }
         sum = warp_reduce_sum(sum);
+        if (lane_id == 0 && repetition_penalty > 1.0f && seen_token_mask && seen_token_mask[m] > 0.0f) {
+            sum = (sum > 0.0f) ? (sum / repetition_penalty) : (sum * repetition_penalty);
+        }
         if (lane_id == 0 && sum > local_max) { local_max = sum; local_max_idx = m; }
     }
     local_max = __shfl_sync(0xffffffff, local_max, 0);
@@ -840,24 +847,20 @@ decode_kernel(
     float *__restrict__ g_normalized,
     unsigned int *__restrict__ barrier_counter,
     unsigned int *__restrict__ barrier_generation,
+    float *__restrict__ seen_token_mask,
+    float repetition_penalty,
     int input_token_id, int position, int max_seq_len)
 {
     int block_id = blockIdx.x;
     int num_blocks = gridDim.x;
 
-    // Initialize barrier
-    if (block_id == 0 && threadIdx.x == 0) { *barrier_counter = 0; *barrier_generation = 0; }
-    __syncthreads();
-    if (threadIdx.x == 0) {
-        asm volatile("fence.acq_rel.gpu;" ::: "memory");
-        unsigned int arrived = atomicAdd(barrier_counter, 1);
-        if (arrived == (unsigned int)num_blocks - 1) { *barrier_counter = 0; asm volatile("fence.acq_rel.gpu;" ::: "memory"); atomicAdd(barrier_generation, 1); }
-        else { volatile unsigned int *vg = (volatile unsigned int *)barrier_generation; while (*vg == 0) {} }
-        asm volatile("fence.acq_rel.gpu;" ::: "memory");
+    if (block_id == 0 && threadIdx.x == 0 &&
+        seen_token_mask && repetition_penalty > 1.0f &&
+        input_token_id >= 0 && input_token_id < VOCAB_SIZE) {
+        seen_token_mask[input_token_id] = 1.0f;
     }
-    __syncthreads();
 
-    AtomicGridSync grid{barrier_counter, barrier_generation, (unsigned int)num_blocks, 1};
+    AtomicGridSync grid{barrier_counter, barrier_generation, (unsigned int)num_blocks, 0};
 
     // Shared memory: large enough for max(HIDDEN_SIZE bf16, INTERMEDIATE_SIZE f32)
     __shared__ __align__(16) char shmem_raw[MAX_ACT_DIM * sizeof(float)];
@@ -916,6 +919,31 @@ decode_kernel(
 // C entry point
 // =============================================================================
 
+static int query_max_safe_decode_blocks_impl()
+{
+    int device_id = 0;
+    int sm_count = 0;
+    int active_blocks_per_sm = 0;
+    int max_safe_blocks = NUM_BLOCKS;
+
+    if (cudaGetDevice(&device_id) == cudaSuccess &&
+        cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device_id) == cudaSuccess &&
+        cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &active_blocks_per_sm,
+            decode_kernel,
+            BLOCK_SIZE,
+            0) == cudaSuccess &&
+        sm_count > 0 &&
+        active_blocks_per_sm > 0) {
+        const int resident_blocks = sm_count * active_blocks_per_sm;
+        if (resident_blocks > 0) {
+            max_safe_blocks = resident_blocks;
+        }
+    }
+
+    return (max_safe_blocks < 1) ? 1 : max_safe_blocks;
+}
+
 extern "C" void launch_decode(
     int input_token_id, int *output_token_id,
     const void *embed_weight, const LayerWeights *layer_weights,
@@ -930,9 +958,26 @@ extern "C" void launch_decode(
     unsigned int *barrier_counter, unsigned int *barrier_generation,
     float *block_max_vals, int *block_max_idxs,
     unsigned int *lm_sync_counter,
+    float *seen_token_mask,
+    float repetition_penalty,
     int position, int max_seq_len, cudaStream_t stream)
 {
-    decode_kernel<<<NUM_BLOCKS, BLOCK_SIZE, 0, stream>>>(
+    const int max_safe_blocks = query_max_safe_decode_blocks_impl();
+    int decode_blocks = NUM_BLOCKS;
+    if (decode_blocks > max_safe_blocks) {
+        decode_blocks = max_safe_blocks;
+    }
+    if (g_decode_blocks_override > 0) {
+        decode_blocks = g_decode_blocks_override;
+        if (decode_blocks > max_safe_blocks) {
+            decode_blocks = max_safe_blocks;
+        }
+    }
+
+    cudaMemsetAsync(barrier_counter, 0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(barrier_generation, 0, sizeof(unsigned int), stream);
+
+    decode_kernel<<<decode_blocks, BLOCK_SIZE, 0, stream>>>(
         (const __nv_bfloat16 *)embed_weight,
         (const __nv_bfloat16 *)final_norm_weight,
         (const __nv_bfloat16 *)lm_head_weight,
@@ -946,6 +991,7 @@ extern "C" void launch_decode(
         (float *)g_z_scratch, (float *)g_beta_scratch,
         (float *)g_alpha_scratch, (float *)g_normalized,
         barrier_counter, barrier_generation,
+        seen_token_mask, repetition_penalty,
         input_token_id, position, max_seq_len);
 
     cudaMemsetAsync(lm_sync_counter, 0, sizeof(unsigned int), stream);
@@ -954,6 +1000,16 @@ extern "C" void launch_decode(
         (const float *)g_normalized,
         (const __nv_bfloat16 *)lm_head_weight,
         block_max_vals, block_max_idxs,
-        output_token_id, lm_sync_counter);
+        output_token_id, lm_sync_counter,
+        seen_token_mask, repetition_penalty);
 }
 
+extern "C" void set_decode_blocks_override(int blocks)
+{
+    g_decode_blocks_override = blocks;
+}
+
+extern "C" int query_max_safe_decode_blocks()
+{
+    return query_max_safe_decode_blocks_impl();
+}

--- a/megakernel/model.py
+++ b/megakernel/model.py
@@ -27,13 +27,31 @@ DN_CONV_KERNEL = 4
 LAYER_TYPE = [0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1]
 
 _decode = None
+_max_safe_decode_blocks = None
+_set_decode_blocks = None
 
 
 def _load_op():
-    global _decode
+    global _decode, _max_safe_decode_blocks, _set_decode_blocks
     if _decode is None:
         import qwen35_megakernel_bf16_C
         _decode = torch.ops.qwen35_megakernel_bf16_C.decode
+        _max_safe_decode_blocks = torch.ops.qwen35_megakernel_bf16_C.max_safe_decode_blocks
+        _set_decode_blocks = torch.ops.qwen35_megakernel_bf16_C.set_decode_blocks
+
+
+def max_safe_decode_blocks() -> int:
+    """Return the resident-block ceiling for the current CUDA device."""
+    _load_op()
+    return int(_max_safe_decode_blocks())
+
+
+def set_decode_blocks(blocks: int):
+    """Override decode blocks, clamped by the CUDA resident-block ceiling."""
+    if blocks < 0:
+        raise ValueError("blocks must be non-negative")
+    _load_op()
+    _set_decode_blocks(int(blocks))
 
 
 def load_weights(model_name="Qwen/Qwen3.5-0.8B", verbose=True):
@@ -143,18 +161,29 @@ class Decoder:
     """Stateful decoder for Qwen3.5-0.8B bf16 megakernel."""
 
     def __init__(self, weights=None, tokenizer=None,
-                 model_name="Qwen/Qwen3.5-0.8B", verbose=True):
+                 model_name="Qwen/Qwen3.5-0.8B", verbose=True,
+                 max_seq_len=MAX_SEQ_LEN, repetition_penalty=1.0,
+                 decode_blocks=None):
         _load_op()
+        if max_seq_len <= 0:
+            raise ValueError("max_seq_len must be positive")
+        if repetition_penalty < 1.0:
+            raise ValueError("repetition_penalty must be >= 1.0")
+        if decode_blocks is not None and decode_blocks < 0:
+            raise ValueError("decode_blocks must be non-negative")
 
         if weights is None:
             weights, tokenizer = load_weights(model_name, verbose=verbose)
         self.tokenizer = tokenizer
         self._position = 0
+        self.max_seq_len = int(max_seq_len)
+        self.repetition_penalty = float(repetition_penalty)
         self._weights = weights
         self._embed_weight = weights["embed_weight"]
         self._final_norm_weight = weights["final_norm_weight"]
         self._lm_head_weight = weights["lm_head_weight"]
         self._layer_weights_packed = _pack_layer_weights(weights["layer_data"])
+        _set_decode_blocks(0 if decode_blocks is None else int(decode_blocks))
 
         bf16 = dict(dtype=torch.bfloat16, device="cuda")
         f32 = dict(dtype=torch.float32, device="cuda")
@@ -162,7 +191,7 @@ class Decoder:
         u32 = dict(dtype=torch.uint32, device="cuda")
 
         n_fa = sum(1 for t in LAYER_TYPE if t == 1)
-        self._fa_k_cache = torch.zeros(n_fa, FA_NUM_KV_HEADS, MAX_SEQ_LEN, FA_HEAD_DIM, **bf16)
+        self._fa_k_cache = torch.zeros(n_fa, FA_NUM_KV_HEADS, self.max_seq_len, FA_HEAD_DIM, **bf16)
         self._fa_v_cache = torch.zeros_like(self._fa_k_cache)
 
         n_dn = sum(1 for t in LAYER_TYPE if t == 0)
@@ -187,10 +216,13 @@ class Decoder:
         self._block_max_vals = torch.empty(1024, **f32)
         self._block_max_idxs = torch.empty(1024, **i32)
         self._lm_sync_counter = torch.zeros(1, **u32)
+        self._seen_token_mask = torch.zeros(VOCAB_SIZE, **f32)
         self._out_token = torch.empty(1, **i32)
 
     def step(self, token_id: int) -> int:
         """Decode one token. Returns next token id."""
+        if self._position >= self.max_seq_len:
+            raise ValueError(f"position {self._position} exceeds max_seq_len={self.max_seq_len}")
         _decode(
             self._out_token, token_id,
             self._embed_weight, self._layer_weights_packed,
@@ -204,7 +236,8 @@ class Decoder:
             self._barrier_counter, self._barrier_generation,
             self._block_max_vals, self._block_max_idxs,
             self._lm_sync_counter,
-            self._position, MAX_SEQ_LEN,
+            self._seen_token_mask, self.repetition_penalty,
+            self._position, self.max_seq_len,
         )
         self._position += 1
         return self._out_token.item()
@@ -215,6 +248,7 @@ class Decoder:
         self._fa_v_cache.zero_()
         self._dn_states.zero_()
         self._conv_bufs.zero_()
+        self._seen_token_mask.zero_()
 
     def generate(self, prompt: str, max_tokens: int = 100) -> str:
         self.reset()

--- a/megakernel/prefill.cu
+++ b/megakernel/prefill.cu
@@ -343,6 +343,7 @@ extern "C" void launch_prefill_bf16(
     float *beta_buf, float *alpha_buf,
     __nv_bfloat16 *final_normed, __nv_bfloat16 *hidden_bf16_out,
     float *lm_bmv, int *lm_bmi,
+    int max_seq_len,
     cudaStream_t stream)
 {
     static cublasHandle_t cublas = nullptr;
@@ -358,7 +359,7 @@ extern "C" void launch_prefill_bf16(
 
     pf_embed<<<bk, 256, 0, stream>>>(token_ids, embed_weight, hidden, S);
 
-    int fa_stride = FA_KV_HEADS * 2048 * FA_HEAD_DIM;
+    int fa_stride = FA_KV_HEADS * max_seq_len * FA_HEAD_DIM;
     int dn_stride = DN_HEADS * DN_KEY * DN_VAL;
     int fa_idx = 0, dn_idx = 0;
 
@@ -433,7 +434,7 @@ extern "C" void launch_prefill_bf16(
             int total_heads = S*(FA_Q_HEADS+FA_KV_HEADS);
             pf_qk_norm_rope<<<(total_heads+15)/16, 512, 0, stream>>>(
                 proj_buf, proj_buf2, attn_buf, q_nw, k_nw,
-                fa_k_cache + fa_idx*fa_stride, fa_v_cache + fa_idx*fa_stride, S, 2048);
+                fa_k_cache + fa_idx*fa_stride, fa_v_cache + fa_idx*fa_stride, S, max_seq_len);
 
             pf_causal_attn<<<(S*FA_Q_HEADS+15)/16, 512, 0, stream>>>(
                 proj_buf, proj_buf2, attn_buf, dn_out_buf, S);

--- a/megakernel/torch_bindings.cpp
+++ b/megakernel/torch_bindings.cpp
@@ -66,6 +66,8 @@ extern "C" void launch_decode(
     unsigned int *barrier_counter, unsigned int *barrier_generation,
     float *block_max_vals, int *block_max_idxs,
     unsigned int *lm_sync_counter,
+    float *seen_token_mask,
+    float repetition_penalty,
     int position, int max_seq_len, cudaStream_t stream);
 
 #ifdef MEGAKERNEL_HAS_NVFP4
@@ -139,6 +141,8 @@ static void seed_token_buffer(torch::Tensor token_buffer, int token_id) {
     TORCH_CHECK(err == cudaSuccess, "cudaMemcpyAsync(token_buffer) failed: ", cudaGetErrorString(err));
 }
 #endif  // MEGAKERNEL_HAS_NVFP4
+extern "C" void set_decode_blocks_override(int blocks);
+extern "C" int query_max_safe_decode_blocks();
 
 void decode(
     torch::Tensor output_token, int64_t input_token_id,
@@ -152,7 +156,8 @@ void decode(
     torch::Tensor alpha_scratch, torch::Tensor normalized,
     torch::Tensor barrier_counter, torch::Tensor barrier_generation,
     torch::Tensor block_max_vals, torch::Tensor block_max_idxs,
-    torch::Tensor lm_sync_counter, int64_t position, int64_t max_seq_len)
+    torch::Tensor lm_sync_counter, torch::Tensor seen_token_mask,
+    double repetition_penalty, int64_t position, int64_t max_seq_len)
 {
     launch_decode(
         (int)input_token_id, (int*)output_token.data_ptr(),
@@ -168,6 +173,7 @@ void decode(
         (unsigned int*)barrier_counter.data_ptr(), (unsigned int*)barrier_generation.data_ptr(),
         (float*)block_max_vals.data_ptr(), (int*)block_max_idxs.data_ptr(),
         (unsigned int*)lm_sync_counter.data_ptr(),
+        (float*)seen_token_mask.data_ptr(), (float)repetition_penalty,
         (int)position, (int)max_seq_len,
         c10::cuda::getCurrentCUDAStream().stream());
 }
@@ -331,6 +337,16 @@ void quantize_nvfp4_lm_out(
 }
 #endif  // MEGAKERNEL_HAS_NVFP4
 
+int64_t max_safe_decode_blocks()
+{
+    return query_max_safe_decode_blocks();
+}
+
+void set_decode_blocks(int64_t blocks)
+{
+    set_decode_blocks_override((int)blocks);
+}
+
 // ===== Prefill BF16 =====
 
 extern "C" void launch_prefill_bf16(
@@ -343,6 +359,7 @@ extern "C" void launch_prefill_bf16(
     void *dn_out_buf, void *beta_buf, void *alpha_buf,
     void *final_normed, void *hidden_bf16_out,
     void *lm_bmv, void *lm_bmi,
+    int max_seq_len,
     cudaStream_t stream);
 
 void prefill_bf16(
@@ -356,7 +373,8 @@ void prefill_bf16(
     torch::Tensor attn_buf, torch::Tensor mlp_buf,
     torch::Tensor dn_out_buf, torch::Tensor beta_buf, torch::Tensor alpha_buf,
     torch::Tensor final_normed, torch::Tensor hidden_bf16_out,
-    torch::Tensor lm_bmv, torch::Tensor lm_bmi)
+    torch::Tensor lm_bmv, torch::Tensor lm_bmi,
+    int64_t max_seq_len)
 {
     launch_prefill_bf16(
         (const int*)token_ids.data_ptr(), token_ids.size(0),
@@ -372,6 +390,7 @@ void prefill_bf16(
         dn_out_buf.data_ptr(), beta_buf.data_ptr(), alpha_buf.data_ptr(),
         final_normed.data_ptr(), hidden_bf16_out.data_ptr(),
         lm_bmv.data_ptr(), lm_bmi.data_ptr(),
+        (int)max_seq_len,
         c10::cuda::getCurrentCUDAStream().stream());
 }
 
@@ -546,8 +565,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor alpha_scratch, Tensor normalized, "
             "Tensor barrier_counter, Tensor barrier_generation, "
             "Tensor block_max_vals, Tensor block_max_idxs, Tensor lm_sync_counter, "
+            "Tensor seen_token_mask, float repetition_penalty, "
             "int position, int max_seq_len) -> ()");
     ops.impl("decode", torch::kCUDA, &decode);
+
+    ops.def("max_safe_decode_blocks() -> int");
+    ops.impl("max_safe_decode_blocks", &max_safe_decode_blocks);
+
+    ops.def("set_decode_blocks(int blocks) -> ()");
+    ops.impl("set_decode_blocks", &set_decode_blocks);
 
     ops.def("prefill_bf16(Tensor output_token, Tensor token_ids, "
             "Tensor embed_weight, Tensor layer_weights_packed, "
@@ -557,7 +583,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
             "Tensor proj_buf, Tensor proj_buf2, Tensor attn_buf, Tensor mlp_buf, "
             "Tensor dn_out_buf, Tensor beta_buf, Tensor alpha_buf, "
             "Tensor final_normed, Tensor hidden_bf16_out, "
-            "Tensor lm_bmv, Tensor lm_bmi) -> ()");
+            "Tensor lm_bmv, Tensor lm_bmi, int max_seq_len) -> ()");
     ops.impl("prefill_bf16", torch::kCUDA, &prefill_bf16);
 
 #ifdef MEGAKERNEL_HAS_NVFP4


### PR DESCRIPTION
Cherry-picked from @Danmoreng's [`fix-megakernel-correctness-generalization`](https://github.com/Danmoreng/lucebox-hub/tree/fix-megakernel-correctness-generalization) branch (commit kept as his authorship, Co-Authored-By auto-preserved by cherry-pick). Issue: #28.

## What this changes

1. **DeltaNet decode recurrence fix** — `error = (v - decay * (state · k)) * beta`. Decay applied to the state·key term before computing the beta-scaled update. This is the load-bearing correctness fix.
2. **Host-stream barrier reset** — `cudaMemsetAsync(barrier_counter)` and `cudaMemsetAsync(barrier_generation)` moved out of the kernel; `AtomicGridSync.local_gen=0` initialized consistently.
3. **Resident-block clamp** — new `query_max_safe_decode_blocks()` + `set_decode_blocks_override()` (exposed in Python via `model.max_safe_decode_blocks()` / `set_decode_blocks(n)`); decode launch is clamped to the CUDA resident-block ceiling so smaller GPUs than the RTX 3090 default don't deadlock at the in-kernel grid barriers.
4. **Optional repetition penalty** — opt-in `Decoder(..., repetition_penalty=1.5)`; default 1.0 preserves existing greedy behavior.
5. **`max_seq_len` generalization** — `Decoder(max_seq_len=...)` allocates KV from the runtime arg; prefill plumbs the same value through, no more hardcoded 2048.

## Validation on lucebox 3090 (already done in #28)

| | pp520 | tg128 |
|---|---:|---:|
| main | 8,548 | 412 |
| this | 8,567 | 412 |

Correctness: 512-token greedy decode against HF transformers shows fix branch stays coherent ("...began to explore the possibility of creating machines that could learn from experience...") while main collapses into repetitive factually-wrong loops by token ~30, exactly the DeltaNet drift signature the recurrence fix addresses.

## Merge conflict with main

Merged with `torch_bindings.cpp` in main which gained the Blackwell NVFP4 block (PR #30) since Danmoreng forked. Resolution: keep both — NVFP4 declarations/functions stay, his `set_decode_blocks_override` / `query_max_safe_decode_blocks` declarations + helpers added alongside. Both registered in `TORCH_LIBRARY_EXPAND`. No semantic overlap.

## Why cherry-pick instead of waiting for a PR from Danmoreng

He flagged on #28 he can't test on RTX 3090 (Windows + different HW). We validated on lucebox, fix is correct, downstream work (CUDA graphs / spec-prefill v3) shouldn't build on a broken baseline.

🧙 Built with [WOZCODE](https://wozcode.com)