### PR TITLE
RESULTS.md: add RTX 5090 long-context NIAH validation section

### DIFF
--- a/dflash/RESULTS.md
+++ b/dflash/RESULTS.md
@@ -344,14 +344,14 @@ Draft: local Qwen3.6-27B DFlash safetensors + Qwen3-0.6B-BF16 PFlash drafter.
 Build: `cmake -B build-luce-sm120 -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=120 -DDFLASH27B_USER_CUDA_ARCHITECTURES=120 -DDFLASH27B_ENABLE_BSA=ON`
 
 Final ("V4") runtime config — driven via the `pflash/tests/bench_niah_cpp.py`
-CLI flags added in #90 plus daemon env vars; the bracketed names are the
-exact interfaces:
+CLI flags added in #90 plus daemon env vars (each bullet leads with the
+exact interface):
 
 - `--keep-ratio=0.05` (PFlash compression target ratio)
-- `DFLASH_FP_USE_BSA=1` env, `--alpha=0.70` (BSA enabled, block-selection threshold)
+- `DFLASH_FP_USE_BSA=1` and `DFLASH_FP_ALPHA=0.70` (BSA enabled, block-selection threshold; both are daemon env vars)
 - `--ddtree-budget=22`
 - `--fa-window=4096` (also settable via `DFLASH27B_FA_WINDOW=4096`)
