### PR TITLE
feat(dflash): optional sampling (temperature/top_p/top_k/seed)

### DIFF
--- a/dflash/README.md
+++ b/dflash/README.md
@@ -237,7 +237,7 @@ Research proof-of-concept, not production.
 
 - **Batch size 1**, single-user local inference target (Ollama / LM Studio use case)
 - **One model pair**: Qwen3.5-27B Q4_K_M target + z-lab DFlash BF16 draft. Does not generalize without rewriting the graph builders.
-- **Greedy only**: `temperature`/`top_p` on the OpenAI server accepted but ignored. Rejection sampling in the verify path is a weekend-sized addition.
+- **Optional sampling**: `temperature`, `top_p`, `top_k`, `seed`, and `frequency_penalty` are honored on the OpenAI endpoint. The DDTree verify skeleton stays argmax (preserves accept rate); only the *committed* token at each verify step is drawn from a small CPU sampler chain (rep-pen → top-k → top-p → temp → multinomial). `temperature=0` (default) keeps the path bit-exact greedy. Full Leviathan-style rejection sampling on the tree is still a future addition.
 - **CUDA sm_86+ / sm_110 Thor** only. No Metal, ROCm, multi-GPU.
 - **Q4_K_M target** costs ~30 points of per-position accept vs the paper's BF16. Q5_K_M / Q6_K would recover most of it, if they fit.
 
@@ -247,7 +247,7 @@ Correctness: `test_vs_oracle` validates the draft graph at cos sim 0.999812 vs t
 
 Open an issue or PR against `Luce-Org/lucebox-hub`. Good first picks:
 
-- **Temperature / top-k sampling** in the verify path
+- **Leviathan-style rejection sampling** on each DDTree branch (the current implementation samples only the committed token; full prob-matching across the tree is the next step)
 - **Full llama.cpp integration**: new arch, `llama-speculative-dflash.cpp`, `llama-cli` / `llama-server` wiring
 
 ## Citation

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -117,6 +117,7 @@ class ChatRequest(BaseModel):
     seed: int | None = None             # rng seed for sampling
     top_p: float | None = None         # nucleus, applied when temperature > 0
     top_k: int | None = None           # top-k, applied when temperature > 0
+    frequency_penalty: float | None = None  # OAI -> rep_pen = 1 + freq_pen (sampling only)
     stop: list[str] | str | None = None  # FIX 3: accept stop field (Open WebUI sends it)
     chat_template_kwargs: dict | None = None
 
@@ -135,6 +136,7 @@ class AnthropicMessagesRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     seed: int | None = None
+    frequency_penalty: float | None = None
     stop_sequences: list[str] | None = None
     chat_template_kwargs: dict | None = None
 
@@ -395,11 +397,12 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
         if compression_fired:
             full_snap_prep = prefix_cache.prepare_full_snap(prompt_ids)
             full_snap_prep_ref[0] = full_snap_prep
+            samp = _samp_suffix(req)
             if full_snap_prep is not None:
                 fslot, _ = full_snap_prep
-                return f"{cur_bin} {gen_len} snap={len(cur_ids)}:{fslot}\n", None
+                return f"{cur_bin} {gen_len} snap={len(cur_ids)}:{fslot}" + samp + "\n", None
             else:
-                return f"{cur_bin} {gen_len}\n", None
+                return f"{cur_bin} {gen_len}" + samp + "\n", None
         else:
             full_snap_prep_ref[0] = None
             hit = prefix_cache.lookup(cur_ids)

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -113,9 +113,10 @@ class ChatRequest(BaseModel):
     messages: list[ChatMessage]
     stream: bool = False
     max_tokens: int = 512
-    temperature: float | None = None   # accepted, ignored (greedy-only)
-    top_p: float | None = None         # accepted, ignored
-    top_k: int | None = None           # accepted, ignored
+    temperature: float | None = None   # 0 = greedy, >0 = sample
+    seed: int | None = None             # rng seed for sampling
+    top_p: float | None = None         # nucleus, applied when temperature > 0
+    top_k: int | None = None           # top-k, applied when temperature > 0
     stop: list[str] | str | None = None  # FIX 3: accept stop field (Open WebUI sends it)
     chat_template_kwargs: dict | None = None
 
