### PR TITLE
dflash: read model params from GGUF at runtime, support any qwen35 size

### DIFF
--- a/dflash/src/gguf_draft_loader.cpp
+++ b/dflash/src/gguf_draft_loader.cpp
@@ -140,33 +140,30 @@ bool load_draft_gguf(const std::string & path,
         }
     }
 
-    // Validate dimensions that the graph builder hardcodes
+    // Read dimensions from GGUF metadata
     const char * A = "qwen35-dflash-draft";
     char key[128];
 
-    auto check_u32 = [&](const char * suffix, uint32_t expected) -> bool {
+    auto read_u32 = [&](const char * suffix, uint32_t fallback) -> uint32_t {
         std::snprintf(key, sizeof(key), "%s.%s", A, suffix);
-        uint32_t v = get_u32_or(gctx, key, 0);
-        if (v != expected) {
-            char b[256];
-            std::snprintf(b, sizeof(b), "draft GGUF: %s=%u expected %u", key, v, expected);
-            set_last_error(b);
-            return false;
-        }
-        return true;
+        return get_u32_or(gctx, key, fallback);
     };
 
-    bool ok = true;
-    ok = ok && check_u32("embedding_length",        DFLASH27B_TARGET_HIDDEN);
-    ok = ok && check_u32("block_count",             DFLASH27B_DRAFT_LAYERS);
-    ok = ok && check_u32("feed_forward_length",     DFLASH27B_TARGET_INTERMEDIATE);
-    ok = ok && check_u32("attention.head_count",    DFLASH27B_TARGET_N_HEADS);
-    ok = ok && check_u32("attention.head_count_kv", DFLASH27B_TARGET_N_KV_HEADS);
-    ok = ok && check_u32("attention.key_length",    DFLASH27B_TARGET_HEAD_DIM);
-    ok = ok && check_u32("attention.value_length",  DFLASH27B_TARGET_HEAD_DIM);
-    ok = ok && check_u32("dflash.block_size",       DFLASH27B_DRAFT_BLOCK_SIZE);
-    ok = ok && check_u32("dflash.n_target_layers",  DFLASH27B_DRAFT_N_TARGET_LAYERS);
-    if (!ok) {
+    const uint32_t n_embd    = read_u32("embedding_length",        0);
+    const uint32_t n_layer   = read_u32("block_count",             0);
+    const uint32_t n_ff      = read_u32("feed_forward_length",     0);
+    const uint32_t n_head    = read_u32("attention.head_count",    0);
+    const uint32_t n_head_kv = read_u32("attention.head_count_kv", 0);
+    const uint32_t head_dim  = read_u32("attention.key_length",    0);
+
+    if (n_embd == 0 || n_layer == 0 || n_ff == 0 || n_head == 0 ||
+        n_head_kv == 0 || head_dim == 0) {
+        char buf[256];
+        std::snprintf(buf, sizeof(buf),
+            "draft GGUF: missing hparams: n_embd=%u n_layer=%u n_ff=%u "
+            "n_head=%u n_head_kv=%u head_dim=%u",
+            n_embd, n_layer, n_ff, n_head, n_head_kv, head_dim);
+        set_last_error(buf);
         gguf_free(gctx);
         return false;
     }
@@ -174,7 +171,13 @@ bool load_draft_gguf(const std::string & path,
     // ── 2. Wire tensor pointers into DraftWeights ────────────────────────
     out.ctx     = meta_ctx;
     out.backend = backend;
-    out.layers.assign(DFLASH27B_DRAFT_LAYERS, DraftLayer{});
+    out.n_layer   = (int)n_layer;
+    out.n_head    = (int)n_head;
+    out.n_head_kv = (int)n_head_kv;
+    out.head_dim  = (int)head_dim;
+    out.n_embd    = (int)n_embd;
+    out.n_ff      = (int)n_ff;
+    out.layers.assign((size_t)n_layer, DraftLayer{});
 
     auto g = [&](const char * name) -> ggml_tensor * {
         return ggml_get_tensor(meta_ctx, name);
@@ -190,7 +193,7 @@ bool load_draft_gguf(const std::string & path,
         return false;
     }
 
-    for (int il = 0; il < DFLASH27B_DRAFT_LAYERS; il++) {
+    for (int il = 0; il < out.n_layer; il++) {
         char name[128];
         auto fnd = [&](const char * suffix) -> ggml_tensor * {
             std::snprintf(name, sizeof(name), "blk.%d.%s", il, suffix);

--- a/dflash/src/gguf_draft_loader.cpp
+++ b/dflash/src/gguf_draft_loader.cpp
@@ -155,12 +155,53 @@ bool load_draft_gguf(const std::string & path,
     const uint32_t n_head    = read_u32("attention.head_count",    0);
     const uint32_t n_head_kv = read_u32("attention.head_count_kv", 0);
     const uint32_t head_dim  = read_u32("attention.key_length",    0);
+    const uint32_t block_sz  = read_u32("dflash.block_size",       0);
+    const uint32_t n_tgt_lay = read_u32("dflash.n_target_layers",  0);
 
     if (n_embd == 0 || n_layer == 0 || n_ff == 0 || n_head == 0 ||
         n_head_kv == 0 || head_dim == 0) {
         char buf[256];
         std::snprintf(buf, sizeof(buf),
             "draft GGUF: missing hparams: n_embd=%u n_layer=%u n_ff=%u "
+            "n_head=%u n_head_kv=%u head_dim=%u",
+            n_embd, n_layer, n_ff, n_head, n_head_kv, head_dim);
+        set_last_error(buf);
+        gguf_free(gctx);
+        return false;
+    }
+
+    // The draft graph builder still hardcodes block_size and the number of
+    // captured target layers (drives fc weight shape and capture_layer_ids
+    // array length). Reject GGUFs whose metadata disagrees with the compiled
+    // constants, otherwise we would silently mis-shape the graph.
+    if (block_sz != (uint32_t)DFLASH27B_DRAFT_BLOCK_SIZE ||
+        n_tgt_lay != (uint32_t)DFLASH27B_DRAFT_N_TARGET_LAYERS) {
+        char buf[256];
+        std::snprintf(buf, sizeof(buf),
+            "draft GGUF: dflash.block_size=%u (expected %d), "
+            "dflash.n_target_layers=%u (expected %d)",
+            block_sz, DFLASH27B_DRAFT_BLOCK_SIZE,
+            n_tgt_lay, DFLASH27B_DRAFT_N_TARGET_LAYERS);
+        set_last_error(buf);
+        gguf_free(gctx);
+        return false;
+    }
+
+    // Upper bounds on hparams. Guards against malformed/hostile GGUFs that
+    // would otherwise trigger huge allocations or signed-int overflow when
+    // narrowed below. Limits chosen well above any plausible LLM config.
+    constexpr uint32_t MAX_LAYERS  = 1024;
+    constexpr uint32_t MAX_EMBD    = 1u << 17;   // 131072
+    constexpr uint32_t MAX_FF      = 1u << 19;   // 524288
+    constexpr uint32_t MAX_HEADS   = 1024;
+    constexpr uint32_t MAX_HEADDIM = 1024;
+    if (n_layer   > MAX_LAYERS  || n_embd    > MAX_EMBD  ||
+        n_ff      > MAX_FF      || n_head    > MAX_HEADS ||
+        n_head_kv > MAX_HEADS   || head_dim  > MAX_HEADDIM ||
+        n_head_kv > n_head      || (n_head % n_head_kv) != 0) {
+        char buf[320];
+        std::snprintf(buf, sizeof(buf),
+            "draft GGUF: hparams out of range: n_embd=%u n_layer=%u n_ff=%u "
             "n_head=%u n_head_kv=%u head_dim=%u",
             n_embd, n_layer, n_ff, n_head, n_head_kv, head_dim);
         set_last_error(buf);

--- a/dflash/src/gguf_target_loader.cpp
+++ b/dflash/src/gguf_target_loader.cpp
@@ -233,19 +233,37 @@ bool load_target_gguf(const std::string & path,
     const uint32_t ssm_dt    = get_u32_or(gctx, "qwen35.ssm.time_step_rank",0);
     const uint32_t ssm_grp   = get_u32_or(gctx, "qwen35.ssm.group_count",  0);
 
-    if (n_embd != 5120 || n_layer != 64 || n_head != 24 || n_headkv != 4 ||
-        kl != 256 || vl != 256 || n_ff != 17408 || fai != 4 ||
-        ssm_conv != 4 || ssm_inner != 6144 || ssm_state != 128 ||
-        ssm_dt != 48 || ssm_grp != 16) {
+    if (n_embd == 0 || n_layer == 0 || n_head == 0 || n_headkv == 0 ||
+        kl == 0 || vl == 0 || n_ff == 0 || fai == 0 ||
+        ssm_conv == 0 || ssm_inner == 0 || ssm_state == 0 ||
+        ssm_dt == 0 || ssm_grp == 0) {
         char buf[512];
         std::snprintf(buf, sizeof(buf),
-            "unexpected hparams: n_embd=%u n_layer=%u n_head=%u n_head_kv=%u "
+            "missing or zero hparams: n_embd=%u n_layer=%u n_head=%u n_head_kv=%u "
             "kl=%u vl=%u n_ff=%u fai=%u ssm{conv=%u inner=%u state=%u dt=%u grp=%u}",
             n_embd, n_layer, n_head, n_headkv, kl, vl, n_ff, fai,
             ssm_conv, ssm_inner, ssm_state, ssm_dt, ssm_grp);
         set_last_error(buf);
         gguf_free(gctx);
         return false;
+    }
+
+    // Structural invariants required by the graph builder.
+    if (kl != vl) {
+        set_last_error("key_length != value_length not supported");
+        gguf_free(gctx); return false;
+    }
+    if (ssm_inner % ssm_dt != 0) {
+        char buf[128];
+        std::snprintf(buf, sizeof(buf), "ssm.inner_size=%u not divisible by ssm.time_step_rank=%u", ssm_inner, ssm_dt);
+        set_last_error(buf);
+        gguf_free(gctx); return false;
+    }
+    if (n_layer % fai != 0) {
+        char buf[128];
+        std::snprintf(buf, sizeof(buf), "block_count=%u not divisible by full_attention_interval=%u", n_layer, fai);
+        set_last_error(buf);
+        gguf_free(gctx); return false;
     }
 
     // rope dimension_sections (array of 4 uint32)
@@ -277,6 +295,15 @@ bool load_target_gguf(const std::string & path,
     out.ssm_d_state= (int)ssm_state;
     out.ssm_dt_rank= (int)ssm_dt;
     out.ssm_n_group= (int)ssm_grp;
+
+    // Compute capture layer IDs: evenly spaced through the target layers.
+    // step = (n_layer - 2) / (N - 1), ids[k] = 1 + k * step.
+    {
+        const int N = DFLASH27B_DRAFT_N_TARGET_LAYERS;
+        const int step = ((int)n_layer - 2) / (N - 1);
+        for (int k = 0; k < N; k++) out.capture_layer_ids[k] = 1 + k * step;
+    }
+
     out.layers.assign((size_t)n_layer, TargetLayer{});
 
     // ── 2. Wire our layer pointers to tensors inside meta_ctx ─────────

--- a/dflash/src/gguf_target_loader.cpp
+++ b/dflash/src/gguf_target_loader.cpp
@@ -270,12 +270,43 @@ bool load_target_gguf(const std::string & path,
     int rope_sections[4] = {0, 0, 0, 0};
     {
         int64_t rid = gguf_find_key(gctx, "qwen35.rope.dimension_sections");
-        if (rid >= 0) {
-            size_t n = gguf_get_arr_n(gctx, rid);
-            if (n >= 4) {
-                const int32_t * arr = (const int32_t *)gguf_get_arr_data(gctx, rid);
-                for (int k = 0; k < 4; k++) rope_sections[k] = arr[k];
+        if (rid < 0) {
+            set_last_error("missing qwen35.rope.dimension_sections");
+            gguf_free(gctx); return false;
+        }
+        size_t n = gguf_get_arr_n(gctx, rid);
+        if (n < 4) {
+            set_last_error("qwen35.rope.dimension_sections has < 4 entries");
+            gguf_free(gctx); return false;
+        }
+        const int32_t * arr = (const int32_t *)gguf_get_arr_data(gctx, rid);
+        for (int k = 0; k < 4; k++) rope_sections[k] = arr[k];
+    }
+
+    // Validate rope_sections against head_dim. n_rot = 2 * sum(sections) is
+    // the number of dims rotated by ggml_rope_multi; it must be even, > 0,
+    // and ≤ head_dim, otherwise rope reads/writes out of bounds.
+    {
+        long sum = 0;
+        for (int k = 0; k < 4; k++) {
+            if (rope_sections[k] < 0) {
+                char buf[160];
+                std::snprintf(buf, sizeof(buf),
+                    "rope_sections[%d]=%d is negative", k, rope_sections[k]);
+                set_last_error(buf);
+                gguf_free(gctx); return false;
             }
+            sum += rope_sections[k];
+        }
+        const long n_rot = 2 * sum;
+        if (n_rot <= 0 || n_rot > (long)kl) {
+            char buf[200];
+            std::snprintf(buf, sizeof(buf),
+                "rope_sections {%d,%d,%d,%d} → n_rot=%ld invalid for head_dim=%u",
+                rope_sections[0], rope_sections[1], rope_sections[2], rope_sections[3],
+                n_rot, kl);
+            set_last_error(buf);
+            gguf_free(gctx); return false;
         }
     }
 

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -127,6 +127,11 @@ struct TargetWeights {
     int ssm_d_state             = 128;
     int ssm_dt_rank             = 48;
     int ssm_n_group             = 16;
+
+    // Target layer IDs captured for the DFlash draft model.
+    // Computed from n_layer at load time: step = (n_layer - 2) / (N - 1),
+    // ids[k] = 1 + k * step.  E.g. 27B→{1,16,31,46,61}, 9B→{1,8,15,22,29}.
+    int capture_layer_ids[DFLASH27B_DRAFT_N_TARGET_LAYERS] = {1, 16, 31, 46, 61};
 };
 
 // Load a Q4_K_M target model from a GGUF file on disk.

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -165,8 +165,16 @@ struct DraftWeights {
 
     ggml_tensor *          fc          = nullptr;   // [5*hidden, hidden]
     ggml_tensor *          hidden_norm = nullptr;   // [hidden]
-    std::vector<DraftLayer> layers;                 // size = 5
+    std::vector<DraftLayer> layers;                 // size = n_layer
     ggml_tensor *          out_norm    = nullptr;   // [hidden]
+
+    // Architecture metadata (populated by loader).
+    int n_layer   = DFLASH27B_DRAFT_LAYERS;           // 5
+    int n_head    = DFLASH27B_TARGET_N_HEADS;          // 32
+    int n_head_kv = DFLASH27B_TARGET_N_KV_HEADS;       // 8
+    int head_dim  = DFLASH27B_TARGET_HEAD_DIM;         // 128
+    int n_embd    = DFLASH27B_TARGET_HIDDEN;           // 5120
+    int n_ff      = DFLASH27B_TARGET_INTERMEDIATE;     // 17408
 };
 
 bool load_draft_safetensors(const std::string & path,

--- a/dflash/src/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35_target_graph.cpp
@@ -1,34 +1,24 @@
-// Forward pass of Qwen3.5-27B (qwen35 hybrid) in pure ggml.
+// Forward pass of Qwen3.5 (qwen35 hybrid) in pure ggml.
 //
 // Translates llama.cpp's `src/models/qwen35.cpp` + `delta-net-base.cpp` into
-// our standalone library, hardcoded for Qwen3.5-27B dimensions. No
-// llama.cpp runtime is linked — only ggml ops.
+// our standalone library. All model dimensions are read from GGUF at load time
+// via TargetWeights, supporting any Qwen3.5-dense model size (4B, 9B, 27B).
+// No llama.cpp runtime is linked — only ggml ops.
 //
 // Architecture highlights:
-//   - 64 layers; every 4th (il % 4 == 3) is full attention, rest are Gated DeltaNet
+//   - N layers; every Kth (il % K == K-1) is full attention, rest are Gated DeltaNet
 //   - Full-attention Q projection is PACKED with a gate (attn_q has width 2*q_dim)
-//   - Full attention uses M-RoPE with sections [11,11,10,0]
-//   - Flash attention is GQA 24/4, causal
+//   - Full attention uses M-RoPE with sections from GGUF
+//   - Flash attention is GQA, causal
 //   - Delta-net uses ggml_ssm_conv for the 1D conv + ggml_gated_delta_net for the recurrence
 //   - FFN is SwiGLU (w_gate * silu, element-wise multiply with w_up, then w_down)
 //
 // State (persisted in TargetCache across calls):
-//   - attn_k[16], attn_v[16]     : KV cache for full-attn layers, f16
-//   - conv_state[48]             : 1D conv recurrence state, f32
-//   - ssm_state[48]              : delta-net recurrent state (head_v^2 × H_v), f32
+//   - attn_k, attn_v           : KV cache for full-attn layers
+//   - conv_state               : 1D conv recurrence state, f32
+//   - ssm_state                : delta-net recurrent state, f32
 //
-// Key dimensions (all hardcoded via DFLASH27B_* macros):
-//   n_embd           = 5120
-//   n_head           = 24    head_dim = 256   q_dim = n_head * head_dim = 6144
-//   n_head_kv        = 4     kv_dim = 4 * 256 = 1024
-//   n_ff             = 17408
-//   d_inner (ssm)    = 6144
-//   d_state (ssm)    = 128
-//   dt_rank (ssm)    = 48    (num_v_heads)
-//   n_group (ssm)    = 16    (num_k_heads)
-//   head_v_dim       = d_inner / dt_rank = 128
-//   head_k_dim       = d_state           = 128
-//   conv_kernel      = 4
+// All dimensions are runtime values from TargetWeights (populated by GGUF loader).
 
 #include "internal.h"
 #include "delta_net_chunked.h"
@@ -41,31 +31,9 @@
 
 namespace dflash27b {
 
-// ─── Local qwen35 constants (from the GGUF, hardcoded for this model) ─
-// These complement the DFLASH27B_* macros in dflash27b.h with qwen35-specific
-// hparams that differ from the draft (which uses plain Qwen3 dims).
-namespace q35 {
-constexpr int N_HEAD        = 24;
-constexpr int N_HEAD_KV     = 4;
-constexpr int HEAD_DIM      = 256;   // key_length == value_length
-constexpr int Q_DIM         = N_HEAD * HEAD_DIM;    // 6144
-constexpr int KV_DIM        = N_HEAD_KV * HEAD_DIM; // 1024
-constexpr int FFN_DIM       = 17408;
-
-constexpr int SSM_D_INNER   = 6144;
-constexpr int SSM_D_STATE   = 128;
-constexpr int SSM_DT_RANK   = 48;
-constexpr int SSM_N_GROUP   = 16;
-constexpr int SSM_CONV_KERN = 4;
-
-// Derived
-constexpr int HEAD_V_DIM    = SSM_D_INNER / SSM_DT_RANK;  // 128
-constexpr int HEAD_K_DIM    = SSM_D_STATE;                // 128
-constexpr int CONV_CHANNELS = SSM_D_INNER + 2 * SSM_N_GROUP * SSM_D_STATE; // 6144 + 2*16*128 = 10240
-
-constexpr float EPS         = 1e-6f;
-constexpr float ROPE_THETA  = 10000000.0f;
-}  // namespace q35
+// ─── File-local constants (architecture-invariant across all qwen35 sizes) ──
+static constexpr float EPS         = 1e-6f;
+static constexpr float ROPE_THETA  = 10000000.0f;
 
 // ─── TargetCache allocation ─────────────────────────────────────────
 
@@ -115,14 +83,17 @@ bool create_target_cache(const TargetWeights & w,
         if (!out.base_ctx) { set_last_error("base cache ggml_init failed"); return false; }
 
         int fa_idx = 0, dn_idx = 0;
+        const int head_dim      = w.n_embd_head_k;
+        const int head_v_dim    = w.ssm_d_inner / w.ssm_dt_rank;
+        const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
         for (int il = 0; il < w.n_layer; il++) {
             const bool is_attn = (((il + 1) % w.full_attention_interval) == 0);
             if (is_attn) {
                 // [head_dim, max_ctx_alloc, n_head_kv]
                 ggml_tensor * K = ggml_new_tensor_3d(out.base_ctx, kv_k_type,
-                                                     q35::HEAD_DIM, max_ctx_alloc, q35::N_HEAD_KV);
+                                                     head_dim, max_ctx_alloc, w.n_head_kv);
                 ggml_tensor * V = ggml_new_tensor_3d(out.base_ctx, kv_v_type,
-                                                     q35::HEAD_DIM, max_ctx_alloc, q35::N_HEAD_KV);
+                                                     head_dim, max_ctx_alloc, w.n_head_kv);
                 char name[64];
                 std::snprintf(name, sizeof(name), "cache_k_%d", il);
                 ggml_set_name(K, name);
@@ -134,10 +105,10 @@ bool create_target_cache(const TargetWeights & w,
             } else {
                 // ssm_state: [head_v_dim, head_v_dim, num_v_heads]
                 ggml_tensor * S = ggml_new_tensor_3d(out.base_ctx, GGML_TYPE_F32,
-                                                     q35::HEAD_V_DIM, q35::HEAD_V_DIM, q35::SSM_DT_RANK);
+                                                     head_v_dim, head_v_dim, w.ssm_dt_rank);
                 // conv_state: [kernel-1, conv_channels]
                 ggml_tensor * C = ggml_new_tensor_2d(out.base_ctx, GGML_TYPE_F32,
-                                                     q35::SSM_CONV_KERN - 1, q35::CONV_CHANNELS);
+                                                     w.ssm_d_conv - 1, conv_channels);
                 char name[64];
                 std::snprintf(name, sizeof(name), "ssm_state_%d", il);  ggml_set_name(S, name);
                 std::snprintf(name, sizeof(name), "conv_state_%d", il); ggml_set_name(C, name);
@@ -173,18 +144,20 @@ bool create_target_cache(const TargetWeights & w,
         if (!out.rollback_ctx) { set_last_error("rollback cache ggml_init failed"); return false; }
 
         int dn_idx = 0;
+        const int head_v_dim    = w.ssm_d_inner / w.ssm_dt_rank;
+        const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
         for (int il = 0; il < w.n_layer; il++) {
             if (((il + 1) % w.full_attention_interval) != 0) {
                 ggml_tensor * Sn = ggml_new_tensor_3d(out.rollback_ctx, GGML_TYPE_F32,
-                                                       q35::HEAD_V_DIM, q35::HEAD_V_DIM, q35::SSM_DT_RANK);
+                                                       head_v_dim, head_v_dim, w.ssm_dt_rank);
                 ggml_tensor * Cn = ggml_new_tensor_2d(out.rollback_ctx, GGML_TYPE_F32,
-                                                       q35::SSM_CONV_KERN - 1, q35::CONV_CHANNELS);
+                                                       w.ssm_d_conv - 1, conv_channels);
                 ggml_tensor * Si = ggml_new_tensor_4d(out.rollback_ctx, GGML_TYPE_F16,
-                                                       q35::HEAD_V_DIM, q35::HEAD_V_DIM,
-                                                       q35::SSM_DT_RANK, max_verify_tokens);
+                                                       head_v_dim, head_v_dim,
+                                                       w.ssm_dt_rank, max_verify_tokens);
                 ggml_tensor * Ci = ggml_new_tensor_3d(out.rollback_ctx, GGML_TYPE_F32,
-                                                       (q35::SSM_CONV_KERN - 1) + max_verify_tokens,
-                                                       q35::CONV_CHANNELS, 1);
+                                                       (w.ssm_d_conv - 1) + max_verify_tokens,
+                                                       conv_channels, 1);
                 char name[64];
                 std::snprintf(name, sizeof(name), "ssm_state_snap_%d", il);  ggml_set_name(Sn, name);
                 std::snprintf(name, sizeof(name), "conv_state_snap_%d", il); ggml_set_name(Cn, name);
@@ -297,18 +270,20 @@ bool migrate_prefill_cache(const TargetWeights & w,
     if (!cache.rollback_ctx) { set_last_error("rollback cache ggml_init failed"); return false; }
 
     int dn_idx = 0;
+    const int head_v_dim    = w.ssm_d_inner / w.ssm_dt_rank;
+    const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
     for (int il = 0; il < w.n_layer; il++) {
         if (((il + 1) % w.full_attention_interval) != 0) {
             ggml_tensor * Sn = ggml_new_tensor_3d(cache.rollback_ctx, GGML_TYPE_F32,
-                                                   q35::HEAD_V_DIM, q35::HEAD_V_DIM, q35::SSM_DT_RANK);
+                                                   head_v_dim, head_v_dim, w.ssm_dt_rank);
             ggml_tensor * Cn = ggml_new_tensor_2d(cache.rollback_ctx, GGML_TYPE_F32,
-                                                   q35::SSM_CONV_KERN - 1, q35::CONV_CHANNELS);
+                                                   w.ssm_d_conv - 1, conv_channels);
             ggml_tensor * Si = ggml_new_tensor_4d(cache.rollback_ctx, GGML_TYPE_F16,
-                                                   q35::HEAD_V_DIM, q35::HEAD_V_DIM,
-                                                   q35::SSM_DT_RANK, max_verify_tokens);
+                                                   head_v_dim, head_v_dim,
+                                                   w.ssm_dt_rank, max_verify_tokens);
             ggml_tensor * Ci = ggml_new_tensor_3d(cache.rollback_ctx, GGML_TYPE_F32,
-                                                   (q35::SSM_CONV_KERN - 1) + max_verify_tokens,
-                                                   q35::CONV_CHANNELS, 1);
+                                                   (w.ssm_d_conv - 1) + max_verify_tokens,
+                                                   conv_channels, 1);
             char name[64];
             std::snprintf(name, sizeof(name), "ssm_state_snap_%d", il);  ggml_set_name(Sn, name);
             std::snprintf(name, sizeof(name), "conv_state_snap_%d", il); ggml_set_name(Cn, name);
@@ -387,10 +362,10 @@ static ggml_tensor * build_swiglu_ffn(ggml_context * ctx, ggml_tensor * cur,
 static ggml_tensor * build_full_attn_block(
     ggml_context * ctx,
     ggml_cgraph * gf,
+    const TargetWeights & w,
     const TargetLayer & L,
     ggml_tensor * cur,
     ggml_tensor * positions,
-    const int * rope_sections,
     ggml_tensor * cache_k,
     ggml_tensor * cache_v,
     ggml_tensor * attn_mask,
@@ -400,50 +375,54 @@ static ggml_tensor * build_full_attn_block(
     ggml_type kv_v_type,
     int fa_window = 0
 ) {
+    const int head_dim = w.n_embd_head_k;
+    const int n_head   = w.n_head;
+    const int n_head_kv = w.n_head_kv;
+    const int q_dim    = n_head * head_dim;
+
     // ── Q projection (packed Q || gate), shape [2*q_dim, n_tokens]
     ggml_tensor * QG = ggml_mul_mat(ctx, L.wq, cur);
     // Reshape to [head_dim*2, n_head, n_tokens] so we can view the Q and gate halves
-    QG = ggml_reshape_3d(ctx, QG, q35::HEAD_DIM * 2, q35::N_HEAD, n_tokens);
+    QG = ggml_reshape_3d(ctx, QG, head_dim * 2, n_head, n_tokens);
 
     // Q half: view at offset 0, stride head_dim*2
     // Layout: [head_dim, n_head, n_tokens]
     ggml_tensor * Q = ggml_view_3d(ctx, QG,
-        q35::HEAD_DIM, q35::N_HEAD, n_tokens,
-        ggml_element_size(QG) * q35::HEAD_DIM * 2,                 // nb1: stride over n_head
-        ggml_element_size(QG) * q35::HEAD_DIM * 2 * q35::N_HEAD,   // nb2: stride over n_tokens
+        head_dim, n_head, n_tokens,
+        ggml_element_size(QG) * head_dim * 2,                // nb1: stride over n_head
+        ggml_element_size(QG) * head_dim * 2 * n_head,       // nb2: stride over n_tokens
         /*offset*/ 0);
-    Q = rms_norm_mul(ctx, Q, L.q_norm, q35::EPS);
+    Q = rms_norm_mul(ctx, Q, L.q_norm, EPS);
 
     // Gate half: view at offset head_dim
     ggml_tensor * gate = ggml_view_3d(ctx, QG,
-        q35::HEAD_DIM, q35::N_HEAD, n_tokens,
-        ggml_element_size(QG) * q35::HEAD_DIM * 2,
-        ggml_element_size(QG) * q35::HEAD_DIM * 2 * q35::N_HEAD,
-        ggml_element_size(QG) * q35::HEAD_DIM);
-    gate = ggml_cont_2d(ctx, gate, q35::HEAD_DIM * q35::N_HEAD, n_tokens);  // [q_dim, n_tokens]
+        head_dim, n_head, n_tokens,
+        ggml_element_size(QG) * head_dim * 2,
+        ggml_element_size(QG) * head_dim * 2 * n_head,
+        ggml_element_size(QG) * head_dim);
+    gate = ggml_cont_2d(ctx, gate, q_dim, n_tokens);  // [q_dim, n_tokens]
 
     // ── K and V projections
     ggml_tensor * Kcur = ggml_mul_mat(ctx, L.wk, cur);   // [kv_dim, n_tokens]
     ggml_tensor * Vcur = ggml_mul_mat(ctx, L.wv, cur);   // [kv_dim, n_tokens]
 
-    Kcur = ggml_reshape_3d(ctx, Kcur, q35::HEAD_DIM, q35::N_HEAD_KV, n_tokens);
-    Kcur = rms_norm_mul(ctx, Kcur, L.k_norm, q35::EPS);
-    Vcur = ggml_reshape_3d(ctx, Vcur, q35::HEAD_DIM, q35::N_HEAD_KV, n_tokens);
+    Kcur = ggml_reshape_3d(ctx, Kcur, head_dim, n_head_kv, n_tokens);
+    Kcur = rms_norm_mul(ctx, Kcur, L.k_norm, EPS);
+    Vcur = ggml_reshape_3d(ctx, Vcur, head_dim, n_head_kv, n_tokens);
 
-    // ── M-RoPE (multi-axis rotary). n_rot = HEAD_DIM/4 * 4 ? Actually
-    //    ggml_rope_multi takes n_dims = the number of dims to rotate; for
-    //    qwen35 that's rope.dimension_count=64 (out of head_dim=256).
-    int n_rot = 64;  // qwen35.rope.dimension_count
+    // ── M-RoPE (multi-axis rotary). n_rot derived from rope_sections.
+    const int n_rot = 2 * (w.rope_sections[0] + w.rope_sections[1] +
+                           w.rope_sections[2] + w.rope_sections[3]);
     int sections[4];
-    for (int i = 0; i < 4; i++) sections[i] = rope_sections[i];
+    for (int i = 0; i < 4; i++) sections[i] = w.rope_sections[i];
 
     Q = ggml_rope_multi(ctx, Q, positions, /*freq_factors=*/nullptr,
                         n_rot, sections, GGML_ROPE_TYPE_MROPE,
-                        /*n_ctx_orig=*/0, q35::ROPE_THETA, 1.0f,
+                        /*n_ctx_orig=*/0, ROPE_THETA, 1.0f,
                         0.0f, 1.0f, 0.0f, 0.0f);
     Kcur = ggml_rope_multi(ctx, Kcur, positions, nullptr,
                            n_rot, sections, GGML_ROPE_TYPE_MROPE,
-                           0, q35::ROPE_THETA, 1.0f,
+                           0, ROPE_THETA, 1.0f,
                            0.0f, 1.0f, 0.0f, 0.0f);
 
     // ── Write K/V into the persistent cache at slot [kv_start..kv_start+n_tokens)
@@ -458,11 +437,11 @@ static ggml_tensor * build_full_attn_block(
     ggml_tensor * Vcur_T = ggml_permute(ctx, Vcur, 0, 2, 1, 3);  // [head_dim, n_tokens, n_head_kv]
 
     ggml_tensor * k_slot = ggml_view_3d(ctx, cache_k,
-        q35::HEAD_DIM, n_tokens, q35::N_HEAD_KV,
+        head_dim, n_tokens, n_head_kv,
         cache_k->nb[1], cache_k->nb[2],
         /*offset*/ cache_k->nb[1] * kv_start);
     ggml_tensor * v_slot = ggml_view_3d(ctx, cache_v,
-        q35::HEAD_DIM, n_tokens, q35::N_HEAD_KV,
+        head_dim, n_tokens, n_head_kv,
         cache_v->nb[1], cache_v->nb[2],
         cache_v->nb[1] * kv_start);
 
@@ -498,17 +477,17 @@ static ggml_tensor * build_full_attn_block(
 
     // K and V from cache: a windowed view starting at win_start.
     ggml_tensor * Kfa = ggml_view_3d(ctx, cache_k,
-        q35::HEAD_DIM, win_len_padded, q35::N_HEAD_KV,
+        head_dim, win_len_padded, n_head_kv,
         cache_k->nb[1], cache_k->nb[2], cache_k->nb[1] * win_start);
     ggml_tensor * Vfa = ggml_view_3d(ctx, cache_v,
-        q35::HEAD_DIM, win_len_padded, q35::N_HEAD_KV,
+        head_dim, win_len_padded, n_head_kv,
         cache_v->nb[1], cache_v->nb[2], cache_v->nb[1] * win_start);
 
     // Causal mask: for n_tokens==1 we don't need one (a single query attending
     // to all keys is trivially causal). For n_tokens>1 the caller must provide
     // a mask shaped [kv_len, n_tokens] with 0 for attendable positions and
     // -inf for positions beyond the causal boundary.
-    const float kq_scale = 1.0f / std::sqrt((float)q35::HEAD_DIM);
+    const float kq_scale = 1.0f / std::sqrt((float)head_dim);
     ggml_tensor * attn = ggml_flash_attn_ext(ctx, Qfa, Kfa, Vfa, attn_mask,
                                              kq_scale, 0.0f, 0.0f);
     // attn: [head_dim, n_head, n_tokens] (permuted)
@@ -519,7 +498,7 @@ static ggml_tensor * build_full_attn_block(
         attn = ggml_turbo_wht(ctx, attn, 1);
     }
 
-    attn = ggml_reshape_2d(ctx, attn, q35::Q_DIM, n_tokens);
+    attn = ggml_reshape_2d(ctx, attn, q_dim, n_tokens);
 
     // ── Apply the sigmoid gate from the packed Q
     ggml_tensor * gate_sig = ggml_sigmoid(ctx, gate);
@@ -543,6 +522,7 @@ static ggml_tensor * build_full_attn_block(
 static ggml_tensor * build_delta_net_block(
     ggml_context * ctx,
     ggml_cgraph * gf,
+    const TargetWeights & w,
     const TargetLayer & L,
     ggml_tensor * cur,            // [hidden, n_tokens]
     ggml_tensor * conv_state,     // [kernel-1, conv_channels] persistent
@@ -551,16 +531,17 @@ static ggml_tensor * build_delta_net_block(
     DeltaNetCapture * cap,        // optional: populated on capture_delta_intermediate
     ggml_tensor * parent_ids      // optional [n_tokens] i32; tree mode when non-null
 ) {
-    const int head_k_dim   = q35::HEAD_K_DIM;   // 128
-    const int num_k_heads  = q35::SSM_N_GROUP;  // 16
-    const int num_v_heads  = q35::SSM_DT_RANK;  // 48
-    const int head_v_dim   = q35::HEAD_V_DIM;   // 128
-    const int n_seqs       = 1;
-    const int n_seq_tokens = n_tokens;
+    const int head_k_dim    = w.ssm_d_state;
+    const int num_k_heads   = w.ssm_n_group;
+    const int num_v_heads   = w.ssm_dt_rank;
+    const int head_v_dim    = w.ssm_d_inner / w.ssm_dt_rank;
+    const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
+    const int n_seqs        = 1;
+    const int n_seq_tokens  = n_tokens;
 
-    // ── qkv_mixed = wqkv @ cur         [10240, n_tokens]
+    // ── qkv_mixed = wqkv @ cur         [conv_channels, n_tokens]
     ggml_tensor * qkv_mixed = ggml_mul_mat(ctx, L.wqkv, cur);
-    qkv_mixed = ggml_reshape_3d(ctx, qkv_mixed, q35::CONV_CHANNELS, n_seq_tokens, n_seqs);
+    qkv_mixed = ggml_reshape_3d(ctx, qkv_mixed, conv_channels, n_seq_tokens, n_seqs);
 
     // ── z = wqkv_gate @ cur            [inner, n_tokens]
     ggml_tensor * z = ggml_mul_mat(ctx, L.wqkv_gate, cur);
@@ -584,7 +565,7 @@ static ggml_tensor * build_delta_net_block(
     // ── Fetch conv state [kernel-1, conv_channels] and prepend to qkv_mixed
     //    along the token axis to form the convolution input.
     ggml_tensor * conv_states_r = ggml_reshape_3d(ctx, conv_state,
-        q35::SSM_CONV_KERN - 1, q35::CONV_CHANNELS, n_seqs);
+        w.ssm_d_conv - 1, conv_channels, n_seqs);
 
     // qkv_mixed currently is [conv_channels, n_tokens, n_seqs]; we need
     // [n_tokens, conv_channels, n_seqs] to concat on dim 0.
@@ -604,9 +585,9 @@ static ggml_tensor * build_delta_net_block(
 
     // ── Save the last (kernel-1) steps back to conv_state
     ggml_tensor * last_conv = ggml_view_3d(ctx, conv_input,
-        q35::SSM_CONV_KERN - 1, q35::CONV_CHANNELS, n_seqs,
+        w.ssm_d_conv - 1, conv_channels, n_seqs,
         conv_input->nb[1], conv_input->nb[2],
-        (conv_input->ne[0] - (q35::SSM_CONV_KERN - 1)) * ggml_element_size(conv_input));
+        (conv_input->ne[0] - (w.ssm_d_conv - 1)) * ggml_element_size(conv_input));
     ggml_build_forward_expand(gf, ggml_cpy(ctx, last_conv, conv_state));
 
     // ── 1D conv + silu
@@ -625,7 +606,7 @@ static ggml_tensor * build_delta_net_block(
     const int64_t v_offset = 2 * num_k_heads * head_k_dim;
 
     const size_t elt = ggml_element_size(conv_out);
-    const size_t row_size = q35::CONV_CHANNELS * elt;
+    const size_t row_size = (size_t)conv_channels * elt;
 
     ggml_tensor * q_c = ggml_view_4d(ctx, conv_out,
         head_k_dim, num_k_heads, n_seq_tokens, n_seqs,
@@ -647,8 +628,8 @@ static ggml_tensor * build_delta_net_block(
         v_offset * elt);
 
     // L2 norm on Q and K
-    q_c = ggml_l2_norm(ctx, q_c, q35::EPS);
-    k_c = ggml_l2_norm(ctx, k_c, q35::EPS);
+    q_c = ggml_l2_norm(ctx, q_c, EPS);
+    k_c = ggml_l2_norm(ctx, k_c, EPS);
 
     // Repeat Q and K from num_k_heads to num_v_heads so they match V's layout
     // (only needed if not using the fused op's broadcast support).
@@ -772,7 +753,7 @@ after_delta_net:
 
     // ── Gated output norm: rms_norm(output) * silu(z_4d)
     ggml_tensor * z_4d = ggml_reshape_4d(ctx, z, head_v_dim, num_v_heads, n_seq_tokens, n_seqs);
-    ggml_tensor * output_n = ggml_rms_norm(ctx, output, q35::EPS);
+    ggml_tensor * output_n = ggml_rms_norm(ctx, output, EPS);
     output_n = ggml_mul(ctx, output_n, L.ssm_norm);
     ggml_tensor * z_silu  = ggml_silu(ctx, z_4d);
     output_n = ggml_mul(ctx, output_n, z_silu);
@@ -783,7 +764,7 @@ after_delta_net:
 
     // Output projection
     ggml_tensor * out = ggml_mul_mat(ctx, L.ssm_out, flat);
-    out = ggml_reshape_2d(ctx, out, q35::N_HEAD * 0 + DFLASH27B_TARGET_HIDDEN, n_seq_tokens * n_seqs);
+    out = ggml_reshape_2d(ctx, out, w.n_embd, n_seq_tokens * n_seqs);
     return out;
 }
 
@@ -808,12 +789,9 @@ static ggml_tensor * build_single_layer(
     int                   fa_window = 0)
 {
     const int hidden = w.n_embd;
-    const float eps   = q35::EPS;
+    const float eps   = EPS;
     const TargetLayer & L = w.layers[layer_idx];
     const bool is_attn = (((layer_idx + 1) % w.full_attention_interval) == 0);
-
-    static const int CAPTURE_LAYERS[DFLASH27B_DRAFT_N_TARGET_LAYERS] =
-        { 1, 16, 31, 46, 61 };
 
     ggml_tensor * inpSA = inp;
     ggml_tensor * cur   = rms_norm_mul(ctx, inp, L.attn_norm, eps);
@@ -823,7 +801,7 @@ static ggml_tensor * build_single_layer(
         for (int il = 0; il < layer_idx; il++) {
             if (((il + 1) % w.full_attention_interval) == 0) fa_idx++;
         }
-        cur = build_full_attn_block(ctx, gf, L, cur, positions, w.rope_sections,
+        cur = build_full_attn_block(ctx, gf, w, L, cur, positions,
                                     cache.attn_k[fa_idx], cache.attn_v[fa_idx],
                                     attn_mask, kv_start, n_tokens,
                                     cache.kv_k_type, cache.kv_v_type, fa_window);
@@ -832,7 +810,7 @@ static ggml_tensor * build_single_layer(
         for (int il = 0; il < layer_idx; il++) {
             if (((il + 1) % w.full_attention_interval) != 0) dn_idx++;
         }
-        cur = build_delta_net_block(ctx, gf, L, cur,
+        cur = build_delta_net_block(ctx, gf, w, L, cur,
                                     cache.conv_state[dn_idx], cache.ssm_state[dn_idx],
                                     n_tokens, nullptr, nullptr);
     }
@@ -847,7 +825,7 @@ static ggml_tensor * build_single_layer(
     if (capture && cache.target_feat) {
         int capture_idx = -1;
         for (int k = 0; k < DFLASH27B_DRAFT_N_TARGET_LAYERS; k++) {
-            if (CAPTURE_LAYERS[k] == layer_idx) { capture_idx = k; break; }
+            if (w.capture_layer_ids[k] == layer_idx) { capture_idx = k; break; }
         }
         if (capture_idx >= 0) {
             const size_t elt        = ggml_element_size(cache.target_feat);
@@ -909,13 +887,11 @@ QwenGraphOutputs build_qwen35_graph(
         og_early.delta_captures.resize(n_delta);
     }
 
-    // DFlash target layer IDs for feature capture: {1, 16, 31, 46, 61}
+    // DFlash target layer IDs for feature capture, computed from n_layer.
     // HF hidden_states[lid+1] convention — capture AFTER layer 'lid' runs.
-    static const int CAPTURE_LAYERS[DFLASH27B_DRAFT_N_TARGET_LAYERS] =
-        { 1, 16, 31, 46, 61 };
 
     const int hidden = w.n_embd;
-    const float eps  = q35::EPS;
+    const float eps  = EPS;
 
     for (int il = 0; il < w.n_layer; il++) {
         const TargetLayer & L = w.layers[il];
@@ -927,7 +903,7 @@ QwenGraphOutputs build_qwen35_graph(
         ggml_tensor * cur = rms_norm_mul(ctx, inpL, L.attn_norm, eps);
 
         if (is_attn) {
-            cur = build_full_attn_block(ctx, gf, L, cur, in.positions, w.rope_sections,
+            cur = build_full_attn_block(ctx, gf, w, L, cur, in.positions,
                                         cache.attn_k[fa_idx], cache.attn_v[fa_idx],
                                         in.attn_mask, in.kv_start, n_tokens,
                                         cache.kv_k_type, cache.kv_v_type, in.fa_window);
@@ -944,7 +920,7 @@ QwenGraphOutputs build_qwen35_graph(
                 cap_ptr->ssm_intermediate_states = cache.ssm_intermediate[dn_idx];
                 cap_ptr->conv_input              = cache.conv_input_cache[dn_idx];
             }
-            cur = build_delta_net_block(ctx, gf, L, cur,
+            cur = build_delta_net_block(ctx, gf, w, L, cur,
                                         cache.conv_state[dn_idx], cache.ssm_state[dn_idx],
                                         n_tokens, cap_ptr, in.parent_ids);
             dn_idx++;
@@ -969,7 +945,7 @@ QwenGraphOutputs build_qwen35_graph(
         if (in.capture_layers && cache.target_feat) {
             int capture_idx = -1;
             for (int k = 0; k < DFLASH27B_DRAFT_N_TARGET_LAYERS; k++) {
-                if (CAPTURE_LAYERS[k] == il) { capture_idx = k; break; }
+                if (w.capture_layer_ids[k] == il) { capture_idx = k; break; }
             }
             if (capture_idx >= 0) {
                 const size_t elt        = ggml_element_size(cache.target_feat);
@@ -1011,7 +987,7 @@ QwenGraphOutputs build_qwen35_graph(
     }
 
     // 2. Final norm
-    ggml_tensor * out = rms_norm_mul(ctx, inpL, w.out_norm, q35::EPS);
+    ggml_tensor * out = rms_norm_mul(ctx, inpL, w.out_norm, EPS);
 
     // 3. LM head
     ggml_tensor * logits = ggml_mul_mat(ctx, w.output, out);

--- a/dflash/src/qwen3_dflash_graph.cpp
+++ b/dflash/src/qwen3_dflash_graph.cpp
@@ -43,9 +43,9 @@ DraftGraphOutputs build_draft_graph(
     const int q_len    = DFLASH27B_DRAFT_BLOCK_SIZE;
     const int ctx_len  = in.ctx_len;
     const int total_k  = ctx_len + q_len;
-    const int n_head   = DFLASH27B_TARGET_N_HEADS;           // 32
-    const int n_kv     = DFLASH27B_TARGET_N_KV_HEADS;        // 8
-    const int head_dim = DFLASH27B_TARGET_HEAD_DIM;          // 128
+    const int n_head   = w.n_head;
+    const int n_kv     = w.n_head_kv;
+    const int head_dim = w.head_dim;
     const float eps    = DFLASH27B_RMS_EPS;
     const float rope_base = DFLASH27B_ROPE_THETA;
     (void)ctx_len;  // used only via input tensor shapes
@@ -62,7 +62,7 @@ DraftGraphOutputs build_draft_graph(
     // ── 2. Decoder layers
     ggml_tensor * h = in.noise_embed;  // [hidden, q_len, 1]
 
-    for (int il = 0; il < DFLASH27B_DRAFT_LAYERS; il++) {
+    for (int il = 0; il < w.n_layer; il++) {
         const DraftLayer & L = w.layers[il];
 
         // ── 2a. Attention pre-norm

--- a/dflash/src/safetensors_draft.cpp
+++ b/dflash/src/safetensors_draft.cpp
@@ -381,14 +381,20 @@ bool load_draft_safetensors(const std::string & path,
     out.ctx = ggml_init(ip);
     if (!out.ctx) { set_last_error("ggml_init failed for draft ctx"); return false; }
     out.backend = backend;
+    out.n_layer   = n_layers;
+    out.n_head    = DFLASH27B_TARGET_N_HEADS;
+    out.n_head_kv = DFLASH27B_TARGET_N_KV_HEADS;
+    out.head_dim  = DFLASH27B_TARGET_HEAD_DIM;
+    out.n_embd    = DFLASH27B_TARGET_HIDDEN;
+    out.n_ff      = DFLASH27B_TARGET_INTERMEDIATE;
     out.layers.assign(n_layers, DraftLayer{});
 
-    const int64_t HIDDEN  = DFLASH27B_TARGET_HIDDEN;           // 5120
-    const int64_t Q_DIM   = DFLASH27B_TARGET_N_HEADS * DFLASH27B_TARGET_HEAD_DIM;     // 4096
-    const int64_t KV_DIM  = DFLASH27B_TARGET_N_KV_HEADS * DFLASH27B_TARGET_HEAD_DIM;  // 1024
-    const int64_t INTER   = DFLASH27B_TARGET_INTERMEDIATE;     // 17408
-    const int64_t HD      = DFLASH27B_TARGET_HEAD_DIM;         // 128
-    const int64_t FC_IN   = DFLASH27B_DRAFT_N_TARGET_LAYERS * HIDDEN; // 25600
+    const int64_t HIDDEN  = out.n_embd;
+    const int64_t Q_DIM   = out.n_head * out.head_dim;
+    const int64_t KV_DIM  = out.n_head_kv * out.head_dim;
+    const int64_t INTER   = out.n_ff;
+    const int64_t HD      = out.head_dim;
+    const int64_t FC_IN   = DFLASH27B_DRAFT_N_TARGET_LAYERS * HIDDEN;
 
     // ── 4. Create named tensors in the context ───────────────────
     //


### PR DESCRIPTION
Replace all hardcoded Qwen3.5-27B dimensions with runtime values from
TargetWeights (populated by the GGUF loader), enabling support for any
Qwen3.5-dense model size (4B, 9B, 27B).

Add runtime hparams (n_head, n_head_kv, head_dim, n_embd, n_ff, n_layer)
to DraftWeights, populated by both loaders:

Changes:
- gguf_target_loader.cpp: Remove exact-match validation against 27B dims,
  replace with non-zero + structural invariant checks (key_length==value_length,
  ssm_d_inner%dt_rank==0, n_layer%fai==0). Compute capture_layer_ids from
  n_layer using formula: step=(n_layer-2)/(N-1), ids[k]=1+k*step.
- qwen35_target_graph.cpp: Delete namespace q35 (22 compile-time constants),
  thread TargetWeights hparams through build_full_attn_block() and
  build_delta_net_block(). Derive n_rot from rope_sections. Replace hardcoded
  CAPTURE_LAYERS with w.capture_layer_ids.
- internal.h: Add capture_layer_ids[5] to TargetWeights.
- safetensors_draft.cpp: stores hardcoded values in DraftWeights fields
  (safetensors has no metadata to read from)
- gguf_draft_loader.cpp: reads dimensions from GGUF metadata instead of
  validating against DFLASH27B_TARGET_* macros
- qwen3_dflash_graph.cpp: uses w.n_head/n_head_kv/head_dim/n_layer from
  DraftWeights instead of DFLASH27B_TARGET_* macros

This enables loading DFlash draft models for any Qwen3.5 target size
(4B, 9B, 27B) without recompilation.