-- `--kv-tq3=0` (FP16 KV cache; 5090 has VRAM headroom)
+- `--kv-tq3=0` (Q8_0 KV cache — the daemon default when TQ3_0 is disabled and no other KV type is set; 5090 has VRAM headroom so TQ3_0 isn't needed)
 - `--n-gen=1024`
 
 Test set: 10 NIAH prompts at 117K tokens (margin under Qwen3.6-27B's 131K
@@ -377,21 +377,21 @@ values discovered in the prior phase, so the swept-axis throughput numbers
 are not directly comparable to the headline (different keep ratios produce
 different per-step decode rates, see the keep-ratio table below).
 
-### Phase 1 — alpha sweep (held: `--keep-ratio=0.08`, `--ddtree-budget=28`)
+### Phase 1 — `DFLASH_FP_ALPHA` sweep (held: `--keep-ratio=0.08`, `--ddtree-budget=28`)
 
-| `--alpha` | NIAH    | Decode tok/s |
-|:---------:|:-------:|:------------:|
-| 0.60      | 10/10   | 213.7        |
-| **0.70**  | 10/10   | 210.6        |
-| 0.85      | **8/10**| 204.6        |
+| `DFLASH_FP_ALPHA` | NIAH    | Decode tok/s |
+|:-----------------:|:-------:|:------------:|
+| 0.60              | 10/10   | 213.7        |
+| **0.70**          | 10/10   | 210.6        |
+| 0.85              | **8/10**| 204.6        |
 
-The docs default of `--alpha=0.85` fails 2/10 prompts at this setup. This
-may be specific to long context, Qwen3.6, or Blackwell — I have not
-isolated which. Validating `alpha` per setup is recommended. I chose 0.70
-over 0.60 for reliability margin: 0.60 wins decode by only 1.5%, below the
-run-to-run variance, on an n=10 sample.
+The docs default of `DFLASH_FP_ALPHA=0.85` fails 2/10 prompts at this
+setup. This may be specific to long context, Qwen3.6, or Blackwell — I
+have not isolated which. Validating alpha per setup is recommended. I
+chose 0.70 over 0.60 for reliability margin: 0.60 wins decode by only
+1.5%, below the run-to-run variance, on an n=10 sample.
 
-### Phase 2 — budget sweep (held: `--alpha=0.70`, `--keep-ratio=0.08`)
+### Phase 2 — budget sweep (held: `DFLASH_FP_ALPHA=0.70`, `--keep-ratio=0.08`)
 
 | `--ddtree-budget` | NIAH | Decode tok/s |
 |:-----------------:|:----:|:------------:|
@@ -405,7 +405,7 @@ on budget=22 as throughput-optimal (211.20 mean tok/s at AL 7.25). So
 context regimes**, not a knob that needs per-context-length tuning. This
 is the most useful cross-reference between the two sections.
 
-### Phase 3 — keep-ratio sweep (held: `--alpha=0.70`, `--ddtree-budget=22`)
+### Phase 3 — keep-ratio sweep (held: `DFLASH_FP_ALPHA=0.70`, `--ddtree-budget=22`)
 
 | `--keep-ratio` | NIAH    | Decode tok/s | TTFT    | Compression |
 |:--------------:|:-------:|:------------:|:-------:|:-----------:|
@@ -420,7 +420,10 @@ when sustained throughput on already-compressed prompts dominates.
 
 ### Note on `--kv-tq3`
 
-I set `--kv-tq3=0` (FP16 KV cache). 3-bit KV cache trades VRAM for memory
-bandwidth; on a 5090 with 32 GB and ~22 GB peak usage at 117K, the
-bandwidth trade is not worth it. Users on 4090 or 3090 (24 GB) at this
-context length should likely keep `--kv-tq3=1`.
+I set `--kv-tq3=0`, which leaves the daemon at its Q8_0 KV-cache default
+(no `DFLASH27B_KV_K`/`DFLASH27B_KV_V` overrides). The 3-bit TQ3_0 cache
+trades VRAM for memory bandwidth; on a 5090 with 32 GB and ~22 GB peak
+usage at 117K, that trade isn't worth taking. Users on 4090 or 3090
+(24 GB) at this context length should likely keep `--kv-tq3=1`. To go
+further than Q8_0 in either direction set the K/V types explicitly via
+`DFLASH27B_KV_K=<type> DFLASH27B_KV_V=<type>`.

--- a/dflash/RESULTS.md
+++ b/dflash/RESULTS.md
@@ -326,3 +326,81 @@ Budget 12 failed all prompts with a ggml shape assertion. Budget 22 remains the
 best short-context throughput default on this 5090 build. Budget 30 produced
 the highest mean AL but lower throughput, so it is a quality-biased experiment
 rather than the base setting.
+
+## RTX 5090 (Blackwell, sm_120/sm_120a, 32 GB) — long-context NIAH
+
+> **Companion to the short-context RTX 5090 section** (HumanEval / Math500 /
+> GSM8K, added in #86). That section validates speculative decoding on
+> short prompts where PFlash compression is not engaged; this one validates
+> the full PFlash drafter scoring + ~20× compression + DFlash decode
+> pipeline at 117K tokens.
+
+Single RTX 5090 32 GB, CUDA 13.2, driver 595.58.
+Target: `unsloth/Qwen3.6-27B-GGUF` (`Qwen3.6-27B-Q4_K_M.gguf`, ~16.8 GB).
+Q4_K_M (vs Q5_K_XL in the short-context section above) leaves more
+VRAM headroom for the FP16 KV cache at 117K context.
+Draft: local Qwen3.6-27B DFlash safetensors + Qwen3-0.6B-BF16 PFlash drafter.
+
+Build: `cmake -B build-luce-sm120 -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=120 -DDFLASH27B_USER_CUDA_ARCHITECTURES=120 -DDFLASH27B_ENABLE_BSA=ON`
+
+Runtime config:
+- `keep_ratio=0.05`
+- `alpha=0.70` (with `DFLASH_FP_USE_BSA=1`)
+- `ddtree_budget=22`
+- `fa_window=4096`
+- `kv_tq3=0` (FP16 KV cache; 5090 has VRAM headroom)
+- `n_gen=1024`
+
+Test set: 10 NIAH prompts at 117K tokens (margin under Qwen3.6-27B's 131K
+native RoPE limit, generated with `niah_gen.py` at calibrated
+`char_per_tok`).
+
+### RTX 5090 long-ctx headline
+
+| Metric                 | Value                              |
+|------------------------|------------------------------------|
+| NIAH accuracy          | **20/20** across 2 runs of n=10    |
+| Decode throughput      | 210.7 t/s avg (range 179–230)      |
+| TTFT                   | 10.0 s                             |
+| Compression            | 20.2× (117064 → 5800 tokens)       |
+| Prefill (compressed)   | 3.9 s for ~5800 tokens             |
+| Drafter score+migrate  | ~5.8 s                             |
+
+### Cross-reference: budget=22 holds across context regimes
+
+The short-context budget sweep above identifies budget=22 as the
+throughput-optimal default at HumanEval-scale prompts (211.20 mean tok/s
+at AL 7.25). My long-context sweep at 117K NIAH also converges on
+budget=22:
+
+| Budget | Long-ctx NIAH @ 117K | Decode t/s |
+|:------:|:--------------------:|:----------:|
+| **22** | 10/10                | **217.4**  |
+| 28     | 10/10                | 210.7      |
+| 30     | 10/10                | 211.1      |
+
+Budget=22 is therefore a stable default for Qwen3.6-27B on Blackwell across
+both regimes, not a knob that needs per-context-length tuning.
+
+### Note on `kv_tq3`
+
+I set `kv_tq3=0` (FP16 KV cache). 3-bit KV cache trades VRAM for memory
+bandwidth; on a 5090 with 32 GB and ~22 GB peak usage at 117K, the
+bandwidth trade is not worth it. Users on 4090 or 3090 (24 GB) at this
+context length should likely keep `kv_tq3=1`.
+
+### Note on `alpha`
+
+I tested `alpha=0.60, 0.70, 0.85` at this configuration:
+
+| Alpha | NIAH    | Decode t/s |
+|:-----:|:-------:|:----------:|
+| 0.60  | 10/10   | 213.7      |
+| 0.70  | 10/10   | 210.6      |
+| 0.85  | **8/10**| 204.6      |
+
+The docs default of 0.85 fails 2 prompts at this setup. This may be
+specific to long context, Qwen3.6, or Blackwell — I have not isolated
+which. Either way, validating `alpha` per setup is recommended. I chose
+0.70 over 0.60 for reliability margin (n=10 sample; 0.60 wins decode by
+only 1.5%, below the run-to-run variance).

--- a/dflash/RESULTS.md
+++ b/dflash/RESULTS.md
@@ -343,64 +343,84 @@ Draft: local Qwen3.6-27B DFlash safetensors + Qwen3-0.6B-BF16 PFlash drafter.
 
 Build: `cmake -B build-luce-sm120 -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=120 -DDFLASH27B_USER_CUDA_ARCHITECTURES=120 -DDFLASH27B_ENABLE_BSA=ON`
 
-Runtime config:
-- `keep_ratio=0.05`
-- `alpha=0.70` (with `DFLASH_FP_USE_BSA=1`)
-- `ddtree_budget=22`
-- `fa_window=4096`
-- `kv_tq3=0` (FP16 KV cache; 5090 has VRAM headroom)
-- `n_gen=1024`
+Final ("V4") runtime config — driven via the `pflash/tests/bench_niah_cpp.py`
+CLI flags added in #90 plus daemon env vars; the bracketed names are the
+exact interfaces:
+
+- `--keep-ratio=0.05` (PFlash compression target ratio)
+- `DFLASH_FP_USE_BSA=1` env, `--alpha=0.70` (BSA enabled, block-selection threshold)
+- `--ddtree-budget=22`
+- `--fa-window=4096` (also settable via `DFLASH27B_FA_WINDOW=4096`)
+- `--kv-tq3=0` (FP16 KV cache; 5090 has VRAM headroom)
+- `--n-gen=1024`
 
 Test set: 10 NIAH prompts at 117K tokens (margin under Qwen3.6-27B's 131K
-native RoPE limit, generated with `niah_gen.py` at calibrated
-`char_per_tok`).
+native RoPE limit, generated with [`pflash/tests/niah_gen.py`](../pflash/tests/niah_gen.py)
+at calibrated `char_per_tok`).
 
 ### RTX 5090 long-ctx headline
 
 | Metric                 | Value                              |
 |------------------------|------------------------------------|
 | NIAH accuracy          | **20/20** across 2 runs of n=10    |
-| Decode throughput      | 210.7 t/s avg (range 179–230)      |
+| Decode throughput      | 210.7 tok/s avg (range 179–230)    |
 | TTFT                   | 10.0 s                             |
 | Compression            | 20.2× (117064 → 5800 tokens)       |
 | Prefill (compressed)   | 3.9 s for ~5800 tokens             |
 | Drafter score+migrate  | ~5.8 s                             |
 
-### Cross-reference: budget=22 holds across context regimes
+These headline numbers are the **Phase 4 reliability run** at the V4 config
+above (n=20 across 2 independent runs of 10 prompts each). The three
+exploratory sweeps below — alpha, then budget, then keep — are what
+*selected* the V4 config; each table holds the non-swept parameters at the
+values discovered in the prior phase, so the swept-axis throughput numbers
+are not directly comparable to the headline (different keep ratios produce
+different per-step decode rates, see the keep-ratio table below).
 
-The short-context budget sweep above identifies budget=22 as the
-throughput-optimal default at HumanEval-scale prompts (211.20 mean tok/s
-at AL 7.25). My long-context sweep at 117K NIAH also converges on
-budget=22:
+### Phase 1 — alpha sweep (held: `--keep-ratio=0.08`, `--ddtree-budget=28`)
 
-| Budget | Long-ctx NIAH @ 117K | Decode t/s |
-|:------:|:--------------------:|:----------:|
-| **22** | 10/10                | **217.4**  |
-| 28     | 10/10                | 210.7      |
-| 30     | 10/10                | 211.1      |
+| `--alpha` | NIAH    | Decode tok/s |
+|:---------:|:-------:|:------------:|
+| 0.60      | 10/10   | 213.7        |
+| **0.70**  | 10/10   | 210.6        |
+| 0.85      | **8/10**| 204.6        |
 
-Budget=22 is therefore a stable default for Qwen3.6-27B on Blackwell across
-both regimes, not a knob that needs per-context-length tuning.
+The docs default of `--alpha=0.85` fails 2/10 prompts at this setup. This
+may be specific to long context, Qwen3.6, or Blackwell — I have not
+isolated which. Validating `alpha` per setup is recommended. I chose 0.70
+over 0.60 for reliability margin: 0.60 wins decode by only 1.5%, below the
+run-to-run variance, on an n=10 sample.
 
-### Note on `kv_tq3`
+### Phase 2 — budget sweep (held: `--alpha=0.70`, `--keep-ratio=0.08`)
 
-I set `kv_tq3=0` (FP16 KV cache). 3-bit KV cache trades VRAM for memory
+| `--ddtree-budget` | NIAH | Decode tok/s |
+|:-----------------:|:----:|:------------:|
+| **22**            | 10/10| **217.4**    |
+| 28                | 10/10| 210.7        |
+| 30                | 10/10| 211.1        |
+
+#86's short-context budget sweep above on the same 5090 build also lands
+on budget=22 as throughput-optimal (211.20 mean tok/s at AL 7.25). So
+**budget=22 is a stable default for Qwen3.6-27B on Blackwell across
+context regimes**, not a knob that needs per-context-length tuning. This
+is the most useful cross-reference between the two sections.
+
+### Phase 3 — keep-ratio sweep (held: `--alpha=0.70`, `--ddtree-budget=22`)
+
+| `--keep-ratio` | NIAH    | Decode tok/s | TTFT    | Compression |
+|:--------------:|:-------:|:------------:|:-------:|:-----------:|
+| **0.05**       | 10/10   | 210.4        | 10.0 s  | 20.2×       |
+| 0.06           | 10/10   | 212.1        | 10.5 s  | 16.8×       |
+| 0.08           | 10/10   | 216.5        | 13.0 s  | 12.6×       |
+
+`--keep-ratio=0.08` wins per-token throughput by ~3% but pays 30% more
+TTFT and gives up 38% of the compression. For the 117K NIAH workload I
+chose 0.05 to optimize end-to-end response latency; 0.08 is preferable
+when sustained throughput on already-compressed prompts dominates.
+
+### Note on `--kv-tq3`
+
+I set `--kv-tq3=0` (FP16 KV cache). 3-bit KV cache trades VRAM for memory
 bandwidth; on a 5090 with 32 GB and ~22 GB peak usage at 117K, the
 bandwidth trade is not worth it. Users on 4090 or 3090 (24 GB) at this
-context length should likely keep `kv_tq3=1`.
-
-### Note on `alpha`
-
-I tested `alpha=0.60, 0.70, 0.85` at this configuration:
-
-| Alpha | NIAH    | Decode t/s |
-|:-----:|:-------:|:----------:|
-| 0.60  | 10/10   | 213.7      |
-| 0.70  | 10/10   | 210.6      |
-| 0.85  | **8/10**| 204.6      |
-
-The docs default of 0.85 fails 2 prompts at this setup. This may be
-specific to long context, Qwen3.6, or Blackwell — I have not isolated
-which. Either way, validating `alpha` per setup is recommended. I chose
-0.70 over 0.60 for reliability margin (n=10 sample; 0.60 wins decode by
-only 1.5%, below the run-to-run variance).
+context length should likely keep `--kv-tq3=1`.


### PR DESCRIPTION
> **Status: Draft - depends on #86.** This PR is a pure append to `dflash/RESULTS.md` after the same anchor point #86 appends to, so the rebase once #86 lands is mechanical (my section stacks below #86's). Filed as Draft so review can run in parallel; I'll de-draft and rebase once #86 merges. Numbers and headings here already match #86's short-context environment (`(Blackwell, sm_120/sm_120a, 32 GB)`, build flags, `ddtree_budget=22`).

## Summary

Adds a new section `## RTX 5090 (Blackwell, sm_120/sm_120a, 32 GB) - long-context NIAH` to `dflash/RESULTS.md`, complementing #86's short-context numbers with the long-context PFlash + DFlash pipeline validated at 117K tokens.

Different layer of validation:
- **#86's short-context section**: pure speculative decoding at 50–250 token prompts; PFlash compression not engaged.
- **This section**: full PFlash drafter scoring + ~20× compression + DFlash decode at 117K tokens.

## Headline

| Metric                | Value                              |
|-----------------------|------------------------------------|
| NIAH accuracy         | **20/20** across 2 runs of n=10    |
| Decode throughput     | 210.7 t/s avg (range 179–230)      |
| TTFT                  | 10.0 s                             |
| Compression           | 20.2× (117064 -> 5800 tokens)      |
| Prefill (compressed)  | 3.9 s for ~5800 tokens             |
| Drafter score+migrate | ~5.8 s                             |

## Notable cross-reference with #86

#86's short-context budget sweep identifies **budget=22** as throughput-optimal (211.20 mean tok/s at AL 7.25, in #86's "RTX 5090 DDTree budget sweep" table). My long-context sweep at 117K NIAH **also** converges on budget=22:

| Budget | Long-ctx NIAH @ 117K | Decode t/s |
|:------:|:--------------------:|:----------:|
| **22** | 10/10                | **217.4**  |
| 28     | 10/10                | 210.7      |
| 30     | 10/10                | 211.1      |

So budget=22 is a **stable default across context regimes** for Qwen3.6-27B on Blackwell, not something that needs per-regime tuning. Worth calling out because long-ctx and short-ctx workloads stress different parts of the verify path; the convergence on the same budget is a useful signal.

## Tuning notes included

- `kv_tq3=0` (FP16 KV) - chosen because 5090 has 32 GB; only ~22 GB peak at 117K. Section flags that 24 GB cards (4090/3090) should keep `kv_tq3=1`.
- `alpha` sweep at `0.60 / 0.70 / 0.85` - the docs default of `0.85` fails 2/10 NIAH at this setup; `0.60` and `0.70` pass 10/10. Section recommends per-setup `alpha` validation rather than relying on the docs default.
