### PR TITLE
bench(dflash): add multi-GPU target layer-split harness

### DIFF
--- a/dflash/README.md
+++ b/dflash/README.md
@@ -95,6 +95,30 @@ DFLASH27B_KV_K=q8_0 DFLASH27B_KV_V=q4_0 ./test_dflash …
 ./test_dflash … --cache-type-k=q8_0 --cache-type-v=q4_0
 ```
 
+**Target layer-split harness on `test_dflash`:**
+```bash
+./test_dflash target.gguf draft.safetensors prompt.bin 128 out.bin \
+  --target-gpus=1,2,3,4 --target-layer-split=1,1,1,1
+
+./test_dflash target.gguf draft.safetensors prompt.bin 128 out.bin \
+  --draft-gpu=0 --target-gpus=0,1 --target-layer-split=1,3 \
+  --target-split-load-draft
+
+./test_dflash target.gguf draft.gguf prompt.bin 128 out.bin \
+  --draft-gpu=0 --target-gpus=0,1 --target-layer-split=1,1 \
+  --target-split-dflash
+```
+
+When more than one target GPU is listed, `test_dflash` runs a non-daemon
+target-only layer-split harness. Each target GPU loads only its assigned
+contiguous layer range; `output_norm` and `output.weight` stay on the last
+target GPU. `--target-split-load-draft` additionally loads the DFlash draft
+on `--draft-gpu` (`.safetensors` or quantized draft `.gguf`), captures target
+features into a draft-side mirror, and runs a small draft forward smoke. This
+allows capacity checks where the draft and a target layer range share one GPU
+before serving integration. `--target-split-dflash` runs the same split target
+placement through a chain DFlash decode loop and reports acceptance length.
+
 **Python flags on `scripts/run.py`, `scripts/server.py`, `scripts/server_tools.py`:**
 ```bash
 python3 scripts/run.py --ctk q8_0 --ctv q4_0 --prompt "hello"

--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -178,33 +178,35 @@ PROMPTS = [
 ]
 
 
-def _find_safetensors(root: Path) -> str | None:
+def _find_draft_file(root: Path) -> str | None:
     if root.is_file():
-        return str(root)
+        return str(root) if root.suffix in (".safetensors", ".gguf") else None
     if not root.is_dir():
         return None
     for st in root.rglob("model.safetensors"):
         return str(st)
+    for gguf in root.rglob("*.gguf"):
+        return str(gguf)
     return None
 
 
 def _resolve_draft() -> str:
     env = os.environ.get("DFLASH_DRAFT")
     if env:
-        found = _find_safetensors(Path(env))
+        found = _find_draft_file(Path(env))
         if found:
             return found
-        raise FileNotFoundError(f"DFLASH_DRAFT does not point to model.safetensors: {env}")
+        raise FileNotFoundError(f"DFLASH_DRAFT does not point to a draft file: {env}")
 
     for candidate in (_LOCAL_DRAFT_FILE, _LOCAL_DRAFT_ROOT):
-        found = _find_safetensors(candidate)
+        found = _find_draft_file(candidate)
         if found:
             return found
 
     raise FileNotFoundError(
-        "draft model.safetensors not found. Expected one of:\n"
+        "draft model file not found. Expected one of:\n"
         f"  - {_LOCAL_DRAFT_FILE}\n"
-        "Download it as documented in the README, or set DFLASH_DRAFT to an explicit file or directory."
+        "Download it as documented in the README, or set DFLASH_DRAFT to an explicit .safetensors/.gguf file or directory."
     )
 
 
