### PR TITLE
fix setenv error on windows build

### DIFF
--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -49,6 +49,11 @@ extern "C" void dflash27b_launch_bf16_to_f32(const void * src,
 #include <cmath>
 #include <cstdint>
 
+#ifdef _WIN32
+#define setenv(name, value, overwrite) _putenv_s(name, value)
+#define unsetenv(name) _putenv_s(name, "")
+#endif
+
 #if defined(_WIN32)
 #if !defined(NOMINMAX)
 #define NOMINMAX

--- a/dflash/test/test_generate.cpp
+++ b/dflash/test/test_generate.cpp
@@ -29,6 +29,11 @@
 #include <fstream>
 #include <vector>
 
+#ifdef _WIN32
+#define setenv(name, value, overwrite) _putenv_s(name, value)
+#define unsetenv(name) _putenv_s(name, "")
+#endif
+
 #if defined(_WIN32)
 #if !defined(NOMINMAX)
 #define NOMINMAX

--- a/dflash/test/test_kv_quant.cpp
+++ b/dflash/test/test_kv_quant.cpp
@@ -13,6 +13,11 @@
 #include <cstdlib>
 #include <cstring>
 
+#ifdef _WIN32
+#define setenv(name, value, overwrite) _putenv_s(name, value)
+#define unsetenv(name) _putenv_s(name, "")
+#endif
+
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 static void clear_kv_env() {


### PR DESCRIPTION
This pull request improves cross-platform compatibility for environment variable handling in the test files. Specifically, it adds definitions for `setenv` and `unsetenv` on Windows, ensuring these functions are available and behave as expected during testing.

Platform compatibility improvements:

* Added Windows-specific definitions for `setenv` and `unsetenv` using `_putenv_s` in `test_dflash.cpp`, `test_generate.cpp`, and `test_kv_quant.cpp` to provide consistent environment variable management across platforms. [[1]](diffhunk://#diff-d17942476abf477ad89133044f871a675933810a9028eb532941aee0b55fe744R52-R56) [[2]](diffhunk://#diff-bc793dda96ce6062229e9f2aa5bb442685ec79ea8755a0fdd457cf26c690abaaR32-R36) [[3]](diffhunk://#diff-7808815a86b537086c6d77efd992ccd76efcee13bcd5da92d28ede18117ba83cR16-R20)

closes: #68 