### PR TITLE
fix(dflash): use GGUF-loaded EOS ids instead of hardcoded 248045

### DIFF
--- a/dflash/src/gguf_target_loader.cpp
+++ b/dflash/src/gguf_target_loader.cpp
@@ -327,6 +327,19 @@ bool load_target_gguf(const std::string & path,
     out.ssm_dt_rank= (int)ssm_dt;
     out.ssm_n_group= (int)ssm_grp;
 
+    // EOS token ids from GGUF tokenizer metadata (stored as UINT32 by the
+    // GGUF spec; we use the u32 helper and cast). UINT32_MAX is the
+    // missing-key sentinel and maps to int32_t -1, which the runtime EOS
+    // check rejects via the `>= 0` guard.
+    {
+        const uint32_t kEosKeyMissing = 0xFFFFFFFFu;
+        const uint32_t raw_eos      = get_u32_or(gctx, "tokenizer.ggml.eos_token_id", kEosKeyMissing);
+        const uint32_t raw_eos_chat = get_u32_or(gctx, "tokenizer.ggml.eot_token_id", kEosKeyMissing);
+        out.eos_id      = (raw_eos      == kEosKeyMissing) ? -1 : (int32_t)raw_eos;
+        out.eos_chat_id = (raw_eos_chat == kEosKeyMissing) ? -1 : (int32_t)raw_eos_chat;
+        std::printf("[loader] eos_id=%d eos_chat_id=%d\n", out.eos_id, out.eos_chat_id);
+    }
+
     // Compute capture layer IDs: evenly spaced through the target layers.
     // step = (n_layer - 2) / (N - 1), ids[k] = 1 + k * step.
     {

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -128,6 +128,13 @@ struct TargetWeights {
     int ssm_dt_rank             = 48;
     int ssm_n_group             = 16;
 
+    // EOS token ids loaded from the GGUF tokenizer metadata
+    // (`tokenizer.ggml.eos_token_id` and `tokenizer.ggml.eot_token_id`).
+    // -1 = key absent in this GGUF; the runtime EOS check guards both
+    // comparands with `>= 0` so the sentinel never matches a real token.
+    int32_t eos_id      = -1;
+    int32_t eos_chat_id = -1;
+
     // Target layer IDs captured for the DFlash draft model.
     // Computed from n_layer at load time: step = (n_layer - 2) / (N - 1),
     // ids[k] = 1 + k * step.  E.g. 27B→{1,16,31,46,61}, 9B→{1,8,15,22,29}.

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -81,6 +81,17 @@ extern "C" void dflash27b_launch_bf16_to_f32(const void * src,
 
 using namespace dflash27b;
 
+// True iff `tok` matches one of the model's declared end-of-output ids
+// (loaded into TargetWeights from GGUF tokenizer metadata). Replaces the
+// previous hardcoded `tok == 248045` check at the spec-decode commit
+// sites: token 248045 is `<|im_start|>` (chat-START), not EOS, and the
+// old check truncated chat-formatted output at the natural turn boundary
+// `<|im_end|>\n<|im_start|>`. The `>= 0` guards make a missing GGUF key
+// (-1 sentinel) a never-match.
+#define IS_EOS_TOK(tok, w)                                         \
+    ( ((w).eos_chat_id >= 0 && (tok) == (w).eos_chat_id)                  \
+   || ((w).eos_id      >= 0 && (tok) == (w).eos_id     ) )
+
 // ─── Small utilities ──────────────────────────────────────────────
 
 static std::vector<int32_t> read_int32_file(const std::string & path) {
@@ -2635,7 +2646,7 @@ int main(int argc, char ** argv) {
                     ? last_tok
                     : tree.token_ids[dfs_idx - 1];
                 out_all.push_back(tok); stream_emit(tok);
-                if (tok == 248045) hit_eos = true;
+                if (IS_EOS_TOK(tok, w)) hit_eos = true;
             }
             last_tok = next_token;
 
@@ -3061,7 +3072,7 @@ int main(int argc, char ** argv) {
             bool hit_eos = false;
             for (int i = 0; i < commit_n; i++) {
                 out_all.push_back(draft_tok[i]); stream_emit(draft_tok[i]);
-                if (draft_tok[i] == 248045) hit_eos = true;
+                if (IS_EOS_TOK(draft_tok[i], w)) hit_eos = true;
             }
             if (hit_eos) break;
         } else {
@@ -3127,7 +3138,7 @@ int main(int argc, char ** argv) {
             bool hit_eos = false;
             for (int i = 0; i < commit_n; i++) {
                 out_all.push_back(replay_tok[i]); stream_emit(replay_tok[i]);
-                if (replay_tok[i] == 248045) hit_eos = true;
+                if (IS_EOS_TOK(replay_tok[i], w)) hit_eos = true;
             }
             if (hit_eos) break;
         }


### PR DESCRIPTION
## Bug

Three sites in `test_dflash.cpp`'s spec-decode commit loops checked `tok == 248045` to terminate generation. Token 248045 is `<|im_start|>` — the chat-START marker, **not** EOS. Whenever the model legitimately emitted that token at the natural turn boundary `<|im_end|>\n<|im_start|>`, the loop terminated prematurely and the output included trailing chat-protocol garbage past the real `<|im_end|>`.

## Reproducer

```
PROMPT: "What is 2 + 2? Just the number."

before fix, gen tail: ... 19  248046  198  248044    248045
                          "4" <|end>  \n  <|eot> <|start>   ← stops here (wrong)

after  fix, gen tail: ... 19  248046  198
                          "4" <|end>  \n               ← stops here on real EOS
            (loader prints: eos_id=248046 eos_chat_id=-1
             from GGUF tokenizer.ggml.{eos,eot}_token_id)
```

## Fix

Read `tokenizer.ggml.eos_token_id` and `tokenizer.ggml.eot_token_id` from GGUF metadata into `TargetWeights::{eos_id,eos_chat_id}` at load time. Check against those via a single `IS_EOS_QWEN36_27B(tok, w)` macro. Missing metadata keys default to `-1`, and the `>= 0` guard ensures the sentinel never matches a real token id.

## Verified

Tested across Qwen3.5-27B and Qwen3.6-27B targets in BF16, Q4_K, Q4_K_M, Q6_K, NVFP4, NVFP4_M, NVFP4_Mv2 — all report `eos_id=248046` (= `<|im_end|>`) and stop cleanly there. Body content (including `<think>...</think>` blocks) is byte-identical to the previous binary up to the bug-fire point on every tested prompt.

## Files (3 files, +34 / −3)

- `dflash/src/internal.h` — `eos_id` / `eos_chat_id` fields on `TargetWeights`
- `dflash/src/gguf_target_loader.cpp` — read u32 metadata keys, cast to int32 with `-1` sentinel for missing keys
- `dflash/test/test_dflash.cpp` — `IS_EOS_QWEN36_27B(tok, w)` macro + 3 call-site replacements