### PR TITLE
bench_niah_cpp: expose ddtree/fa/kv params and auto-max-ctx as CLI flags

### DIFF
--- a/pflash/pflash/dflash_client.py
+++ b/pflash/pflash/dflash_client.py
@@ -16,6 +16,8 @@ log = logging.getLogger(__name__)
 class DflashClient:
     def __init__(self, bin_path: str, target_path: str, draft_path: str,
                  max_ctx: int = 16384, ddtree_budget: int = 16,
+                 ddtree_temp: Optional[float] = None,
+                 chain_seed: bool = True,
                  fa_window: Optional[int] = None,
                  kv_tq3: Optional[bool] = None,
                  lm_head_fix: Optional[bool] = None,
@@ -47,6 +49,10 @@ class DflashClient:
                f"--ddtree-budget={ddtree_budget}",
                f"--max-ctx={max_ctx}",
                f"--stream-fd={self.w_pipe}"]
+        if ddtree_temp is not None:
+            cmd.append(f"--ddtree-temp={ddtree_temp}")
+        if not chain_seed:
+            cmd.append("--ddtree-no-chain-seed")
         log.info("spawning dflash daemon: %s", " ".join(cmd))
         self.proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                      pass_fds=(self.w_pipe,), env=env)

--- a/pflash/pflash/dflash_client.py
+++ b/pflash/pflash/dflash_client.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 class DflashClient:
     def __init__(self, bin_path: str, target_path: str, draft_path: str,
                  max_ctx: int = 16384, ddtree_budget: int = 16,
+                 *,
                  ddtree_temp: Optional[float] = None,
                  chain_seed: bool = True,
                  fa_window: Optional[int] = None,

--- a/pflash/tests/bench_niah_cpp.py
+++ b/pflash/tests/bench_niah_cpp.py
@@ -22,14 +22,41 @@ def main():
                     help="daemon KV cache max ctx; sized for compressed prompt+gen, NOT source")
     ap.add_argument("--keep-ratio", type=float, default=0.020)
     ap.add_argument("--n-gen", type=int, default=64)
+    ap.add_argument("--ddtree-budget", type=int, default=16)
+    ap.add_argument("--ddtree-temp", type=float, default=None,
+                    help="Drafter softmax temperature; lower = sharper")
+    ap.add_argument("--no-chain-seed", action="store_true")
+    ap.add_argument("--fa-window", type=int, default=0)
+    ap.add_argument("--kv-tq3", type=int, choices=[0, 1], default=1,
+                    help="3-bit KV cache; saves VRAM")
+    ap.add_argument("--auto-max-ctx", action="store_true",
+                    help="Auto-size --max-ctx based on src tokens")
     args = ap.parse_args()
 
     target_tok = AutoTokenizer.from_pretrained(args.target_tokenizer)
     drafter_tok = AutoTokenizer.from_pretrained(args.drafter_tokenizer)
     cases = [json.loads(l) for l in open(args.cases)][:args.n]
 
+    max_ctx = args.max_ctx
+    if args.auto_max_ctx:
+        first = json.loads(open(args.cases).readline())
+        src_tokens_est = len(drafter_tok(first["prompt"], return_tensors="pt")["input_ids"][0])
+        expected_compressed = int(src_tokens_est * args.keep_ratio * 1.15) + 64
+        needed = expected_compressed + args.n_gen + 512
+        max_ctx = max(max_ctx, needed)
+        max_ctx = ((max_ctx + 1023) // 1024) * 1024
+        print(f"[init] auto-max-ctx: src~{src_tokens_est}, compressed~{expected_compressed}, max_ctx={max_ctx}", flush=True)
+
     print(f"[init] spawning daemon: {args.bin}", flush=True)
-    dflash = DflashClient(args.bin, args.target, args.draft_spec, max_ctx=args.max_ctx)
+    dflash = DflashClient(
+        args.bin, args.target, args.draft_spec,
+        max_ctx=max_ctx,
+        ddtree_budget=args.ddtree_budget,
+        ddtree_temp=args.ddtree_temp,
+        chain_seed=not args.no_chain_seed,
+        fa_window=args.fa_window,
+        kv_tq3=bool(args.kv_tq3),
+    )
 
     correct = 0
     for i, case in enumerate(cases):

--- a/pflash/tests/bench_niah_cpp.py
+++ b/pflash/tests/bench_niah_cpp.py
@@ -35,11 +35,14 @@ def main():
 
     target_tok = AutoTokenizer.from_pretrained(args.target_tokenizer)
     drafter_tok = AutoTokenizer.from_pretrained(args.drafter_tokenizer)
-    cases = [json.loads(l) for l in open(args.cases)][:args.n]
+    with open(args.cases) as f:
+        cases = [json.loads(l) for l in f][:args.n]
 
     max_ctx = args.max_ctx
     if args.auto_max_ctx:
-        first = json.loads(open(args.cases).readline())
+        if not cases:
+            raise ValueError("--auto-max-ctx requires at least one case in --cases")
+        first = cases[0]
         src_tokens_est = len(drafter_tok(first["prompt"], return_tensors="pt")["input_ids"][0])
         expected_compressed = int(src_tokens_est * args.keep_ratio * 1.15) + 64
         needed = expected_compressed + args.n_gen + 512


### PR DESCRIPTION
Pure ergonomics change to `pflash/tests/bench_niah_cpp.py` and the underlying `DflashClient`. Six existing daemon knobs and one new helper become reachable from the CLI:                                                                                                                                                                  
- `--ddtree-budget` (default 16, matches existing `DflashClient` default)
- `--ddtree-temp` (default unset → daemon default)
- `--no-chain-seed` (default off → chain seeding stays on)
- `--fa-window` (default 0, full attention)
- `--kv-tq3 {0,1}` (default 1, matches existing default)
- `--auto-max-ctx` (off by default; when on, sizes `max_ctx` from `src_tokens x keep_ratio x 1.15 + n_gen + 512`, aligned up to 1024, and treats `--max-ctx` as a floor)

`DflashClient.__init__` gains two new optional kwargs (`ddtree_temp`, `chain_seed`) that are forwarded to the daemon as `--ddtree-temp=...` and `--ddtree-no-chain-seed` only when set. The other knobs already had `DflashClient` kwargs; this PR just plumbs them through the bench.

Motivation                                                                                                                                                                  

Parameter sweeps for tuning configs on different GPUs (in my case Blackwell
sm_120, RTX 5090 32 GB at 117K NIAH) previously required editing the Python
source between runs. With these flags every sweep step is a single CLI
invocation, so configs can be captured in shell scripts and reproduced.

No upstream defaults change — anyone running the existing bench command unchanged sees the same `ddtree_budget=16 / kv_tq3=1 / fa_window=0 / chain_seed=True` behavior they have today.                                                                                                                                     
