### PR TITLE
bench: add Math500 answer scoring via \boxed{} extraction

### DIFF
--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -38,9 +38,9 @@ BUDGET = 22
 N_SAMPLE = 10
 
 BENCHES = [
-    ("HumanEval", "openai_humaneval", None, "test", lambda x: x["prompt"]),
-    ("GSM8K", "gsm8k", "main", "test", lambda x: f"Question: {x['question']}\nAnswer: "),
-    ("Math500", "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: "),
+    ("HumanEval", "openai_humaneval", None, "test", lambda x: x["prompt"], None, N_GEN),
+    ("GSM8K", "gsm8k", "main", "test", lambda x: f"Question: {x['question']}\nAnswer: ", None, N_GEN),
+    ("Math500", "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: ", lambda x: x["answer"], 2048),
 ]
 
 
@@ -95,10 +95,10 @@ def tokenize(tok, p, path: Path):
     return len(ids)
 
 
-def run_ar(path: Path):
+def run_ar(path: Path, n_gen: int = N_GEN):
     out_bin = TMPDIR / "ar_out.bin"
     r = _run_checked(
-        [TEST_GENERATE, TARGET, str(path), str(N_GEN), str(out_bin)],
+        [TEST_GENERATE, TARGET, str(path), str(n_gen), str(out_bin)],
         timeout=300,
         label="test_generate",
     )
@@ -108,25 +108,25 @@ def run_ar(path: Path):
     return float(m.group(1))
 
 
-def _auto_max_ctx(n_prompt):
+def _auto_max_ctx(n_prompt, n_gen: int = N_GEN):
     # Auto-fit attention budget: prompt + gen + small verify pad, aligned to
     # FATTN_KQ_STRIDE=256. Oversizing max_ctx makes attention stride over
     # unused KV and can cost >20× prefill time (32K prompt + --kv-q4 +
     # max_ctx=131072 → 1035s vs 38s at max_ctx=32768). See scripts/run.py.
     pad = 64  # covers q_len=16 + ddtree budget up to 22 with margin
