### PR TITLE
feat(pflash): compress role=tool messages in place for agent transcripts

### DIFF
--- a/dflash/scripts/_prefill_hook.py
+++ b/dflash/scripts/_prefill_hook.py
@@ -161,3 +161,67 @@ def compress_text_via_daemon(
 
     # 6) decode compressed drafter ids back to text for re-tokenisation by target
     return drafter_tokenizer.decode(compressed_ids, skip_special_tokens=True)
+
+
+def compress_texts_batch_via_daemon(
+    *,
+    daemon_stdin,
+    r_pipe: int,
+    drafter_tokenizer,
+    cfg: PrefillConfig,
+    prompt_texts: list,
+) -> list:
+    """Compress N texts in one daemon dance (park-once, drafter-loads-once,
+    free-once). Each compress reuses the loaded drafter; only the final
+    `free drafter` + unpark fires after all texts are done.
+
+    Returns a list of compressed texts, one per input. Empty inputs map to
+    empty outputs without triggering a daemon round-trip.
+    """
+    if not prompt_texts:
+        return []
+
+    # 1) park target + draft so drafter has VRAM headroom on a 24 GB card
+    _send_and_ack(daemon_stdin, r_pipe, "park target\n")
+    _send_and_ack(daemon_stdin, r_pipe, "park draft\n")
+
+    keep_x1000 = int(round(cfg.keep_ratio * 1000))
+    out: list[str] = []
+    tmp_paths: list[str] = []
+    try:
+        for prompt_text in prompt_texts:
+            if not prompt_text:
+                out.append("")
+                continue
+
+            drafter_ids = drafter_tokenizer(
+                prompt_text, return_tensors=None,
+                add_special_tokens=False)["input_ids"]
+            if isinstance(drafter_ids[0], list):
+                drafter_ids = drafter_ids[0]
+
+            fd, path = tempfile.mkstemp(suffix=".bin")
+            tmp_paths.append(path)
+            with os.fdopen(fd, "wb") as f:
+                for t in drafter_ids:
+                    f.write(struct.pack("<i", int(t)))
+
+            # The first compress loads the drafter; subsequent calls reuse
+            # the loaded weights (the daemon only frees on `free drafter`).
+            daemon_stdin.write(
+                f"compress {path} {keep_x1000} {cfg.drafter_gguf}\n".encode("utf-8"))
+            daemon_stdin.flush()
+            compressed_ids = _drain_until_sentinel(r_pipe)
+            out.append(drafter_tokenizer.decode(
+                compressed_ids, skip_special_tokens=True))
+
+        # 2) free drafter once at the end, then restore target + draft.
+        _send_and_ack(daemon_stdin, r_pipe, "free drafter\n")
+        _send_and_ack(daemon_stdin, r_pipe, "unpark target\n")
+        _send_and_ack(daemon_stdin, r_pipe, "unpark draft\n")
+    finally:
+        for path in tmp_paths:
+            try: os.unlink(path)
+            except Exception: pass
+
+    return out

--- a/dflash/scripts/server_tools.py
+++ b/dflash/scripts/server_tools.py
@@ -40,6 +40,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from _prefill_hook import (
+    compress_texts_batch_via_daemon,
     PrefillConfig, add_cli_flags, config_from_args,
     compress_text_via_daemon,
 )
@@ -337,10 +338,19 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
     def _maybe_compress_tool_chat(req: "ChatRequest", prompt_bin: Path,
                                   prompt_len: int, started_in_thinking: bool
                                   ) -> tuple[Path, int, bool]:
-        """If prefill is on and the request has no tools and the last user
-        message is long, run the daemon compress + re-tokenise. Returns
-        (bin, prompt_len, started_in_thinking) — the last is recomputed when
-        compression fires, otherwise passed through."""
+        """If prefill is on, compress every role=tool message in place,
+        preserving role / tool_call_id / assistant.tool_calls so the OpenAI
+        tool-call structure is intact end-to-end. One daemon dance covers
+        all tool messages (drafter loads once, compresses N messages, frees
+        once). Falls back to compressing the last user message when there
+        are no tool messages — preserves the original RAG / single-shot
+        path.
+
+        Agent transcripts put 99% of their bytes in tool messages
+        (Read/Bash/Grep output); compressing only last_user is a no-op on
+        that shape. Compressing each tool message in place keeps tool
+        semantics correct while pflash compresses the bulk.
+        """
         if not prefill_cfg or not prefill_cfg.enabled:
             return prompt_bin, prompt_len, started_in_thinking
         if req.tools:
@@ -349,29 +359,76 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
         if not prefill_cfg.should_compress(prompt_len) or drafter_tokenizer is None:
             return prompt_bin, prompt_len, started_in_thinking
 
-        last_user = next((m for m in reversed(req.messages) if m.role == "user"), None)
-        if last_user is None or not isinstance(last_user.content, str):
-            return prompt_bin, prompt_len, started_in_thinking
+        tool_msg_indices = [i for i, m in enumerate(req.messages)
+                            if m.role == "tool"
+                            and isinstance(m.content, str) and m.content]
 
-        compressed_text = compress_text_via_daemon(
-            daemon_stdin=daemon_proc.stdin,
-            r_pipe=r_pipe,
-            drafter_tokenizer=drafter_tokenizer,
-            cfg=prefill_cfg,
-            prompt_text=last_user.content,
-        )
+        if tool_msg_indices:
+            # Compress all tool messages with one drafter load.
+            tool_texts = [req.messages[i].content for i in tool_msg_indices]
+            compressed_texts = compress_texts_batch_via_daemon(
+                daemon_stdin=daemon_proc.stdin,
+                r_pipe=r_pipe,
+                drafter_tokenizer=drafter_tokenizer,
+                cfg=prefill_cfg,
+                prompt_texts=tool_texts,
+            )
+            compressed_by_idx = dict(zip(tool_msg_indices, compressed_texts))
 
-        new_msgs = []
-        compressed_emitted = False
-        for m in req.messages:
-            if m is last_user and not compressed_emitted:
-                new_msgs.append({"role": "user", "content": compressed_text})
-                compressed_emitted = True
-            else:
-                d = {"role": m.role}
-                if m.content is not None:
+            # Rebuild messages preserving every other field; only swap the
+            # tool message contents.
+            new_msgs = []
+            for i, m in enumerate(req.messages):
+                d: dict = {"role": m.role}
+                if i in compressed_by_idx:
+                    d["content"] = compressed_by_idx[i]
+                elif m.content is not None:
                     d["content"] = m.content
+                if m.tool_call_id is not None:
+                    d["tool_call_id"] = m.tool_call_id
+                if m.tool_calls is not None:
+                    # Qwen template calls .items() on arguments — needs to
+                    # be a parsed dict, not the JSON string the API surface
+                    # carries it as.
+                    d["tool_calls"] = []
+                    for tc in m.tool_calls:
+                        args = tc.function.arguments
+                        if isinstance(args, str):
+                            try:
+                                args = json.loads(args)
+                            except (json.JSONDecodeError, ValueError):
+                                args = {"_raw": tc.function.arguments}
+                        d["tool_calls"].append({
+                            "id": tc.id, "type": tc.type,
+                            "function": {"name": tc.function.name,
+                                         "arguments": args},
+                        })
+                if m.name is not None:
+                    d["name"] = m.name
                 new_msgs.append(d)
+        else:
+            # RAG / single-shot path: compress last user message.
+            last_user = next((m for m in reversed(req.messages) if m.role == "user"), None)
+            if last_user is None or not isinstance(last_user.content, str):
+                return prompt_bin, prompt_len, started_in_thinking
+            compressed_text = compress_text_via_daemon(
+                daemon_stdin=daemon_proc.stdin,
+                r_pipe=r_pipe,
+                drafter_tokenizer=drafter_tokenizer,
+                cfg=prefill_cfg,
+                prompt_text=last_user.content,
+            )
+            new_msgs = []
+            compressed_emitted = False
+            for m in req.messages:
+                if m is last_user and not compressed_emitted:
+                    new_msgs.append({"role": "user", "content": compressed_text})
+                    compressed_emitted = True
+                else:
+                    d = {"role": m.role}
+                    if m.content is not None:
+                        d["content"] = m.content
+                    new_msgs.append(d)
 
         kwargs = dict(tokenize=False, add_generation_prompt=True)
         if req.chat_template_kwargs:


### PR DESCRIPTION
Extends `_maybe_compress_tool_chat` so pflash compresses every `role: tool` message in place, instead of only the last user message. Targets the multi-turn agent-loop workload that #70's hook bypasses today.

## Why

In Claude Code / OpenAI tool-call agent loops the prefix grows turn-over-turn through `role: tool` messages — Read / Bash / Grep output. The user-typed messages are short (\"continue\", \"what next\"). On a real 70K-char Claude Code transcript:

| role | count | chars | % of bytes |
|---|---|---|---|
| system | 1 | 78 | 0.1% |
| user | 1 | 249 | 0.4% |
| assistant | 9 | 255 | 0.4% |
| tool | 10 | **69,453** | **99%** |

The current hook compresses only `last_user.content` (249 chars in this example). With `--prefill-compression always --prefill-threshold 1` it still does the full daemon dance and leaves the 69K of tool output alone. Result: pflash adds latency and gives no benefit on agent transcripts.

## What

Two file change:

**`dflash/scripts/_prefill_hook.py`** — new helper `compress_texts_batch_via_daemon(prompt_texts: list)`. One daemon dance for N texts: park target+draft → load drafter (first compress) → run compress for each text reusing the loaded drafter → `free drafter` + unpark target+draft once. The existing `compress_text_via_daemon` is unchanged.

**`dflash/scripts/server_tools.py`** — `_maybe_compress_tool_chat` now:

1. If any `role: tool` message has string content, batch-compress them all in place. Each tool message keeps its `role`, `tool_call_id`, and the assistant `tool_calls` that pair with it. `assistant.tool_calls[i].function.arguments` is JSON-parsed (matching the canonical `_tokenize_prompt` path) before going to the chat template — Qwen's template calls `.items()` on it.
2. Else fall back to the existing last-user RAG path unchanged.
3. The `should_compress(prompt_len)` gate, the `req.tools` bypass, and all other guards are preserved.

## Validated

### 10-turn replay of a real Claude Code session (helix-large), agent-loop pattern

RTX 3090 Ti, CUDA 13.2, Qwen3.6-27B Q4_K_M target, Qwen3-0.6B BF16 drafter, `DFLASH_FP_USE_BSA=1 DFLASH_FP_ALPHA=0.85 keep_ratio=0.05`, `--max-ctx 24576`, prefix grows 327 → 71K chars over the 10 calls.

| metric | cold (no pflash) | warm (pflash + this patch) | speedup |
|---|---|---|---|
| total TTFT (10 calls) | 243.70 s | **99.89 s** | **2.44×** |
| total wall (10 calls) | 255.84 s | **108.88 s** | **2.35×** |
| empty responses | 0 / 10 | 0 / 10 | — |

### 3-turn pilot, per-call breakdown

Same hardware/config, helix turns 1–3:

| call | content shape | cold TTFT | warm TTFT | speedup | tok |
|---|---|---|---|---|---|
| 1 | 327 ch, no tool msgs | 0.96 s | 4.71 s | 0.20× ⚠ | 64 |
| 2 | 38K ch, 2 tool msgs | 16.47 s | **7.59 s** | **2.17×** | 64 |
| 3 | 38K ch, 3 tool msgs | 17.71 s | **8.14 s** | **2.18×** | 47 |
| total | | 35.14 s | 20.43 s | **1.72×** | |

Per-tool-message compression on call 3: `6482 → 306` (21×), `5018 → 218` (23×), `78 → 14` (5.5×). Generation quality preserved — every warm call returned real completion tokens, no empty bodies, OpenAI tool structure intact through the chat template.

### Call-1 caveat

The pilot's call 1 (no tool messages, 327-char prompt) regressed because pflash still does the daemon dance to compress a 249-char last_user fallback. **This is masked under the default `--prefill-threshold 32000`** — short prompts don't cross the gate, so pflash bypasses entirely. The bench used `--threshold 1` to force activation on every call. Worth noting; not worth a special case in this PR.

## Compatibility

- Default `--prefill-compression off` is unchanged. No behaviour change for anyone not opting in.
- `req.tools` non-empty bypass is unchanged.
- The RAG / single-shot path (long last user message, no tool messages) is unchanged.
- Tool semantics preserved end-to-end: `role: tool` messages keep their `tool_call_id`; assistant `tool_calls` are passed through with the same arg-parsing the canonical tokenize path uses.
- Daemon protocol is unchanged. The new helper just sequences existing `compress` commands within one park/unpark window.

## Test plan

- [x] 3-turn pilot on real Claude Code transcript with tool messages (per-call numbers above)
- [x] 10-turn helix-large run (totals above)
- [x] Single-shot RAG fallback path still works (no tool messages → compresses last user, unchanged)
- [ ] Sweep across smaller sessions (lucebox ≤11K, nexiq ≤25K, axon ≤39K) — first attempt was lost to a logging collision in the bench harness; will rerun and post numbers as a comment. Predicted: smaller sessions break even or slightly regress (overhead dominates) while medium+ shows the win.
- [ ] NIAH single-shot bench still works post-patch (should — fallback path is preserved verbatim)
- [ ] Validate on Blackwell / sm_120 (only tested on RTX 3090 Ti / sm_86)

## Caveats

- Per-tool-message compression means N daemon round-trips inside one drafter session. Each message at ~6K tokens compresses in ~0.4 s on a 3090 Ti, so 10 tool messages = ~4 s of scoring on top of the ~0.5 s drafter-load amortised once. For sessions with many small tool messages this is a tax; could be reduced by a min-size threshold per-message (\"don't compress tool messages under 1 K chars\") in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)