### PR TITLE
feat: independent K/V cache quantization types

### DIFF
--- a/dflash/src/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35_target_graph.cpp
@@ -105,6 +105,29 @@ bool create_target_cache(const TargetWeights & w,
     if (const char * s = std::getenv("DFLASH27B_KV_TQ3")) {
         if (std::atoi(s) != 0) { kv_k_type = GGML_TYPE_TQ3_0; kv_v_type = GGML_TYPE_TQ3_0; }
     }
+    // Per-axis overrides (applied after joint vars, so they take priority).
+    // E.g. DFLASH27B_KV_TQ3=1 + DFLASH27B_KV_K=q8  →  K=Q8, V=TQ3.
+    if (const char * s = std::getenv("DFLASH27B_KV_K")) {
+        if (std::atoi(s) != 0) {
+            // accept: f16, q4, q8, tq3
+            std::string sv = std::string(s);
+            for (auto &c : sv) c = std::tolower(c);
+            if (sv == "f16") kv_k_type = GGML_TYPE_F16;
+            else if (sv == "q4" || sv == "q4_0") kv_k_type = GGML_TYPE_Q4_0;
+            else if (sv == "q8" || sv == "q8_0") kv_k_type = GGML_TYPE_Q8_0;
+            else if (sv == "tq3" || sv == "tq3_0") kv_k_type = GGML_TYPE_TQ3_0;
+        }
+    }
+    if (const char * s = std::getenv("DFLASH27B_KV_V")) {
+        if (std::atoi(s) != 0) {
+            std::string sv = std::string(s);
+            for (auto &c : sv) c = std::tolower(c);
+            if (sv == "f16") kv_v_type = GGML_TYPE_F16;
+            else if (sv == "q4" || sv == "q4_0") kv_v_type = GGML_TYPE_Q4_0;
+            else if (sv == "q8" || sv == "q8_0") kv_v_type = GGML_TYPE_Q8_0;
+            else if (sv == "tq3" || sv == "tq3_0") kv_v_type = GGML_TYPE_TQ3_0;
+        }
+    }
     out.kv_k_type = kv_k_type;
     const int max_ctx_alloc = (kv_k_type == GGML_TYPE_TQ3_0)
         ? ((max_ctx + 255) / 256) * 256


### PR DESCRIPTION
## Summary

Add `DFLASH27B_KV_K` and `DFLASH27B_KV_V` environment variables to override K and V cache types independently.

Previously, KV cache quantization was applied jointly via `DFLASH27B_KV_F16`, `DFLASH27B_KV_Q4`, or `DFLASH27B_KV_TQ3`.

## Usage

```bash
# Joint (unchanged)
DFLASH27B_KV_TQ3=1 ./test_dflash ...  # K=TQ3, V=TQ3

# Per-axis override (new)
DFLASH27B_KV_TQ3=1 DFLASH27B_KV_K=q8 ./test_dflash ...  # K=Q8, V=TQ3
DFLASH27B_KV_Q4=1  DFLASH27B_KV_V=f16 ./test_dflash ... # K=Q4, V=F16
```

Accepts: `f16`, `q4`/`q4_0`, `q8`/`q8_0`, `tq3`/`tq3_0` (case-insensitive).

## Motivation

K and V have different VRAM footprints and precision needs:
- **K** (128-dim) is used for attention scoring → benefits from higher precision
- **V** (40-dim, GQA-16) is a weighted output → tolerates more compression

Mixed configs like K=Q8 + V=TQ3 offer better VRAM/quality trade-offs.

## Notes

- Overrides apply **after** joint vars, so they take priority
- The `max_ctx_alloc` alignment (TQ3 requires 256-token multiples) still follows `kv_k_type`
- Purely additive — existing env vars continue working unchanged
