### PR TITLE
fix(dflash): auto-detect GPU arch to prevent sm_120a on consumer Blackwell

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -3,6 +3,34 @@ set(DFLASH27B_GPU_BACKEND "cuda" CACHE STRING "GPU backend to build: cuda or hip
 set_property(CACHE DFLASH27B_GPU_BACKEND PROPERTY STRINGS cuda hip)
 string(TOLOWER "${DFLASH27B_GPU_BACKEND}" DFLASH27B_GPU_BACKEND)
 if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    # CUDA 12.8+ can resolve "native" on some Blackwell systems to the
+    # accelerator-specific sm_120a target. Consumer Blackwell needs the plain
+    # SM target, so translate an explicit native request via nvidia-smi before
+    # CMake initializes CUDA and before downstream ggml target properties read
+    # the architecture list. The default empty value still takes this file's
+    # portable multi-arch list below.
+    if(CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+        find_program(_DFLASH_NVIDIA_SMI nvidia-smi)
+        if(_DFLASH_NVIDIA_SMI)
+            execute_process(
+                COMMAND "${_DFLASH_NVIDIA_SMI}"
+                        --query-gpu=compute_cap --format=csv,noheader
+                OUTPUT_VARIABLE _dflash_gpu_caps
+                ERROR_QUIET
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE _dflash_smi_rc
+            )
+            if(_dflash_smi_rc EQUAL 0 AND _dflash_gpu_caps)
+                string(REGEX MATCH "^[0-9]+\\.[0-9]+" _dflash_cap "${_dflash_gpu_caps}")
+                string(REPLACE "." "" _dflash_arch "${_dflash_cap}")
+                if(_dflash_arch)
+                    set(CMAKE_CUDA_ARCHITECTURES "${_dflash_arch}" CACHE STRING
+                        "CUDA architectures (auto-detected from nvidia-smi: ${_dflash_cap})" FORCE)
+                    message(STATUS "dflash: GPU compute_cap ${_dflash_cap} -> CUDA_ARCHITECTURES=${_dflash_arch}")
+                endif()
+            endif()
+        endif()
+    endif()
     set(DFLASH27B_USER_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
     project(dflash LANGUAGES C CXX CUDA)
 elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")


### PR DESCRIPTION
## Problem

On CUDA 13.2+ with consumer Blackwell GPUs (for example, RTX 5090, SM 12.0), using an unset
`CMAKE_CUDA_ARCHITECTURES` or `native` can resolve to `sm_120a` instead of
`sm_120`, which can trigger `CUDA_ERROR_ILLEGAL_INSTRUCTION` at runtime on
consumer hardware.

## Fix (auto-detect only)

- At configure time, if `CMAKE_CUDA_ARCHITECTURES` is unset or `native`, run
  `nvidia-smi --query-gpu=compute_cap --format=csv,noheader`.
- Parse the compute capability (for example `12.0`) and set
  `CMAKE_CUDA_ARCHITECTURES` explicitly (for example `120`).
- Keep the change isolated to `dflash/CMakeLists.txt` so it can be reviewed and
  merged independently from consumer-specific workaround behavior.

## Test plan

- [ ] `cmake -B build -S dflash/` prints `dflash27b: GPU compute_cap 12.0 → CUDA_ARCHITECTURES=120` on Blackwell hardware.
- [ ] `cmake --build build` succeeds without CUDA-arch related compiler/runtime errors on a Blackwell consumer system.
