### PR TITLE
fix(prefix_cache): bump startup_sync timeout 10s → 120s for sm_120 cold-boot JIT

### DIFF
--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -657,24 +657,30 @@ class PrefixCache:
                     pass
                 self.abort_inline_snap(slot)
 
-    async def startup_sync(self) -> None:
+    async def startup_sync(self, timeout: float = 120.0) -> None:
         """Query the daemon for existing slots and free them all.
 
         Called once at server startup to ensure Python's hash table is
         consistent with the daemon's slot state (both empty after this).
+
+        The default ``timeout`` is intentionally generous (120s) because
+        first-boot CUDA kernel JIT compilation can dominate startup wall
+        time on architectures whose kernels aren't pre-compiled (notably
+        consumer Blackwell sm_120, where the megakernel + DFlash kernels
+        compile from scratch on first launch).
         """
         if self.disabled:
             return
         async with self.lock:
             self._send("LIST_SLOTS\n")
-            reply = await self._await_reply("[snap] slots=")
+            reply = await self._await_reply("[snap] slots=", timeout=timeout)
             slots_str = reply.split("[snap] slots=", 1)[1].strip()
             if not slots_str:
                 return
             orphans = [s.strip() for s in slots_str.split(",") if s.strip()]
             for s in orphans:
                 self._send(f"FREE_SNAPSHOT {s}\n")
-                await self._await_reply("[snap] freed slot=")
+                await self._await_reply("[snap] freed slot=", timeout=timeout)
             print(f"{self.log_prefix} freed {len(orphans)} orphaned daemon slots",
                   flush=True)
 


### PR DESCRIPTION
## Problem

On first boot of `scripts/server.py`, the lifespan startup hook calls
`prefix_cache.startup_sync()` which sends `LIST_SLOTS\n` to the daemon
and waits for the `[snap] slots=` reply via `_await_reply(...)`. That
call inherits the default 10s timeout from
`DaemonStdoutBus.await_reply`.

On hardware where the daemon's CUDA kernels need to be JIT-compiled at
process start (notably **consumer Blackwell sm_120 / RTX 5090 Laptop**),
the daemon can spend 30-60s compiling the megakernel + DFlash custom
kernels before printing the LIST_SLOTS reply. The 10s default fires
first and the FastAPI startup raises `asyncio.exceptions.TimeoutError`,
killing the server even though the daemon is healthy.

```
File ".../scripts/server.py", line 215, in _startup
    await prefix_cache.startup_sync()
File ".../scripts/prefix_cache.py", line 670, in startup_sync
    reply = await self._await_reply("[snap] slots=")
asyncio.exceptions.TimeoutError
```

Workaround until now was to set `--prefix-cache-slots 0
--prefill-cache-slots 0` so `startup_sync` short-circuits via
`self.disabled`, at the cost of losing prefix-cache reuse for chat
streaming.

## Fix

Add an explicit `timeout: float = 120.0` parameter to
`PrefixCache.startup_sync` and propagate it to the two
`_await_reply` calls inside (the LIST_SLOTS reply and the
FREE_SNAPSHOT acks). Steady-state daemon reply latency is
sub-millisecond, so the higher ceiling only matters on cold boot.

No change to `DaemonStdoutBus.await_reply` defaults elsewhere — this
is scoped to the startup-time path that is uniquely affected by JIT
compilation.

## Reproduction

Hardware: Olares One — NVIDIA RTX 5090 Laptop GPU 24GB, sm_120
Stack: Qwen3.6-27B Q4_K_M target + `z-lab/Qwen3.6-27B-DFlash` BF16
safetensors drafter, TQ3_0 KV, DDTree budget 22.

Before this PR: `server.py` startup fails with the timeout above on
every fresh container spawn (CUDA module cache empty).

After: same container, daemon prints `[snap] slots=` at ~28s, server
startup completes, first chat completion latency normal.

## Notes

- Wall-clock time of the JIT compile is dominated by the CUDA driver
  caching kernels per `CUDA_CACHE_PATH`. Subsequent boots on a warm
  cache fall back well under the original 10s, so existing setups are
  unaffected.
- I considered making the timeout an env / CLI flag but a 120s ceiling
  feels like a reasonable hard limit (a daemon that can't reply in
  120s is genuinely broken, not slow). Happy to add a CLI flag if the
  maintainer prefers.
- Tested manually on the hardware described. No automated test exists
  for this path so I haven't added one.

Related: this is the second of three layered issues I hit getting
DFlash to run via `scripts/server.py` on consumer Blackwell mobile
(the others — HAMi-core memory limit parsing and drafter-format
detection — are upstream of this repo).