@@ -259,17 +261,37 @@ def run_test_dflash(prompt_path: Path, n_gen: int, fast_rollback: bool,
         print("STDERR:", r.stderr[-2000:])
         raise RuntimeError(f"test_dflash exited {r.returncode}")
 
-    # Parse output
+    # Parse output. The target layer-split harness prints both prefill and
+    # decode lines, so avoid the older "first tok/s wins" regexp there.
     out = r.stdout
+    m_prefill = re.search(
+        r"\[target-split\] prefill tokens=(\d+) time=(\d+(?:\.\d+)?) s speed=(\d+(?:\.\d+)?) tok/s",
+        out,
+    )
+    m_decode_split = re.search(
+        r"\[target-split-dflash\] decode tokens=(\d+) time=(\d+(?:\.\d+)?) s speed=(\d+(?:\.\d+)?) tok/s",
+        out,
+    )
+    m_decode_default = re.search(
+        r"\[dflash\] generated \d+ tokens in \d+(?:\.\d+)? s\s+->\s+(\d+(?:\.\d+)?) tok/s",
+        out,
+    )
     m_tps = re.search(r"(\d+(?:\.\d+)?)\s+tok/s", out)
     m_commit = re.search(r"avg commit/step=(\d+(?:\.\d+)?)", out)
     m_accept = re.search(r"accepted=(\d+)/(\d+) \((\d+(?:\.\d+)?)%", out)
     m_steps = re.search(r"(\d+) draft steps", out)
-    if not (m_tps and m_commit and m_accept and m_steps):
+    if not ((m_decode_split or m_decode_default or m_tps) and m_commit and m_accept and m_steps):
         print("STDOUT tail:", out[-2000:])
         raise RuntimeError("failed to parse output")
+    if m_decode_split:
+        tok_s = float(m_decode_split.group(3))
+    elif m_decode_default:
+        tok_s = float(m_decode_default.group(1))
+    else:
+        tok_s = float(m_tps.group(1))
     return {
-        "tok_s": float(m_tps.group(1)),
+        "tok_s": tok_s,
+        "prefill_tok_s": float(m_prefill.group(3)) if m_prefill else None,
         "commit_per_step": float(m_commit.group(1)),
         "accepted": int(m_accept.group(1)),
         "total_draft_pos": int(m_accept.group(2)),
@@ -300,6 +322,18 @@ def main():
                     help="Visible CUDA device id for the target backend")
     ap.add_argument("--draft-gpu", type=int, default=None,
                     help="Visible CUDA device id for the draft backend")
+    ap.add_argument("--target-gpus", default=None,
+                    help="Comma-separated target GPU ids for the layer-split harness")
+    ap.add_argument("--target-layer-split", default=None,
+                    help="Comma-separated layer split weights matching --target-gpus")
+    ap.add_argument("--target-split-load-draft", action="store_true",
+                    help="Load the draft alongside the target layer-split harness")
+    ap.add_argument("--target-split-dflash", action="store_true",
+                    help="Run chain DFlash decode through the target layer-split harness")
+    ap.add_argument("--max-ctx", type=int, default=None,
+                    help="Forward --max-ctx=N to test_dflash")
+    ap.add_argument("--prefill-ubatch", type=int, default=None,
+                    help="Set DFLASH27B_PREFILL_UBATCH for target split prefill")
     ap.add_argument("--cuda-visible-devices", default=None,
                     help="Optional CUDA_VISIBLE_DEVICES override for test_dflash")
     ap.add_argument("--target-tokenizer",
@@ -341,8 +375,8 @@ def main():
         print(f"[bench] skipping tokenize (reusing {_prompt_path(0, tok_slug).parent})")
 
     print(f"\n[bench] mode={args.mode}  n_gen={args.n_gen}")
-    print(f"{'prompt':28s}  {'steps':>6s} {'AL':>6s} {'pct%':>6s} {'tok/s':>8s}")
-    print("-" * 62)
+    print(f"{'prompt':28s}  {'steps':>6s} {'AL':>6s} {'pct%':>6s} {'prefill':>8s} {'decode':>8s}")
+    print("-" * 72)
 
     extra_args = []
     if args.draft_feature_mirror:
@@ -351,17 +385,29 @@ def main():
         extra_args.append(f"--target-gpu={args.target_gpu}")
     if args.draft_gpu is not None:
         extra_args.append(f"--draft-gpu={args.draft_gpu}")
+    if args.target_gpus:
+        extra_args.append(f"--target-gpus={args.target_gpus}")
+    if args.target_layer_split:
+        extra_args.append(f"--target-layer-split={args.target_layer_split}")
+    if args.target_split_load_draft:
+        extra_args.append("--target-split-load-draft")
+    if args.target_split_dflash:
+        extra_args.append("--target-split-dflash")
+    if args.max_ctx is not None:
+        extra_args.append(f"--max-ctx={args.max_ctx}")
 
     extra_env = {}
     if args.cuda_visible_devices:
         extra_env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+    if args.prefill_ubatch is not None:
+        extra_env["DFLASH27B_PREFILL_UBATCH"] = str(args.prefill_ubatch)
 
     results = []
     for i, (name, _) in enumerate(PROMPTS):
         path = _prompt_path(i, tok_slug)
         try:
             r = run_test_dflash(path, args.n_gen,
-                                fast_rollback=(args.mode == "fast"),
+                                fast_rollback=(args.mode == "fast" and not args.target_split_dflash),
                                 ddtree_budget=args.ddtree_budget,
                                 ddtree_temp=args.ddtree_temp,
                                 ddtree_no_chain_seed=args.ddtree_no_chain_seed,
@@ -371,9 +417,10 @@ def main():
             print(f"  [{i:02d}] {name:26s}  FAILED: {e}")
             continue
         results.append((name, r))
+        prefill_s = f"{r['prefill_tok_s']:8.2f}" if r["prefill_tok_s"] is not None else f"{'n/a':>8s}"
         print(
             f"  {name:26s}  {r['steps']:6d} {r['commit_per_step']:6.2f} "
-            f"{r['pct']:6.1f} {r['tok_s']:8.2f}"
+            f"{r['pct']:6.1f} {prefill_s} {r['tok_s']:8.2f}"
         )
 
     if not results:
@@ -384,9 +431,12 @@ def main():
     mean_al = sum(r["commit_per_step"] for _, r in results) / n
     mean_tps = sum(r["tok_s"] for _, r in results) / n
     mean_pct = sum(r["pct"] for _, r in results) / n
+    prefill_vals = [r["prefill_tok_s"] for _, r in results if r["prefill_tok_s"] is not None]
+    mean_prefill = sum(prefill_vals) / len(prefill_vals) if prefill_vals else None
 
-    print("-" * 62)
-    print(f"{'MEAN':28s}  {'':6s} {mean_al:6.2f} {mean_pct:6.1f} {mean_tps:8.2f}")
+    print("-" * 72)
+    prefill_s = f"{mean_prefill:8.2f}" if mean_prefill is not None else f"{'n/a':>8s}"
+    print(f"{'MEAN':28s}  {'':6s} {mean_al:6.2f} {mean_pct:6.1f} {prefill_s} {mean_tps:8.2f}")
     print()
     print(f"commit/step range: {min(r['commit_per_step'] for _,r in results):.2f} - "
           f"{max(r['commit_per_step'] for _,r in results):.2f}")

--- a/dflash/src/gguf_draft_loader.cpp
+++ b/dflash/src/gguf_draft_loader.cpp
@@ -6,10 +6,12 @@
 // types — ggml's ggml_mul_mat handles Q8_0 × F32 dequantization transparently.
 //
 // GGUF arch: "qwen35-dflash-draft" (from convert_dflash_to_gguf.py /
-// quantize_draft_q8.py). Tensor naming convention:
+// quantize_draft_q8.py) or the newer "dflash-draft" export. Tensor naming
+// convention:
 //
-//   dflash.fc.weight                        [5*hidden, hidden]  Q8_0 / F16
-//   dflash.hidden_norm.weight               [hidden]            F32
+//   dflash.fc.weight / dflash_fc.weight     [5*hidden, hidden]  Q8_0 / F16
+//   dflash.hidden_norm.weight /
+//   dflash_hidden_norm.weight               [hidden]            F32
 //   output_norm.weight                      [hidden]            F32
 //   blk.<i>.attn_norm.weight                [hidden]            F32
 //   blk.<i>.ffn_norm.weight                 [hidden]            F32
@@ -132,16 +134,18 @@ bool load_draft_gguf(const std::string & path,
             return false;
         }
         const char * arch = gguf_get_val_str(gctx, arch_id);
-        if (std::string(arch) != "qwen35-dflash-draft") {
+        if (std::string(arch) != "qwen35-dflash-draft" &&
+            std::string(arch) != "dflash-draft") {
             set_last_error(std::string("unexpected draft arch: ") + arch +
-                           " (expected qwen35-dflash-draft)");
+                           " (expected qwen35-dflash-draft or dflash-draft)");
             gguf_free(gctx);
             return false;
         }
     }
 
     // Read dimensions from GGUF metadata
-    const char * A = "qwen35-dflash-draft";
+    int64_t arch_id = gguf_find_key(gctx, "general.architecture");
+    const char * A = gguf_get_val_str(gctx, arch_id);
     char key[128];
 
     auto read_u32 = [&](const char * suffix, uint32_t fallback) -> uint32_t {
@@ -156,7 +160,20 @@ bool load_draft_gguf(const std::string & path,
     const uint32_t n_head_kv = read_u32("attention.head_count_kv", 0);
     const uint32_t head_dim  = read_u32("attention.key_length",    0);
     const uint32_t block_sz  = read_u32("dflash.block_size",       0);
-    const uint32_t n_tgt_lay = read_u32("dflash.n_target_layers",  0);
+    uint32_t n_tgt_lay       = read_u32("dflash.n_target_layers",  0);
+    if (n_tgt_lay == 0) {
+        const uint32_t n_tgt_feat = read_u32("dflash.n_target_features", 0);
+        if (n_tgt_feat != 0 && n_embd != 0 && (n_tgt_feat % n_embd) == 0) {
+            n_tgt_lay = n_tgt_feat / n_embd;
+        }
+    }
+    if (n_tgt_lay == 0) {
+        std::snprintf(key, sizeof(key), "%s.%s", A, "dflash.target_layer_ids");
+        int64_t id = gguf_find_key(gctx, key);
+        if (id >= 0) {
+            n_tgt_lay = (uint32_t)gguf_get_arr_n(gctx, id);
+        }
+    }
 
     if (n_embd == 0 || n_layer == 0 || n_ff == 0 || n_head == 0 ||
         n_head_kv == 0 || head_dim == 0) {
@@ -224,12 +241,16 @@ bool load_draft_gguf(const std::string & path,
         return ggml_get_tensor(meta_ctx, name);
     };
 
-    out.fc          = g("dflash.fc.weight");
-    out.hidden_norm = g("dflash.hidden_norm.weight");
+    auto first = [](ggml_tensor * a, ggml_tensor * b) -> ggml_tensor * {
+        return a ? a : b;
+    };
+
+    out.fc          = first(g("dflash.fc.weight"), g("dflash_fc.weight"));
+    out.hidden_norm = first(g("dflash.hidden_norm.weight"), g("dflash_hidden_norm.weight"));
     out.out_norm    = g("output_norm.weight");
     if (!out.fc || !out.hidden_norm || !out.out_norm) {
         set_last_error("draft GGUF: missing top-level tensors "
-                       "(dflash.fc / dflash.hidden_norm / output_norm)");
+                       "(dflash fc / dflash hidden norm / output_norm)");
         gguf_free(gctx);
         return false;
     }
@@ -242,7 +263,7 @@ bool load_draft_gguf(const std::string & path,
         };
         DraftLayer & L = out.layers[il];
         L.attn_norm = fnd("attn_norm.weight");
-        L.ffn_norm  = fnd("ffn_norm.weight");
+        L.ffn_norm  = first(fnd("ffn_norm.weight"), fnd("post_attention_norm.weight"));
         L.wq        = fnd("attn_q.weight");
         L.wk        = fnd("attn_k.weight");
         L.wv        = fnd("attn_v.weight");

--- a/dflash/src/gguf_target_loader.cpp
+++ b/dflash/src/gguf_target_loader.cpp
@@ -48,8 +48,10 @@
 #include <cinttypes>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #if !defined(_WIN32)
 #include <cerrno>
@@ -185,11 +187,61 @@ uint32_t get_u32_or(const gguf_context * g, const char * key, uint32_t fallback)
     return gguf_get_val_u32(g, id);
 }
 
+static size_t align_up_size(size_t x, size_t a) {
+    if (a == 0) return x;
+    const size_t r = x % a;
+    return r == 0 ? x : x + (a - r);
+}
+
+static bool parse_block_tensor_name(const char * name, int & layer_id) {
+    const char prefix[] = "blk.";
+    const size_t prefix_len = sizeof(prefix) - 1;
+    if (std::strncmp(name, prefix, prefix_len) != 0) return false;
+    const char * p = name + prefix_len;
+    if (*p < '0' || *p > '9') return false;
+    char * end = nullptr;
+    long v = std::strtol(p, &end, 10);
+    if (!end || *end != '.' || v < 0 || v > INT32_MAX) return false;
+    layer_id = (int)v;
+    return true;
+}
+
+static bool should_load_target_tensor(const char * name,
+                                      int layer_begin,
+                                      int layer_end,
+                                      bool load_output) {
+    if (std::strcmp(name, "token_embd.weight") == 0) return false;
+    if (std::strcmp(name, "output_norm.weight") == 0 ||
+        std::strcmp(name, "output.weight") == 0) {
+        return load_output;
+    }
+    int layer_id = -1;
+    if (parse_block_tensor_name(name, layer_id)) {
+        return layer_id >= layer_begin && layer_id < layer_end;
+    }
+    return false;
+}
+
+struct TargetTensorAlloc {
+    ggml_tensor * tensor = nullptr;
+    size_t file_offset = 0;
+    size_t file_size = 0;
+    size_t buffer_offset = 0;
+};
+
 } // namespace
 
 bool load_target_gguf(const std::string & path,
                       ggml_backend_t       backend,
                       TargetWeights &      out) {
+    TargetLoadPlan plan;
+    return load_target_gguf_partial(path, backend, plan, out);
+}
+
+bool load_target_gguf_partial(const std::string & path,
+                              ggml_backend_t       backend,
+                              const TargetLoadPlan & plan_in,
+                              TargetWeights &      out) {
 
     // ── 1. Parse metadata + create a ggml_context holding tensor descriptors ─
     ggml_context * meta_ctx = nullptr;
@@ -310,6 +362,20 @@ bool load_target_gguf(const std::string & path,
         }
     }
 
+    TargetLoadPlan plan = plan_in;
+    if (plan.layer_begin < 0) plan.layer_begin = 0;
+    if (plan.layer_end < 0) plan.layer_end = (int)n_layer;
+    if (plan.layer_begin > plan.layer_end ||
+        plan.layer_end > (int)n_layer) {
+        char buf[160];
+        std::snprintf(buf, sizeof(buf),
+            "invalid target load layer range [%d,%d) for n_layer=%u",
+            plan.layer_begin, plan.layer_end, n_layer);
+        set_last_error(buf);
+        gguf_free(gctx);
+        return false;
+    }
+
     out.ctx     = meta_ctx;
     out.backend = backend;
     out.n_layer = (int)n_layer;
@@ -425,12 +491,48 @@ bool load_target_gguf(const std::string & path,
         }
     }
 
-    // ── 3. Allocate CUDA buffer for all tensors in meta_ctx ───────────
-    out.buf = ggml_backend_alloc_ctx_tensors(meta_ctx, backend);
+    // 3. Allocate CUDA buffer only for the selected target tensors.
+    ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(backend);
+    const size_t alignment = ggml_backend_buft_get_alignment(buft);
+    std::vector<TargetTensorAlloc> allocs;
+    size_t alloc_total = 0;
+    const int64_t n_tensors = gguf_get_n_tensors(gctx);
+    for (int64_t tid = 0; tid < n_tensors; tid++) {
+        const char * tname = gguf_get_tensor_name(gctx, tid);
+        ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
+        if (!t || !should_load_target_tensor(tname, plan.layer_begin, plan.layer_end, plan.load_output)) {
+            continue;
+        }
+        alloc_total = align_up_size(alloc_total, alignment);
+        TargetTensorAlloc a;
+        a.tensor = t;
+        a.file_offset = gguf_get_data_offset(gctx) + gguf_get_tensor_offset(gctx, tid);
+        a.file_size = gguf_get_tensor_size(gctx, tid);
+        a.buffer_offset = alloc_total;
+        alloc_total += ggml_backend_buft_get_alloc_size(buft, t);
+        allocs.push_back(a);
+    }
+    if (allocs.empty()) {
+        set_last_error("target load plan selected no GPU tensors");
+        gguf_free(gctx);
+        return false;
+    }
+
+    out.buf = ggml_backend_alloc_buffer(backend, alloc_total);
     if (!out.buf) {
         set_last_error("ggml_backend_alloc_ctx_tensors failed (target)");
         gguf_free(gctx);
         return false;
+    }
+    ggml_backend_buffer_set_usage(out.buf, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+
+    char * base = (char *)ggml_backend_buffer_get_base(out.buf);
+    for (const TargetTensorAlloc & a : allocs) {
+        if (ggml_backend_tensor_alloc(out.buf, a.tensor, base + a.buffer_offset) != GGML_STATUS_SUCCESS) {
+            set_last_error("ggml_backend_tensor_alloc failed (target)");
+            gguf_free(gctx);
+            return false;
+        }
     }
 
     // ── 4. mmap the file and copy tensor bytes to CUDA ────────────────
@@ -441,7 +543,6 @@ bool load_target_gguf(const std::string & path,
     Mmap mm;
     if (!mm.open_ro(path, err)) { set_last_error(err); gguf_free(gctx); return false; }
     const size_t data_start = gguf_get_data_offset(gctx);
-    const int64_t n_tensors = gguf_get_n_tensors(gctx);
 
     size_t total = 0;
     size_t tok_embd_off = 0, tok_embd_sz = 0;
@@ -462,6 +563,9 @@ bool load_target_gguf(const std::string & path,
             tok_embd_off  = off;
             tok_embd_sz   = sz;
             tok_embd_type = gguf_get_tensor_type(gctx, tid);
+            continue;
+        }
+        if (!should_load_target_tensor(tname, plan.layer_begin, plan.layer_end, plan.load_output)) {
             continue;
         }
         ggml_backend_tensor_set(t, (const uint8_t *)mm.addr + off, 0, sz);
@@ -495,8 +599,9 @@ bool load_target_gguf(const std::string & path,
     // Stash the total for callers that want to print it
     char summary[192];
     std::snprintf(summary, sizeof(summary),
-        "target loaded: %" PRId64 " tensors on GPU %.2f GiB, tok_embd %.0f MiB CPU-only (%s)",
-        n_tensors, total / (1024.0 * 1024.0 * 1024.0),
+        "target loaded: layers [%d,%d) output=%d, %zu tensors on GPU %.2f GiB, tok_embd %.0f MiB CPU-only (%s)",
+        plan.layer_begin, plan.layer_end, (int)plan.load_output, allocs.size(),
+        total / (1024.0 * 1024.0 * 1024.0),
         tok_embd_sz / (1024.0 * 1024.0), ggml_type_name(tok_embd_type));
     set_last_error(summary);
 

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -141,11 +141,22 @@ struct TargetWeights {
     int capture_layer_ids[DFLASH27B_DRAFT_N_TARGET_LAYERS] = {1, 16, 31, 46, 61};
 };
 
+struct TargetLoadPlan {
+    int  layer_begin = 0;     // inclusive
+    int  layer_end   = -1;    // exclusive; <0 means all layers
+    bool load_output = true;  // output_norm + lm_head
+};
+
 // Load a Q4_K_M target model from a GGUF file on disk.
 // Returns false and sets last_error on failure.
 bool load_target_gguf(const std::string & path,
                       ggml_backend_t backend,
                       TargetWeights & out);
+
+bool load_target_gguf_partial(const std::string & path,
+                              ggml_backend_t backend,
+                              const TargetLoadPlan & plan,
+                              TargetWeights & out);
 
 void free_target_weights(TargetWeights & w);
 
@@ -368,6 +379,16 @@ bool create_target_cache(const TargetWeights & w,
                          ggml_backend_t backend,
                          TargetCache & out,
                          bool prefill_only = false);
+
+bool create_target_cache_partial(const TargetWeights & w,
+                                 int max_ctx,
+                                 int max_verify_tokens,
+                                 ggml_backend_t backend,
+                                 TargetCache & out,
+                                 bool prefill_only,
+                                 int layer_begin,
+                                 int layer_end,
+                                 bool allocate_target_feat);
 
 void free_target_cache(TargetCache & c);
 

--- a/dflash/src/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35_target_graph.cpp
@@ -43,6 +43,26 @@ bool create_target_cache(const TargetWeights & w,
                          ggml_backend_t backend,
                          TargetCache & out,
                          bool prefill_only) {
+    return create_target_cache_partial(w, max_ctx, max_verify_tokens, backend,
+                                       out, prefill_only,
+                                       0, w.n_layer, true);
+}
+
+bool create_target_cache_partial(const TargetWeights & w,
+                                 int max_ctx,
+                                 int max_verify_tokens,
+                                 ggml_backend_t backend,
+                                 TargetCache & out,
+                                 bool prefill_only,
+                                 int layer_begin,
+                                 int layer_end,
+                                 bool allocate_target_feat) {
+    if (layer_begin < 0) layer_begin = 0;
+    if (layer_end < 0 || layer_end > w.n_layer) layer_end = w.n_layer;
+    if (layer_begin > layer_end) {
+        set_last_error("invalid target cache layer range");
+        return false;
+    }
     out.backend = backend;
     out.max_ctx = max_ctx;
     out.cur_pos = 0;
@@ -88,7 +108,9 @@ bool create_target_cache(const TargetWeights & w,
         const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
         for (int il = 0; il < w.n_layer; il++) {
             const bool is_attn = (((il + 1) % w.full_attention_interval) == 0);
+            const bool owns_layer = il >= layer_begin && il < layer_end;
             if (is_attn) {
+                if (!owns_layer) { fa_idx++; continue; }
                 // [head_dim, max_ctx_alloc, n_head_kv]
                 ggml_tensor * K = ggml_new_tensor_3d(out.base_ctx, kv_k_type,
                                                      head_dim, max_ctx_alloc, w.n_head_kv);
@@ -103,6 +125,7 @@ bool create_target_cache(const TargetWeights & w,
                 out.attn_v[fa_idx] = V;
                 fa_idx++;
             } else {
+                if (!owns_layer) { dn_idx++; continue; }
                 // ssm_state: [head_v_dim, head_v_dim, num_v_heads]
                 ggml_tensor * S = ggml_new_tensor_3d(out.base_ctx, GGML_TYPE_F32,
                                                      head_v_dim, head_v_dim, w.ssm_dt_rank);
@@ -120,9 +143,13 @@ bool create_target_cache(const TargetWeights & w,
 
         constexpr int TARGET_FEAT_CAP_DEFAULT = 4096;
         out.target_feat_cap = std::min(max_ctx, TARGET_FEAT_CAP_DEFAULT);
-        const int fc_in = DFLASH27B_DRAFT_N_TARGET_LAYERS * w.n_embd;  // 25600
-        out.target_feat = ggml_new_tensor_2d(out.base_ctx, GGML_TYPE_BF16, fc_in, out.target_feat_cap);
-        ggml_set_name(out.target_feat, "target_feat");
+        if (allocate_target_feat) {
+            const int fc_in = DFLASH27B_DRAFT_N_TARGET_LAYERS * w.n_embd;  // 25600
+            out.target_feat = ggml_new_tensor_2d(out.base_ctx, GGML_TYPE_BF16, fc_in, out.target_feat_cap);
+            ggml_set_name(out.target_feat, "target_feat");
+        } else {
+            out.target_feat = nullptr;
+        }
 
         out.base_buf = ggml_backend_alloc_ctx_tensors(out.base_ctx, backend);
         if (!out.base_buf) {
@@ -148,6 +175,8 @@ bool create_target_cache(const TargetWeights & w,
         const int conv_channels = w.ssm_d_inner + 2 * w.ssm_n_group * w.ssm_d_state;
         for (int il = 0; il < w.n_layer; il++) {
             if (((il + 1) % w.full_attention_interval) != 0) {
+                const bool owns_layer = il >= layer_begin && il < layer_end;
+                if (!owns_layer) { dn_idx++; continue; }
                 ggml_tensor * Sn = ggml_new_tensor_3d(out.rollback_ctx, GGML_TYPE_F32,
                                                        head_v_dim, head_v_dim, w.ssm_dt_rank);
                 ggml_tensor * Cn = ggml_new_tensor_2d(out.rollback_ctx, GGML_TYPE_F32,
@@ -327,14 +356,18 @@ bool migrate_prefill_cache(const TargetWeights & w,
 // tensor copy (ggml_backend_tensor_copy). Called outside of any compute graph.
 void snapshot_ssm_state(TargetCache & c) {
     for (size_t i = 0; i < c.ssm_state.size(); i++) {
+        if (!c.ssm_state[i] || !c.ssm_state_snap[i]) continue;
         ggml_backend_tensor_copy(c.ssm_state[i], c.ssm_state_snap[i]);
+        if (!c.conv_state[i] || !c.conv_state_snap[i]) continue;
         ggml_backend_tensor_copy(c.conv_state[i], c.conv_state_snap[i]);
     }
 }
 
 void restore_ssm_state(TargetCache & c) {
     for (size_t i = 0; i < c.ssm_state.size(); i++) {
+        if (!c.ssm_state_snap[i] || !c.ssm_state[i]) continue;
         ggml_backend_tensor_copy(c.ssm_state_snap[i], c.ssm_state[i]);
+        if (!c.conv_state_snap[i] || !c.conv_state[i]) continue;
         ggml_backend_tensor_copy(c.conv_state_snap[i], c.conv_state[i]);
     }
 }

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -1059,12 +1059,909 @@ static bool build_lm_head_projection_step(
     sg.logits = ggml_mul_mat(sg.ctx, w.output, sg.hidden_input);
     ggml_set_name(sg.logits, "draft_projected_logits");
     ggml_set_output(sg.logits);
-    ggml_build_forward_expand(sg.gf, sg.logits);
+    sg.argmax_tokens = ggml_argmax(sg.ctx, sg.logits);
+    ggml_set_name(sg.argmax_tokens, "draft_projected_argmax");
+    ggml_set_output(sg.argmax_tokens);
+    ggml_build_forward_expand(sg.gf, sg.argmax_tokens);
 
     if (!sg.alloc) {
         sg.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
     }
     return ggml_gallocr_alloc_graph(sg.alloc, sg.gf);
+}
+
+struct TargetLayerSplitShard {
+    int gpu = 0;
+    int layer_begin = 0;
+    int layer_end = 0;
+    ggml_backend_t backend = nullptr;
+    TargetWeights weights;
+    TargetCache cache;
+    StepGraph layer_graph;
+};
+
+struct ActivationPair {
+    ggml_context * ctx = nullptr;
+    ggml_backend_buffer_t buf = nullptr;
+    ggml_tensor * a = nullptr;
+    ggml_tensor * b = nullptr;
+    ggml_backend_t backend = nullptr;
+    int n_tokens = 0;
+};
+
+static void activation_pair_free(ActivationPair & p) {
+    if (p.buf) { ggml_backend_buffer_free(p.buf); p.buf = nullptr; }
+    if (p.ctx) { ggml_free(p.ctx); p.ctx = nullptr; }
+    p.a = nullptr;
+    p.b = nullptr;
+    p.backend = nullptr;
+    p.n_tokens = 0;
+}
+
+static bool activation_pair_init(ActivationPair & p,
+                                 ggml_backend_t backend,
+                                 int hidden,
+                                 int n_tokens) {
+    activation_pair_free(p);
+    if (n_tokens <= 0) return false;
+    p.backend = backend;
+    p.n_tokens = n_tokens;
+    ggml_init_params ip{};
+    ip.mem_size = (size_t)8 * ggml_tensor_overhead() + 16 * 1024;
+    ip.mem_buffer = nullptr;
+    ip.no_alloc = true;
+    p.ctx = ggml_init(ip);
+    if (!p.ctx) return false;
+    p.a = ggml_new_tensor_2d(p.ctx, GGML_TYPE_F32, hidden, n_tokens);
+    p.b = ggml_new_tensor_2d(p.ctx, GGML_TYPE_F32, hidden, n_tokens);
+    ggml_set_name(p.a, "target_split_act_a");
+    ggml_set_name(p.b, "target_split_act_b");
+    p.buf = ggml_backend_alloc_ctx_tensors(p.ctx, backend);
+    if (!p.buf) {
+        activation_pair_free(p);
+        return false;
+    }
+    return true;
+}
+
+static bool parse_int_list(const char * text, std::vector<int> & out) {
+    out.clear();
+    if (!text || !*text) return false;
+    const char * p = text;
+    while (*p) {
+        char * end = nullptr;
+        long v = std::strtol(p, &end, 10);
+        if (end == p || v < 0 || v > INT32_MAX) return false;
+        out.push_back((int)v);
+        if (*end == '\0') break;
+        if (*end != ',') return false;
+        p = end + 1;
+    }
+    return !out.empty();
+}
+
+static bool parse_float_list(const char * text, std::vector<double> & out) {
+    out.clear();
+    if (!text || !*text) return false;
+    const char * p = text;
+    while (*p) {
+        char * end = nullptr;
+        double v = std::strtod(p, &end);
+        if (end == p || v <= 0.0) return false;
+        out.push_back(v);
+        if (*end == '\0') break;
+        if (*end != ',') return false;
+        p = end + 1;
+    }
+    return !out.empty();
+}
+
+static int inspect_target_layer_count(const char * target_path) {
+    ggml_context * meta_ctx = nullptr;
+    gguf_init_params gip{};
+    gip.no_alloc = true;
+    gip.ctx = &meta_ctx;
+    gguf_context * gctx = gguf_init_from_file(target_path, gip);
+    if (!gctx) return -1;
+    int64_t id = gguf_find_key(gctx, "qwen35.block_count");
+    int n_layer = id >= 0 ? (int)gguf_get_val_u32(gctx, id) : -1;
+    gguf_free(gctx);
+    if (meta_ctx) ggml_free(meta_ctx);
+    return n_layer;
+}
+
+static std::vector<std::pair<int, int>> compute_layer_ranges(
+        int n_layer,
+        int n_shards,
+        const std::vector<double> & weights) {
+    std::vector<std::pair<int, int>> ranges;
+    if (n_layer <= 0 || n_shards <= 0 || n_shards > n_layer) return ranges;
+    std::vector<double> w = weights;
+    if (w.empty()) w.assign((size_t)n_shards, 1.0);
+    if ((int)w.size() != n_shards) return ranges;
+    double sum = 0.0;
+    for (double v : w) sum += v;
+    if (sum <= 0.0) return ranges;
+    ranges.reserve((size_t)n_shards);
+    int begin = 0;
+    double accum = 0.0;
+    for (int i = 0; i < n_shards; i++) {
+        accum += w[i];
+        int end = (i == n_shards - 1)
+            ? n_layer
+            : (int)std::llround((accum / sum) * n_layer);
+        const int min_end = begin + 1;
+        const int max_end = n_layer - (n_shards - i - 1);
+        end = std::max(min_end, std::min(max_end, end));
+        ranges.push_back({begin, end});
+        begin = end;
+    }
+    return ranges;
+}
+
+static TargetLayerSplitShard * find_target_shard(
+        std::vector<TargetLayerSplitShard> & shards,
+        int layer_idx) {
+    for (auto & shard : shards) {
+        if (layer_idx >= shard.layer_begin && layer_idx < shard.layer_end) {
+            return &shard;
+        }
+    }
+    return nullptr;
+}
+
+static int target_capture_index(const TargetWeights & w, int layer_idx) {
+    for (int k = 0; k < DFLASH27B_DRAFT_N_TARGET_LAYERS; k++) {
+        if (w.capture_layer_ids[k] == layer_idx) return k;
+    }
+    return -1;
+}
+
+static bool copy_capture_slice_to_draft_ring(
+        DraftFeatureMirror & feature_ring,
+        int capture_idx,
+        const ggml_tensor * act_out,
+        int src_device,
+        int chunk_start,
+        int start_pos,
+        int n_tokens) {
+    if (!feature_ring.target_feat || capture_idx < 0 || n_tokens <= 0) return true;
+    if (feature_ring.cap <= 0) return false;
+    const int hidden = DFLASH27B_TARGET_HIDDEN;
+    const size_t dst_stride = feature_ring.target_feat->nb[1];
+    const size_t src_stride = act_out->nb[1];
+    const size_t row_bytes = (size_t)hidden * sizeof(float);
+    for (int i = 0; i < n_tokens; i++) {
+        const int slot = (start_pos + i) % feature_ring.cap;
+        const void * src = (const char *)act_out->data +
+            (size_t)(chunk_start + i) * src_stride;
+        void * dst = (char *)feature_ring.target_feat->data +
+            (size_t)slot * dst_stride +
+            (size_t)capture_idx * (size_t)hidden * sizeof(float);
+        if (!copy_peer_async(dst, feature_ring.device, src, src_device, row_bytes)) {
+            return false;
+        }
+    }
+    return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+static bool copy_feature_ring_range_to_tensor(
+        const DraftFeatureMirror & feature_ring,
+        ggml_tensor * dst,
+        int start_pos,
+        int n_tokens) {
+    if (!feature_ring.target_feat || !dst || feature_ring.cap <= 0) return false;
+    if (n_tokens <= 0 || n_tokens > feature_ring.cap) return false;
+
+    const int fc_in = DFLASH27B_DRAFT_N_TARGET_LAYERS * DFLASH27B_TARGET_HIDDEN;
+    const size_t row_bytes = (size_t)fc_in * sizeof(float);
+    const size_t src_stride = feature_ring.target_feat->nb[1];
+    const size_t dst_stride = dst->nb[1];
+    int done = 0;
+    while (done < n_tokens) {
+        const int slot = (start_pos + done) % feature_ring.cap;
+        const int run = std::min(n_tokens - done, feature_ring.cap - slot);
+        const char * src_base =
+            (const char *)feature_ring.target_feat->data + (size_t)slot * src_stride;
+        char * dst_base = (char *)dst->data + (size_t)done * dst_stride;
+        if (src_stride == row_bytes && dst_stride == row_bytes) {
+            if (!copy_peer_async(dst_base, feature_ring.device,
+                                 src_base, feature_ring.device,
+                                 row_bytes * (size_t)run)) {
+                return false;
+            }
+        } else {
+            for (int i = 0; i < run; i++) {
+                if (!copy_peer_async(dst_base + (size_t)i * dst_stride,
+                                     feature_ring.device,
+                                     src_base + (size_t)i * src_stride,
+                                     feature_ring.device,
+                                     row_bytes)) {
+                    return false;
+                }
+            }
+        }
+        done += run;
+    }
+    return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+static bool compute_target_split_argmax(
+        StepGraph & sg,
+        const TargetWeights & w,
+        ggml_backend_t backend,
+        ggml_tensor * act,
+        int n_tokens,
+        int hidden,
+        int vocab,
+        std::vector<int32_t> & argmax_out) {
+    step_graph_free(sg);
+    ggml_init_params ip{};
+    ip.mem_size = 256 * 1024 * 1024;
+    ip.mem_buffer = nullptr;
+    ip.no_alloc = true;
+    sg.ctx = ggml_init(ip);
+    if (!sg.ctx) return false;
+
+    ggml_tensor * act_view = ggml_view_2d(
+        sg.ctx, act, hidden, n_tokens, act->nb[1], 0);
+    ggml_tensor * normed = ggml_rms_norm(sg.ctx, act_view, DFLASH27B_RMS_EPS);
+    normed = ggml_mul(sg.ctx, normed, w.out_norm);
+    ggml_tensor * logits = ggml_mul_mat(sg.ctx, w.output, normed);
+    ggml_set_name(logits, "target_split_logits");
+    sg.logits = logits;
+    sg.argmax_tokens = ggml_argmax(sg.ctx, logits);
+    ggml_set_name(sg.argmax_tokens, "target_split_argmax");
+    ggml_set_output(sg.argmax_tokens);
+    sg.gf = ggml_new_graph_custom(sg.ctx, 1024, false);
+    ggml_build_forward_expand(sg.gf, sg.argmax_tokens);
+    if (!sg.alloc) {
+        sg.alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    }
+    if (!ggml_gallocr_alloc_graph(sg.alloc, sg.gf)) return false;
+    auto st = ggml_backend_graph_compute(backend, sg.gf);
+    if (st != GGML_STATUS_SUCCESS) return false;
+    (void)vocab;
+    argmax_out.assign((size_t)n_tokens, 0);
+    ggml_backend_tensor_get(sg.argmax_tokens, argmax_out.data(), 0,
+                            sizeof(int32_t) * (size_t)n_tokens);
+    return true;
+}
+
+static bool run_target_layer_split_forward(
+        std::vector<TargetLayerSplitShard> & shards,
+        const TargetWeights & embed_source,
+        const std::vector<int32_t> & tokens,
+        int base_pos,
+        int ubatch,
+        int & last_tok,
+        DraftFeatureMirror * feature_ring = nullptr,
+        std::vector<int32_t> * argmax_out = nullptr,
+        std::vector<float> * logits_out = nullptr) {
+    if (shards.empty() || tokens.empty()) return false;
+    const int hidden = DFLASH27B_TARGET_HIDDEN;
+    const int vocab = DFLASH27B_TARGET_VOCAB;
+    const int n_tokens_total = (int)tokens.size();
+    ubatch = std::max(1, ubatch);
+
+    ActivationPair acts;
+    if (!activation_pair_init(acts, shards.front().backend, hidden, n_tokens_total)) {
+        std::fprintf(stderr, "target-split activation alloc failed on gpu %d\n", shards.front().gpu);
+        return false;
+    }
+    ggml_tensor * act_in = acts.a;
+    ggml_tensor * act_out = acts.b;
+
+    {
+        const int EMBED_BATCH = 4096;
+        std::vector<float> emb_buf((size_t)hidden * std::min(EMBED_BATCH, n_tokens_total));
+        for (int i = 0; i < n_tokens_total; i += EMBED_BATCH) {
+            const int n = std::min(EMBED_BATCH, n_tokens_total - i);
+            if ((int)emb_buf.size() < hidden * n) emb_buf.resize((size_t)hidden * n);
+            if (!embed_source.embedder.embed(tokens.data() + i, n, emb_buf.data())) {
+                activation_pair_free(acts);
+                return false;
+            }
+            ggml_backend_tensor_set(act_in, emb_buf.data(),
+                                    (size_t)i * act_in->nb[1],
+                                    sizeof(float) * (size_t)hidden * n);
+        }
+    }
+
+    TargetLayerSplitShard * current_shard = &shards.front();
+    std::vector<uint16_t> mask_buf;
+    std::vector<int32_t> pos_buf;
+    for (int il = 0; il < embed_source.n_layer; il++) {
+        TargetLayerSplitShard * shard = find_target_shard(shards, il);
+        if (!shard) {
+            std::fprintf(stderr, "target-split missing owner for layer %d\n", il);
+            activation_pair_free(acts);
+            return false;
+        }
+        if (shard != current_shard) {
+            ActivationPair next_acts;
+            if (!activation_pair_init(next_acts, shard->backend, hidden, n_tokens_total)) {
+                std::fprintf(stderr, "target-split activation alloc failed on gpu %d\n", shard->gpu);
+                activation_pair_free(acts);
+                return false;
+            }
+            ggml_backend_synchronize(current_shard->backend);
+            ggml_backend_tensor_copy(act_in, next_acts.a);
+            ggml_backend_synchronize(shard->backend);
+            activation_pair_free(acts);
+            acts = next_acts;
+            act_in = acts.a;
+            act_out = acts.b;
+            current_shard = shard;
+        }
+
+        const bool is_attn = (((il + 1) % embed_source.full_attention_interval) == 0);
+        const int capture_idx = target_capture_index(embed_source, il);
+        for (int start = 0; start < n_tokens_total; start += ubatch) {
+            const int n = std::min(ubatch, n_tokens_total - start);
+            const int kv_start = base_pos + start;
+            const int kv_len = kv_start + n;
+            const bool with_mask = (g_kq_stride_pad > KQ_MASK_PAD) || (n > 1);
+            if (!build_layer_step(shard->layer_graph, shard->weights, shard->cache,
+                                  shard->backend, il, act_in, act_out,
+                                  start, n, kv_start, with_mask,
+                                  /*capture=*/false, g_fa_window)) {
+                std::fprintf(stderr, "target-split build layer=%d @%d gpu=%d\n",
+                             il, start, shard->gpu);
+                activation_pair_free(acts);
+                return false;
+            }
+            if (is_attn && shard->layer_graph.positions) {
+                pos_buf.assign((size_t)4 * n, 0);
+                for (int i = 0; i < n; i++) {
+                    const int p = kv_start + i;
+                    pos_buf[0 * n + i] = p;
+                    pos_buf[1 * n + i] = p;
+                    pos_buf[2 * n + i] = p;
+                    pos_buf[3 * n + i] = 0;
+                }
+                ggml_backend_tensor_set(shard->layer_graph.positions, pos_buf.data(), 0,
+                                        sizeof(int32_t) * pos_buf.size());
+            }
+            if (is_attn && with_mask && shard->layer_graph.attn_mask) {
+                const int win_start_l = (g_fa_window > 0 && kv_start > g_fa_window)
+                                            ? (kv_start - g_fa_window) : 0;
+                const int win_len_l = kv_len - win_start_l;
+                build_causal_mask(mask_buf, win_len_l, n, kv_start, win_start_l);
+                ggml_backend_tensor_set(shard->layer_graph.attn_mask, mask_buf.data(), 0,
+                                        sizeof(uint16_t) * mask_buf.size());
+            }
+            auto st = ggml_backend_graph_compute(shard->backend, shard->layer_graph.gf);
+            if (st != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr, "target-split compute layer=%d @%d gpu=%d status=%d\n",
+                             il, start, shard->gpu, (int)st);
+                activation_pair_free(acts);
+                return false;
+            }
+            if (feature_ring && capture_idx >= 0) {
+                if (!copy_capture_slice_to_draft_ring(*feature_ring, capture_idx,
+                                                      act_out, shard->gpu,
+                                                      start, base_pos + start, n)) {
+                    std::fprintf(stderr,
+                                 "target-split capture copy failed layer=%d capture=%d gpu=%d\n",
+                                 il, capture_idx, shard->gpu);
+                    activation_pair_free(acts);
+                    return false;
+                }
+            }
+        }
+        std::swap(act_in, act_out);
+    }
+
+    StepGraph final_sg;
+    std::vector<int32_t> argmax_tokens;
+    TargetLayerSplitShard & last_shard = shards.back();
+    const bool ok = compute_target_split_argmax(
+        final_sg, last_shard.weights, last_shard.backend, act_in,
+        n_tokens_total, hidden, vocab, argmax_tokens);
+    step_graph_destroy(final_sg);
+    activation_pair_free(acts);
+    if (!ok) return false;
+    last_tok = argmax_tokens.empty() ? -1 : argmax_tokens.back();
+    if (argmax_out) *argmax_out = std::move(argmax_tokens);
+    if (logits_out) logits_out->clear();
+    return true;
+}
+
+static void free_target_layer_split_shards(std::vector<TargetLayerSplitShard> & shards) {
+    for (auto & shard : shards) {
+        step_graph_destroy(shard.layer_graph);
+        free_target_cache(shard.cache);
+        free_target_weights(shard.weights);
+        if (shard.backend) {
+            ggml_backend_free(shard.backend);
+            shard.backend = nullptr;
+        }
+    }
+    shards.clear();
+}
+
+static bool run_target_layer_split_dflash_decode(
+        std::vector<TargetLayerSplitShard> & shards,
+        DraftWeights & draft_weights,
+        ggml_backend_t draft_backend,
+        int draft_gpu,
+        DraftFeatureMirror & feature_ring,
+        const std::vector<int32_t> & prompt,
+        int n_gen,
+        int last_tok,
+        const char * out_path) {
+    if (shards.empty() || !feature_ring.target_feat) return false;
+    const int hidden = DFLASH27B_TARGET_HIDDEN;
+    const int vocab = DFLASH27B_TARGET_VOCAB;
+    const int q_len = DFLASH27B_DRAFT_BLOCK_SIZE;
+    const int output_gpu = shards.back().gpu;
+    ggml_backend_t output_backend = shards.back().backend;
+
+    StepGraph draft_sg;
+    StepGraph proj_sg;
+    std::vector<float> noise_embed((size_t)hidden * q_len);
+    std::vector<int32_t> noise_ids(q_len);
+    std::vector<int32_t> draft_tok(q_len);
+    std::vector<int32_t> target_tok(q_len);
+    std::vector<int32_t> pos_q(q_len);
+    std::vector<int32_t> pos_k;
+    std::vector<int32_t> out_all = prompt;
+    int committed = (int)prompt.size();
+    int n_generated = 0;
+    int n_draft_steps = 0;
+    int n_accept_sum = 0;
+
+    auto sync_all = [&]() {
+        for (auto & shard : shards) ggml_backend_synchronize(shard.backend);
+        ggml_backend_synchronize(draft_backend);
+    };
+
+    auto t_dec0 = std::chrono::steady_clock::now();
+    while (n_generated < n_gen) {
+        const int need_commit_budget = n_gen - n_generated;
+
+        noise_ids[0] = last_tok;
+        for (int i = 1; i < q_len; i++) noise_ids[i] = DFLASH27B_DRAFT_MASK_TOKEN_ID;
+        if (!shards.front().weights.embedder.embed(noise_ids.data(), q_len,
+                                                   noise_embed.data())) {
+            std::fprintf(stderr, "target-split-dflash noise embed failed\n");
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+
+        constexpr int DRAFT_CTX_MAX = 2048;
+        const int draft_ctx = std::min(committed, std::min(feature_ring.cap, DRAFT_CTX_MAX));
+        const int draft_start = committed - draft_ctx;
+        int mirror_slot0 = 0;
+        const bool use_mirror_view =
+            draft_feature_mirror_can_view(feature_ring, committed, draft_ctx, mirror_slot0);
+        if (!build_draft_step(draft_sg, draft_weights, nullptr, draft_backend,
+                              draft_ctx, use_mirror_view ? &feature_ring : nullptr,
+                              committed)) {
+            std::fprintf(stderr, "target-split-dflash draft build failed\n");
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+        if (!use_mirror_view &&
+            !copy_feature_ring_range_to_tensor(feature_ring, draft_sg.target_hidden_cat,
+                                               draft_start, draft_ctx)) {
+            std::fprintf(stderr, "target-split-dflash draft feature copy failed\n");
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+        ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
+                                sizeof(float) * noise_embed.size());
+        pos_k.resize((size_t)draft_ctx + q_len);
+        for (int i = 0; i < q_len; i++) pos_q[i] = draft_ctx + i;
+        for (int i = 0; i < draft_ctx + q_len; i++) pos_k[i] = i;
+        ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
+                                sizeof(int32_t) * pos_q.size());
+        ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
+                                sizeof(int32_t) * pos_k.size());
+        auto st = ggml_backend_graph_compute(draft_backend, draft_sg.gf);
+        if (st != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "target-split-dflash draft compute %d\n", (int)st);
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+
+        if (!proj_sg.gf || !proj_sg.hidden_input || proj_sg.hidden_input->ne[1] != q_len) {
+            if (!build_lm_head_projection_step(proj_sg, shards.back().weights,
+                                               output_backend, q_len)) {
+                std::fprintf(stderr, "target-split-dflash projection build failed\n");
+                step_graph_destroy(draft_sg);
+                step_graph_destroy(proj_sg);
+                return false;
+            }
+        }
+        const size_t hidden_bytes = ggml_nbytes(draft_sg.hidden_states);
+        if (!copy_peer_async(proj_sg.hidden_input->data, output_gpu,
+                             draft_sg.hidden_states->data, draft_gpu,
+                             hidden_bytes)) {
+            std::fprintf(stderr, "target-split-dflash hidden peer copy failed\n");
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+        cudaSetDevice(output_gpu);
+        cudaDeviceSynchronize();
+        st = ggml_backend_graph_compute(output_backend, proj_sg.gf);
+        if (st != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "target-split-dflash projection compute %d\n", (int)st);
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+        ggml_backend_tensor_get(proj_sg.argmax_tokens, draft_tok.data(), 0,
+                                sizeof(int32_t) * q_len);
+        draft_tok[0] = last_tok;
+
+        for (auto & shard : shards) snapshot_ssm_state(shard.cache);
+
+        int verify_last_tok = -1;
+        if (!run_target_layer_split_forward(shards, shards.front().weights,
+                                            draft_tok, committed, q_len,
+                                            verify_last_tok, &feature_ring,
+                                            &target_tok)) {
+            std::fprintf(stderr, "target-split-dflash verify failed\n");
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+
+        int accept_n = 1;
+        for (int i = 0; i < q_len - 1; i++) {
+            if (draft_tok[i + 1] == target_tok[i]) accept_n++;
+            else break;
+        }
+        int bonus_tok = (accept_n < q_len) ? target_tok[accept_n - 1] : -1;
+        int commit_n = accept_n + (bonus_tok >= 0 ? 1 : 0);
+        if (commit_n > need_commit_budget) {
+            commit_n = need_commit_budget;
+            if (commit_n <= accept_n) bonus_tok = -1;
+        }
+
+        for (auto & shard : shards) restore_ssm_state(shard.cache);
+
+        std::vector<int32_t> replay_tok((size_t)commit_n);
+        for (int i = 0; i < commit_n; i++) {
+            replay_tok[i] = (i < accept_n) ? draft_tok[i] : bonus_tok;
+        }
+        int replay_last_tok = -1;
+        if (!run_target_layer_split_forward(shards, shards.front().weights,
+                                            replay_tok, committed, commit_n,
+                                            replay_last_tok, &feature_ring)) {
+            std::fprintf(stderr, "target-split-dflash replay failed\n");
+            step_graph_destroy(draft_sg);
+            step_graph_destroy(proj_sg);
+            return false;
+        }
+        last_tok = replay_last_tok;
+
+        bool hit_eos = false;
+        for (int i = 0; i < commit_n; i++) {
+            out_all.push_back(replay_tok[i]);
+            if (IS_EOS_TOK(replay_tok[i], shards.front().weights)) hit_eos = true;
+        }
+        committed += commit_n;
+        n_generated += commit_n;
+        n_accept_sum += std::min(accept_n, commit_n);
+        n_draft_steps++;
+        if (hit_eos) break;
+    }
+    sync_all();
+    auto t_dec1 = std::chrono::steady_clock::now();
+    const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
+    const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+    const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
+    std::printf("[target-split-dflash] decode tokens=%d time=%.3f s speed=%.2f tok/s\n",
+                n_generated, decode_s, n_generated > 0 ? n_generated / decode_s : 0.0);
+    std::printf("[target-split-dflash] %d draft steps, accepted=%d/%d (%.1f%%), avg commit/step=%.2f\n",
+                n_draft_steps, n_accept_sum, total_draft_pos, accept_pct,
+                n_draft_steps > 0 ? (double)n_generated / (double)n_draft_steps : 0.0);
+    if (out_path) write_int32_file(out_path, out_all);
+
+    step_graph_destroy(draft_sg);
+    step_graph_destroy(proj_sg);
+    return true;
+}
+
+static int run_target_layer_split_harness(
+        const char * target_path,
+        const char * draft_path,
+        const char * prompt_path,
+        int n_gen,
+        const char * out_path,
+        const std::vector<int> & target_gpus,
+        const std::vector<double> & split_weights,
+        int draft_gpu,
+        bool load_draft,
+        bool run_draft_smoke,
+        bool run_dflash,
+        int max_ctx,
+        int max_verify_tokens) {
+    if (!prompt_path || !out_path) {
+        std::fprintf(stderr, "target layer split requires prompt/n_gen/out positional args\n");
+        return 2;
+    }
+    const int n_layer = inspect_target_layer_count(target_path);
+    if (n_layer <= 0) {
+        std::fprintf(stderr, "target-split could not read qwen35.block_count\n");
+        return 1;
+    }
+    const auto ranges = compute_layer_ranges(n_layer, (int)target_gpus.size(), split_weights);
+    if ((int)ranges.size() != (int)target_gpus.size()) {
+        std::fprintf(stderr, "bad --target-layer-split for %zu target GPUs and %d layers\n",
+                     target_gpus.size(), n_layer);
+        return 2;
+    }
+    std::vector<TargetLayerSplitShard> shards;
+    shards.resize(target_gpus.size());
+    for (size_t i = 0; i < target_gpus.size(); i++) {
+        shards[i].gpu = target_gpus[i];
+        shards[i].layer_begin = ranges[i].first;
+        shards[i].layer_end = ranges[i].second;
+    }
+    for (auto & shard : shards) {
+        shard.backend = ggml_backend_cuda_init(shard.gpu);
+        if (!shard.backend) {
+            std::fprintf(stderr, "target-split cuda init failed for gpu %d\n", shard.gpu);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+    }
+    for (size_t i = 0; i < target_gpus.size(); i++) {
+        for (size_t j = i + 1; j < target_gpus.size(); j++) {
+            if (!enable_peer_access_pair(target_gpus[i], target_gpus[j])) {
+                std::fprintf(stderr,
+                             "warning: CUDA peer access not fully enabled for target gpus %d,%d\n",
+                             target_gpus[i], target_gpus[j]);
+            }
+        }
+    }
+    for (auto & shard : shards) {
+        TargetLoadPlan plan;
+        plan.layer_begin = shard.layer_begin;
+        plan.layer_end = shard.layer_end;
+        plan.load_output = (&shard == &shards.back());
+        if (!load_target_gguf_partial(target_path, shard.backend, plan, shard.weights)) {
+            std::fprintf(stderr, "target-split load gpu=%d: %s\n",
+                         shard.gpu, dflash27b_last_error());
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        std::printf("[target-split] gpu=%d layers=[%d,%d) %s\n",
+                    shard.gpu, shard.layer_begin, shard.layer_end,
+                    dflash27b_last_error());
+        const bool allocate_target_feat = false;
+        if (!create_target_cache_partial(shard.weights, max_ctx, max_verify_tokens,
+                                         shard.backend, shard.cache,
+                                         /*prefill_only=*/!run_dflash,
+                                         shard.layer_begin, shard.layer_end,
+                                         allocate_target_feat)) {
+            std::fprintf(stderr, "target-split cache gpu=%d: %s\n",
+                         shard.gpu, dflash27b_last_error());
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+    }
+
+    ggml_backend_t draft_backend = nullptr;
+    DraftWeights draft_weights;
+    DraftFeatureMirror feature_ring;
+    bool draft_backend_owned = false;
+    if (load_draft) {
+        for (auto & shard : shards) {
+            if (shard.gpu == draft_gpu) {
+                draft_backend = shard.backend;
+                break;
+            }
+        }
+        if (!draft_backend) {
+            draft_backend = ggml_backend_cuda_init(draft_gpu);
+            if (!draft_backend) {
+                std::fprintf(stderr, "target-split draft cuda init failed for gpu %d\n", draft_gpu);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            draft_backend_owned = true;
+        }
+        std::string dp(draft_path);
+        bool draft_ok = false;
+        if (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf") {
+            draft_ok = load_draft_gguf(draft_path, draft_backend, draft_weights);
+        } else {
+            draft_ok = load_draft_safetensors(draft_path, draft_backend, draft_weights);
+        }
+        if (!draft_ok) {
+            std::fprintf(stderr, "target-split draft load gpu=%d: %s\n",
+                         draft_gpu, dflash27b_last_error());
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        std::printf("[target-split] draft loaded on gpu=%d format=%s\n",
+                    draft_gpu,
+                    (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf")
+                        ? "gguf" : "safetensors");
+        const int cap = std::min(max_ctx, 4096);
+        if (!draft_feature_mirror_init(feature_ring, draft_backend,
+                                       draft_gpu, draft_gpu, cap)) {
+            std::fprintf(stderr, "target-split feature ring init failed on gpu=%d\n", draft_gpu);
+            draft_feature_mirror_free(feature_ring);
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        std::printf("[target-split] draft feature ring cap=%d gpu=%d\n", cap, draft_gpu);
+    }
+
+    auto prompt = read_int32_file(prompt_path);
+    if (prompt.empty()) {
+        std::fprintf(stderr, "target-split empty prompt\n");
+        draft_feature_mirror_free(feature_ring);
+        free_draft_weights(draft_weights);
+        if (draft_backend_owned) ggml_backend_free(draft_backend);
+        free_target_layer_split_shards(shards);
+        return 1;
+    }
+    if ((int)prompt.size() + n_gen + 1 > max_ctx) {
+        std::fprintf(stderr, "target-split prompt (%zu) + gen (%d) exceeds max_ctx (%d)\n",
+                     prompt.size(), n_gen, max_ctx);
+        draft_feature_mirror_free(feature_ring);
+        free_draft_weights(draft_weights);
+        if (draft_backend_owned) ggml_backend_free(draft_backend);
+        free_target_layer_split_shards(shards);
+        return 1;
+    }
+
+    int ubatch = (prompt.size() > 2048) ? 384 : 16;
+    if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
+        ubatch = std::max(1, std::atoi(s));
+    }
+    std::printf("[target-split] n_gpus=%zu n_layer=%d ubatch=%d max_ctx=%d\n",
+                target_gpus.size(), n_layer, ubatch, max_ctx);
+
+    int last_tok = -1;
+    auto t_pf0 = std::chrono::steady_clock::now();
+    if (!run_target_layer_split_forward(shards, shards.front().weights,
+                                        prompt, 0, ubatch, last_tok,
+                                        load_draft ? &feature_ring : nullptr)) {
+        std::fprintf(stderr, "target-split prefill failed\n");
+        draft_feature_mirror_free(feature_ring);
+        free_draft_weights(draft_weights);
+        if (draft_backend_owned) ggml_backend_free(draft_backend);
+        free_target_layer_split_shards(shards);
+        return 1;
+    }
+    auto t_pf1 = std::chrono::steady_clock::now();
+    const double prefill_s = std::chrono::duration<double>(t_pf1 - t_pf0).count();
+    std::printf("[target-split] prefill tokens=%zu time=%.3f s speed=%.2f tok/s last_tok=%d\n",
+                prompt.size(), prefill_s, prompt.size() / prefill_s, last_tok);
+
+    if (run_draft_smoke) {
+        const int hidden = DFLASH27B_TARGET_HIDDEN;
+        const int q_len = DFLASH27B_DRAFT_BLOCK_SIZE;
+        const int draft_ctx = std::min((int)prompt.size(), feature_ring.cap);
+        const int draft_start = (int)prompt.size() - draft_ctx;
+        StepGraph draft_sg;
+        int mirror_slot0 = 0;
+        const bool use_mirror_view =
+            draft_feature_mirror_can_view(feature_ring, (int)prompt.size(),
+                                          draft_ctx, mirror_slot0);
+        if (!build_draft_step(draft_sg, draft_weights, nullptr, draft_backend,
+                              draft_ctx, use_mirror_view ? &feature_ring : nullptr,
+                              (int)prompt.size())) {
+            std::fprintf(stderr, "target-split draft smoke build failed\n");
+            step_graph_destroy(draft_sg);
+            draft_feature_mirror_free(feature_ring);
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        if (!use_mirror_view &&
+            !copy_feature_ring_range_to_tensor(feature_ring,
+                                               draft_sg.target_hidden_cat,
+                                               draft_start, draft_ctx)) {
+            std::fprintf(stderr, "target-split draft smoke feature copy failed\n");
+            step_graph_destroy(draft_sg);
+            draft_feature_mirror_free(feature_ring);
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        std::vector<int32_t> noise_ids(q_len, DFLASH27B_DRAFT_MASK_TOKEN_ID);
+        noise_ids[0] = last_tok;
+        std::vector<float> noise_embed((size_t)hidden * q_len);
+        if (!shards.front().weights.embedder.embed(noise_ids.data(), q_len, noise_embed.data())) {
+            std::fprintf(stderr, "target-split draft smoke embed failed\n");
+            step_graph_destroy(draft_sg);
+            draft_feature_mirror_free(feature_ring);
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
+                                sizeof(float) * noise_embed.size());
+        std::vector<int32_t> pos_q(q_len), pos_k(draft_ctx + q_len);
+        for (int i = 0; i < q_len; i++) pos_q[i] = draft_ctx + i;
+        for (int i = 0; i < draft_ctx + q_len; i++) pos_k[i] = i;
+        ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
+                                sizeof(int32_t) * pos_q.size());
+        ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
+                                sizeof(int32_t) * pos_k.size());
+        auto t_ds0 = std::chrono::steady_clock::now();
+        auto st = ggml_backend_graph_compute(draft_backend, draft_sg.gf);
+        auto t_ds1 = std::chrono::steady_clock::now();
+        if (st != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "target-split draft smoke compute failed status=%d\n", (int)st);
+            step_graph_destroy(draft_sg);
+            draft_feature_mirror_free(feature_ring);
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        std::printf("[target-split] draft smoke ctx=%d q=%d time=%.3f ms\n",
+                    draft_ctx, q_len,
+                    std::chrono::duration<double, std::milli>(t_ds1 - t_ds0).count());
+        step_graph_destroy(draft_sg);
+    }
+
+    if (run_dflash) {
+        const bool ok = run_target_layer_split_dflash_decode(
+            shards, draft_weights, draft_backend, draft_gpu, feature_ring,
+            prompt, n_gen, last_tok, out_path);
+        draft_feature_mirror_free(feature_ring);
+        free_draft_weights(draft_weights);
+        if (draft_backend_owned) ggml_backend_free(draft_backend);
+        free_target_layer_split_shards(shards);
+        return ok ? 0 : 1;
+    }
+
+    std::vector<int32_t> out_all = prompt;
+    auto t_dec0 = std::chrono::steady_clock::now();
+    int generated = 0;
+    for (; generated < n_gen; generated++) {
+        std::vector<int32_t> one(1, last_tok);
+        int next_tok = -1;
+        if (!run_target_layer_split_forward(shards, shards.front().weights,
+                                            one, (int)out_all.size(), 1, next_tok,
+                                            load_draft ? &feature_ring : nullptr)) {
+            std::fprintf(stderr, "target-split decode failed at %d\n", generated);
+            draft_feature_mirror_free(feature_ring);
+            free_draft_weights(draft_weights);
+            if (draft_backend_owned) ggml_backend_free(draft_backend);
+            free_target_layer_split_shards(shards);
+            return 1;
+        }
+        out_all.push_back(last_tok);
+        if (IS_EOS_TOK(last_tok, shards.front().weights)) {
+            generated++;
+            break;
+        }
+        last_tok = next_tok;
+    }
+    auto t_dec1 = std::chrono::steady_clock::now();
+    const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
+    std::printf("[target-split] decode tokens=%d time=%.3f s speed=%.2f tok/s\n",
+                generated, decode_s, generated > 0 ? generated / decode_s : 0.0);
+    if (out_path) write_int32_file(out_path, out_all);
+    draft_feature_mirror_free(feature_ring);
+    free_draft_weights(draft_weights);
+    if (draft_backend_owned) ggml_backend_free(draft_backend);
+    free_target_layer_split_shards(shards);
+    return 0;
 }
 
 // ─── Main ─────────────────────────────────────────────────────────
@@ -1114,13 +2011,29 @@ int main(int argc, char ** argv) {
     bool  profile_scaling = false;  // microbench: time target forward at varying N
     bool  test_window_mode = false;
     bool  draft_feature_mirror = false;
+    bool  target_split_load_draft = false;
+    bool  target_split_dflash = false;
     int   target_gpu = 0;
     int   draft_gpu = 0;
+    std::vector<int> target_gpus;
+    std::vector<double> target_split_weights;
     if (const char * s = std::getenv("DFLASH_TARGET_GPU")) {
         target_gpu = std::max(0, std::atoi(s));
     }
     if (const char * s = std::getenv("DFLASH_DRAFT_GPU")) {
         draft_gpu = std::max(0, std::atoi(s));
+    }
+    if (const char * s = std::getenv("DFLASH_TARGET_GPUS")) {
+        if (!parse_int_list(s, target_gpus)) {
+            std::fprintf(stderr, "bad DFLASH_TARGET_GPUS=%s\n", s);
+            return 2;
+        }
+    }
+    if (const char * s = std::getenv("DFLASH_TARGET_LAYER_SPLIT")) {
+        if (!parse_float_list(s, target_split_weights)) {
+            std::fprintf(stderr, "bad DFLASH_TARGET_LAYER_SPLIT=%s\n", s);
+            return 2;
+        }
     }
     int   stream_fd     = -1;     // write each committed token to this fd (int32 LE) as they land
     bool  daemon_mode   = false;
@@ -1144,11 +2057,42 @@ int main(int argc, char ** argv) {
         else if (std::strcmp(argv[i], "--draft-feature-mirror") == 0) {
             draft_feature_mirror = true;
         }
+        else if (std::strcmp(argv[i], "--target-split-load-draft") == 0) {
+            target_split_load_draft = true;
+        }
+        else if (std::strcmp(argv[i], "--target-split-dflash") == 0) {
+            target_split_dflash = true;
+            target_split_load_draft = true;
+        }
         else if (std::strncmp(argv[i], "--target-gpu=", 13) == 0) {
             target_gpu = std::max(0, std::atoi(argv[i] + 13));
         }
         else if (std::strcmp(argv[i], "--target-gpu") == 0) {
             if (i + 1 < argc) target_gpu = std::max(0, std::atoi(argv[++i]));
+        }
+        else if (std::strncmp(argv[i], "--target-gpus=", 14) == 0) {
+            if (!parse_int_list(argv[i] + 14, target_gpus)) {
+                std::fprintf(stderr, "bad --target-gpus value\n");
+                return 2;
+            }
+        }
+        else if (std::strcmp(argv[i], "--target-gpus") == 0) {
+            if (i + 1 >= argc || !parse_int_list(argv[++i], target_gpus)) {
+                std::fprintf(stderr, "bad --target-gpus value\n");
+                return 2;
+            }
+        }
+        else if (std::strncmp(argv[i], "--target-layer-split=", 21) == 0) {
+            if (!parse_float_list(argv[i] + 21, target_split_weights)) {
+                std::fprintf(stderr, "bad --target-layer-split value\n");
+                return 2;
+            }
+        }
+        else if (std::strcmp(argv[i], "--target-layer-split") == 0) {
+            if (i + 1 >= argc || !parse_float_list(argv[++i], target_split_weights)) {
+                std::fprintf(stderr, "bad --target-layer-split value\n");
+                return 2;
+            }
         }
         else if (std::strncmp(argv[i], "--draft-gpu=", 12) == 0) {
             draft_gpu = std::max(0, std::atoi(argv[i] + 12));
@@ -1210,6 +2154,9 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "--fast-rollback and --seq-verify are mutually exclusive\n");
         return 2;
     }
+    if (target_split_dflash) target_split_load_draft = true;
+    if (target_gpus.empty()) target_gpus.push_back(target_gpu);
+    if (target_gpus.size() == 1) target_gpu = target_gpus[0];
     std::printf("[cfg] seq_verify=%d fast_rollback=%d ddtree=%d budget=%d temp=%.2f chain_seed=%d fa_window=%d draft_feature_mirror=%d target_gpu=%d draft_gpu=%d\n",
                 (int)seq_verify, (int)fast_rollback, (int)ddtree_mode,
                 ddtree_budget, ddtree_temp, (int)ddtree_chain_seed, g_fa_window,
@@ -1217,10 +2164,37 @@ int main(int argc, char ** argv) {
 
     int cuda_device_count = 0;
     cudaGetDeviceCount(&cuda_device_count);
+    for (int gpu : target_gpus) {
+        if (gpu >= cuda_device_count) {
+            std::fprintf(stderr, "bad target gpu id %d device_count=%d\n",
+                         gpu, cuda_device_count);
+            return 2;
+        }
+    }
     if (target_gpu >= cuda_device_count || draft_gpu >= cuda_device_count) {
         std::fprintf(stderr, "bad gpu ids target=%d draft=%d device_count=%d\n",
                      target_gpu, draft_gpu, cuda_device_count);
         return 2;
+    }
+    if (target_gpus.size() > 1) {
+        if (daemon_mode || test_window_mode || profile_scaling) {
+            std::fprintf(stderr, "--target-gpus multi-GPU harness currently supports non-daemon generation only\n");
+            return 2;
+        }
+        if (target_split_dflash && fast_rollback) {
+            std::fprintf(stderr,
+                         "warning: --fast-rollback is not implemented for target layer-split DFlash; using replay rollback\n");
+        }
+        return run_target_layer_split_harness(target_path, draft_path, prompt_path, n_gen, out_path,
+                                             target_gpus, target_split_weights,
+                                             draft_gpu,
+                                             target_split_load_draft,
+                                             target_split_load_draft && !target_split_dflash,
+                                             target_split_dflash,
+                                             g_max_ctx_override > 0 ? g_max_ctx_override : 4096,
+                                             ddtree_mode
+                                                 ? std::max<int>(DFLASH27B_DRAFT_BLOCK_SIZE, ddtree_budget + 1)
+                                                 : DFLASH27B_DRAFT_BLOCK_SIZE);
     }
 
     const bool split_gpus = target_gpu != draft_gpu;


### PR DESCRIPTION
# bench(dflash): add multi-GPU target layer-split harness

## Summary

Adds an opt-in `test_dflash` path for multi-GPU target layer split with explicit DFlash draft placement.

New harness flags:

- `--target-gpus=0,1,...` selects target shard devices.
- `--target-layer-split=1,1,...` assigns target layer ranges by weight.
- `--draft-gpu=N` selects the DFlash draft device.
- `--target-split-load-draft` loads the draft beside the split target for residency checks.
- `--target-split-dflash` runs split-target DFlash decode.

Example:

```bash
./test_dflash target.gguf draft.gguf prompt.bin 128 out.bin \
  --draft-gpu=0 --target-gpus=0,1 --target-layer-split=1,1 \
  --target-split-dflash
```

## Why Useful

Plain target layer split can make a larger or higher-precision target fit, but decode throughput can become low enough to limit usefulness. This patch keeps the target split across GPUs while using DFlash to recover practical decode throughput.

## What Changed

- Added partial target GGUF loading: each shard loads only its contiguous layer range, and the final shard owns `output_norm` / `output.weight`.
- Added partial target cache allocation for shard-owned KV, SSM, convolution, and rollback buffers.
- Added split-target activation transfer and final logits on the last target GPU.
- Added split-target DFlash decode with draft-side feature mirroring.
- Extended `bench_he.py` with split-target flags and decode/acceptance parsing.
- Added draft GGUF compatibility for newer `dflash-draft` exports and tensor-name aliases.

## Scope And Compatibility

This is kept in `test_dflash` deliberately to validate placement, capture, activation transfer, and rollback behavior before server lifecycle integration.

It is compatible with the existing PFlash phase-split benchmark flow at the artifact level: PFlash can produce compressed token IDs, and this path can consume token ID prompt files for split-target DFlash decode. This PR does not add a unified PFlash + DFlash server pipeline.

## Limitation

Split-target DFlash currently uses replay rollback. The upstream `--fast-rollback` path is not enabled for split-target DFlash because its per-step state capture/commit assumptions do not yet hold across target shards. If both flags are passed, the harness warns and falls back to replay rollback.

## Local Evidence

Hardware: dual RTX 2080 Ti, 22GB VRAM per card.  
Target: `Qwen3.6-27B-Q8_0.gguf`  
Draft: Qwen3.6 27B DFlash draft, Q8 GGUF  
Placement: `--draft-gpu=0 --target-gpus=0,1 --target-layer-split=1,1`  
Task: HumanEval 10-prompt sweep, `n_gen=128`, `max_ctx=1024`

| setup | decode tok/s | AL / commit | notes |
|---|---:|---:|---|
| split target, target-only harness | 14.66 | n/a | Qwen3.6 27B Q8 split across both GPUs |
| split target + DFlash draft | 42.63 | 7.99 | Q8 draft on GPU 0, replay rollback |

This is about 2.9x decode throughput over the target-only split harness in this local sweep.

## Validation

- Build: `cmake --build dflash/build-target-layer-split --target test_dflash -j 8`
- Python syntax: `python3 -m py_compile dflash/scripts/bench_he.py`
- Whitespace: `git diff --check`
- Text audit: no non-ASCII text in added PR-target lines
- Correctness spot checks: split-target DFlash replay matched target-only greedy output on HE00 / 32 tokens and HE02 / 128 tokens
