### PR TITLE
perf(pflash): add SM75 target-resident TTFT path

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(dflash27b STATIC
     src/qwen35_target_graph.cpp
     src/qwen3_dflash_graph.cpp
     src/qwen3_drafter.cpp
+    src/pflash_chunk_select.cpp
     src/qwen3_0p6b_loader.cpp
     src/qwen3_0p6b_graph.cpp
     src/flashprefill_kernels.cu
@@ -169,7 +170,13 @@ if(DFLASH27B_TESTS)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flashprefill_kernels.cpp")
         add_executable(test_flashprefill_kernels test/test_flashprefill_kernels.cpp)
         set_target_properties(test_flashprefill_kernels PROPERTIES CUDA_ARCHITECTURES "${_dflash27b_archs}")
+        target_compile_definitions(test_flashprefill_kernels PRIVATE DFLASH27B_MIN_SM=${_dflash27b_min_sm})
         target_link_libraries(test_flashprefill_kernels PRIVATE dflash27b CUDA::cudart)
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_pflash_chunk_select.cpp")
+        add_executable(test_pflash_chunk_select test/test_pflash_chunk_select.cpp)
+        target_include_directories(test_pflash_chunk_select PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        target_link_libraries(test_pflash_chunk_select PRIVATE dflash27b)
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_kv_quant.cpp")
         add_executable(test_kv_quant test/test_kv_quant.cpp)

--- a/dflash/docs/SPEC_PREFILL.md
+++ b/dflash/docs/SPEC_PREFILL.md
@@ -51,6 +51,66 @@ DFLASH_FP_PROFILE=1    # log mean/score/select/forward stage timings
 
 See `src/flashprefill.h` for the full list and defaults.
 
+PFlash compression is tuned separately from the sparse-attention kernel:
+
+```
+DFLASH_PFLASH_LOOKAHEAD=8       # override tail Q count used for scoring
+DFLASH_PFLASH_KEEP_TARGET=0     # experimental: keep target resident during
+                                # compression; caller should park draft first
+DFLASH_PFLASH_SKIP_DRAFT_RELOAD=0
+                                # experimental: after PFlash compression, keep
+                                # DFlash draft parked for TTFT-only fallback
+DFLASH_PFLASH_CHUNK_RADIUS=0    # keep neighbor chunks around score winners
+DFLASH_PFLASH_QUERY_TAIL=128    # tail tokens scanned for lexical rescue
+DFLASH_PFLASH_RARE_MAX_FREQ=4   # only rare tail tokens can rescue chunks
+DFLASH_PFLASH_QUERY_MIN_HITS=2  # rare-token hits required in a body chunk
+DFLASH_PFLASH_QUERY_RADIUS=1    # keep neighbor chunks around lexical hits
+DFLASH_PFLASH_DUMP_CHUNKS=/tmp/pflash_chunks.csv
+```
+
+The lexical rescue path is a quality guard for long-prompt retrieval cases:
+if the final question contains rare tokens also present near the answer, those
+body chunks are kept even when the score-only top-K misses them. It only scans
+body chunks before the query tail, so the query itself does not spuriously
+rescue neighboring tail chunks. Set `DFLASH_PFLASH_RARE_MAX_FREQ=0` to disable
+it for controlled ablations.
+
+## SM75 / RTX 2080 Ti
+
+SM75 does not have BF16 tensor cores and cannot run the BSA backend
+(`DFLASH27B_ENABLE_BSA=ON` auto-disables when the build arch includes 75).
+For RTX 2080 Ti, build the local path with FP16 drafter compute:
+
+```
+cmake -S . -B build-sm75-f16 -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES=75 -DDFLASH27B_ENABLE_BSA=OFF
+cmake --build build-sm75-f16 --target \
+      test_dflash test_flashprefill_kernels test_pflash_chunk_select -j
+```
+
+Local benchmark setup: RTX 2080 Ti 22 GB, driver 595.58.03, CUDA 12.0,
+power limit 280 W, persistence mode enabled, Qwen3.6-27B Q4_K_M target,
+Qwen3-0.6B FP16 GGUF drafter, same 16K NIAH qtail prompt, model load excluded.
+
+| Case | Request time | Speedup | Notes |
+|------|-------------:|--------:|-------|
+| no PFlash | 50.35 s | 1.00x | original 16K prompt |
+| current PFlash hook | 26.11 s | 1.93x | parks and reloads target + draft |
+| `DFLASH_PFLASH_KEEP_TARGET=1` | 14.19 s | 3.55x | target stays resident, draft reloads |
+| `KEEP_TARGET=1` + `SKIP_DRAFT_RELOAD=1` | 4.13 s | 12.21x | TTFT-only fallback; no speculative decode |
+
+The last row is a TTFT / very short-output fallback, not a replacement for
+full DFlash speculative decode. The daemon skips `migrate_prefill_cache` when
+the DFlash draft remains parked because rollback tensors are only needed by
+speculative verification. This fallback should not be used as a decode
+performance claim.
+
+The candidate quality smoke is retrieval-only: the original 16K NIAH prompt
+and a 5-position synthetic 16K NIAH sweep retained the key and answer. Broader
+long-prompt QA should pass before enabling this by default. Keeping the 0.6B
+PFlash drafter resident across requests was rejected locally because the lower
+second compression time was offset by slower target prefill.
+
 ## Performance
 
 NIAH single-needle end-to-end on RTX 3090 (Qwen3.6-27B Q4_K_M target,
@@ -73,6 +133,7 @@ src/
   flashprefill.{h,cpp}         FlashPrefill C++ entry + dispatcher
   flashprefill_kernels.cu       4 CUDA kernels (mean_K, score, select, sparse_fwd)
   flashprefill_select.cpp       Host fallback for block_select (rarely used)
+  pflash_chunk_select.{h,cpp}   CPU chunk top-K + lexical rescue + span merge
   bsa_launcher.cu               BSA launcher: blockmask conversion + Flash_fwd_params
   bsa_fwd_inst.cu               Single-TU instantiation of BSA's hdim128 kernel
   qwen3_0p6b_loader.cpp         GGUF → Qwen3-0.6B BF16 weight tensors
@@ -85,6 +146,7 @@ test/
   test_dflash.cpp               daemon executable; supports
                                   `compress / generate / park / unpark / free drafter`
   test_flashprefill_kernels.cpp parity tests for the 4 FP kernels
+  test_pflash_chunk_select.cpp  regression for rare-query lexical rescue
   smoke_qwen3_0p6b_forward.cpp  drafter forward smoke at S=8K-128K
 deps/
   llama.cpp/                    submodule (ggml only; libllama not built)

--- a/dflash/scripts/_prefill_hook.py
+++ b/dflash/scripts/_prefill_hook.py
@@ -125,7 +125,9 @@ def compress_text_via_daemon(
     """Run the daemon's compress + memory dance, return the compressed text.
 
     Caller holds the daemon lock for the full duration. After this returns,
-    the daemon has its target + draft restored and is ready for ``generate``.
+    the daemon has its target restored and is ready for ``generate``. If
+    ``DFLASH_PFLASH_SKIP_DRAFT_RELOAD=1`` is set, the draft remains parked and
+    the daemon must use its target-only decode fallback for that request.
     """
     # 1) drafter-tokenize the prompt
     drafter_ids = drafter_tokenizer(prompt_text, return_tensors=None,
@@ -140,8 +142,13 @@ def compress_text_via_daemon(
             for t in drafter_ids:
                 f.write(struct.pack("<i", int(t)))
 
-        # 3) park target + draft so drafter has VRAM headroom on a 24 GB card
-        _send_and_ack(daemon_stdin, r_pipe, "park target\n")
+        # 3) park target + draft so drafter has VRAM headroom on a 24 GB card.
+        # Experimental SM75 path: keep target resident and only park the DFlash
+        # draft. This avoids reloading the 27B target after compression, but can
+        # OOM on tighter contexts, so it is opt-in via env.
+        keep_target = os.environ.get("DFLASH_PFLASH_KEEP_TARGET", "0") not in ("", "0")
+        if not keep_target:
+            _send_and_ack(daemon_stdin, r_pipe, "park target\n")
         _send_and_ack(daemon_stdin, r_pipe, "park draft\n")
 
         # 4) compress: drafter loads, FlashPrefill scoring, emit compressed ids, drafter held
@@ -151,10 +158,15 @@ def compress_text_via_daemon(
         daemon_stdin.flush()
         compressed_ids = _drain_until_sentinel(r_pipe)
 
-        # 5) free drafter weights + BSA scratch, then restore target + draft
+        # 5) free drafter weights + BSA scratch, then restore target + draft.
+        # For short outputs, reloading the DFlash draft can dominate the whole
+        # PFlash path; the matching daemon env falls back to target-only decode.
+        skip_draft_reload = os.environ.get("DFLASH_PFLASH_SKIP_DRAFT_RELOAD", "0") not in ("", "0")
         _send_and_ack(daemon_stdin, r_pipe, "free drafter\n")
-        _send_and_ack(daemon_stdin, r_pipe, "unpark target\n")
-        _send_and_ack(daemon_stdin, r_pipe, "unpark draft\n")
+        if not keep_target:
+            _send_and_ack(daemon_stdin, r_pipe, "unpark target\n")
+        if not skip_draft_reload:
+            _send_and_ack(daemon_stdin, r_pipe, "unpark draft\n")
     finally:
         try: os.unlink(path)
         except Exception: pass

--- a/dflash/src/flashprefill.cpp
+++ b/dflash/src/flashprefill.cpp
@@ -1,7 +1,7 @@
 // Glue between the 4 FlashPrefill steps:
 //   1. compute_mean_vector_bf16    (kernel)
-//   2. compute_block_score_bf16    (kernel)  + normalise on host
-//   3. block_select_host           (host)
+//   2. compute_block_score_bf16    (kernel)
+//   3. block_select                (kernel)
 //   4. sparse_flash_forward_bf16   (kernel)
 
 #include "flashprefill.h"
@@ -25,13 +25,12 @@ void launch_compute_mean_vector_bf16(
 
 void launch_compute_block_score_bf16(
     const void * Q, const void * mean_K, float sm_scale,
-    void * score, void * score_max,
+    void * score,
     int batch, int n_q_heads, int n_k_heads,
     int seq_len, int head_dim, int block_size,
     int s_Q_b, int s_Q_n, int s_Q_h, int s_Q_d,
     int s_mK_b, int s_mK_m, int s_mK_h, int s_mK_d,
     int s_S_b, int s_S_m, int s_S_n, int s_S_h,
-    int s_M_b, int s_M_m, int s_M_n, int s_M_h,
     cudaStream_t stream);
 
 void launch_block_select(
@@ -107,12 +106,11 @@ int flash_prefill_forward_bf16(
 
     // Allocate scratch on the same device as Q.
     void * dmK = nullptr;
-    float * dS = nullptr, * dM = nullptr;
+    float * dS = nullptr;
     int32_t * dIdx = nullptr, * dCnt = nullptr;
     cudaError_t e;
     if ((e = cudaMalloc(&dmK,  (size_t)B * M * Hk * D * 2)) != cudaSuccess) goto err;  // bf16
     if ((e = cudaMalloc(&dS,   (size_t)B * M * N * H * sizeof(float))) != cudaSuccess) goto err;
-    if ((e = cudaMalloc(&dM,   (size_t)B * M * N * H * sizeof(float))) != cudaSuccess) goto err;
     if ((e = cudaMalloc(&dIdx, (size_t)B * M * N * H * sizeof(int32_t))) != cudaSuccess) goto err;
     if ((e = cudaMalloc(&dCnt, (size_t)B * M * H * sizeof(int32_t))) != cudaSuccess) goto err;
 
@@ -129,11 +127,10 @@ int flash_prefill_forward_bf16(
     if (prof) cudaEventRecord(pE[1]);
     // 2. block scores
     launch_compute_block_score_bf16(
-        Q, dmK, scale, dS, dM,
+        Q, dmK, scale, dS,
         B, H, Hk, S, D, BLOCK,
         s_Q_b, s_Q_n, s_Q_h, s_Q_d,
         s_mK_b, s_mK_m, s_mK_h, s_mK_d,
-        s_S_b, s_S_m, s_S_n, s_S_h,
         s_S_b, s_S_m, s_S_n, s_S_h, 0);
 
     if (prof) cudaEventRecord(pE[2]);
@@ -192,17 +189,25 @@ int flash_prefill_forward_bf16(
             S, n_q_heads, n_k_heads, t1, t2, t3, t4);
         for (int i=0;i<5;i++) cudaEventDestroy(pE[i]);
     }
-    cudaFree(dmK); cudaFree(dS); cudaFree(dM); cudaFree(dIdx); cudaFree(dCnt);
+    cudaFree(dmK); cudaFree(dS); cudaFree(dIdx); cudaFree(dCnt);
     return 0;
 
 err:
     if (dmK)  cudaFree(dmK);
     if (dS)   cudaFree(dS);
-    if (dM)   cudaFree(dM);
     if (dIdx) cudaFree(dIdx);
     if (dCnt) cudaFree(dCnt);
     std::fprintf(stderr, "[flashprefill] cudaMalloc failed: %s\n", cudaGetErrorString(e));
     return -1;
+}
+
+int flash_prefill_forward_f16(
+    const void * Q, const void * K, const void * V, void * O,
+    int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
+    float scale,
+    const FlashPrefillConfig & cfg)
+{
+    return flash_prefill_forward_bf16(Q, K, V, O, batch, seq_len, n_q_heads, n_k_heads, head_dim, scale, cfg);
 }
 
 } // namespace flashprefill

--- a/dflash/src/flashprefill.h
+++ b/dflash/src/flashprefill.h
@@ -4,7 +4,7 @@
 // Wraps kernels 1-4 + GPU block_select into one call. Call signature mirrors
 // the upstream `flash_prefill` from qhfan/FlashPrefill (arXiv:2603.06199).
 //
-// Tensor layout (all CUDA, bf16, contiguous, D fastest):
+// Tensor layout (all CUDA, fp16/bf16, contiguous, D fastest):
 //   Q[B, S, n_q_heads, D]
 //   K[B, S, n_k_heads, D]
 //   V[B, S, n_k_heads, D]
@@ -16,6 +16,10 @@
 //     kernel (FA-2 derived, m16n8k16 PTX, sm_80+ via cuBLAS BF16 GEMM).
 //     Requires building with -DDFLASH27B_ENABLE_BSA=ON. ~3x faster than WMMA
 //     on RTX 3090 at S=128K.
+//   - On SM75/Turing (e.g. RTX 2080 Ti), BSA is unavailable and BF16 tensor
+//     cores do not exist. The drafter should use FP16 weights/compute and this
+//     WMMA path; tune alpha/keep ratio and preserve quality with the PFlash
+//     compressor knobs documented in qwen3_drafter.h.
 //
 // Tunables (env vars):
 //   DFLASH_FP_USE_BSA      [0/1] enable BSA backend (default: 0).
@@ -26,6 +30,9 @@
 //   DFLASH_FP_PROFILE      [set] log per-stage timing (mean / score / select /
 //                          forward) to stderr.
 //   DFLASH_FP_DUMP_COUNTS  [set] log per-row select counts to stderr.
+//   DFLASH_FP_K_TILE       [32/64] internal WMMA sparse-forward tile tuning.
+//                          Default 32 on SM75, 64 elsewhere; 32 trades more
+//                          inner iterations for lower shared/register pressure.
 
 #pragma once
 
@@ -50,6 +57,12 @@ struct FlashPrefillConfig {
 // Scratch memory (allocated/freed per call inside): ~M*M*H*4 * 3 + M*H*4
 // where M = ceil(seq_len/block_size). At S=140K, M≈1093, H=16: ~300 MB.
 int flash_prefill_forward_bf16(
+    const void * Q, const void * K, const void * V, void * O,
+    int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
+    float scale,
+    const FlashPrefillConfig & cfg);
+
+int flash_prefill_forward_f16(
     const void * Q, const void * K, const void * V, void * O,
     int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
     float scale,

--- a/dflash/src/flashprefill_kernels.cu
+++ b/dflash/src/flashprefill_kernels.cu
@@ -8,7 +8,7 @@
 //   1. compute_mean_vector_kernel  — mean K over BLOCK_SIZE blocks.
 //      Output: mean_k[B, n_k_blocks, n_kv_heads, D]
 //   2. compute_block_score_kernel  — per (q_block, k_block) score via
-//      Q · mean_K^T.  Output: score[B, M, N, H], max[B, M, N, H]
+//      Q · mean_K^T.  Output: score[B, M, N, H]
 //   3. block_select (host or CUDA) — pick top-K blocks per Q row, with
 //      sink + window + dynamic alpha threshold + always-on last blocks.
 //      Output: compact_indices[B, M, N, H], counts[B, M, H]
@@ -26,27 +26,45 @@
 //   - score shape: [B, M, N, n_q_heads]   (M = N = ceil(S/BLOCK))
 
 #include <cstdint>
+#include <cstdlib>
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #include <mma.h>
 
 namespace dflash27b {
 namespace flashprefill {
 
+#if defined(DFLASH27B_MIN_SM) && DFLASH27B_MIN_SM < 80
+// SM75 has no native BF16 tensor cores. Remap the existing BF16 kernel source
+// to FP16 so the same code path compiles and runs on Turing.
+#define __nv_bfloat16 __half
+#define __bfloat162float __half2float
+#define __float2bfloat16 __float2half
+#endif
+
 // ── cp.async helpers (sm_8x) ─────────────────────────────────────────
 // 16-byte (uint4) async global → shared copy. Issued by every thread that
 // participates in the cooperative load. wait_all() drains all outstanding
 // transfers; commit_group()/wait_group(N) supports multi-stage pipelines.
 __device__ inline void cp_async16(void * smem_ptr, const void * gmem_ptr) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
     unsigned smem_addr = __cvta_generic_to_shared(smem_ptr);
     asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n"
                  :: "r"(smem_addr), "l"(gmem_ptr));
+#else
+    *reinterpret_cast<uint4 *>(smem_ptr) = *reinterpret_cast<const uint4 *>(gmem_ptr);
+#endif
 }
 __device__ inline void cp_async_commit() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
     asm volatile("cp.async.commit_group;\n");
+#endif
 }
 __device__ inline void cp_async_wait_all() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
     asm volatile("cp.async.wait_all;\n");
+#endif
 }
 
 
@@ -133,15 +151,13 @@ __global__ void compute_block_score_kernel_bf16(
     const __nv_bfloat16 * __restrict__ mean_K,
     float sm_scale,
     float * __restrict__ score,    // [B, M, N, H]
-    float * __restrict__ score_max,// [B, M, N, H]
     int batch, int n_q_heads, int n_k_heads,
     int q_block_idx_max,           // total q blocks  M = ceil(S/BLOCK)
     int k_block_idx_max,           // total k blocks  N = ceil(S/BLOCK)
     // strides (in elements)
     int s_Q_b, int s_Q_n, int s_Q_h, int s_Q_d,
     int s_mK_b, int s_mK_m, int s_mK_h, int s_mK_d,
-    int s_S_b, int s_S_m, int s_S_n, int s_S_h,
-    int s_M_b, int s_M_m, int s_M_n, int s_M_h)
+    int s_S_b, int s_S_m, int s_S_n, int s_S_h)
 {
     const int q_block_idx = blockIdx.x;
     const int zh = blockIdx.y;
@@ -208,25 +224,24 @@ __global__ void compute_block_score_kernel_bf16(
         float p_sum = smem[0];
         __syncthreads();
 
-        // Thread 0 writes the (score, max) for this (q_block, n).
+        // Thread 0 writes the score for this (q_block, n). The row max was
+        // needed by an earlier host normalization path; block_select only
+        // consumes the final score.
         if (tid == 0) {
             score    [(size_t)b * s_S_b + (size_t)q_block_idx * s_S_m
                       + (size_t)n * s_S_n + (size_t)qh * s_S_h] = p_sum;
-            score_max[(size_t)b * s_M_b + (size_t)q_block_idx * s_M_m
-                      + (size_t)n * s_M_n + (size_t)qh * s_M_h] = m_block;
         }
     }
 }
 
 extern "C" void launch_compute_block_score_bf16(
     const void * Q, const void * mean_K, float sm_scale,
-    void * score, void * score_max,
+    void * score,
     int batch, int n_q_heads, int n_k_heads,
     int seq_len, int head_dim, int block_size,
     int s_Q_b, int s_Q_n, int s_Q_h, int s_Q_d,
     int s_mK_b, int s_mK_m, int s_mK_h, int s_mK_d,
     int s_S_b, int s_S_m, int s_S_n, int s_S_h,
-    int s_M_b, int s_M_m, int s_M_n, int s_M_h,
     cudaStream_t stream)
 {
     const int M = (seq_len + block_size - 1) / block_size;
@@ -236,12 +251,11 @@ extern "C" void launch_compute_block_score_bf16(
     if (head_dim == 128 && block_size == 128) {
         compute_block_score_kernel_bf16<128, 128, 1><<<grid, block, smem, stream>>>(
             (const __nv_bfloat16 *)Q, (const __nv_bfloat16 *)mean_K, sm_scale,
-            (float *)score, (float *)score_max,
+            (float *)score,
             batch, n_q_heads, n_k_heads, M, M,
             s_Q_b, s_Q_n, s_Q_h, s_Q_d,
             s_mK_b, s_mK_m, s_mK_h, s_mK_d,
-            s_S_b, s_S_m, s_S_n, s_S_h,
-            s_M_b, s_M_m, s_M_n, s_M_h);
+            s_S_b, s_S_m, s_S_n, s_S_h);
     }
 }
 
@@ -292,6 +306,8 @@ __global__ void sparse_flash_forward_kernel_bf16(
     constexpr int NNK = K_TILE / MMA_N;       // 4 N-tiles along K_TILE (when K_TILE=64)
     constexpr int N_INNER = BLOCK / K_TILE;   // 2 inner iters per selected block
     constexpr int NTHREADS = (Q_TILE / MMA_M) * 32;  // 1 warp per 16 Q rows
+    constexpr int D_STRIDE = D_HEAD + 8;
+    constexpr int P_STRIDE = K_TILE + 8;
 
     const int q_tile_idx = blockIdx.x;
     const int zh = blockIdx.y;
@@ -308,9 +324,9 @@ __global__ void sparse_flash_forward_kernel_bf16(
     // SMEM: Q + KV (K or V at a time, alias) + P + row state
     extern __shared__ __align__(16) unsigned char smem_raw[];
     __nv_bfloat16 * Q_sh   = reinterpret_cast<__nv_bfloat16*>(smem_raw);
-    __nv_bfloat16 * KV_sh  = Q_sh + (size_t)Q_TILE * D_HEAD;
-    __nv_bfloat16 * P_sh   = KV_sh + (size_t)K_TILE * D_HEAD;
-    float         * row_m  = reinterpret_cast<float*>(P_sh + (size_t)Q_TILE * K_TILE);
+    __nv_bfloat16 * KV_sh  = Q_sh + (size_t)Q_TILE * D_STRIDE;
+    __nv_bfloat16 * P_sh   = KV_sh + (size_t)K_TILE * D_STRIDE;
+    float         * row_m  = reinterpret_cast<float*>(P_sh + (size_t)Q_TILE * P_STRIDE);
     float         * row_l  = row_m + Q_TILE;
 
     if (tid < Q_TILE) {
@@ -325,7 +341,7 @@ __global__ void sparse_flash_forward_kernel_bf16(
             int row = idx / D_HEAD;
             int dim = idx - row * D_HEAD;
             int q_global = q_tile_idx * Q_TILE + row;
-            Q_sh[row * D_HEAD + dim] = (q_global < seq_len)
+            Q_sh[row * D_STRIDE + dim] = (q_global < seq_len)
                 ? Qp[(size_t)q_global * s_Q_n + (size_t)dim * s_Q_d]
                 : __float2bfloat16(0.0f);
         }
@@ -336,8 +352,10 @@ __global__ void sparse_flash_forward_kernel_bf16(
     {
         const float sm_scale = scale * 1.4426950408889634f;
         for (int idx = tid; idx < Q_TILE * D_HEAD; idx += NTHREADS) {
-            float v = __bfloat162float(Q_sh[idx]);
-            Q_sh[idx] = __float2bfloat16(v * sm_scale);
+            const int row = idx / D_HEAD;
+            const int dim = idx - row * D_HEAD;
+            float v = __bfloat162float(Q_sh[(size_t)row * D_STRIDE + dim]);
+            Q_sh[(size_t)row * D_STRIDE + dim] = __float2bfloat16(v * sm_scale);
         }
     }
     __syncthreads();
@@ -370,7 +388,7 @@ __global__ void sparse_flash_forward_kernel_bf16(
                         int row8 = idx / (D_HEAD / 8);
                         int d8   = idx - row8 * (D_HEAD / 8);
                         int j = k_lo + row8;
-                        __nv_bfloat16 * dst = KV_sh + row8 * D_HEAD + d8 * 8;
+                            __nv_bfloat16 * dst = KV_sh + row8 * D_STRIDE + d8 * 8;
                         if (j < seq_len) {
                             cp_async16(dst, Kp + (size_t)j * s_K_n + (size_t)(d8 * 8));
                         } else {
@@ -395,11 +413,11 @@ __global__ void sparse_flash_forward_kernel_bf16(
                 #pragma unroll
                 for (int dk = 0; dk < NDK; ++dk) {
                     wmma::load_matrix_sync(Af,
-                        Q_sh + (size_t)(wid * MMA_M) * D_HEAD + dk * MMA_K, D_HEAD);
+                        Q_sh + (size_t)(wid * MMA_M) * D_STRIDE + dk * MMA_K, D_STRIDE);
                     #pragma unroll
                     for (int nt = 0; nt < NNK; ++nt) {
                         wmma::load_matrix_sync(Bf,
-                            KV_sh + (size_t)(nt * MMA_N) * D_HEAD + dk * MMA_K, D_HEAD);
+                            KV_sh + (size_t)(nt * MMA_N) * D_STRIDE + dk * MMA_K, D_STRIDE);
                         wmma::mma_sync(S_frag[nt], Af, Bf, S_frag[nt]);
                     }
                 }
@@ -478,7 +496,7 @@ __global__ void sparse_flash_forward_kernel_bf16(
                     float p = (v == -INFINITY) ? 0.0f : exp2f(v - mn);
                     if (i < 4) rs0 += p; else rs1 += p;
                     int p_row = wid * MMA_M + ((i < 4) ? row0_in_warp : row1_in_warp);
-                    P_sh[(size_t)p_row * K_TILE + col_in_KTILE] = __float2bfloat16(p);
+                    P_sh[(size_t)p_row * P_STRIDE + col_in_KTILE] = __float2bfloat16(p);
                 }
             }
             // Reduce rowsum across quad
@@ -522,7 +540,7 @@ __global__ void sparse_flash_forward_kernel_bf16(
                         int row8 = idx / (D_HEAD / 8);
                         int d8   = idx - row8 * (D_HEAD / 8);
                         int j = k_lo + row8;
-                        __nv_bfloat16 * dst = KV_sh + row8 * D_HEAD + d8 * 8;
+                        __nv_bfloat16 * dst = KV_sh + row8 * D_STRIDE + d8 * 8;
                         if (j < seq_len) {
                             cp_async16(dst, Vp + (size_t)j * s_V_n + (size_t)(d8 * 8));
                         } else {
@@ -545,11 +563,11 @@ __global__ void sparse_flash_forward_kernel_bf16(
                 #pragma unroll
                 for (int kk = 0; kk < NNK; ++kk) {
                     wmma::load_matrix_sync(Af,
-                        P_sh + (size_t)(wid * MMA_M) * K_TILE + kk * MMA_K, K_TILE);
+                        P_sh + (size_t)(wid * MMA_M) * P_STRIDE + kk * MMA_K, P_STRIDE);
                     #pragma unroll
                     for (int dt = 0; dt < NDK; ++dt) {
                         wmma::load_matrix_sync(Bf,
-                            KV_sh + (size_t)(kk * MMA_K) * D_HEAD + dt * MMA_N, D_HEAD);
+                            KV_sh + (size_t)(kk * MMA_K) * D_STRIDE + dt * MMA_N, D_STRIDE);
                         wmma::mma_sync(O_frag[dt], Af, Bf, O_frag[dt]);
                     }
                 }
@@ -558,11 +576,10 @@ __global__ void sparse_flash_forward_kernel_bf16(
         } // inner
     } // it
 
-    // Write O = acc / l_i. Store frag → SMEM (reuse Q_sh region as scratch), divide row-wise.
-    // Q_sh is no longer needed; treat Q_sh region as f32 [Q_TILE][D_HEAD] (since 64*128*2 bf16 = 64*128*2 = 16K, but f32 needs 64*128*4 = 32K — won't fit). Use P_sh as scratch (8K, only first 4K rows needed for D=128 per warp store).
-    // Simpler: store one D col tile at a time into a small scratch and write out.
-    // We'll reuse the KV_sh region as f32 staging ([Q_TILE, MMA_N] = 64*16*4 = 4K) for one col tile at a time.
-    float * stage_f32 = reinterpret_cast<float*>(KV_sh);  // 4 KB needed, KV_sh is 16 KB, plenty.
+    // Write O = acc / l_i. Store frag -> SMEM one D tile at a time, then
+    // divide row-wise and write global. This is sync-heavy but numerically
+    // stable across the WMMA fragment layouts we currently support.
+    float * stage_f32 = reinterpret_cast<float*>(KV_sh);  // 4 KB needed, KV_sh is at least 8 KB.
     #pragma unroll
     for (int d = 0; d < NDK; ++d) {
         __syncthreads();
@@ -619,28 +636,68 @@ extern "C" void launch_sparse_flash_forward_bf16(
     dim3 grid(q_tiles, batch * n_q_heads, 1);
     dim3 block(q_tile, 1, 1);
     if (q_tile == 64 && block_size == 128 && head_dim == 128) {
-        // FA-2 register-resident layout @ Q_TILE=64 (4 warps, 128 threads), 2 CTAs/SM.
-        constexpr int Q_TILE = 64, K_TILE = 64, BLOCK = 128, D_HEAD = 128;
-        size_t smem_bytes = sizeof(__nv_bfloat16) * (Q_TILE * D_HEAD)
-                           + sizeof(__nv_bfloat16) * (K_TILE * D_HEAD)
-                           + sizeof(__nv_bfloat16) * (Q_TILE * K_TILE)
-                           + sizeof(float)         * (2 * Q_TILE);
+        // FA-2 register-resident layout @ Q_TILE=64 (4 warps, 128 threads).
+        // K_TILE=64 is the original path. K_TILE=32 is useful on SM75/Turing
+        // experiments because it cuts dynamic shared memory and S fragments,
+        // at the cost of twice as many inner K iterations.
+        int k_tile = 64;
+#if defined(DFLASH27B_MIN_SM) && DFLASH27B_MIN_SM < 80
+        k_tile = 32;
+#endif
+        if (const char * env = std::getenv("DFLASH_FP_K_TILE")) {
+            const int v = std::atoi(env);
+            if (v == 32 || v == 64) {
+                k_tile = v;
+            }
+        }
         dim3 block128(128, 1, 1);
-        cudaFuncSetAttribute(
-            (const void*)sparse_flash_forward_kernel_bf16<Q_TILE, K_TILE, BLOCK, D_HEAD>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize,
-            (int)smem_bytes);
-        sparse_flash_forward_kernel_bf16<Q_TILE, K_TILE, BLOCK, D_HEAD><<<grid, block128, smem_bytes, stream>>>(
-            (const __nv_bfloat16 *)Q, (const __nv_bfloat16 *)K,
-            (const __nv_bfloat16 *)V, (__nv_bfloat16 *)O,
-            block_index, counts, scale,
-            batch, n_q_heads, n_k_heads, seq_len, M,
-            s_Q_b, s_Q_n, s_Q_h, s_Q_d,
-            s_K_b, s_K_n, s_K_h, s_K_d,
-            s_V_b, s_V_n, s_V_h, s_V_d,
-            s_O_b, s_O_n, s_O_h, s_O_d,
-            s_idx_b, s_idx_m, s_idx_n, s_idx_h,
-            s_cnt_b, s_cnt_m, s_cnt_h);
+        if (k_tile == 32) {
+            constexpr int Q_TILE = 64, K_TILE = 32, BLOCK = 128, D_HEAD = 128;
+            constexpr int D_STRIDE = D_HEAD + 8;
+            constexpr int P_STRIDE = K_TILE + 8;
+            size_t smem_bytes = sizeof(__nv_bfloat16) * (Q_TILE * D_STRIDE)
+                               + sizeof(__nv_bfloat16) * (K_TILE * D_STRIDE)
+                               + sizeof(__nv_bfloat16) * (Q_TILE * P_STRIDE)
+                               + sizeof(float)         * (2 * Q_TILE);
+            cudaFuncSetAttribute(
+                (const void*)sparse_flash_forward_kernel_bf16<Q_TILE, K_TILE, BLOCK, D_HEAD>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                (int)smem_bytes);
+            sparse_flash_forward_kernel_bf16<Q_TILE, K_TILE, BLOCK, D_HEAD><<<grid, block128, smem_bytes, stream>>>(
+                (const __nv_bfloat16 *)Q, (const __nv_bfloat16 *)K,
+                (const __nv_bfloat16 *)V, (__nv_bfloat16 *)O,
+                block_index, counts, scale,
+                batch, n_q_heads, n_k_heads, seq_len, M,
+                s_Q_b, s_Q_n, s_Q_h, s_Q_d,
+                s_K_b, s_K_n, s_K_h, s_K_d,
+                s_V_b, s_V_n, s_V_h, s_V_d,
+                s_O_b, s_O_n, s_O_h, s_O_d,
+                s_idx_b, s_idx_m, s_idx_n, s_idx_h,
+                s_cnt_b, s_cnt_m, s_cnt_h);
+        } else {
+            constexpr int Q_TILE = 64, K_TILE = 64, BLOCK = 128, D_HEAD = 128;
+            constexpr int D_STRIDE = D_HEAD + 8;
+            constexpr int P_STRIDE = K_TILE + 8;
+            size_t smem_bytes = sizeof(__nv_bfloat16) * (Q_TILE * D_STRIDE)
+                               + sizeof(__nv_bfloat16) * (K_TILE * D_STRIDE)
+                               + sizeof(__nv_bfloat16) * (Q_TILE * P_STRIDE)
+                               + sizeof(float)         * (2 * Q_TILE);
+            cudaFuncSetAttribute(
+                (const void*)sparse_flash_forward_kernel_bf16<Q_TILE, K_TILE, BLOCK, D_HEAD>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                (int)smem_bytes);
+            sparse_flash_forward_kernel_bf16<Q_TILE, K_TILE, BLOCK, D_HEAD><<<grid, block128, smem_bytes, stream>>>(
+                (const __nv_bfloat16 *)Q, (const __nv_bfloat16 *)K,
+                (const __nv_bfloat16 *)V, (__nv_bfloat16 *)O,
+                block_index, counts, scale,
+                batch, n_q_heads, n_k_heads, seq_len, M,
+                s_Q_b, s_Q_n, s_Q_h, s_Q_d,
+                s_K_b, s_K_n, s_K_h, s_K_d,
+                s_V_b, s_V_n, s_V_h, s_V_d,
+                s_O_b, s_O_n, s_O_h, s_O_d,
+                s_idx_b, s_idx_m, s_idx_n, s_idx_h,
+                s_cnt_b, s_cnt_m, s_cnt_h);
+        }
     }
 }
 

--- a/dflash/src/pflash_chunk_select.cpp
+++ b/dflash/src/pflash_chunk_select.cpp
@@ -1,0 +1,175 @@
+#include "pflash_chunk_select.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace dflash27b {
+
+std::vector<int32_t> pflash_select_and_compress(
+    const std::vector<int32_t> & ids,
+    const std::vector<float> & smooth_scores,
+    const PFlashChunkSelectOptions & opts,
+    PFlashChunkSelectStats * stats) {
+    const int S = (int) ids.size();
+    if (stats) {
+        *stats = {};
+    }
+    if (S <= 0 || smooth_scores.size() < ids.size() || opts.chunk_size <= 0) {
+        return {};
+    }
+
+    const int n_chunks = (S + opts.chunk_size - 1) / opts.chunk_size;
+    const int raw_keep = (int) ((float) n_chunks * opts.keep_ratio);
+    const int n_keep = std::min(n_chunks, std::max(1, raw_keep));
+    const int chunk_radius = std::max(0, opts.chunk_radius);
+
+    std::vector<std::pair<float, int>> chunk_means;
+    chunk_means.reserve((size_t) n_chunks);
+    for (int c = 0; c < n_chunks; ++c) {
+        const int s = c * opts.chunk_size;
+        const int e = std::min(S, (c + 1) * opts.chunk_size);
+        float m = 0.0f;
+        for (int j = s; j < e; ++j) {
+            m += smooth_scores[(size_t) j];
+        }
+        m /= (float) std::max(1, e - s);
+        chunk_means.push_back({m, c});
+    }
+
+    std::partial_sort(chunk_means.begin(),
+                      chunk_means.begin() + n_keep,
+                      chunk_means.end(),
+                      [](auto a, auto b) { return a.first > b.first; });
+
+    std::vector<uint8_t> selected_mask((size_t) n_chunks, 0);
+    for (int i = 0; i < n_keep; ++i) {
+        const int c = chunk_means[(size_t) i].second;
+        const int lo = std::max(0, c - chunk_radius);
+        const int hi = std::min(n_chunks - 1, c + chunk_radius);
+        for (int x = lo; x <= hi; ++x) {
+            selected_mask[(size_t) x] = 1;
+        }
+    }
+
+    int lexical_chunks = 0;
+    if (opts.query_tail > 0 && opts.rare_max_freq > 0 && opts.query_min_hits > 0) {
+        std::unordered_map<int32_t, int> freq;
+        freq.reserve(ids.size());
+        for (int32_t tok : ids) {
+            ++freq[tok];
+        }
+
+        const int q0 = std::max(0, S - opts.query_tail);
+        std::unordered_set<int32_t> rare_query_tokens;
+        rare_query_tokens.reserve((size_t) std::max(1, S - q0));
+        for (int i = q0; i < S; ++i) {
+            const int32_t tok = ids[(size_t) i];
+            const auto it = freq.find(tok);
+            if (it != freq.end() && it->second <= opts.rare_max_freq) {
+                rare_query_tokens.insert(tok);
+            }
+        }
+
+        if (!rare_query_tokens.empty()) {
+            const int query_radius = std::max(0, opts.query_radius);
+            for (int c = 0; c < n_chunks; ++c) {
+                const int s = c * opts.chunk_size;
+                const int e = std::min(S, (c + 1) * opts.chunk_size);
+                const int scan_e = std::min(e, q0);
+                if (s >= scan_e) {
+                    continue;
+                }
+                int hits = 0;
+                for (int j = s; j < scan_e; ++j) {
+                    if (rare_query_tokens.find(ids[(size_t) j]) != rare_query_tokens.end()) {
+                        ++hits;
+                        if (hits >= opts.query_min_hits) {
+                            break;
+                        }
+                    }
+                }
+                if (hits >= opts.query_min_hits) {
+                    const int lo = std::max(0, c - query_radius);
+                    const int hi = std::min(n_chunks - 1, c + query_radius);
+                    bool added = false;
+                    for (int x = lo; x <= hi; ++x) {
+                        if (!selected_mask[(size_t) x]) {
+                            added = true;
+                        }
+                        selected_mask[(size_t) x] = 1;
+                    }
+                    if (added) {
+                        ++lexical_chunks;
+                    }
+                }
+            }
+        }
+    }
+
+    std::vector<int> selected;
+    selected.reserve((size_t) n_chunks);
+    for (int c = 0; c < n_chunks; ++c) {
+        if (selected_mask[(size_t) c]) {
+            selected.push_back(c);
+        }
+    }
+
+    if (!opts.dump_chunks_path.empty()) {
+        FILE * fp = std::fopen(opts.dump_chunks_path.c_str(), "w");
+        if (fp) {
+            std::fprintf(fp, "chunk,start,end,score,selected\n");
+            for (int c = 0; c < n_chunks; ++c) {
+                const int s = c * opts.chunk_size;
+                const int e = std::min(S, (c + 1) * opts.chunk_size);
+                float m = 0.0f;
+                for (int j = s; j < e; ++j) {
+                    m += smooth_scores[(size_t) j];
+                }
+                m /= (float) std::max(1, e - s);
+                std::fprintf(fp, "%d,%d,%d,%.9g,%d\n",
+                             c, s, e, (double) m, selected_mask[(size_t) c] ? 1 : 0);
+            }
+            std::fclose(fp);
+        }
+    }
+
+    std::vector<int32_t> out;
+    out.reserve((size_t) n_keep * (size_t) opts.chunk_size + 16);
+    int span_start = -1;
+    int span_end = -1;
+    for (int c : selected) {
+        const int s = c * opts.chunk_size;
+        const int e = std::min(S, (c + 1) * opts.chunk_size);
+        if (span_start < 0) {
+            span_start = s;
+            span_end = e;
+        } else if (s == span_end) {
+            span_end = e;
+        } else {
+            for (int j = span_start; j < span_end; ++j) {
+                out.push_back(ids[(size_t) j]);
+            }
+            span_start = s;
+            span_end = e;
+        }
+    }
+    if (span_start >= 0) {
+        for (int j = span_start; j < span_end; ++j) {
+            out.push_back(ids[(size_t) j]);
+        }
+    }
+
+    if (stats) {
+        stats->n_chunks = n_chunks;
+        stats->top_keep_chunks = n_keep;
+        stats->selected_chunks = (int) selected.size();
+        stats->lexical_chunks = lexical_chunks;
+        stats->out_tokens = out.size();
+    }
+    return out;
+}
+
+} // namespace dflash27b

--- a/dflash/src/pflash_chunk_select.h
+++ b/dflash/src/pflash_chunk_select.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dflash27b {
+
+struct PFlashChunkSelectOptions {
+    float keep_ratio      = 0.02f;
+    int   chunk_size      = 32;
+    int   chunk_radius    = 0;
+    int   query_tail      = 128;
+    int   rare_max_freq   = 4;
+    int   query_min_hits  = 2;
+    int   query_radius    = 1;
+    std::string dump_chunks_path;
+};
+
+struct PFlashChunkSelectStats {
+    int    n_chunks        = 0;
+    int    top_keep_chunks = 0;
+    int    selected_chunks = 0;
+    int    lexical_chunks  = 0;
+    size_t out_tokens      = 0;
+};
+
+std::vector<int32_t> pflash_select_and_compress(
+    const std::vector<int32_t> & ids,
+    const std::vector<float> & smooth_scores,
+    const PFlashChunkSelectOptions & opts,
+    PFlashChunkSelectStats * stats = nullptr);
+
+} // namespace dflash27b

--- a/dflash/src/qwen3_0p6b_drafter.h
+++ b/dflash/src/qwen3_0p6b_drafter.h
@@ -18,6 +18,8 @@
 #include <string>
 #include <vector>
 
+#include "ggml.h"
+
 struct ggml_context;
 struct ggml_tensor;
 struct ggml_backend;
@@ -51,6 +53,10 @@ struct Qwen3DrafterWeights {
     ggml_tensor * output      = nullptr;  // [hidden, vocab] (lm_head)
 
     std::vector<Qwen3DrafterLayer> layers;  // size = n_layer = 28
+
+    // Projection/embedding compute dtype. SM75 should use F16; BF16 is only
+    // kept for native-BF16 GPUs.
+    ggml_type compute_type = GGML_TYPE_BF16;
 
     // Architecture metadata.
     int n_layer    = 28;

--- a/dflash/src/qwen3_0p6b_graph.cpp
+++ b/dflash/src/qwen3_0p6b_graph.cpp
@@ -24,7 +24,7 @@
 // Memory at S=140K, B=1, H=16, Hk=8, D=128, hidden=1024, ff=3072:
 //   weights                                            ~1.5 GB
 //   28 × K_curr [D, Hk, S] bf16 + 28 × V_curr same   ~15.7 GB
-//   28 × Q_last [D, H, N] bf16                        ~1 KB
+//   28 × Q_last [D, H, N] fp16/bf16                    ~1 KB
 //   hidden_buf [hidden, S] f32                         0.57 GB
 //   pos / mask_tail                                    1 MB
 //   per-ubatch graph transients (chunk_s sized)        ~2-3 GB
@@ -115,6 +115,7 @@ bool forward_qwen3_0p6b_drafter(
     const float eps    = 1e-6f;
     const float scale  = 1.0f / std::sqrt((float)D);
     const float rope_b = w.rope_theta;
+    const ggml_type compute_type = w.compute_type;
 
     if (S < n_lookahead + 1) {
         set_last_error("forward_qwen3_0p6b_drafter: S too small");
@@ -147,16 +148,16 @@ bool forward_qwen3_0p6b_drafter(
         if (!make_pers(w.backend, GGML_TYPE_F32,  2, d_h, hidden_buf) ||
             !make_pers(w.backend, GGML_TYPE_I32,  1, d_p, pos_buf)    ||
             !make_pers(w.backend, GGML_TYPE_F32,  2, d_mt, mask_tail_buf) ||
-            !make_pers(w.backend, GGML_TYPE_BF16, 3, d_q, Q_buf) ||
-            !make_pers(w.backend, GGML_TYPE_BF16, 3, d_q, attn_out_buf)) {
+            !make_pers(w.backend, compute_type,  3, d_q, Q_buf) ||
+            !make_pers(w.backend, compute_type,  3, d_q, attn_out_buf)) {
             set_last_error("forward_qwen3_0p6b: persistent alloc failed (hidden/pos/mask/Q/attn_out)");
             cleanup_all();
             return false;
         }
         for (int il = 0; il < w.n_layer; ++il) {
-            if (!make_pers(w.backend, GGML_TYPE_BF16, 3, d_kv, K_curr_v[il]) ||
-                !make_pers(w.backend, GGML_TYPE_BF16, 3, d_kv, V_curr_v[il]) ||
-                !make_pers(w.backend, GGML_TYPE_F32, 3, d_ql, Q_last_v[il])) {
+            if (!make_pers(w.backend, compute_type,  3, d_kv, K_curr_v[il]) ||
+                !make_pers(w.backend, compute_type,  3, d_kv, V_curr_v[il]) ||
+                !make_pers(w.backend, compute_type, 3, d_ql, Q_last_v[il])) {
                 set_last_error("forward_qwen3_0p6b: K_curr/V_curr/Q_last alloc failed at layer " + std::to_string(il));
                 cleanup_all();
                 return false;
@@ -315,14 +316,23 @@ bool forward_qwen3_0p6b_drafter(
 
         // ── FP CUDA call: attn = flash_prefill(Q, K, V) ──
         auto tF0 = std::chrono::steady_clock::now();
-        int rc = flashprefill::flash_prefill_forward_bf16(
-            Q_buf.t->data,
-            K_curr_v[il].t->data,
-            V_curr_v[il].t->data,
-            attn_out_buf.t->data,
-            1, S, H, Hk, D, scale, fp_cfg);
+        int rc = (compute_type == GGML_TYPE_F16)
+            ? flashprefill::flash_prefill_forward_f16(
+                Q_buf.t->data,
+                K_curr_v[il].t->data,
+                V_curr_v[il].t->data,
+                attn_out_buf.t->data,
+                1, S, H, Hk, D, scale, fp_cfg)
+            : flashprefill::flash_prefill_forward_bf16(
+                Q_buf.t->data,
+                K_curr_v[il].t->data,
+                V_curr_v[il].t->data,
+                attn_out_buf.t->data,
+                1, S, H, Hk, D, scale, fp_cfg);
         if (rc != 0) {
-            set_last_error("flash_prefill_forward_bf16 failed at layer " + std::to_string(il));
+            set_last_error(std::string("flash_prefill_forward_") +
+                           ggml_type_name(compute_type) +
+                           " failed at layer " + std::to_string(il));
             ggml_gallocr_free(galloc); cleanup_all(); return false;
         }
         cudaError_t e = cudaGetLastError();
@@ -403,10 +413,8 @@ bool forward_qwen3_0p6b_drafter(
         ip.no_alloc = true;
         ggml_context * gctx = ggml_init(ip);
 
-        ggml_tensor * K_f32 = ggml_new_tensor_3d(gctx, GGML_TYPE_F32, D, Hk, S);
-        ggml_tensor * K_cast = ggml_cpy(gctx, K_curr_v[il].t, K_f32);
         ggml_tensor * K_perm = ggml_cont(gctx,
-            ggml_permute(gctx, K_cast, 0, 2, 1, 3));
+            ggml_permute(gctx, K_curr_v[il].t, 0, 2, 1, 3));
         ggml_tensor * K_score = K_perm;
         if (gqa > 1) {
             ggml_tensor * K_4d = ggml_reshape_4d(gctx, K_perm, D, S, 1, Hk);

--- a/dflash/src/qwen3_0p6b_loader.cpp
+++ b/dflash/src/qwen3_0p6b_loader.cpp
@@ -26,11 +26,14 @@
 #include "internal.h"
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <vector>
+#include <cuda_runtime.h>
 
 namespace dflash27b {
 
@@ -46,9 +49,62 @@ bool copy_tensor_from_file(gguf_context * gctx, const char * name,
     }
     const size_t off = gguf_get_tensor_offset(gctx, idx);
     const size_t bytes = ggml_nbytes(dst);
+    const ggml_type src_type = gguf_get_tensor_type(gctx, idx);
     const uint8_t * src = (const uint8_t *)mmap_base + data_offset + off;
-    ggml_backend_tensor_set(dst, src, 0, bytes);
-    return true;
+
+    if (src_type == dst->type) {
+        ggml_backend_tensor_set(dst, src, 0, bytes);
+        return true;
+    }
+
+    if (src_type == GGML_TYPE_BF16 && dst->type == GGML_TYPE_F16) {
+        const size_t n = ggml_nelements(dst);
+        if (bytes != n * sizeof(uint16_t)) {
+            std::fprintf(stderr, "[qwen3-0.6b] BF16->F16 size mismatch: %s\n", name);
+            return false;
+        }
+        std::vector<uint16_t> tmp(n);
+        const uint16_t * s = (const uint16_t *)src;
+        for (size_t i = 0; i < n; ++i) {
+            uint32_t bits = ((uint32_t)s[i]) << 16;
+            float f;
+            std::memcpy(&f, &bits, 4);
+            uint32_t u;
+            std::memcpy(&u, &f, 4);
+            uint32_t sign = (u >> 16) & 0x8000;
+            int32_t  exp  = ((u >> 23) & 0xFF) - 127 + 15;
+            uint32_t mant = (u >> 13) & 0x03FF;
+            if (exp <= 0)       tmp[i] = (uint16_t)sign;
+            else if (exp >= 31) tmp[i] = (uint16_t)(sign | 0x7C00);
+            else                tmp[i] = (uint16_t)(sign | (exp << 10) | mant);
+        }
+        ggml_backend_tensor_set(dst, tmp.data(), 0, bytes);
+        return true;
+    }
+
+    std::fprintf(stderr, "[qwen3-0.6b] unsupported tensor dtype for %s: %s -> %s\n",
+                 name, ggml_type_name(src_type), ggml_type_name(dst->type));
+    return false;
+}
+
+bool cuda_has_native_bf16() {
+    const char * env = std::getenv("DFLASH27B_DRAFT_FP16");
+    if (env && std::atoi(env) != 0) return false;
+    int device = 0;
+    cudaError_t err = cudaGetDevice(&device);
+    if (err != cudaSuccess) {
+        std::fprintf(stderr, "[qwen3-0.6b] cudaGetDevice failed: %s; using FP16 draft weights\n",
+                     cudaGetErrorString(err));
+        return false;
+    }
+    cudaDeviceProp prop{};
+    err = cudaGetDeviceProperties(&prop, device);
+    if (err != cudaSuccess) {
+        std::fprintf(stderr, "[qwen3-0.6b] cudaGetDeviceProperties failed: %s; using FP16 draft weights\n",
+                     cudaGetErrorString(err));
+        return false;
+    }
+    return prop.major >= 8;
 }
 
 uint32_t get_u32(gguf_context * g, const char * key, uint32_t def) {
@@ -86,6 +142,24 @@ bool load_qwen3_0p6b_drafter(const std::string & path,
     out.head_dim   = (int)get_u32(gctx, "qwen3.attention.key_length", 128);
     out.rope_theta = get_f32(gctx, "qwen3.rope.freq_base", 1000000.0f);
 
+    const int tok_idx = gguf_find_tensor(gctx, "token_embd.weight");
+    if (tok_idx < 0) {
+        set_last_error("Qwen3-0.6B GGUF missing token_embd.weight");
+        gguf_free(gctx);
+        return false;
+    }
+    const ggml_type src_weight_type = gguf_get_tensor_type(gctx, tok_idx);
+    if (src_weight_type == GGML_TYPE_F16) {
+        out.compute_type = GGML_TYPE_F16;
+    } else if (src_weight_type == GGML_TYPE_BF16) {
+        out.compute_type = cuda_has_native_bf16() ? GGML_TYPE_BF16 : GGML_TYPE_F16;
+    } else {
+        set_last_error(std::string("unsupported Qwen3-0.6B weight type: ") +
+                       ggml_type_name(src_weight_type));
+        gguf_free(gctx);
+        return false;
+    }
+
     // Compute total tensor metadata size for context allocation.
     const int n_layer = out.n_layer;
     const int n_tensors_per_layer = 11;
@@ -106,11 +180,12 @@ bool load_qwen3_0p6b_drafter(const std::string & path,
     const int n_vocab   = out.n_vocab;
     const int q_dim     = n_head * head_dim;
     const int kv_dim    = n_head_kv * head_dim;
+    const ggml_type WT  = out.compute_type;
 
     // Top-level tensors.
-    out.tok_embd = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_vocab);
+    out.tok_embd = ggml_new_tensor_2d(out.ctx, WT, n_embd, n_vocab);
     out.out_norm = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, n_embd);
-    out.output   = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_vocab);
+    out.output   = ggml_new_tensor_2d(out.ctx, WT, n_embd, n_vocab);
     ggml_set_name(out.tok_embd, "token_embd.weight");
     ggml_set_name(out.out_norm, "output_norm.weight");
     ggml_set_name(out.output,   "output.weight");
@@ -119,16 +194,16 @@ bool load_qwen3_0p6b_drafter(const std::string & path,
     for (int il = 0; il < n_layer; ++il) {
         auto & L = out.layers[il];
         L.attn_norm = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, n_embd);
-        L.wq        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, q_dim);
-        L.wk        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, kv_dim);
-        L.wv        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, kv_dim);
-        L.wo        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, q_dim, n_embd);
+        L.wq        = ggml_new_tensor_2d(out.ctx, WT, n_embd, q_dim);
+        L.wk        = ggml_new_tensor_2d(out.ctx, WT, n_embd, kv_dim);
+        L.wv        = ggml_new_tensor_2d(out.ctx, WT, n_embd, kv_dim);
+        L.wo        = ggml_new_tensor_2d(out.ctx, WT, q_dim, n_embd);
         L.q_norm    = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, head_dim);
         L.k_norm    = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, head_dim);
         L.ffn_norm  = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, n_embd);
-        L.ffn_gate  = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_ff);
-        L.ffn_up    = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_ff);
-        L.ffn_down  = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_ff, n_embd);
+        L.ffn_gate  = ggml_new_tensor_2d(out.ctx, WT, n_embd, n_ff);
+        L.ffn_up    = ggml_new_tensor_2d(out.ctx, WT, n_embd, n_ff);
+        L.ffn_down  = ggml_new_tensor_2d(out.ctx, WT, n_ff, n_embd);
     }
 
     out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, backend);

--- a/dflash/src/qwen3_drafter.cpp
+++ b/dflash/src/qwen3_drafter.cpp
@@ -16,6 +16,7 @@
 #include "qwen3_drafter.h"
 #include "qwen3_0p6b_drafter.h"
 #include "internal.h"
+#include "pflash_chunk_select.h"
 
 #include "ggml.h"
 #include "ggml-backend.h"
@@ -24,6 +25,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -62,8 +64,9 @@ bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
 
     out.loaded = true;
     std::fprintf(stderr,
-        "[drafter] loaded Qwen3-0.6B BF16: n_layer=%d n_head=%d n_kv=%d "
+        "[drafter] loaded Qwen3-0.6B %s: n_layer=%d n_head=%d n_kv=%d "
         "n_embd=%d n_ff=%d head_dim=%d vocab=%d\n",
+        ggml_type_name(out.weights.compute_type),
         out.weights.n_layer, out.weights.n_head, out.weights.n_head_kv,
         out.weights.n_embd, out.weights.n_ff, out.weights.head_dim,
         out.weights.n_vocab);
@@ -94,6 +97,14 @@ std::vector<int32_t> drafter_score_and_compress(
         return {};
     }
     const int S = (int)ids.size();
+
+    if (const char * env = std::getenv("DFLASH_PFLASH_LOOKAHEAD")) {
+        int v = std::atoi(env);
+        if (v > 0 && v <= 256) {
+            n_lookahead = v;
+        }
+    }
+
     if (S < n_lookahead + 1) {
         // Too short to score — return as-is.
         return ids;
@@ -132,52 +143,55 @@ std::vector<int32_t> drafter_score_and_compress(
         smooth[j] = (n > 0) ? (s / (float)n) : 0.0f;
     }
 
-    // ── 4. Chunk-top-K + span merge ───────────────────────────────────
-    int n_chunks = (S + chunk_size - 1) / chunk_size;
-    int n_keep   = std::max(1, (int)((float)n_chunks * keep_ratio));
-    std::vector<std::pair<float, int>> chunk_means;
-    chunk_means.reserve((size_t)n_chunks);
-    for (int c = 0; c < n_chunks; ++c) {
-        int s_ = c * chunk_size;
-        int e_ = std::min(S, (c + 1) * chunk_size);
-        float m = 0.0f;
-        for (int j = s_; j < e_; ++j) m += smooth[j];
-        m /= std::max(1, e_ - s_);
-        chunk_means.push_back({m, c});
-    }
-    std::partial_sort(chunk_means.begin(),
-                      chunk_means.begin() + n_keep,
-                      chunk_means.end(),
-                      [](auto a, auto b) { return a.first > b.first; });
-    std::vector<int> selected;
-    selected.reserve((size_t)n_keep);
-    for (int i = 0; i < n_keep; ++i) selected.push_back(chunk_means[i].second);
-    std::sort(selected.begin(), selected.end());
-
-    std::vector<int32_t> out;
-    out.reserve((size_t)n_keep * chunk_size + 16);
-    int span_start = -1, span_end = -1;
-    for (int c : selected) {
-        int s_ = c * chunk_size;
-        int e_ = std::min(S, (c + 1) * chunk_size);
-        if (span_start < 0) {
-            span_start = s_; span_end = e_;
-        } else if (s_ == span_end) {
-            span_end = e_;
-        } else {
-            for (int j = span_start; j < span_end; ++j) out.push_back(ids[j]);
-            span_start = s_; span_end = e_;
+    // ── 4. Chunk-top-K + lexical rescue + span merge ──────────────────
+    PFlashChunkSelectOptions select_opts;
+    select_opts.keep_ratio = keep_ratio;
+    select_opts.chunk_size = chunk_size;
+    if (const char * env = std::getenv("DFLASH_PFLASH_CHUNK_RADIUS")) {
+        int v = std::atoi(env);
+        if (v >= 0 && v <= 16) {
+            select_opts.chunk_radius = v;
         }
     }
-    if (span_start >= 0) {
-        for (int j = span_start; j < span_end; ++j) out.push_back(ids[j]);
+    if (const char * env = std::getenv("DFLASH_PFLASH_QUERY_TAIL")) {
+        int v = std::atoi(env);
+        if (v >= 0 && v <= 4096) {
+            select_opts.query_tail = v;
+        }
     }
+    if (const char * env = std::getenv("DFLASH_PFLASH_RARE_MAX_FREQ")) {
+        int v = std::atoi(env);
+        if (v >= 0 && v <= 1024) {
+            select_opts.rare_max_freq = v;
+        }
+    }
+    if (const char * env = std::getenv("DFLASH_PFLASH_QUERY_MIN_HITS")) {
+        int v = std::atoi(env);
+        if (v >= 1 && v <= 64) {
+            select_opts.query_min_hits = v;
+        }
+    }
+    if (const char * env = std::getenv("DFLASH_PFLASH_QUERY_RADIUS")) {
+        int v = std::atoi(env);
+        if (v >= 0 && v <= 16) {
+            select_opts.query_radius = v;
+        }
+    }
+    if (const char * dump_path = std::getenv("DFLASH_PFLASH_DUMP_CHUNKS")) {
+        select_opts.dump_chunks_path = dump_path;
+    }
+    PFlashChunkSelectStats select_stats;
+    std::vector<int32_t> out =
+        pflash_select_and_compress(ids, smooth, select_opts, &select_stats);
 
     auto t2 = std::chrono::steady_clock::now();
     std::fprintf(stderr,
-        "[drafter] score_and_compress total %.2fs S=%d kept=%zu (%d/%d chunks)\n",
+        "[drafter] score_and_compress total %.2fs S=%d kept=%zu (%zu selected chunks, top=%d/%d radius=%d lexical=%d tail=%d rare<=%d min_hits=%d q_radius=%d)\n",
         std::chrono::duration<double>(t2 - t0).count(),
-        S, out.size(), n_keep, n_chunks);
+        S, out.size(), (size_t) select_stats.selected_chunks,
+        select_stats.top_keep_chunks, select_stats.n_chunks, select_opts.chunk_radius,
+        select_stats.lexical_chunks, select_opts.query_tail, select_opts.rare_max_freq,
+        select_opts.query_min_hits, select_opts.query_radius);
     std::fflush(stderr);
 
     return out;

--- a/dflash/src/qwen3_drafter.h
+++ b/dflash/src/qwen3_drafter.h
@@ -43,7 +43,16 @@ bool load_drafter(const std::string & gguf_path, int gpu_layers,
 void free_drafter(DrafterContext & ctx);
 
 // Score importance per token via Liu Q-hook tail attention, then chunk-top-K
-// span merge. Returns surviving token IDs (drafter vocab).
+// lexical rescue + span merge. Returns surviving token IDs (drafter vocab).
+//
+// Runtime quality/speed knobs:
+//   DFLASH_PFLASH_LOOKAHEAD        override n_lookahead
+//   DFLASH_PFLASH_CHUNK_RADIUS     keep neighbor chunks around score winners
+//   DFLASH_PFLASH_QUERY_TAIL       tail window used for rare-token rescue
+//   DFLASH_PFLASH_RARE_MAX_FREQ    max whole-prompt frequency for a rescue token
+//   DFLASH_PFLASH_QUERY_MIN_HITS   rare-token hits needed to rescue a chunk
+//   DFLASH_PFLASH_QUERY_RADIUS     keep neighbor chunks around lexical hits
+//   DFLASH_PFLASH_DUMP_CHUNKS      CSV dump of chunk scores/selections
 //
 //   ids          input token IDs of length S
 //   keep_ratio   fraction of `chunk_size`-token chunks to keep

--- a/dflash/test/smoke_qwen3_0p6b_forward.cpp
+++ b/dflash/test/smoke_qwen3_0p6b_forward.cpp
@@ -6,7 +6,7 @@
 // without touching the daemon.
 //
 // Usage:
-//   smoke_qwen3_0p6b_forward <gguf_path> <seq_len_or_FILE:path> [keep_ratio]
+//   smoke_qwen3_0p6b_forward <gguf_path> <seq_len_or_FILE:path> [keep_ratio] [n_lookahead] [chunk_size] [pool_kernel]
 // Examples:
 //   smoke_qwen3_0p6b_forward .../Qwen3-0.6B-BF16.gguf 140000 0.02
 //   smoke_qwen3_0p6b_forward .../Qwen3-0.6B-BF16.gguf FILE:/tmp/niah_32k.bin 0.05
@@ -28,12 +28,17 @@ using namespace dflash27b;
 
 int main(int argc, char ** argv) {
     if (argc < 3) {
-        std::fprintf(stderr, "usage: %s <gguf> <seq_len> [keep_ratio=0.02]\n", argv[0]);
+        std::fprintf(stderr,
+            "usage: %s <gguf> <seq_len_or_FILE:path> [keep_ratio=0.02] [n_lookahead=8] [chunk_size=32] [pool_kernel=13]\n",
+            argv[0]);
         return 2;
     }
     const std::string gguf = argv[1];
     const std::string arg2 = argv[2];
     const float keep_ratio = (argc >= 4) ? std::atof(argv[3]) : 0.02f;
+    const int n_lookahead = (argc >= 5) ? std::atoi(argv[4]) : 8;
+    const int chunk_size  = (argc >= 6) ? std::atoi(argv[5]) : 32;
+    const int pool_kernel = (argc >= 7) ? std::atoi(argv[6]) : 13;
 
     std::vector<int32_t> ids_from_file;
     int S = 0;
@@ -83,14 +88,14 @@ int main(int argc, char ** argv) {
         for (int i = 0; i < S; ++i) ids[i] = dist(rng);
     }
 
-    std::printf("[smoke] running drafter_score_and_compress S=%d keep_ratio=%.3f...\n",
-        S, keep_ratio);
+    std::printf("[smoke] running drafter_score_and_compress S=%d keep_ratio=%.3f n_lookahead=%d chunk_size=%d pool_kernel=%d...\n",
+        S, keep_ratio, n_lookahead, chunk_size, pool_kernel);
     std::fflush(stdout);
 
     auto t0 = std::chrono::steady_clock::now();
     std::vector<int32_t> out = drafter_score_and_compress(
         ctx, ids, keep_ratio,
-        /*chunk_size=*/32, /*n_lookahead=*/8, /*pool_kernel=*/13);
+        chunk_size, n_lookahead, pool_kernel);
     auto t1 = std::chrono::steady_clock::now();
 
     if (out.empty()) {

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -107,6 +107,11 @@ static int argmax_f32(const float * x, int n) {
     return best;
 }
 
+static bool env_flag_enabled(const char * name) {
+    const char * s = std::getenv(name);
+    return s && s[0] != '\0' && std::atoi(s) != 0;
+}
+
 // ggml_flash_attn_ext expects kv_len aligned to KQ_MASK_PAD (32) on the
 // f16/Q* paths, and to FATTN_KQ_STRIDE (256) on the TurboQuant FA paths.
 // The global `g_kq_stride_pad` below is set at init time and applied by
@@ -1316,14 +1321,42 @@ int main(int argc, char ** argv) {
                 // Park target + draft before allocating drafter context so
                 // the drafter's KV (~1.3 GB Q4_0) + scratch (~600 MB) have
                 // headroom on a 24 GB card. Restore after scoring.
-                bool restore_target = !target_parked;
-                bool restore_draft  = !draft_parked;
-                if (restore_target) {
+                //
+                // On SM75/22 GB, reloading the 27B target costs ~11 s. Allow
+                // an experimental target-resident path when the caller has
+                // already freed enough headroom (typically by parking draft).
+                bool keep_target_for_pflash = env_flag_enabled("DFLASH_PFLASH_KEEP_TARGET");
+                bool skip_draft_restore = env_flag_enabled("DFLASH_PFLASH_SKIP_DRAFT_RELOAD");
+                if (keep_target_for_pflash) {
+                    step_graph_destroy(sg);
+                    if (cache.rollback_buf || cache.rollback_ctx) {
+                        if (cache.rollback_buf) {
+                            ggml_backend_buffer_free(cache.rollback_buf);
+                            cache.rollback_buf = nullptr;
+                        }
+                        if (cache.rollback_ctx) {
+                            ggml_free(cache.rollback_ctx);
+                            cache.rollback_ctx = nullptr;
+                        }
+                        const size_t n_delta = cache.ssm_state.size();
+                        cache.ssm_state_snap.assign(n_delta, nullptr);
+                        cache.conv_state_snap.assign(n_delta, nullptr);
+                        cache.ssm_intermediate.assign(n_delta, nullptr);
+                        cache.conv_input_cache.assign(n_delta, nullptr);
+                        std::printf("[compress] rollback cache released for keep-target pflash\n");
+                        std::fflush(stdout);
+                    }
+                }
+                bool parked_target_for_compress = !target_parked && !keep_target_for_pflash;
+                bool parked_draft_for_compress  = !draft_parked;
+                bool restore_target = parked_target_for_compress;
+                bool restore_draft  = parked_draft_for_compress && !skip_draft_restore;
+                if (parked_target_for_compress) {
                     free_target_weights(w);
                     target_parked = true;
                     std::printf("[compress] target parked\n"); std::fflush(stdout);
                 }
-                if (restore_draft) {
+                if (parked_draft_for_compress) {
                     free_draft_weights(dw);
                     draft_parked = true;
                     std::printf("[compress] draft parked\n"); std::fflush(stdout);
@@ -1368,6 +1401,9 @@ int main(int argc, char ** argv) {
                     }
                     draft_parked = false;
                     std::printf("[compress] draft restored\n"); std::fflush(stdout);
+                } else if (parked_draft_for_compress && skip_draft_restore) {
+                    std::printf("[compress] draft left parked (DFLASH_PFLASH_SKIP_DRAFT_RELOAD=1)\n");
+                    std::fflush(stdout);
                 }
 
                 for (int32_t t : compressed) stream_emit(t);
@@ -1408,6 +1444,24 @@ int main(int argc, char ** argv) {
         std::vector<int32_t> out_all = prompt;
         int committed = 0;
         int32_t last_tok = -1;
+        const bool force_target_only_decode = env_flag_enabled("DFLASH_TARGET_ONLY_DECODE");
+        const bool target_only_when_draft_parked =
+            env_flag_enabled("DFLASH_TARGET_ONLY_WHEN_DRAFT_PARKED") ||
+            env_flag_enabled("DFLASH_PFLASH_TARGET_ONLY_WHEN_DRAFT_PARKED") ||
+            env_flag_enabled("DFLASH_PFLASH_SKIP_DRAFT_RELOAD");
+        const bool target_only_decode =
+            force_target_only_decode || (draft_parked && target_only_when_draft_parked);
+        if (target_parked) {
+            std::fprintf(stderr,
+                         "target is parked; unpark target before generate or keep target resident during PFlash\n");
+            if (daemon_mode) { stream_emit(-1); continue; } else return 1;
+        }
+        if (draft_parked && !target_only_decode) {
+            std::fprintf(stderr,
+                         "draft is parked; set DFLASH_PFLASH_SKIP_DRAFT_RELOAD=1 "
+                         "or unpark draft before DFlash decode\n");
+            if (daemon_mode) { stream_emit(-1); continue; } else return 1;
+        }
 
     // ── Prefill: two modes available ────────────────────────────────────
     // Layer-segmented: iterate layers (outer) × token chunks (inner).
@@ -1561,16 +1615,21 @@ int main(int argc, char ** argv) {
                     std::chrono::duration<double>(t_pf1 - t_pf0).count(),
                     last_tok);
 
-        // Promote prefill-only cache to full decode cache
-        auto t_mig0 = std::chrono::steady_clock::now();
-        step_graph_destroy(sg);
-        if (!migrate_prefill_cache(w, max_ctx, max_verify_tokens, backend, cache)) {
-            std::fprintf(stderr, "cache migration: %s\n", dflash27b_last_error());
-            return 1;
+        if (target_only_decode) {
+            step_graph_destroy(sg);
+            std::printf("[migrate] skipped for target-only decode\n");
+        } else {
+            // Promote prefill-only cache to full decode cache
+            auto t_mig0 = std::chrono::steady_clock::now();
+            step_graph_destroy(sg);
+            if (!migrate_prefill_cache(w, max_ctx, max_verify_tokens, backend, cache)) {
+                std::fprintf(stderr, "cache migration: %s\n", dflash27b_last_error());
+                return 1;
+            }
+            auto t_mig1 = std::chrono::steady_clock::now();
+            std::printf("[migrate] %.2f ms\n",
+                        std::chrono::duration<double, std::milli>(t_mig1 - t_mig0).count());
         }
-        auto t_mig1 = std::chrono::steady_clock::now();
-        std::printf("[migrate] %.2f ms\n",
-                    std::chrono::duration<double, std::milli>(t_mig1 - t_mig0).count());
     }
     // ── Token-segmented prefill (legacy) ────────────────────────────────
     if (!layer_prefill) {
@@ -1641,18 +1700,92 @@ int main(int argc, char ** argv) {
                 std::chrono::duration<double>(t_pf1 - t_pf0).count(),
                 last_tok);
 
-    // Promote prefill-only cache to full decode cache with rollback tensors.
-    // Copies KV, SSM/conv state, and target_feat device→device (~1 ms).
-    auto t_mig0 = std::chrono::steady_clock::now();
-    step_graph_destroy(sg);
-    if (!migrate_prefill_cache(w, max_ctx, max_verify_tokens, backend, cache)) {
-        std::fprintf(stderr, "cache migration: %s\n", dflash27b_last_error());
-        return 1;
+    if (target_only_decode) {
+        step_graph_destroy(sg);
+        std::printf("[migrate] skipped for target-only decode\n");
+    } else {
+        // Promote prefill-only cache to full decode cache with rollback tensors.
+        auto t_mig0 = std::chrono::steady_clock::now();
+        step_graph_destroy(sg);
+        if (!migrate_prefill_cache(w, max_ctx, max_verify_tokens, backend, cache)) {
+            std::fprintf(stderr, "cache migration: %s\n", dflash27b_last_error());
+            return 1;
+        }
+        auto t_mig1 = std::chrono::steady_clock::now();
+        std::printf("[migrate] %.2f ms\n",
+                    std::chrono::duration<double, std::milli>(t_mig1 - t_mig0).count());
     }
-    auto t_mig1 = std::chrono::steady_clock::now();
-    std::printf("[migrate] %.2f ms\n",
-                std::chrono::duration<double, std::milli>(t_mig1 - t_mig0).count());
     } // end if (!layer_prefill)
+
+    if (target_only_decode) {
+        std::vector<float> ar_embed_buf(hidden);
+        std::vector<float> ar_logits_buf(vocab);
+        int32_t ar_pos4[4];
+        int n_generated = 0;
+        bool ar_failed = false;
+        auto t_gen0 = std::chrono::steady_clock::now();
+        while (n_generated < n_gen) {
+            const int32_t tok = last_tok;
+            out_all.push_back(tok);
+            stream_emit(tok);
+            n_generated++;
+            if (tok == 248045 || n_generated >= n_gen) {
+                committed++;
+                break;
+            }
+
+            if (!build_target_step(sg, w, cache, backend,
+                                    /*kv_start=*/committed, /*n_tokens=*/1,
+                                    /*with_mask=*/false, /*capture=*/true,
+                                    /*capture_delta_intermediate=*/false,
+                                    g_fa_window)) {
+                std::fprintf(stderr, "target-only build failed\n");
+                if (daemon_mode) { ar_failed = true; break; } else return 1;
+            }
+            if (!w.embedder.embed(&tok, 1, ar_embed_buf.data())) {
+                if (daemon_mode) { ar_failed = true; break; } else return 1;
+            }
+            ggml_backend_tensor_set(sg.inp_embed, ar_embed_buf.data(), 0,
+                                    sizeof(float) * ar_embed_buf.size());
+            ar_pos4[0] = committed;
+            ar_pos4[1] = committed;
+            ar_pos4[2] = committed;
+            ar_pos4[3] = 0;
+            ggml_backend_tensor_set(sg.positions, ar_pos4, 0, sizeof(ar_pos4));
+
+            auto st_ar = ggml_backend_graph_compute(backend, sg.gf);
+            if (st_ar != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr, "target-only compute %d\n", (int)st_ar);
+                if (daemon_mode) { ar_failed = true; break; } else return 1;
+            }
+            ggml_backend_tensor_get(sg.logits, ar_logits_buf.data(), 0,
+                                    sizeof(float) * ar_logits_buf.size());
+            last_tok = argmax_f32(ar_logits_buf.data(), vocab);
+            committed++;
+        }
+        if (ar_failed) {
+            stream_emit(-1);
+            continue;
+        }
+
+        auto t_gen1 = std::chrono::steady_clock::now();
+        double gen_s = std::chrono::duration<double>(t_gen1 - t_gen0).count();
+        double tps = n_generated / std::max(1e-9, gen_s);
+        std::printf("\n[target-only] generated %d tokens in %.3f s  ->  %.2f tok/s\n",
+                    n_generated, gen_s, tps);
+        std::printf("[target-only] output tail: ");
+        int tail_start = std::max(0, (int)out_all.size() - 20);
+        for (int i = tail_start; i < (int)out_all.size(); i++) std::printf("%d ", out_all[i]);
+        std::printf("\n");
+
+        if (daemon_mode) {
+            stream_emit(-1);
+            continue;
+        } else {
+            if (out_path) write_int32_file(out_path, out_all);
+            break;
+        }
+    }
 
     // ── DFlash decode loop
     int n_draft_steps = 0, n_accept_sum = 0, n_generated = 0;

--- a/dflash/test/test_flashprefill_kernels.cpp
+++ b/dflash/test/test_flashprefill_kernels.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <random>
 #include <cuda_runtime.h>
+#include <cuda_fp16.h>
 #include <cuda_bf16.h>
 
 #include "../src/flashprefill.h"
@@ -31,13 +32,12 @@ void launch_compute_mean_vector_bf16(
 
 void launch_compute_block_score_bf16(
     const void * Q, const void * mean_K, float sm_scale,
-    void * score, void * score_max,
+    void * score,
     int batch, int n_q_heads, int n_k_heads,
     int seq_len, int head_dim, int block_size,
     int s_Q_b, int s_Q_n, int s_Q_h, int s_Q_d,
     int s_mK_b, int s_mK_m, int s_mK_h, int s_mK_d,
     int s_S_b, int s_S_m, int s_S_n, int s_S_h,
-    int s_M_b, int s_M_m, int s_M_n, int s_M_h,
     cudaStream_t stream);
 
 void launch_sparse_flash_forward_bf16(
@@ -63,8 +63,15 @@ void launch_sparse_flash_forward_bf16(
     } \
 } while (0)
 
-static __nv_bfloat16 f2b(float x) { return __float2bfloat16(x); }
-static float b2f(__nv_bfloat16 x) { return __bfloat162float(x); }
+#if defined(DFLASH27B_MIN_SM) && DFLASH27B_MIN_SM < 80
+using fp_elem = __half;
+static fp_elem f2b(float x) { return __float2half(x); }
+static float b2f(fp_elem x) { return __half2float(x); }
+#else
+using fp_elem = __nv_bfloat16;
+static fp_elem f2b(float x) { return __float2bfloat16(x); }
+static float b2f(fp_elem x) { return __bfloat162float(x); }
+#endif
 
 int main() {
     constexpr int B = 1;
@@ -79,27 +86,26 @@ int main() {
     std::mt19937 rng(42);
     std::uniform_real_distribution<float> dist(-0.1f, 0.1f);
 
-    std::vector<__nv_bfloat16> Q(B * S * H * D), K(B * S * Hk * D), V(B * S * Hk * D);
+    std::vector<fp_elem> Q(B * S * H * D), K(B * S * Hk * D), V(B * S * Hk * D);
     for (auto & x : Q) x = f2b(dist(rng));
     for (auto & x : K) x = f2b(dist(rng));
     for (auto & x : V) x = f2b(dist(rng));
 
-    __nv_bfloat16 *dQ, *dK, *dV, *dO, *dmK;
-    float *dS, *dM;
+    fp_elem *dQ, *dK, *dV, *dO, *dmK;
+    float *dS;
     int32_t *dIdx, *dCnt;
-    CK(cudaMalloc(&dQ, Q.size() * sizeof(__nv_bfloat16)));
-    CK(cudaMalloc(&dK, K.size() * sizeof(__nv_bfloat16)));
-    CK(cudaMalloc(&dV, V.size() * sizeof(__nv_bfloat16)));
-    CK(cudaMalloc(&dO, B * S * H * D * sizeof(__nv_bfloat16)));
-    CK(cudaMalloc(&dmK, B * M * Hk * D * sizeof(__nv_bfloat16)));
+    CK(cudaMalloc(&dQ, Q.size() * sizeof(fp_elem)));
+    CK(cudaMalloc(&dK, K.size() * sizeof(fp_elem)));
+    CK(cudaMalloc(&dV, V.size() * sizeof(fp_elem)));
+    CK(cudaMalloc(&dO, B * S * H * D * sizeof(fp_elem)));
+    CK(cudaMalloc(&dmK, B * M * Hk * D * sizeof(fp_elem)));
     CK(cudaMalloc(&dS, B * M * M * H * sizeof(float)));
-    CK(cudaMalloc(&dM, B * M * M * H * sizeof(float)));
     CK(cudaMalloc(&dIdx, B * M * M * H * sizeof(int32_t)));
     CK(cudaMalloc(&dCnt, B * M * H * sizeof(int32_t)));
 
-    CK(cudaMemcpy(dQ, Q.data(), Q.size() * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice));
-    CK(cudaMemcpy(dK, K.data(), K.size() * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice));
-    CK(cudaMemcpy(dV, V.data(), V.size() * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(dQ, Q.data(), Q.size() * sizeof(fp_elem), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(dK, K.data(), K.size() * sizeof(fp_elem), cudaMemcpyHostToDevice));
+    CK(cudaMemcpy(dV, V.data(), V.size() * sizeof(fp_elem), cudaMemcpyHostToDevice));
 
     // Strides (elements). Layout: [B, S, H, D] row-major, D fastest.
     int s_Q_b = S * H * D, s_Q_n = H * D, s_Q_h = D, s_Q_d = 1;
@@ -117,8 +123,8 @@ int main() {
     CK(cudaDeviceSynchronize());
 
     // Verify host vs GPU mean for one block.
-    std::vector<__nv_bfloat16> mK_h(B * M * Hk * D);
-    CK(cudaMemcpy(mK_h.data(), dmK, mK_h.size() * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+    std::vector<fp_elem> mK_h(B * M * Hk * D);
+    CK(cudaMemcpy(mK_h.data(), dmK, mK_h.size() * sizeof(fp_elem), cudaMemcpyDeviceToHost));
     float max_diff_mean = 0.0f;
     for (int n = 0; n < M; ++n) {
         for (int h = 0; h < Hk; ++h) {
@@ -137,15 +143,17 @@ int main() {
     }
     std::printf("[fp-test] kernel 1 (compute_mean_vector): max diff = %.5f %s\n",
                 max_diff_mean, max_diff_mean < 1e-2f ? "PASS" : "FAIL");
+    if (max_diff_mean >= 1e-2f) {
+        return 1;
+    }
 
     // ── Kernel 2: compute_block_score ──
     float scale = 1.0f / std::sqrt((float)D);
     launch_compute_block_score_bf16(
-        dQ, dmK, scale, dS, dM,
+        dQ, dmK, scale, dS,
         B, H, Hk, S, D, BLOCK,
         s_Q_b, s_Q_n, s_Q_h, s_Q_d,
         s_mK_b, s_mK_m, s_mK_h, s_mK_d,
-        s_S_b, s_S_m, s_S_n, s_S_h,
         s_S_b, s_S_m, s_S_n, s_S_h, 0);
     CK(cudaDeviceSynchronize());
     std::printf("[fp-test] kernel 2 (compute_block_score): launch ok\n");
@@ -176,12 +184,15 @@ int main() {
     cudaError_t le = cudaDeviceSynchronize();
     std::printf("[fp-test] kernel 4 (sparse_flash_forward): launch %s\n",
                 le == cudaSuccess ? "ok" : cudaGetErrorString(le));
+    if (le != cudaSuccess) {
+        return 1;
+    }
 
     // Numerical check kernel 4: compare GPU sparse output to CPU dense
     // attention reference (full mask, fully causal). Should match within bf16
     // numerical tolerance.
-    std::vector<__nv_bfloat16> O_h(B * S * H * D);
-    CK(cudaMemcpy(O_h.data(), dO, O_h.size() * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost));
+    std::vector<fp_elem> O_h(B * S * H * D);
+    CK(cudaMemcpy(O_h.data(), dO, O_h.size() * sizeof(fp_elem), cudaMemcpyDeviceToHost));
 
     float max_diff_attn = 0.0f;
     for (int q = 0; q < S; ++q) {
@@ -212,16 +223,31 @@ int main() {
                     ref += p[j] * b2f(V[j * Hk * D + hk * D + d]);
                 }
                 float gpu = b2f(O_h[q * H * D + h * D + d]);
+                if (!std::isfinite(ref) || !std::isfinite(gpu)) {
+                    std::fprintf(stderr,
+                                 "[fp-test] non-finite attention output at q=%d h=%d d=%d: ref=%g gpu=%g\n",
+                                 q, h, d, ref, gpu);
+                    return 1;
+                }
                 float diff = std::fabs(ref - gpu);
+                if (!std::isfinite(diff)) {
+                    std::fprintf(stderr,
+                                 "[fp-test] non-finite attention diff at q=%d h=%d d=%d: ref=%g gpu=%g\n",
+                                 q, h, d, ref, gpu);
+                    return 1;
+                }
                 if (diff > max_diff_attn) max_diff_attn = diff;
             }
         }
     }
     std::printf("[fp-test] kernel 4 (sparse_flash_forward) numerics: max diff = %.5f %s\n",
                 max_diff_attn, max_diff_attn < 5e-2f ? "PASS" : "FAIL");
+    if (max_diff_attn >= 5e-2f) {
+        return 1;
+    }
 
     cudaFree(dQ); cudaFree(dK); cudaFree(dV); cudaFree(dO);
-    cudaFree(dmK); cudaFree(dS); cudaFree(dM); cudaFree(dIdx); cudaFree(dCnt);
+    cudaFree(dmK); cudaFree(dS); cudaFree(dIdx); cudaFree(dCnt);
 
     // ── End-to-end FlashPrefill at 8K context ──
     // Tests the full pipeline (kernels 1-4 + block_select) wrapped via
@@ -231,22 +257,22 @@ int main() {
         constexpr int BB = 1, BS = 8192, BH = 16, BHk = 8, BD = 128;
         constexpr int BL = 128;
 
-        std::vector<__nv_bfloat16> bQ(BB * BS * BH * BD);
-        std::vector<__nv_bfloat16> bK(BB * BS * BHk * BD);
-        std::vector<__nv_bfloat16> bV(BB * BS * BHk * BD);
+        std::vector<fp_elem> bQ(BB * BS * BH * BD);
+        std::vector<fp_elem> bK(BB * BS * BHk * BD);
+        std::vector<fp_elem> bV(BB * BS * BHk * BD);
         for (auto & x : bQ) x = f2b(dist(rng));
         for (auto & x : bK) x = f2b(dist(rng));
         for (auto & x : bV) x = f2b(dist(rng));
 
-        __nv_bfloat16 *bdQ, *bdK, *bdV, *bdO;
-        CK(cudaMalloc(&bdQ, bQ.size() * sizeof(__nv_bfloat16)));
-        CK(cudaMalloc(&bdK, bK.size() * sizeof(__nv_bfloat16)));
-        CK(cudaMalloc(&bdV, bV.size() * sizeof(__nv_bfloat16)));
-        CK(cudaMalloc(&bdO, bQ.size() * sizeof(__nv_bfloat16)));
+        fp_elem *bdQ, *bdK, *bdV, *bdO;
+        CK(cudaMalloc(&bdQ, bQ.size() * sizeof(fp_elem)));
+        CK(cudaMalloc(&bdK, bK.size() * sizeof(fp_elem)));
+        CK(cudaMalloc(&bdV, bV.size() * sizeof(fp_elem)));
+        CK(cudaMalloc(&bdO, bQ.size() * sizeof(fp_elem)));
 
-        CK(cudaMemcpy(bdQ, bQ.data(), bQ.size() * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice));
-        CK(cudaMemcpy(bdK, bK.data(), bK.size() * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice));
-        CK(cudaMemcpy(bdV, bV.data(), bV.size() * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice));
+        CK(cudaMemcpy(bdQ, bQ.data(), bQ.size() * sizeof(fp_elem), cudaMemcpyHostToDevice));
+        CK(cudaMemcpy(bdK, bK.data(), bK.size() * sizeof(fp_elem), cudaMemcpyHostToDevice));
+        CK(cudaMemcpy(bdV, bV.data(), bV.size() * sizeof(fp_elem), cudaMemcpyHostToDevice));
 
         dflash27b::flashprefill::FlashPrefillConfig cfg;
         cfg.block_size = BL;

--- a/dflash/test/test_pflash_chunk_select.cpp
+++ b/dflash/test/test_pflash_chunk_select.cpp
@@ -1,0 +1,71 @@
+#include "../src/pflash_chunk_select.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+using namespace dflash27b;
+
+static bool contains_token(const std::vector<int32_t> & xs, int32_t tok) {
+    return std::find(xs.begin(), xs.end(), tok) != xs.end();
+}
+
+int main() {
+    constexpr int S = 512;
+    constexpr int chunk = 32;
+    constexpr int answer_token = 424242;
+
+    std::vector<int32_t> ids((size_t) S, 1);
+    std::vector<float> scores((size_t) S, 0.01f);
+
+    // Force the plain score top-K path to keep only chunk 1.
+    for (int i = chunk; i < 2 * chunk; ++i) {
+        scores[(size_t) i] = 10.0f;
+    }
+
+    // Needle is in chunk 8. The query tail repeats two rare marker tokens.
+    ids[(size_t) (8 * chunk + 5)] = 777;
+    ids[(size_t) (8 * chunk + 6)] = 888;
+    ids[(size_t) (8 * chunk + 7)] = answer_token;
+    ids[(size_t) (15 * chunk + 5)] = 777;
+    ids[(size_t) (15 * chunk + 6)] = 888;
+
+    PFlashChunkSelectOptions opts;
+    opts.keep_ratio = 0.05f;
+    opts.chunk_size = chunk;
+    opts.chunk_radius = 0;
+    opts.query_tail = 0;
+    opts.rare_max_freq = 4;
+    opts.query_min_hits = 2;
+    opts.query_radius = 1;
+
+    PFlashChunkSelectStats off_stats;
+    std::vector<int32_t> off = pflash_select_and_compress(ids, scores, opts, &off_stats);
+    if (contains_token(off, answer_token)) {
+        std::fprintf(stderr, "lexical-off unexpectedly kept answer token\n");
+        return 1;
+    }
+    if (off_stats.selected_chunks != 1 || off_stats.lexical_chunks != 0) {
+        std::fprintf(stderr, "lexical-off stats mismatch: selected=%d lexical=%d\n",
+                     off_stats.selected_chunks, off_stats.lexical_chunks);
+        return 1;
+    }
+
+    opts.query_tail = 64;
+    PFlashChunkSelectStats on_stats;
+    std::vector<int32_t> on = pflash_select_and_compress(ids, scores, opts, &on_stats);
+    if (!contains_token(on, answer_token)) {
+        std::fprintf(stderr, "lexical rescue failed to keep answer token\n");
+        return 1;
+    }
+    if (on_stats.lexical_chunks <= 0 || on_stats.selected_chunks <= off_stats.selected_chunks) {
+        std::fprintf(stderr, "lexical-on stats mismatch: selected=%d lexical=%d\n",
+                     on_stats.selected_chunks, on_stats.lexical_chunks);
+        return 1;
+    }
+
+    std::printf("[pflash-chunk-select] PASS lexical rescue kept answer token "
+                "(off chunks=%d, on chunks=%d, lexical=%d)\n",
+                off_stats.selected_chunks, on_stats.selected_chunks, on_stats.lexical_chunks);
+    return 0;
+}

--- a/pflash/README.md
+++ b/pflash/README.md
@@ -148,6 +148,15 @@ Everything is configured via env vars on the daemon process. Full list in [`../d
 | `DFLASH_FP_ALPHA` | `0.12` | Block-selection threshold. Higher = stricter = fewer K-blocks per Q-row. `0.85` is the bench setting; `0.99` cuts another second at 128K with a small NIAH-margin loss. |
 | `DFLASH_FP_PROFILE` | `0` | Set to `1` to log per-stage timings (`mean_K / score / select / forward`). |
 | `DFLASH_FP_DUMP_COUNTS` | `0` | Set to `1` to dump per-row K-block counts for debugging keep-ratio tuning. |
+| `DFLASH_PFLASH_LOOKAHEAD` | unset | Override the tail Q-token count used by the drafter scorer. |
+| `DFLASH_PFLASH_KEEP_TARGET` | `0` | Experimental low-VRAM mode: keep the target resident during compression when the caller has already parked the DFlash draft. |
+| `DFLASH_PFLASH_SKIP_DRAFT_RELOAD` | `0` | Experimental TTFT / very short-output fallback: leave the DFlash draft parked after compression. This is not a replacement for speculative decode. |
+| `DFLASH_PFLASH_CHUNK_RADIUS` | `0` | Keep neighbor chunks around score-selected chunks. Higher is safer but keeps more tokens. |
+| `DFLASH_PFLASH_QUERY_TAIL` | `128` | Tail token window used for rare-token lexical rescue; body scan excludes this tail window. |
+| `DFLASH_PFLASH_RARE_MAX_FREQ` | `4` | Max whole-prompt frequency for tail tokens that can rescue a body chunk. Set `0` to disable lexical rescue. |
+| `DFLASH_PFLASH_QUERY_MIN_HITS` | `2` | Rare-token hits required before a body chunk is rescued. |
+| `DFLASH_PFLASH_QUERY_RADIUS` | `1` | Keep neighbor chunks around lexical hits. |
+| `DFLASH_PFLASH_DUMP_CHUNKS` | unset | Write chunk score/selection CSV for quality debugging. |
 | `DFLASH27B_FA_WINDOW` | (auto) | Set to `0` to force full attention on the compressed prompt (recommended). |
 | `DFLASH27B_KV_K` / `DFLASH27B_KV_V` | (auto) | KV-cache quant types. `q4_0` / `q4_0` is the bench setting. `tq3_0` saves another ~4 GB at 128K. |
 
@@ -183,7 +192,7 @@ prompt (≤ 128K tokens)
 
 **Drafter forward.** Custom Qwen3-0.6B graph (`qwen3_0p6b_graph.cpp`) per-layer A/FP/B blocks: dense attention up to ~32K source, FlashPrefill sparse attention at and above. The 4 FP kernels live in `flashprefill_kernels.cu`; BSA dispatch is in `bsa_launcher.cu` + `bsa_fwd_inst.cu`.
 
-**Scoring + selection.** Tail attention `Q[-N:] @ K^T / sqrt(d)` per layer/head, max over (L, H), mean over the tail window. Block-level threshold by `alpha * mean(scores)` selects which K-blocks each Q-block attends to. Configurable via `DFLASH_FP_ALPHA`.
+**Scoring + selection.** Tail attention `Q[-N:] @ K^T / sqrt(d)` per layer/head, max over (L, H), mean over the tail window. The compressor keeps the top scoring chunks, merges spans, and then applies rare-query lexical rescue: rare tokens from the final question can pull matching body chunks back into the compressed prompt. `DFLASH_FP_ALPHA` controls sparse-attention block selection inside the drafter forward; the `DFLASH_PFLASH_*` knobs control final token retention.
 
 **Memory budget on 24 GB.** Drafter scoring at 128K needs ~7-10 GB (drafter + KV + BSA scratch). Target + draft idle is ~18 GB. They can't coexist. The daemon's `park` / `unpark` / `free drafter` commands sequence VRAM occupancy across the request:
 
@@ -219,6 +228,8 @@ What we built:
 - **Qwen3.6-27B Q4_K_M target + Qwen3-0.6B drafter** is the validated pair. Other targets/drafters need keep_ratio + alpha re-calibration.
 - **NIAH single-needle** is the only retrieval task validated end-to-end. Multi-doc QA, long-form code retrieval, etc. still TBD.
 - **sm_80+** required for BSA (RTX 3090 sm_86 is the reference). On sm_75 (Turing) the build auto-disables BSA and falls back to the WMMA path; expect a slower drafter forward at long ctx.
+- **SM75 local path** should use FP16 drafter weights. BF16 tensor cores are not available on RTX 2080 Ti, so the 3090/BSA headline numbers are not the right comparison target. The local WMMA path uses padded shared-memory tiles and defaults to `DFLASH_FP_K_TILE=32` on SM75.
+- **SM75 target-resident mode** (`DFLASH_PFLASH_KEEP_TARGET=1 DFLASH_PFLASH_SKIP_DRAFT_RELOAD=1`) is an opt-in TTFT / very short-output fallback. It avoids target and draft reload on RTX 2080 Ti, but should not be presented as full PFlash + DFlash speculative decode or as a decode-speed result.
 
 ## Citation
 


### PR DESCRIPTION
# perf(pflash): add SM75 target-resident TTFT path

## Summary

This PR adds an opt-in SM75 / RTX 2080 Ti path for PFlash TTFT-oriented use cases.

- Adds FP16 drafter compute support for SM75, including BF16->F16 GGUF load conversion when native BF16 tensor cores are unavailable.
- Tunes the WMMA FlashPrefill fallback for SM75 with padded shared-memory layout and `DFLASH_FP_K_TILE=32`.
- Adds PFlash chunk selection with rare-query lexical rescue, plus `test_pflash_chunk_select`.
- Adds opt-in target-resident PFlash daemon flow:
  - `DFLASH_PFLASH_KEEP_TARGET=1`
  - `DFLASH_PFLASH_SKIP_DRAFT_RELOAD=1`
  - default-off fallback when the DFlash draft remains parked
  - skip `migrate_prefill_cache` in that fallback because rollback tensors are not used
- Documents the SM75 benchmark as an experimental TTFT path, not as full PFlash + DFlash speculative decode.

## Benchmark

Hardware and environment:

- GPU: RTX 2080 Ti 22 GB / SM75
- Driver: 595.58.03
- CUDA toolkit: 12.0
- CMake: 3.28.3
- Power limit: 280 W
- Persistence mode: enabled
- Target: Qwen3.6-27B Q4_K_M via `test_dflash`
- PFlash drafter: Qwen3-0.6B FP16 GGUF
- Prompt: same 16K NIAH qtail prompt
- Methodology: warm daemon request timing after model load; tokenizers treated as preloaded; same hardware, same power limit, same prompt

| Case | Request time | Speedup | Notes |
|------|-------------:|--------:|-------|
| no PFlash | 50.35 s | 1.00x | original 16K prompt |
| current PFlash hook | 26.11 s | 1.93x | parks and reloads target + draft |
| `DFLASH_PFLASH_KEEP_TARGET=1` | 14.19 s | 3.55x | target stays resident, draft reloads |
| `KEEP_TARGET=1` + `SKIP_DRAFT_RELOAD=1` | 4.13 s | 12.21x | TTFT-only fallback; no speculative decode |

## Correctness / Validation

- `cmake --build build-sm75-f16 --target test_dflash test_pflash_chunk_select test_flashprefill_kernels -j$(nproc)` passes.
- `test_pflash_chunk_select` passes.
- `test_flashprefill_kernels` passes on SM75:
  - mean vector max diff `0.00000`
  - sparse forward max diff `0.00043`
  - S=8192 e2e FlashPrefill `13.8 ms / iter`
- `_prefill_hook.py` passes `python -m py_compile`.
- Clean PR-worktree SM75 build passes:
  `cmake --build dflash/build-sm75-pr --target test_dflash test_pflash_chunk_select test_flashprefill_kernels -j24`.
- 16K NIAH quality smoke retained the key and answer on the original prompt and a 5-position synthetic NIAH sweep.

## Caveats

- This is a PFlash TTFT path. It intentionally does not claim new DFlash/DDTree decode results on RTX 2080 Ti.
- With `DFLASH_PFLASH_SKIP_DRAFT_RELOAD=1`, the draft remains parked after compressed prefill. This is a default-off fallback for TTFT / very short output, not a decode-speed path.
- A keep-target + DFlash draft reload countercheck at `max_ctx=17000` hit a 106 MiB CUDA allocation OOM in the draft graph on RTX 2080 Ti.
- The quality validation here is retrieval-style NIAH smoke, not broad Math/GSM/code/chat validation.
- The new residency flags remain default-off.