@@ -133,8 +134,22 @@ class AnthropicMessagesRequest(BaseModel):
     stream: bool = False
     temperature: float | None = None
     top_p: float | None = None
+    seed: int | None = None
     stop_sequences: list[str] | None = None
     chat_template_kwargs: dict | None = None
+
+
+def _samp_suffix(req) -> str:
+    # Render ` samp=temp,top_p,top_k,rep_pen[,seed]` tail when the request asks for
+    # non-greedy decoding. Empty string keeps the daemon protocol greedy-compatible.
+    t  = float(getattr(req, "temperature", 0.0) or 0.0)
+    if t <= 0.0:
+        return ""
+    tp = float(getattr(req, "top_p", 1.0) or 1.0)
+    tk = int(getattr(req, "top_k", 0) or 0)
+    rp = float(getattr(req, "frequency_penalty", 0.0) or 0.0) + 1.0
+    seed = int(getattr(req, "seed", 0) or 0)
+    return f" samp={t:.4f},{tp:.4f},{tk},{rp:.4f},{seed}"
 
 
 def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: int,
@@ -368,7 +383,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
         daemon_proc.stdin.write(cmd_line.encode("utf-8"))
         daemon_proc.stdin.flush()
 
-    def _build_cmd_line(cur_bin, cur_ids, gen_len, prefix_cache,
+    def _build_cmd_line(req, cur_bin, cur_ids, gen_len, prefix_cache,
                         prompt_ids, full_snap_prep_ref: list,
                         compression_fired: bool):
         """
@@ -396,7 +411,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                 cmd_line = f"{cur_bin} {gen_len}"
             if snap_prep:
                 cmd_line += f" snap={snap_prep[1]}:{snap_prep[0]}"
-            return cmd_line + "\n", snap_prep
+            return cmd_line + _samp_suffix(req) + "\n", snap_prep
 
     def _gen_len_for(prompt_len: int, max_tokens: int) -> int:
         return min(max_tokens, max_ctx - prompt_len - 20)
@@ -431,7 +446,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                             yield f"data: {json.dumps(err)}\n\n"
                             yield "data: [DONE]\n\n"
                             return
-                        cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}\n"
+                        cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
                     else:
                         cur_bin, cur_ids = await asyncio.to_thread(
                             _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
@@ -450,7 +465,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                             return
                         compression_fired = (cur_bin != prompt_bin)
                         cmd_line, snap_prep = _build_cmd_line(
-                            cur_bin, cur_ids, gen_len, prefix_cache,
+                            req, cur_bin, cur_ids, gen_len, prefix_cache,
                             prompt_ids, full_snap_prep_ref, compression_fired)
 
                     # FIX 7: guard against dead daemon
@@ -525,7 +540,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                     return JSONResponse(
                         {"detail": f"Prompt length ({prompt_len}) exceeds max_ctx ({max_ctx})"},
                         status_code=400)
-                cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}\n"
+                cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
             else:
                 cur_bin, cur_ids = await asyncio.to_thread(
                     _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
@@ -540,7 +555,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                         status_code=400)
                 compression_fired = (cur_bin != prompt_bin)
                 cmd_line, snap_prep = _build_cmd_line(
-                    cur_bin, cur_ids, gen_len, prefix_cache,
+                    req, cur_bin, cur_ids, gen_len, prefix_cache,
                     prompt_ids, full_snap_prep_ref, compression_fired)
 
             try:
@@ -620,7 +635,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                                              "message": f"Prompt length ({prompt_len}) exceeds max_ctx ({max_ctx})"}}
                             yield f"event: error\ndata: {json.dumps(err)}\n\n"
                             return
-                        cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}\n"
+                        cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
                     else:
                         cur_bin, cur_ids = await asyncio.to_thread(
                             _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
@@ -637,7 +652,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                             return
                         compression_fired = (cur_bin != prompt_bin)
                         cmd_line, snap_prep = _build_cmd_line(
-                            cur_bin, cur_ids, gen_len, prefix_cache,
+                            req, cur_bin, cur_ids, gen_len, prefix_cache,
                             prompt_ids, full_snap_prep_ref, compression_fired)
 
                     message_start = {
@@ -713,7 +728,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                         {"type": "error", "error": {"type": "invalid_request_error",
                          "message": f"Prompt length ({prompt_len}) exceeds max_ctx ({max_ctx})"}},
                         status_code=400)
-                cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}\n"
+                cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
             else:
                 cur_bin, cur_ids = await asyncio.to_thread(
                     _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
@@ -729,7 +744,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
                         status_code=400)
                 compression_fired = (cur_bin != prompt_bin)
                 cmd_line, snap_prep = _build_cmd_line(
-                    cur_bin, cur_ids, gen_len, prefix_cache,
+                    req, cur_bin, cur_ids, gen_len, prefix_cache,
                     prompt_ids, full_snap_prep_ref, compression_fired)
 
             try:

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -78,6 +78,8 @@ extern "C" void dflash27b_launch_bf16_to_f32(const void * src,
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <random>
+#include <unordered_set>
 
 using namespace dflash27b;
 
@@ -116,6 +118,104 @@ static int argmax_f32(const float * x, int n) {
     float bv = x[0];
     for (int i = 1; i < n; i++) if (x[i] > bv) { bv = x[i]; best = i; }
     return best;
+}
+
+// Optional sampling. Greedy is the default. When SamplerCfg.temp > 0
+// the corresponding committed-token argmax sites instead run a small
+// CPU sampler chain (rep penalty -> top_k -> top_p -> temp -> draw).
+// The DDTree skeleton itself stays argmax to keep accept rate intact.
+struct SamplerCfg {
+    float    temp       = 0.0f;
+    float    top_p      = 1.0f;
+    int      top_k      = 0;
+    float    rep_pen    = 1.0f;
+    int      rep_window = 256;
+    uint64_t seed       = 0;
+};
+
+static int sample_logits(const float * logits_in,
+                         int vocab,
+                         const SamplerCfg & cfg,
+                         const std::vector<int32_t> & history,
+                         std::mt19937_64 & rng) {
+    std::vector<std::pair<float,int>> cand(vocab);
+    for (int i = 0; i < vocab; i++) cand[i] = {logits_in[i], i};
+
+    if (cfg.rep_pen > 1.0f && !history.empty()) {
+        const int win  = std::min((int)history.size(), cfg.rep_window);
+        const int from = (int)history.size() - win;
+        std::unordered_set<int> seen;
+        for (int i = from; i < (int)history.size(); i++) seen.insert(history[i]);
+        for (auto & c : cand) {
+            if (seen.count(c.second)) {
+                c.first = (c.first > 0.0f) ? c.first / cfg.rep_pen
+                                           : c.first * cfg.rep_pen;
+            }
+        }
+    }
+
+    if (cfg.top_k > 0 && cfg.top_k < vocab) {
+        std::partial_sort(cand.begin(), cand.begin() + cfg.top_k, cand.end(),
+                          [](auto & a, auto & b){ return a.first > b.first; });
+        cand.resize(cfg.top_k);
+    } else {
+        std::sort(cand.begin(), cand.end(),
+                  [](auto & a, auto & b){ return a.first > b.first; });
+    }
+
+    const float inv_t = 1.0f / std::max(1e-3f, cfg.temp);
+    float maxv = cand.front().first * inv_t;
+    double Z   = 0.0;
+    std::vector<float> probs(cand.size());
+    for (size_t i = 0; i < cand.size(); i++) {
+        probs[i] = std::exp(cand[i].first * inv_t - maxv);
+        Z       += probs[i];
+    }
+    for (auto & p : probs) p = (float)(p / Z);
+
+    if (cfg.top_p > 0.0f && cfg.top_p < 1.0f) {
+        double cum = 0.0;
+        size_t cut = probs.size();
+        for (size_t i = 0; i < probs.size(); i++) {
+            cum += probs[i];
+            if (cum >= cfg.top_p) { cut = i + 1; break; }
+        }
+        probs.resize(cut); cand.resize(cut);
+        double zz = 0.0;
+        for (auto p : probs) zz += p;
+        for (auto & p : probs) p = (float)(p / zz);
+    }
+
+    std::uniform_real_distribution<double> u(0.0, 1.0);
+    double r   = u(rng);
+    double acc = 0.0;
+    for (size_t i = 0; i < probs.size(); i++) {
+        acc += probs[i];
+        if (r <= acc) return cand[i].second;
+    }
+    return cand.back().second;
+}
+
+static bool parse_sampler_token(std::string & line, SamplerCfg & out) {
+    auto pos = line.find(" samp=");
+    if (pos == std::string::npos) return false;
+    auto end = line.find(' ', pos + 1);
+    std::string tok = (end == std::string::npos)
+                          ? line.substr(pos + 6)
+                          : line.substr(pos + 6, end - (pos + 6));
+    line.erase(pos, (end == std::string::npos ? std::string::npos : end - pos));
+    float t = 0.0f, tp = 1.0f, rp = 1.0f;
+    int   tk = 0;
+    unsigned long long sd = 0;
+    int n = std::sscanf(tok.c_str(), "%f,%f,%d,%f,%llu",
+                        &t, &tp, &tk, &rp, &sd);
+    if (n < 1) return false;
+    out.temp    = t;
+    out.top_p   = tp;
+    out.top_k   = tk;
+    out.rep_pen = rp;
+    out.seed    = sd;
+    return true;
 }
 
 // ggml_flash_attn_ext expects kv_len aligned to KQ_MASK_PAD (32) on the
@@ -417,7 +517,8 @@ static DDTree build_ddtree(const float * top_log_probs,
 // deepest accepted node, which didn't match any of that node's children).
 static std::vector<int> follow_verified_tree(const DDTree & tree,
                                              const int32_t * posterior,
-                                             int & out_next_token) {
+                                             int & out_next_token,
+                                             int * out_node_idx = nullptr) {
     std::vector<int> accepted;
     accepted.reserve(tree.n_nodes + 1);
     accepted.push_back(0);
@@ -433,6 +534,7 @@ static std::vector<int> follow_verified_tree(const DDTree & tree,
         next_token = posterior[current_index];
     }
     out_next_token = next_token;
+    if (out_node_idx) *out_node_idx = current_index;
     return accepted;
 }
 
@@ -1069,6 +1171,9 @@ static bool build_lm_head_projection_step(
 
 // ─── Main ─────────────────────────────────────────────────────────
 
+static SamplerCfg     g_sampler;
+static std::mt19937_64 g_sampler_rng{std::random_device{}()};
+
 int main(int argc, char ** argv) {
     if (argc < 3) {
         std::fprintf(stderr,
@@ -1576,6 +1681,10 @@ int main(int argc, char ** argv) {
         if (daemon_mode) {
             std::string line;
             if (!std::getline(std::cin, line)) break;
+            g_sampler = SamplerCfg{};
+            if (parse_sampler_token(line, g_sampler) && g_sampler.seed != 0) {
+                g_sampler_rng.seed(g_sampler.seed);
+            }
 
             // ── Park/unpark commands (additive on top of latest daemon) ─────
             // "park draft" frees ~3.3GB, "park target" frees ~15GB,
@@ -2087,7 +2196,9 @@ int main(int argc, char ** argv) {
             std::vector<float> logits_buf(vocab, 0.0f);
             ggml_backend_tensor_get(lsg.logits, logits_buf.data(), 0,
                                     sizeof(float) * vocab);
-            last_tok = argmax_f32(logits_buf.data(), vocab);
+            last_tok = (g_sampler.temp > 0.0f)
+                ? sample_logits(logits_buf.data(), vocab, g_sampler, out_all, g_sampler_rng)
+                : argmax_f32(logits_buf.data(), vocab);
             step_graph_destroy(lsg);
         }
 
@@ -2203,7 +2314,9 @@ int main(int argc, char ** argv) {
         const size_t last_row_off = (size_t)(n_tokens - 1) * vocab * sizeof(float);
         ggml_backend_tensor_get(sg.logits, pf_logits_buf.data(), last_row_off,
                                 sizeof(float) * vocab);
-        last_tok = argmax_f32(pf_logits_buf.data(), vocab);
+        last_tok = (g_sampler.temp > 0.0f)
+            ? sample_logits(pf_logits_buf.data(), vocab, g_sampler, out_all, g_sampler_rng)
+            : argmax_f32(pf_logits_buf.data(), vocab);
         committed = start + n_tokens;
 
         // Fire inline snapshot after compute, so cache boundary is exact.
@@ -2623,7 +2736,15 @@ int main(int argc, char ** argv) {
 
             // Walk tree: accepted DFS indices and next bonus token.
             int next_token = -1;
-            std::vector<int> accepted = follow_verified_tree(tree, posterior.data(), next_token);
+            int bonus_node_idx = 0;
+            std::vector<int> accepted = follow_verified_tree(tree, posterior.data(), next_token, &bonus_node_idx);
+            if (g_sampler.temp > 0.0f) {
+                std::vector<float> bonus_logits(vocab);
+                ggml_backend_tensor_get(sg.logits, bonus_logits.data(),
+                                        (size_t)bonus_node_idx * sg.logits->nb[1],
+                                        (size_t)vocab * sizeof(float));
+                next_token = sample_logits(bonus_logits.data(), vocab, g_sampler, out_all, g_sampler_rng);
+            }
             const int accept_depth = (int)accepted.size();  // includes root
 
             // Detect when the walk takes a sibling branch (accepted node


### PR DESCRIPTION
## Summary

Wires `temperature`, `top_p`, `top_k`, `seed`, and OpenAI-style `frequency_penalty` through the OpenAI server → daemon → verify path. Greedy stays the default (`temperature=0` is bit-exact unchanged).

Closes the README's "Greedy only — accepted but ignored" caveat.

## Architecture

- **DDTree verify skeleton stays argmax** → accept rate preserved.
- **Only the committed token** at each verify step is drawn from a small CPU sampler chain: rep-pen → top-k → top-p → temp → multinomial.
- **`seed` reproducibility**: identical seed + same prompt + temp + top-p + top-k → identical output across calls.

## Wire format

Daemon protocol gets one optional tail token:

```
GENERATE_LINE [samp=temp,top_p,top_k,rep_pen,seed]
```

Tail absent → greedy → backward-compatible with all existing clients.

## Files

| File | Change |
|---|---|
| `dflash/test/test_dflash.cpp` | +120 / −5 — `SamplerCfg`, `sample_logits`, `parse_sampler_token`, 3 inject sites (DDTree bonus, chain bonus, prefill seed), per-request parsing in daemon loop |
| `dflash/scripts/server.py` | +33 / −10 — `ChatRequest.seed`, module-level `_samp_suffix`, `_build_cmd_line(req, …)` plumbing, dropped "ignored" comments |
| `dflash/README.md` | 2 bullets updated (limitations + roadmap) |

## Live verification (RTX 3090, Qwen3.6-27B Q4_K_M)

| Test | Property | Result |
|---|---|---|
| A `T=0` vs B `T=0.8 seed=42` | different output | ✓ |
| B `T=0.8 seed=42` vs C `T=0.8 seed=42` | identical (reproducible) | ✓ |
| B `T=0.8 seed=42` vs D `T=0.8 seed=99` | different (seed effect) | ✓ |

Tok/s 46-58 across all 4 calls (within cold-start variance). DDTree accept rate unchanged.

## What's NOT in this PR

- Full Leviathan-style rejection sampling on each DDTree branch (current implementation samples only the committed token; the tree itself stays greedy). Listed in roadmap.
- `mirostat`, `xtc`, `typical_p`, `dry`, `grammar` — keeping the v1 scope to the OpenAI fields users actually send.

## Test plan

- [x] Build: `cmake --build build-smoke --target test_dflash -j8` clean
- [x] Greedy regression: bit-exact decode at temp=0 vs main HEAD
- [x] Sampling correctness: A≠B, B=C, B≠D (see table above)
- [ ] HumanEval pass@1 at temp=0 unchanged (not run; greedy path mechanically identical)
- [ ] Long-context smoke (not run; sampler runs once per verify step regardless of ctx)

🧙 Built with [WOZCODE](https://wozcode.com)