### PR TITLE
dflash: add reset_target_cache for fast daemon mode cache reuse

### DIFF
--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -255,6 +255,11 @@ bool create_target_cache(const TargetWeights & w,
 
 void free_target_cache(TargetCache & c);
 
+// Zero all state tensors (KV, SSM, conv, target_feat, rollback) in place
+// without freeing/reallocating GPU buffers. Used by daemon mode between
+// requests to avoid the ~5 s overhead of full cache destruction + recreation.
+void reset_target_cache(TargetCache & c);
+
 // Reallocate a prefill-only cache with full rollback tensors, copying all live
 // state (KV, SSM, conv, target_feat) device-to-device. Frees the old cache.
 bool migrate_prefill_cache(const TargetWeights & w,

--- a/dflash/src/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35_target_graph.cpp
@@ -245,14 +245,39 @@ void free_target_cache(TargetCache & c) {
     c.cur_pos = 0;
 }
 
+void reset_target_cache(TargetCache & c) {
+    c.cur_pos = 0;
+    std::vector<uint8_t> zeros(1 * 1024 * 1024, 0);
+    ggml_context * ctx_list[] = { c.base_ctx, c.rollback_ctx };
+    for (int ci = 0; ci < 2; ci++) {
+        ggml_context * ctx = ctx_list[ci];
+        if (!ctx) continue;
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr;
+             t = ggml_get_next_tensor(ctx, t)) {
+            size_t nb = ggml_nbytes(t);
+            size_t off = 0;
+            while (off < nb) {
+                size_t chunk = std::min(nb - off, zeros.size());
+                ggml_backend_tensor_set(t, zeros.data(), off, chunk);
+                off += chunk;
+            }
+        }
+    }
+}
+
 // Attach rollback tensors to an existing prefill cache without touching the
 // base tensors (KV, SSM, conv, target_feat) that prefill already populated.
 // No D2D copies — the base tensors stay right where the graph wrote them.
+// If rollback tensors are already present (e.g. daemon mode second request),
+// this is a no-op.
 bool migrate_prefill_cache(const TargetWeights & w,
                            int max_ctx,
                            int max_verify_tokens,
                            ggml_backend_t backend,
                            TargetCache & cache) {
+    // Already migrated (e.g. daemon mode second+ request after reset_target_cache).
+    if (cache.rollback_ctx) return true;
+
     const int n_delta = (int)cache.ssm_state.size(); // 48
     if (max_verify_tokens <= 0) {
         max_verify_tokens = DFLASH27B_DRAFT_BLOCK_SIZE;

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -1226,17 +1226,13 @@ int main(int argc, char ** argv) {
             prompt_file_str = ppath;
             prompt_path = prompt_file_str.c_str();
 
-            // Rebuild cache + step graph between requests so KV / SSM / conv /
-            // target_feat ring start fresh. Weights stay resident.
+            // Reset cache state between requests. On the first request the
+            // cache was promoted from prefill-only to full (with rollback
+            // tensors) by migrate_prefill_cache. On subsequent requests we
+            // just zero all state tensors in place — no GPU buffer free/alloc.
             if (!daemon_first_iter) {
-                step_graph_destroy(sg);
-                free_target_cache(cache);
-                if (!create_target_cache(w, max_ctx, max_verify_tokens, backend, cache,
-                                         /*prefill_only=*/true)) {
-                    std::fprintf(stderr, "cache realloc: %s\n", dflash27b_last_error());
-                    stream_emit(-1);
-                    continue;
-                }
+                step_graph_free(sg);
+                reset_target_cache(cache);
             }
             daemon_first_iter = false;
         }


### PR DESCRIPTION
In daemon mode, the old code destroyed and recreated the entire GPU cache (KV + SSM + conv + rollback + target_feat) between requests, costing ~5 seconds of allocation overhead per request. This halved throughput from 46 to 22 tok/s.

Fix: add reset_target_cache() that zeros all state tensors in-place without freeing/reallocating GPU buffers. Daemon mode now calls step_graph_free + reset_target_cache instead of step_graph_destroy + free_target_cache + create_target_cache.

Also make migrate_prefill_cache() a no-op when rollback tensors already exist (daemon second+ request).

Results on RTX 2080 Ti:
  1st request (cold, with migrate): 35 tok/s
  2nd+ requests (warm):             47 tok/s (was 22, now matches standalone)