### PR TITLE
fix(dflash): plug three ggml_gallocr CUDA buffer leaks in daemon mode

### DIFF
--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -1209,8 +1209,7 @@ int main(int argc, char ** argv) {
             // Rebuild cache + step graph between requests so KV / SSM / conv /
             // target_feat ring start fresh. Weights stay resident.
             if (!daemon_first_iter) {
-                step_graph_free(sg);
-                sg = StepGraph{};
+                step_graph_destroy(sg);
                 free_target_cache(cache);
                 if (!create_target_cache(w, max_ctx, max_verify_tokens, backend, cache,
                                          /*prefill_only=*/true)) {
@@ -1394,7 +1393,7 @@ int main(int argc, char ** argv) {
 
         // Promote prefill-only cache to full decode cache
         auto t_mig0 = std::chrono::steady_clock::now();
-        sg = StepGraph{};
+        step_graph_destroy(sg);
         if (!migrate_prefill_cache(w, max_ctx, max_verify_tokens, backend, cache)) {
             std::fprintf(stderr, "cache migration: %s\n", dflash27b_last_error());
             return 1;
@@ -1475,8 +1474,7 @@ int main(int argc, char ** argv) {
     // Promote prefill-only cache to full decode cache with rollback tensors.
     // Copies KV, SSM/conv state, and target_feat device→device (~1 ms).
     auto t_mig0 = std::chrono::steady_clock::now();
-    step_graph_free(sg);
-    sg = StepGraph{};
+    step_graph_destroy(sg);
     if (!migrate_prefill_cache(w, max_ctx, max_verify_tokens, backend, cache)) {
         std::fprintf(stderr, "cache migration: %s\n", dflash27b_last_error());
         return 1;


### PR DESCRIPTION
Closes #49

Fixes #46 — the daemon mode server dies on the second prompt because leaked gallocr buffers from the first request leave no VRAM for the second request's cache migration.

## Root cause

step_graph_free() intentionally preserves sg.alloc (ggml_gallocr) for intra-request reuse across draft/verify/replay passes. But the daemon restart code discarded the StepGraph struct via sg = StepGraph{} without freeing the alloc, leaking the CUDA backing buffer on every request cycle.

Three leak sites, all in 	est_dflash.cpp:
- Line 1212: decode gallocr (~0.3 GB) per daemon request restart
- Line 1396: prefill gallocr (~1.0 GB) at layer-seg prefill migration transition  
- Line 1477: prefill gallocr (~1.5 GB) at token-seg prefill migration transition

## Fix

Replace all three with step_graph_destroy(sg) — frees both the ggml context AND the gallocr's CUDA buffer.

## Verification

Tested on RTX 3090 24 GB with Qwen3.6-27B IQ4_XS at 60K context, TQ3_0 KV cache. Before: VRAM grew continuously, OOM on request 2-3. After: stable at ~22.5 GB across unlimited requests.