### PR TITLE
perf(dflash): use ggml_swiglu_split for FFN

### DIFF
--- a/dflash/src/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35_target_graph.cpp
@@ -373,9 +373,8 @@ static ggml_tensor * rms_norm_mul(ggml_context * ctx, ggml_tensor * x,
 static ggml_tensor * build_swiglu_ffn(ggml_context * ctx, ggml_tensor * cur,
                                       const TargetLayer & L) {
     ggml_tensor * gate = ggml_mul_mat(ctx, L.w_gate, cur);   // [inter, n_tokens]
-    gate = ggml_silu(ctx, gate);
     ggml_tensor * up = ggml_mul_mat(ctx, L.w_up, cur);
-    ggml_tensor * gu = ggml_mul(ctx, gate, up);
+    ggml_tensor * gu = ggml_swiglu_split(ctx, gate, up);
     return ggml_mul_mat(ctx, L.w_down, gu);                  // [hidden, n_tokens]
 }
 


### PR DESCRIPTION
FFN: Replace separate silu(gate) * up with ggml_swiglu_split(gate, up). This reduces graph nodes from 3059 to 2995 (-64, one per layer) and enables ggml-cuda's MUL_MAT+MUL_MAT+GLU three-way fusion, which merges the gate matvec, up matvec, and SwiGLU activation into a single kernel launch. Saves 192 kernel launches per forward (128 from triple fusion + 64 from node elimination).

Output is bit-identical to the previous separate silu+mul path.