### PR TITLE
fix(dflash): resolve target split prefill OOM from full-prompt logits

### DIFF
--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -1385,6 +1385,7 @@ static bool compute_target_split_argmax(
         const TargetWeights & w,
         ggml_backend_t backend,
         ggml_tensor * act,
+        int token_offset,
         int n_tokens,
         int hidden,
         int vocab,
@@ -1398,7 +1399,8 @@ static bool compute_target_split_argmax(
     if (!sg.ctx) return false;
 
     ggml_tensor * act_view = ggml_view_2d(
-        sg.ctx, act, hidden, n_tokens, act->nb[1], 0);
+        sg.ctx, act, hidden, n_tokens, act->nb[1],
+        (size_t)token_offset * act->nb[1]);
     ggml_tensor * normed = ggml_rms_norm(sg.ctx, act_view, DFLASH27B_RMS_EPS);
     normed = ggml_mul(sg.ctx, normed, w.out_norm);
     ggml_tensor * logits = ggml_mul_mat(sg.ctx, w.output, normed);
@@ -1550,9 +1552,12 @@ static bool run_target_layer_split_forward(
     StepGraph final_sg;
     std::vector<int32_t> argmax_tokens;
     TargetLayerSplitShard & last_shard = shards.back();
+    const bool need_all_argmax = argmax_out != nullptr;
+    const int argmax_offset = need_all_argmax ? 0 : (n_tokens_total - 1);
+    const int argmax_count = need_all_argmax ? n_tokens_total : 1;
     const bool ok = compute_target_split_argmax(
         final_sg, last_shard.weights, last_shard.backend, act_in,
-        n_tokens_total, hidden, vocab, argmax_tokens);
+        argmax_offset, argmax_count, hidden, vocab, argmax_tokens);
     step_graph_destroy(final_sg);
     activation_pair_free(acts);
     if (!ok) return false;


### PR DESCRIPTION
## Summary

This fixes an unnecessary full-prompt logits allocation in the target layer-split prefill path.

## Background

Normal prefill only needs the final token's next-token argmax. The previous target layer-split path still ran output norm + lm_head + argmax over the whole prompt activation, which materialized a `[vocab, prompt_len]` logits workspace.

For Qwen3.6-27B, that temporary workspace is about 7.9 GiB at an 8K prompt and about 15.8 GiB at a 16K prompt. As a result, split target runs could OOM even when the target weights and KV cache fit.

## Changes

This PR only changes `dflash/test/test_dflash.cpp`.

- Update `compute_target_split_argmax()` to accept a `token_offset`.
- Build the final activation input with `ggml_view_2d()` from the requested token range instead of always viewing the full prompt.
- In `run_target_layer_split_forward()`, compute logits and argmax only for the last token in normal prefill, replay, and autoregressive decode calls.
- In `run_target_layer_split_forward()`, keep full-range argmax when `argmax_out != nullptr`, which preserves the DFlash verify path where each candidate token still needs its own argmax.
- Keep target weights, target cache allocation, layer ownership, and target layer-split execution unchanged.

## Rationale

The normal prefill path only consumes the last token's argmax as the seed for the next generation step. Computing logits for every prompt token does not change the result, but it creates a large temporary allocation for large-vocab models.

DFlash verification is different: it compares multiple candidate positions, so it still needs multi-token argmax. This change keeps that behavior intact while removing the unused full-prompt logits allocation from the ordinary prefill path.

## Validation

| State | Target split prefill path | Qwen3.6-27B Q8_0 / 2x RTX 2080 Ti result |
| --- | --- | --- |
| Before | Full-prompt logits / argmax over the whole prompt activation | 8K prompt OOM |
| After | Last-token-only logits / argmax for normal prefill; multi-token argmax preserved for DFlash verify | 127K prompt passed |
