### PR TITLE
fix(dflash): set consumer Blackwell ggml flag when 12x arch selected

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -44,6 +44,33 @@ endif()
 # the spec_prefill demo (target_gen path uses standard quant pairs).
 option(DFLASH27B_FA_ALL_QUANTS "Compile ggml-cuda fattn kernels for all KV-quant pairs" ON)
 set(GGML_CUDA_FA_ALL_QUANTS ${DFLASH27B_FA_ALL_QUANTS} CACHE BOOL "" FORCE)
+
+# Consumer Blackwell workaround: skip sm_12x→sm_12xa replacement and FP4
+# mmq kernels that can trigger illegal-instruction faults on consumer chips.
+# By default, auto-enable when the resolved CUDA arch list includes a 12x
+# entry. Set DFLASH27B_USE_BLACKWELL_CONSUMER_FIX=ON to force this behavior
+# explicitly (for cross-compiles or custom arch lists).
+option(DFLASH27B_USE_BLACKWELL_CONSUMER_FIX
+    "Enable ggml consumer-Blackwell workaround (skip sm_12x→sm_12xa, exclude FP4 mmq kernels)" OFF)
+if(DFLASH27B_USE_BLACKWELL_CONSUMER_FIX)
+    set(_dflash_is_consumer_blackwell ON)
+endif()
+
+if(NOT DEFINED _dflash_is_consumer_blackwell)
+    set(_dflash_is_consumer_blackwell OFF)
+    foreach(_arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+        string(REGEX REPLACE "[^0-9]" "" _dflash_arch_num "${_arch}")
+        if(_dflash_arch_num MATCHES "^12[0-9]$")
+            set(_dflash_is_consumer_blackwell ON)
+            break()
+        endif()
+    endforeach()
+endif()
+
+if(_dflash_is_consumer_blackwell)
+    set(GGML_CUDA_BLACKWELL_CONSUMER ON CACHE BOOL
+        "Skip sm_12X→sm_12Xa for consumer Blackwell (no FP4)" FORCE)
+endif()
 # Use only the ggml subtree of llama.cpp (skip libllama).
 add_subdirectory(deps/llama.cpp/ggml EXCLUDE_FROM_ALL)
 

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -45,6 +45,30 @@ endif()
 option(DFLASH27B_FA_ALL_QUANTS "Compile ggml-cuda fattn kernels for all KV-quant pairs" ON)
 set(GGML_CUDA_FA_ALL_QUANTS ${DFLASH27B_FA_ALL_QUANTS} CACHE BOOL "" FORCE)
 
+# Resolve the CUDA architecture list up-front so downstream logic (notably
+# the consumer-Blackwell ggml workaround below) can inspect the actual
+# arches nvcc will compile for. The dflash27b target itself is created
+# later; its CUDA_ARCHITECTURES property is applied via
+# set_target_properties once the target exists.
+#
+# Turing (75) and Ampere (86) always; Blackwell consumer (120) and Thor
+# (110 on CUDA 13+) added when nvcc supports them. DGX Spark /
+# GB10 is compute capability 12.1 (121), added at CUDA 12.9+.
+if(DFLASH27B_USER_CUDA_ARCHITECTURES)
+    set(_dflash27b_archs "${DFLASH27B_USER_CUDA_ARCHITECTURES}")
+else()
+    set(_dflash27b_archs "75;86")
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
+        list(APPEND _dflash27b_archs "120")
+    endif()
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
+        list(APPEND _dflash27b_archs "110")
+    endif()
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.9")
+        list(APPEND _dflash27b_archs "121")
+    endif()
+endif()
+
 # Consumer Blackwell workaround: skip sm_12x→sm_12xa replacement and FP4
 # mmq kernels that can trigger illegal-instruction faults on consumer chips.
 # By default, auto-enable when the resolved CUDA arch list includes a 12x
@@ -58,7 +82,9 @@ endif()
 
 if(NOT DEFINED _dflash_is_consumer_blackwell)
     set(_dflash_is_consumer_blackwell OFF)
-    foreach(_arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
+    # Iterate the resolved dflash27b arch list, not raw CMAKE_CUDA_ARCHITECTURES,
+    # which is empty on the default path (the project supplies its own list above).
+    foreach(_arch IN LISTS _dflash27b_archs)
         string(REGEX REPLACE "[^0-9]" "" _dflash_arch_num "${_arch}")
         if(_dflash_arch_num MATCHES "^12[0-9]$")
             set(_dflash_is_consumer_blackwell ON)
@@ -106,23 +132,8 @@ if(NOT DEFINED DFLASH27B_ENABLE_BSA)
     set(DFLASH27B_ENABLE_BSA ON)
 endif()
 
-# Turing (75) and Ampere (86) always; Blackwell consumer (120) and Thor
-# (110 on CUDA 13+) added when nvcc supports them. DGX Spark /
-# GB10 is compute capability 12.1 (121), added at CUDA 12.9+.
-if(DFLASH27B_USER_CUDA_ARCHITECTURES)
-    set(_dflash27b_archs "${DFLASH27B_USER_CUDA_ARCHITECTURES}")
-else()
-    set(_dflash27b_archs "75;86")
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
-        list(APPEND _dflash27b_archs "120")
-    endif()
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
-        list(APPEND _dflash27b_archs "110")
-    endif()
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.9")
-        list(APPEND _dflash27b_archs "121")
-    endif()
-endif()
+# Apply the arch list resolved above (before add_subdirectory, so the
+# consumer-Blackwell workaround can inspect it) to the dflash27b target.
 set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "${_dflash27b_archs}")
 
 # Extract the minimum SM from the arch list so safetensors_draft.cpp can decide


### PR DESCRIPTION
## Problem

Consumer Blackwell GPUs use `sm_12x` but not `sm_120a`, and ggml's
`sm_12X -> sm_12Xa` handling plus FP4 MMA kernels can trigger illegal-instruction
crashes.

## Fix

- Enable `GGML_CUDA_BLACKWELL_CONSUMER` automatically when the resolved
  CUDA arch list contains any `12x` entry.
- Add explicit override flag `DFLASH27B_USE_BLACKWELL_CONSUMER_FIX=ON` to force
  workaround behavior for custom cross-compile or custom arch-list flows.

## Notes

This PR now intentionally does not include the llama.cpp submodule pointer update;
it was dropped because the required dependency is already present in current upstream
submodule history.

## Test plan

- [ ] Configure and build with a consumer Blackwell setup to confirm
  `GGML_CUDA_BLACKWELL_CONSUMER=ON`.
- [ ] Validate runtime no longer trips `CUDA_ERROR_ILLEGAL_INSTRUCTION` in the FP4 MMQ
  path without applying auto-detect workaround.