-    return ((n_prompt + N_GEN + pad + 255) // 256) * 256
+    return ((n_prompt + n_gen + pad + 255) // 256) * 256
 
 
-def run_df(path: Path, n_prompt):
-    max_ctx = _auto_max_ctx(n_prompt)
-    out_bin = TMPDIR / "df_out.bin"
+def run_df(path: Path, n_prompt, n_gen: int = N_GEN):
+    max_ctx = _auto_max_ctx(n_prompt, n_gen)
+    out_bin = TMPDIR / f"df_out.bin"
     r = _run_checked(
         [
             TEST_DFLASH,
             TARGET,
             DRAFT,
             str(path),
-            str(N_GEN),
+            str(n_gen),
             str(out_bin),
             "--fast-rollback",
             "--ddtree",
@@ -140,7 +140,146 @@ def run_df(path: Path, n_prompt):
     al = re.search(r"avg commit/step=(\d+(?:\.\d+)?)", r.stdout)
     if not (tps and al):
         raise RuntimeError(f"test_dflash output parse failed: {r.stdout[-1500:]}")
-    return float(tps.group(1)), float(al.group(1))
+    return float(tps.group(1)), float(al.group(1)), out_bin
+
+
+def _read_ids(path: Path):
+    """Read a binary file of packed int32 token IDs."""
+    data = path.read_bytes()
+    return list(struct.unpack(f"<{len(data)//4}i", data))
+
+
+def _extract_boxed(text: str) -> str | None:
+    """Extract the last \\boxed{...} from a string, handling nested braces."""
+    results = []
+    i = 0
+    while i < len(text):
+        idx = text.find("\\boxed{", i)
+        if idx == -1:
+            break
+        start = idx + len("\\boxed{")
+        depth = 1
+        j = start
+        while j < len(text) and depth > 0:
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+            j += 1
+        if depth == 0:
+            results.append(text[start:j-1].strip())
+        i = j
+    return results[-1] if results else None
+
+
+def _normalize_math(s: str) -> str:
+    """Normalize a math answer string for comparison."""
+    if s is None:
+        return ""
+    s = s.strip()
+    if s.startswith("$") and s.endswith("$"):
+        s = s[1:-1].strip()
+    s = re.sub(r"\\text\s*\{([^}]*)\}", r"\1", s)
+    s = re.sub(r"\\mathrm\s*\{([^}]*)\}", r"\1", s)
+    for cmd in [r"\left", r"\right", r"\displaystyle", r"\tfrac", r"\dfrac"]:
+        s = s.replace(cmd, "")
+    for unit in [" cm", " m", " km", " kg", " g", " s", " ms",
+                 " degrees", " degree", "°", " inches", " feet",
+                 " square units", " units", " dollars"]:
+        if s.lower().rstrip(".").endswith(unit):
+            s = s[:len(s) - len(unit) - (1 if s.endswith(".") else 0)]
+    s = re.sub(r"\s+", " ", s).strip()
+    s = s.rstrip(".,")
+    return s
+
+
+def _math_equiv(pred: str, gold: str) -> bool:
+    """Check if two math answers are equivalent."""
+    if pred is None or gold is None:
+        return False
+    p = _normalize_math(pred)
+    g = _normalize_math(gold)
+    if p == g:
+        return True
+    p_c = re.sub(r"\s*\\frac", r"\\frac", p)
+    g_c = re.sub(r"\s*\\frac", r"\\frac", g)
+    if p_c == g_c:
+        return True
+    try:
+        pf = float(p.replace(",", ""))
+        gf = float(g.replace(",", ""))
+        return abs(pf - gf) < 1e-6
+    except (ValueError, TypeError):
+        pass
+    mixed_pat = re.compile(r"^(\d+)\s*\\frac\s*\{(\d+)\}\s*\{(\d+)\}$")
+    for s, other in [(p, g), (g, p)]:
+        m = mixed_pat.match(s)
+        if m:
+            try:
+                val = float(m.group(1)) + float(m.group(2)) / float(m.group(3))
+                oval = float(other.replace(",", ""))
+                if abs(val - oval) < 1e-6:
+                    return True
+            except (ValueError, ZeroDivisionError):
+                pass
+    frac_pat = re.compile(r"\\?frac\s*\{([^}]+)\}\s*\{([^}]+)\}")
+    for s, other in [(p, g), (g, p)]:
+        m = frac_pat.search(s)
+        if m:
+            try:
+                val = float(m.group(1)) / float(m.group(2))
+                oval = float(other.replace(",", ""))
+                if abs(val - oval) < 1e-6:
+                    return True
+            except (ValueError, ZeroDivisionError):
+                pass
+    return False
+
+
+def score_math(output_bin: Path, gold_answer: str, tok) -> tuple[bool, str]:
+    """Score a Math500 output against the gold answer.
+
+    Extracts \\boxed{} answers from model output (after </think> for thinking
+    models), compares against gold with normalized string matching + numeric/
+    fraction equivalence. Returns (correct, detail_str).
+    """
+    ids = _read_ids(output_bin)
+    text = tok.decode(ids)
+
+    think_end = text.rfind("</think>")
+    answer_text = text[think_end + len("</think>"):] if think_end >= 0 else text
+
+    pred = _extract_boxed(answer_text)
+    if not pred:
+        pred = _extract_boxed(text)
+    if not pred:
+        pred = None
+
+    # Fallback: "the answer is **X**" patterns
+    if pred is None:
+        bold_pattern = re.compile(
+            r'(?:answer\s+is|there\s+are|result\s+is|equals?|=)\s*\*\*(.+?)\*\*',
+            re.IGNORECASE)
+        m = bold_pattern.search(answer_text)
+        if m:
+            pred = m.group(1).strip().rstrip(".")
+
+    # Fallback: last $...$ expression
+    if pred is None:
+        matches = re.findall(r'\$([^$]+)\$', answer_text)
+        if matches:
+            pred = matches[-1].strip()
+
+    correct = _math_equiv(pred, gold_answer)
+    pred_short = (pred[:60] + "…") if pred and len(pred) > 60 else pred
+    gold_short = (gold_answer[:60] + "…") if len(gold_answer) > 60 else gold_answer
+    if correct:
+        detail = f"🎯 {pred_short}"
+    elif pred:
+        detail = f"✗ pred={pred_short} gold={gold_short}"
+    else:
+        detail = f"✗ no answer found, gold={gold_short}"
+    return correct, detail
 
 
 def main():
@@ -161,40 +300,57 @@ def main():
     tok = AutoTokenizer.from_pretrained(TOKENIZER, trust_remote_code=True)
 
     results = {}
-    for name, ds_name, cfg, split, extract in BENCHES:
-        print(f"\n[bench] ==== {name} (n={N_SAMPLE}) ====", flush=True)
+    for name, ds_name, cfg, split, extract, gold_extract, gen in BENCHES:
+        print(f"\n[bench] ==== {name} (n={N_SAMPLE}, n_gen={gen}) ====", flush=True)
         ds = load_dataset(ds_name, cfg, split=split)
-        ds = ds.shuffle(seed=42).select(range(N_SAMPLE))
+        ds_selected = ds.shuffle(seed=42).select(range(N_SAMPLE))
+        prompt_list = [extract(s) for s in ds_selected]
+        gold_list = [gold_extract(s) for s in ds_selected] if gold_extract else [None] * len(prompt_list)
+
         ar_tps, df_tps, df_al = [], [], []
-        for i, s in enumerate(ds):
-            p = extract(s)
+        n_score_correct, n_scored = 0, 0
+        for i, (p, gold) in enumerate(zip(prompt_list, gold_list)):
             path = TMPDIR / f"b_{name}_{i:02d}.bin"
             n = tokenize(tok, p, path)
             if n == 0 or n > 3500:
                 continue
             try:
-                ar = run_ar(path)
-                df, al = run_df(path, n)
+                ar = run_ar(path, gen)
+                df, al, df_bin = run_df(path, n, gen)
             except Exception as e:
                 print(f"  [{i+1:02d}/{N_SAMPLE}] n_tok={n:4d}  FAILED: {e}", flush=True)
                 continue
+
+            score_detail = ""
+            if gold is not None:
+                correct, score_detail = score_math(df_bin, gold, tok)
+                n_scored += 1
+                if correct:
+                    n_score_correct += 1
+                score_detail = f"  {score_detail}"
+
             if ar > 0:
                 ar_tps.append(ar)
             if df > 0:
                 df_tps.append(df)
                 df_al.append(al)
-            print(f"  [{i+1:02d}/{N_SAMPLE}] n_tok={n:4d}  AR={ar:6.2f}  DFlash={df:7.2f}  AL={al:5.2f}", flush=True)
+            print(f"  [{i+1:02d}/{N_SAMPLE}] n_tok={n:4d}  AR={ar:6.2f}  DFlash={df:7.2f}  AL={al:5.2f}{score_detail}", flush=True)
         ar_m = sum(ar_tps) / len(ar_tps) if ar_tps else 0
         df_m = sum(df_tps) / len(df_tps) if df_tps else 0
         al_m = sum(df_al) / len(df_al) if df_al else 0
+        score_str = f"{n_score_correct}/{n_scored}" if n_scored else ""
         results[name] = {"ar": ar_m, "dflash": df_m, "al": al_m,
-                         "speedup": df_m / ar_m if ar_m else 0}
-        print(f"  {name} mean: AR={ar_m:.2f}  DFlash={df_m:.2f}  AL={al_m:.2f}  {results[name]['speedup']:.2f}x", flush=True)
+                         "speedup": df_m / ar_m if ar_m else 0,
+                         "score": score_str}
+        summary = f"  {name} mean: AR={ar_m:.2f}  DFlash={df_m:.2f}  AL={al_m:.2f}  {results[name]['speedup']:.2f}x"
+        if score_str:
+            summary += f"  score={score_str} ({n_score_correct/n_scored*100:.0f}%)"
+        print(summary, flush=True)
 
     print("\n[bench] === SUMMARY ===")
-    print(f"{'Task':12s}  {'AR':>8s}  {'DFlash':>8s}  {'AL':>6s}  {'Speedup':>8s}")
+    print(f"{'Task':12s}  {'AR':>8s}  {'DFlash':>8s}  {'AL':>6s}  {'Speedup':>8s}  {'Score':>8s}")
     for name, r in results.items():
-        print(f"{name:12s}  {r['ar']:8.2f}  {r['dflash']:8.2f}  {r['al']:6.2f}  {r['speedup']:7.2f}x")
+        print(f"{name:12s}  {r['ar']:8.2f}  {r['dflash']:8.2f}  {r['al']:6.2f}  {r['speedup']:7.2f}x  {r.get('score',''):>8s}")
 
     out_json = TMPDIR / "bench_llm_results.json"
     with open(out_json, "w") as f:


### PR DESCRIPTION
Extract \boxed{} answers from model output (after </think> for thinking models), compare against MATH-500 gold answers with normalized string matching + numeric/fraction equivalence.

Reports per-prompt 🎯/✗ and aggregate score in summary table.
