### PR TITLE
fix(dflash): conv_input/ssm_intermediate size mismatch during prefill

### DIFF
--- a/dflash/src/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35_target_graph.cpp
@@ -878,7 +878,19 @@ static ggml_tensor * build_delta_net_block(
     // past graph_compute). After graph_compute, the cache buffer's data is
     // always valid; the rollback code slices it at commit_n.
     if (cap && cap->conv_input) {
-        ggml_build_forward_expand(gf, ggml_cpy(ctx, conv_input, cap->conv_input));
+        // conv_input may be shorter than the pre-allocated cache
+        // (e.g. during prefill when n_tokens < max_verify_tokens).
+        // Copy into a matching-sized view of the cache destination.
+        const int64_t ci_len = conv_input->ne[0];
+        ggml_tensor * dst;
+        if (ci_len == cap->conv_input->ne[0]) {
+            dst = cap->conv_input;
+        } else {
+            dst = ggml_view_3d(ctx, cap->conv_input,
+                ci_len, cap->conv_input->ne[1], cap->conv_input->ne[2],
+                cap->conv_input->nb[1], cap->conv_input->nb[2], 0);
+        }
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, conv_input, dst));
     }
 
     // ── Save the last (kernel-1) steps back to conv_state
@@ -1034,8 +1046,14 @@ static ggml_tensor * build_delta_net_block(
             S_v * S_v * r_elt,
             S_v * S_v * H_v * r_elt,
             inter_offset);
-        ggml_build_forward_expand(gf,
-            ggml_cpy(ctx, inter_view, cap->ssm_intermediate_states));
+        // inter_view may be shorter than pre-allocated cache during prefill
+        ggml_tensor * inter_dst = cap->ssm_intermediate_states;
+        if (ggml_nelements(inter_view) != ggml_nelements(inter_dst)) {
+            inter_dst = ggml_view_4d(ctx, inter_dst,
+                inter_view->ne[0], inter_view->ne[1], inter_view->ne[2], inter_view->ne[3],
+                inter_dst->nb[1], inter_dst->nb[2], inter_dst->nb[3], 0);
+        }
+        ggml_build_forward_expand(gf, ggml_cpy(ctx, inter_view, inter_dst));
     }
     } // end of block started at `{` before `const int64_t S_v = head_v_dim;`
 


### PR DESCRIPTION
## Summary

Fixes the `GGML_ASSERT(ggml_nelements(a) == ggml_nelements(b))` crash that occurs on every run of `test_dflash`.

## Root cause

During prefill, `conv_input` has shape `[kernel-1 + n_tokens, channels]` but `conv_input_cache` is pre-allocated for `[kernel-1 + max_verify_tokens, channels]`. When `n_tokens < max_verify_tokens` (always true on short prompts), `ggml_cpy` asserts because the source and destination have different element counts.

Same issue exists for `ssm_intermediate_states`.

## Fix

Create a view of the destination cache matching the source dimensions before copying (2 locations in `qwen35_target_graph.cpp`).

## Diagnostic that found it

Added to `ggml_cpy_impl`:
```
CPY MISMATCH: a=[8,10240,1,1](81920) b=[19,10240,1,1](194560) a.name= b.name=conv_input_cache_0
```
Detailed shapes:
```
d_conv=4, conv_state=[3,10240], conv_states_r=[3,10240], qkv_T=[5,10240]
conv_input=[8,10240] (3+5=8 ✓), cap->conv_input=[19,10240] (3+16=19)
```
Source is correct. Destination is over-allocated. Fix: view into the first `ci_len` rows.

## Test

RTX 4090 24 GB, Qwen3.5-27B Q4_K_M + z-lab/Qwen3.5-27B-DFlash draft:
- Before: crashes on every config (budget 1-22, max-ctx 64-131072)
- After: generates 100 tokens, 28.4% acceptance, 4.55 tokens/step

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)