### PR TITLE
bench: make target tokenizer overrideable in bench_he and bench_llm

### DIFF
--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -213,8 +213,13 @@ def _require_file(path: str, label: str):
         raise FileNotFoundError(f"{label} not found: {path}")
 
 
-def _prompt_path(i: int) -> Path:
-    return TMPDIR / f"he_prompt_{i:02d}.bin"
+def _tokenizer_slug(tokenizer_id: str) -> str:
+    """Filesystem-safe slug for tokenizer cache keying."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", tokenizer_id)
+
+
+def _prompt_path(i: int, tokenizer_slug: str) -> Path:
+    return TMPDIR / f"he_prompt_{tokenizer_slug}_{i:02d}.bin"
 
 
 def tokenize_prompt(prompt: str, out_path: Path, tokenizer) -> int:
@@ -305,21 +310,35 @@ def main():
                          "--target-tokenizer Qwen/Qwen3.6-27B")
     args = ap.parse_args()
 
-    print(f"[bench] target = {TARGET}")
-    print(f"[bench] draft  = {DRAFT}")
-    print(f"[bench] bin    = {TEST_DFLASH}")
-    print(f"[bench] tmp    = {TMPDIR}")
+    # Tokenized prompts are cached at TMPDIR/he_prompt_<slug>_NN.bin so
+    # different --target-tokenizer values never collide. Without the slug,
+    # `--skip-tokenize` after a prior run with a different tokenizer would
+    # silently feed the wrong token IDs to the bench.
+    tok_slug = _tokenizer_slug(args.target_tokenizer)
+
+    print(f"[bench] target    = {TARGET}")
+    print(f"[bench] draft     = {DRAFT}")
+    print(f"[bench] bin       = {TEST_DFLASH}")
+    print(f"[bench] tmp       = {TMPDIR}")
+    print(f"[bench] tokenizer = {args.target_tokenizer}")
 
     if not args.skip_tokenize:
-        print(f"[bench] tokenizing prompts via HF (tokenizer={args.target_tokenizer})…")
+        print(f"[bench] tokenizing prompts via HF…")
         from transformers import AutoTokenizer
         tok = AutoTokenizer.from_pretrained(args.target_tokenizer, trust_remote_code=True)
         for i, (name, p) in enumerate(PROMPTS):
-            path = _prompt_path(i)
+            path = _prompt_path(i, tok_slug)
             n = tokenize_prompt(p, path, tok)
             print(f"  [{i:02d}] {name:26s}  {n:4d} tokens")
     else:
-        print(f"[bench] skipping tokenize (reusing {_prompt_path(0).parent})")
+        if not _prompt_path(0, tok_slug).exists():
+            sys.exit(
+                f"[error] --skip-tokenize requested but no cache for "
+                f"tokenizer={args.target_tokenizer!r} (looked for "
+                f"{_prompt_path(0, tok_slug)}). Drop --skip-tokenize to "
+                f"tokenize fresh, or pass --target-tokenizer matching a "
+                f"previous run.")
+        print(f"[bench] skipping tokenize (reusing {_prompt_path(0, tok_slug).parent})")
 
     print(f"\n[bench] mode={args.mode}  n_gen={args.n_gen}")
     print(f"{'prompt':28s}  {'steps':>6s} {'AL':>6s} {'pct%':>6s} {'tok/s':>8s}")
@@ -339,7 +358,7 @@ def main():
 
     results = []
     for i, (name, _) in enumerate(PROMPTS):
-        path = _prompt_path(i)
+        path = _prompt_path(i, tok_slug)
         try:
             r = run_test_dflash(path, args.n_gen,
                                 fast_rollback=(args.mode == "fast"),

--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -297,6 +297,12 @@ def main():
                     help="Visible CUDA device id for the draft backend")
     ap.add_argument("--cuda-visible-devices", default=None,
                     help="Optional CUDA_VISIBLE_DEVICES override for test_dflash")
+    ap.add_argument("--target-tokenizer",
+                    default=os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.5-27B"),
+                    help="HuggingFace tokenizer repo for the target. Defaults to "
+                         "$DFLASH_TOKENIZER, then Qwen/Qwen3.5-27B. Override for "
+                         "Qwen3.6 or other variants, e.g. "
+                         "--target-tokenizer Qwen/Qwen3.6-27B")
     args = ap.parse_args()
 
     print(f"[bench] target = {TARGET}")
@@ -305,9 +311,9 @@ def main():
     print(f"[bench] tmp    = {TMPDIR}")
 
     if not args.skip_tokenize:
-        print("[bench] tokenizing prompts via HF…")
+        print(f"[bench] tokenizing prompts via HF (tokenizer={args.target_tokenizer})…")
         from transformers import AutoTokenizer
-        tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B", trust_remote_code=True)
+        tok = AutoTokenizer.from_pretrained(args.target_tokenizer, trust_remote_code=True)
         for i, (name, p) in enumerate(PROMPTS):
             path = _prompt_path(i)
             n = tokenize_prompt(p, path, tok)

--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -28,6 +28,7 @@ _LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
 DRAFT = None
 TEST_DFLASH = os.environ.get("DFLASH_BIN", str(ROOT / "build" / f"test_dflash{BIN_SUFFIX}"))
 TEST_GENERATE = os.environ.get("DFLASH_BIN_AR", str(ROOT / "build" / f"test_generate{BIN_SUFFIX}"))
+TOKENIZER = os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.5-27B")
 TMPDIR = Path(tempfile.gettempdir()) / "dflash_bench"
 TMPDIR.mkdir(parents=True, exist_ok=True)
 
@@ -148,14 +149,15 @@ def main():
     _require_file(TEST_DFLASH, "test_dflash binary")
     _require_file(TEST_GENERATE, "test_generate binary")
 
-    print(f"[bench] target = {TARGET}", flush=True)
-    print(f"[bench] draft  = {DRAFT}", flush=True)
-    print(f"[bench] ar bin = {TEST_GENERATE}", flush=True)
-    print(f"[bench] df bin = {TEST_DFLASH}", flush=True)
+    print(f"[bench] target    = {TARGET}", flush=True)
+    print(f"[bench] draft     = {DRAFT}", flush=True)
+    print(f"[bench] ar bin    = {TEST_GENERATE}", flush=True)
+    print(f"[bench] df bin    = {TEST_DFLASH}", flush=True)
+    print(f"[bench] tokenizer = {TOKENIZER}", flush=True)
 
     from datasets import load_dataset
     from transformers import AutoTokenizer
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B", trust_remote_code=True)
+    tok = AutoTokenizer.from_pretrained(TOKENIZER, trust_remote_code=True)
 
     results = {}
     for name, ds_name, cfg, split, extract in BENCHES:

--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -4,10 +4,11 @@
     python3 scripts/bench_llm.py
 
 Paths resolve from the repo root by default. Override with env vars:
-    DFLASH_TARGET   path to target Qwen3.6-27B-Q4_K_M.gguf (or 3.5)
-    DFLASH_DRAFT    path to draft model.safetensors
-    DFLASH_BIN      path to build/test_dflash
-    DFLASH_BIN_AR   path to build/test_generate
+    DFLASH_TARGET    path to target Qwen3.6-27B-Q4_K_M.gguf (or 3.5)
+    DFLASH_DRAFT     path to draft model.safetensors
+    DFLASH_BIN       path to build/test_dflash
+    DFLASH_BIN_AR    path to build/test_generate
+    DFLASH_TOKENIZER HF tokenizer repo (default Qwen/Qwen3.5-27B; matches run.py)
 """
 import json
 import os


### PR DESCRIPTION
Both bench scripts hardcoded Qwen/Qwen3.5-27B as the HF tokenizer reference, making them unusable for Qwen3.6 or future Qwen variants without forking the repo. This was already inconsistent with run.py, which honors $DFLASH_TOKENIZER and defaults to Qwen/Qwen3.6-27B.

Each bench script gets the override via its own idiomatic API:

  bench_he.py:   --target-tokenizer CLI flag (joins the existing
                 argparse surface). Default falls back through
                 $DFLASH_TOKENIZER -> "Qwen/Qwen3.5-27B", so:
                   - no flag, no env  -> Qwen/Qwen3.5-27B (current behavior)
                   - $DFLASH_TOKENIZER set -> that wins
                   - --target-tokenizer foo  -> that wins over both

  bench_llm.py:  TOKENIZER module-level read from $DFLASH_TOKENIZER
                 (matches the file's existing env-driven config style
                 - TARGET, DRAFT, TEST_DFLASH, etc. are all env vars).
                 Same default chain. Logged on the [bench] line.

Defaults preserve current behavior on both scripts; existing call sites that don't set the env var or pass the flag are unaffected. Users running Qwen3.6 set DFLASH_TOKENIZER once and both scripts pick it up, matching run.py's convention.