### PR TITLE
bench(dflash,pflash): add CUDA/HIP mixed backend placement

### DIFF
--- a/dflash/.gitignore
+++ b/dflash/.gitignore
@@ -1,4 +1,6 @@
 build/
+build-*/
+reports/
 *.o
 *.a
 *.so

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.18)
-set(DFLASH27B_USER_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
-project(dflash27b LANGUAGES C CXX CUDA)
+set(DFLASH27B_GPU_BACKEND "cuda" CACHE STRING "GPU backend to build: cuda or hip")
+set_property(CACHE DFLASH27B_GPU_BACKEND PROPERTY STRINGS cuda hip)
+string(TOLOWER "${DFLASH27B_GPU_BACKEND}" DFLASH27B_GPU_BACKEND)
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    set(DFLASH27B_USER_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+    project(dflash27b LANGUAGES C CXX CUDA)
+elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+    project(dflash27b LANGUAGES C CXX)
+else()
+    message(FATAL_ERROR "DFLASH27B_GPU_BACKEND must be 'cuda' or 'hip', got '${DFLASH27B_GPU_BACKEND}'")
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -8,9 +17,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # If we do not set this, ggml will output to bin and DLLs will not load
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-# Bake portable rpath into all executables so bundled libggml-cuda / libggml-base
+# Bake portable rpath into all executables so bundled ggml backend libs / libggml-base
 # are found regardless of LD_LIBRARY_PATH or stale /usr/local/lib (closes #31).
-set(CMAKE_INSTALL_RPATH "$ORIGIN/deps/llama.cpp/ggml/src;$ORIGIN/deps/llama.cpp/ggml/src/ggml-cuda;$ORIGIN/../deps/llama.cpp/ggml/src;$ORIGIN/../deps/llama.cpp/ggml/src/ggml-cuda")
+set(CMAKE_INSTALL_RPATH "$ORIGIN/deps/llama.cpp/ggml/src;$ORIGIN/deps/llama.cpp/ggml/src/ggml-cuda;$ORIGIN/deps/llama.cpp/ggml/src/ggml-hip;$ORIGIN/../deps/llama.cpp/ggml/src;$ORIGIN/../deps/llama.cpp/ggml/src/ggml-cuda;$ORIGIN/../deps/llama.cpp/ggml/src/ggml-hip")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -23,9 +32,22 @@ endif()
 # loaded via our own custom Qwen3-0.6B forward (qwen3_0p6b_loader.cpp +
 # qwen3_0p6b_graph.cpp) rather than libllama, so libllama is not built.
 #
-# Hardcoded for CUDA. No BLAS, no Metal, no Vulkan, no examples/tests/tools.
+# No BLAS, no Metal, no Vulkan, no examples/tests/tools.
 
-set(GGML_CUDA         ON  CACHE BOOL "" FORCE)
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    set(GGML_CUDA ON CACHE BOOL "" FORCE)
+    set(GGML_HIP  OFF CACHE BOOL "" FORCE)
+    set(DFLASH27B_GGML_BACKEND_TARGET ggml-cuda)
+elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+    set(GGML_CUDA OFF CACHE BOOL "" FORCE)
+    set(GGML_HIP  ON  CACHE BOOL "" FORCE)
+    set(GGML_HIP_RCCL OFF CACHE BOOL "" FORCE)
+    set(DFLASH27B_GGML_BACKEND_TARGET ggml-hip)
+    set(DFLASH27B_HIP_ARCHITECTURES "" CACHE STRING "HIP GPU targets, e.g. gfx906;gfx1100")
+    if(DFLASH27B_HIP_ARCHITECTURES AND NOT CMAKE_HIP_ARCHITECTURES)
+        set(CMAKE_HIP_ARCHITECTURES "${DFLASH27B_HIP_ARCHITECTURES}" CACHE STRING "" FORCE)
+    endif()
+endif()
 set(GGML_BACKEND_DL   OFF CACHE BOOL "" FORCE)
 set(GGML_METAL        OFF CACHE BOOL "" FORCE)
 set(GGML_VULKAN       OFF CACHE BOOL "" FORCE)
@@ -46,27 +68,29 @@ option(DFLASH27B_FA_ALL_QUANTS "Compile ggml-cuda fattn kernels for all KV-quant
 set(GGML_CUDA_FA_ALL_QUANTS ${DFLASH27B_FA_ALL_QUANTS} CACHE BOOL "" FORCE)
 
 # Resolve the CUDA architecture list up-front so downstream logic (notably
-# the consumer-Blackwell ggml workaround below) can inspect the actual
-# arches nvcc will compile for. The dflash27b target itself is created
-# later; its CUDA_ARCHITECTURES property is applied via
-# set_target_properties once the target exists.
-#
-# Turing (75) and Ampere (86) always; Blackwell consumer (120) and Thor
-# (110 on CUDA 13+) added when nvcc supports them. DGX Spark /
-# GB10 is compute capability 12.1 (121), added at CUDA 12.9+.
-if(DFLASH27B_USER_CUDA_ARCHITECTURES)
-    set(_dflash27b_archs "${DFLASH27B_USER_CUDA_ARCHITECTURES}")
+# the consumer-Blackwell ggml workaround below) can inspect the actual arches
+# nvcc will compile for. HIP builds use the portable ggml flash_attn_ext path
+# for the PFlash drafter and set the local CUDA-kernel feature level to 0.
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    # Turing (75) and Ampere (86) always; Blackwell consumer (120) and Thor
+    # (110 on CUDA 13+) added when nvcc supports them. DGX Spark /
+    # GB10 is compute capability 12.1 (121), added at CUDA 12.9+.
+    if(DFLASH27B_USER_CUDA_ARCHITECTURES)
+        set(_dflash27b_archs "${DFLASH27B_USER_CUDA_ARCHITECTURES}")
+    else()
+        set(_dflash27b_archs "75;86")
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
+            list(APPEND _dflash27b_archs "120")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
+            list(APPEND _dflash27b_archs "110")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.9")
+            list(APPEND _dflash27b_archs "121")
+        endif()
+    endif()
 else()
-    set(_dflash27b_archs "75;86")
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
-        list(APPEND _dflash27b_archs "120")
-    endif()
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
-        list(APPEND _dflash27b_archs "110")
-    endif()
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.9")
-        list(APPEND _dflash27b_archs "121")
-    endif()
+    set(_dflash27b_archs "")
 endif()
 
 # Consumer Blackwell workaround: skip sm_12x→sm_12xa replacement and FP4
@@ -80,7 +104,7 @@ if(DFLASH27B_USE_BLACKWELL_CONSUMER_FIX)
     set(_dflash_is_consumer_blackwell ON)
 endif()
 
-if(NOT DEFINED _dflash_is_consumer_blackwell)
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND NOT DEFINED _dflash_is_consumer_blackwell)
     set(_dflash_is_consumer_blackwell OFF)
     # Iterate the resolved dflash27b arch list, not raw CMAKE_CUDA_ARCHITECTURES,
     # which is empty on the default path (the project supplies its own list above).
@@ -93,16 +117,34 @@ if(NOT DEFINED _dflash_is_consumer_blackwell)
     endforeach()
 endif()
 
-if(_dflash_is_consumer_blackwell)
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash_is_consumer_blackwell)
     set(GGML_CUDA_BLACKWELL_CONSUMER ON CACHE BOOL
         "Skip sm_12X→sm_12Xa for consumer Blackwell (no FP4)" FORCE)
 endif()
 # Use only the ggml subtree of llama.cpp (skip libllama).
 add_subdirectory(deps/llama.cpp/ggml EXCLUDE_FROM_ALL)
 
-# The C++ sources include <cuda_runtime.h> directly, so the toolkit headers must
-# be available when compiling the library.
-find_package(CUDAToolkit REQUIRED)
+if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+    # The vendored ggml HIP shim still uses a few CUDA spellings that are not
+    # mapped in this submodule snapshot. Keep the compatibility layer in this
+    # repo so the parent PR is reproducible without a dirty submodule checkout.
+    target_compile_definitions(ggml-hip PRIVATE
+        cublasSgemmStridedBatched=hipblasSgemmStridedBatched
+        cudaStreamCaptureStatus=hipStreamCaptureStatus
+        cudaStreamCaptureStatusNone=hipStreamCaptureStatusNone
+        cudaStreamIsCapturing=hipStreamIsCapturing
+    )
+    target_include_directories(ggml-hip BEFORE PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/hip_compat)
+endif()
+
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    # The CUDA-only sources include <cuda_runtime.h> directly, so the toolkit
+    # headers must be available when compiling the library.
+    find_package(CUDAToolkit REQUIRED)
+elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+    find_package(hip REQUIRED)
+endif()
 
 # ─── dflash27b static library ──────────────────────────────────────
 
@@ -121,40 +163,50 @@ add_library(dflash27b STATIC
     src/kv_quant.cpp
     src/delta_net_chunked.cpp
 )
-# FlashPrefill custom CUDA kernels need BF16 WMMA (sm_80+). On Turing (sm_75)
-# the drafter uses ggml's flash_attn_ext instead. Guard added after SM check.
+# FlashPrefill custom CUDA kernels need CUDA BF16 WMMA (sm_80+). Other CUDA
+# arches and HIP use ggml's flash_attn_ext instead.
 # BSA (Block-Sparse Attention) backs the speculative-prefill drafter scoring
 # path. Default ON so prefill is fast out of the box. Turn OFF if you don't
-# run the spec-prefill stack or are building for sm<80 (cutlass BSA kernels
-# need sm_80+; the auto-detect below also disables BSA on legacy arches).
+# run the spec-prefill stack or are building without CUDA BF16 WMMA support
+# (cutlass BSA kernels need sm_80+; the auto-detect below also disables BSA on
+# legacy CUDA arches).
 if(NOT DEFINED DFLASH27B_ENABLE_BSA)
     set(DFLASH27B_ENABLE_BSA ON)
 endif()
 
-# Apply the arch list resolved above (before add_subdirectory, so the
-# consumer-Blackwell workaround can inspect it) to the dflash27b target.
-set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "${_dflash27b_archs}")
+# Apply the CUDA arch list to local CUDA sources. HIP builds do not have a CUDA
+# SM level; they use the backend-portable ggml flash_attn_ext path and pass
+# CMAKE_HIP_ARCHITECTURES through to the HIP toolchain/ggml backend.
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    set_target_properties(dflash27b PROPERTIES CUDA_ARCHITECTURES "${_dflash27b_archs}")
+    list(GET _dflash27b_archs 0 _dflash27b_cuda_min_sm)
+    # Strip any trailing 'a' suffix (e.g. "121a" -> "121")
+    string(REGEX REPLACE "[^0-9]" "" _dflash27b_cuda_min_sm "${_dflash27b_cuda_min_sm}")
+    target_compile_definitions(dflash27b PRIVATE
+        DFLASH27B_BACKEND_CUDA=1
+        DFLASH27B_CUDA_MIN_SM=${_dflash27b_cuda_min_sm})
+else()
+    target_compile_definitions(dflash27b PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
+endif()
 
-# Extract the minimum SM from the arch list so safetensors_draft.cpp can decide
-# at compile time whether to convert BF16 draft weights to FP16 (cuBLAS BF16
-# GEMM has no tensor core acceleration on SM < 80).
-list(GET _dflash27b_archs 0 _dflash27b_min_sm)
-# Strip any trailing 'a' suffix (e.g. "121a" → "121")
-string(REGEX REPLACE "[^0-9]" "" _dflash27b_min_sm "${_dflash27b_min_sm}")
-target_compile_definitions(dflash27b PRIVATE DFLASH27B_MIN_SM=${_dflash27b_min_sm})
-
-# FlashPrefill custom CUDA kernels need BF16 WMMA (sm_80+).
-# On sm_75 the drafter falls back to ggml's flash_attn_ext (see qwen3_0p6b_graph.cpp).
-if(_dflash27b_min_sm GREATER_EQUAL 80)
+# FlashPrefill custom CUDA kernels need BF16 WMMA (sm_80+). Other CUDA arches
+# and all HIP builds fall back to ggml's flash_attn_ext (see qwen3_0p6b_graph.cpp).
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash27b_cuda_min_sm GREATER_EQUAL 80)
     target_sources(dflash27b PRIVATE
         src/flashprefill_kernels.cu
         src/flashprefill_select.cpp
         src/flashprefill.cpp)
-    target_compile_definitions(dflash27b PRIVATE DFLASH27B_HAVE_FLASHPREFILL=1)
+    target_compile_definitions(dflash27b PRIVATE DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL=1)
 endif()
 
 # BSA needs sm_80+ (FA-2 derived kernel uses BF16 tensor cores). Auto-disable
 # on legacy arches with a clear message instead of failing the link.
+if(DFLASH27B_GPU_BACKEND STREQUAL "hip" AND DFLASH27B_ENABLE_BSA)
+    message(WARNING
+        "DFLASH27B_ENABLE_BSA=ON requested with DFLASH27B_GPU_BACKEND=hip; "
+        "disabling BSA because the bundled implementation is CUDA/CUTLASS-only.")
+    set(DFLASH27B_ENABLE_BSA OFF)
+endif()
 if(DFLASH27B_ENABLE_BSA)
     foreach(_arch IN LISTS _dflash27b_archs)
         if(_arch LESS 80)
@@ -187,8 +239,11 @@ target_include_directories(dflash27b
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CUDAToolkit_INCLUDE_DIRS}
+        ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src
 )
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    target_include_directories(dflash27b PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+endif()
 if(DFLASH27B_ENABLE_BSA)
     target_include_directories(dflash27b PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/deps/bsa_stubs
@@ -207,9 +262,12 @@ endif()
 target_link_libraries(dflash27b
     PUBLIC
         ggml
-        ggml-cuda
+        ${DFLASH27B_GGML_BACKEND_TARGET}
         ggml-base
 )
+if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+    target_link_libraries(dflash27b PRIVATE hip::host)
+endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
      target_compile_options(dflash27b PRIVATE
@@ -226,14 +284,14 @@ endif()
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/pflash_daemon.cpp")
     add_executable(pflash_daemon test/pflash_daemon.cpp)
     target_include_directories(pflash_daemon PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-    target_link_libraries(pflash_daemon PRIVATE dflash27b ggml ggml-cuda)
+    target_link_libraries(pflash_daemon PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
 endif()
 
 # ─── Tests (numerics vs oracle) ────────────────────────────────────
 
 option(DFLASH27B_TESTS "Build numerics tests" ON)
 if(DFLASH27B_TESTS)
-    if(_dflash27b_min_sm GREATER_EQUAL 80 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flashprefill_kernels.cpp")
+    if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash27b_cuda_min_sm GREATER_EQUAL 80 AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flashprefill_kernels.cpp")
         add_executable(test_flashprefill_kernels test/test_flashprefill_kernels.cpp)
         set_target_properties(test_flashprefill_kernels PROPERTIES CUDA_ARCHITECTURES "${_dflash27b_archs}")
         target_link_libraries(test_flashprefill_kernels PRIVATE dflash27b CUDA::cudart)
@@ -250,52 +308,62 @@ if(DFLASH27B_TESTS)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/smoke_load_draft.cpp")
         add_executable(smoke_load_draft test/smoke_load_draft.cpp)
         target_include_directories(smoke_load_draft PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(smoke_load_draft PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(smoke_load_draft PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/spike_thin_copy.cpp")
         add_executable(spike_thin_copy test/spike_thin_copy.cpp)
         target_include_directories(spike_thin_copy PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(spike_thin_copy PRIVATE ggml ggml-cuda)
+        target_link_libraries(spike_thin_copy PRIVATE ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/smoke_draft_graph.cpp")
         add_executable(smoke_draft_graph test/smoke_draft_graph.cpp)
         target_include_directories(smoke_draft_graph PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(smoke_draft_graph PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(smoke_draft_graph PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/smoke_qwen3_0p6b_forward.cpp")
         add_executable(smoke_qwen3_0p6b_forward test/smoke_qwen3_0p6b_forward.cpp)
         target_include_directories(smoke_qwen3_0p6b_forward PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(smoke_qwen3_0p6b_forward PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(smoke_qwen3_0p6b_forward PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_vs_oracle.cpp")
         add_executable(test_vs_oracle test/test_vs_oracle.cpp)
         target_include_directories(test_vs_oracle PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(test_vs_oracle PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(test_vs_oracle PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/smoke_load_target.cpp")
         add_executable(smoke_load_target test/smoke_load_target.cpp)
         target_include_directories(smoke_load_target PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(smoke_load_target PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(smoke_load_target PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/smoke_target_forward.cpp")
         add_executable(smoke_target_forward test/smoke_target_forward.cpp)
         target_include_directories(smoke_target_forward PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(smoke_target_forward PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(smoke_target_forward PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_generate.cpp")
         add_executable(test_generate test/test_generate.cpp)
         target_include_directories(test_generate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(test_generate PRIVATE dflash27b ggml ggml-cuda)
+        target_link_libraries(test_generate PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_dflash.cpp")
         add_executable(test_dflash test/test_dflash.cpp)
         target_include_directories(test_dflash PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-        target_link_libraries(test_dflash PRIVATE dflash27b ggml ggml-cuda)
-        # test_dflash uses cudaMemcpyAsync / cudaMemcpy2DAsync directly for the
-        # --fast-rollback path (per-step SSM intermediate state commit). Needs
-        # the CUDA runtime on its own link line.
-        find_package(CUDAToolkit REQUIRED)
-        target_link_libraries(test_dflash PRIVATE CUDA::cudart)
+        if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+            target_compile_definitions(test_dflash PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
+        else()
+            target_compile_definitions(test_dflash PRIVATE
+                DFLASH27B_BACKEND_CUDA=1
+                DFLASH27B_CUDA_MIN_SM=${_dflash27b_cuda_min_sm})
+        endif()
+        target_link_libraries(test_dflash PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
+        # test_dflash uses cuda*/hip* runtime calls directly for fast rollback,
+        # peer access, and target-layer split copies. Link the selected runtime.
+        if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+            find_package(CUDAToolkit REQUIRED)
+            target_link_libraries(test_dflash PRIVATE CUDA::cudart)
+        else()
+            target_link_libraries(test_dflash PRIVATE hip::host)
+        endif()
         # OpenMP for parallel CPU top-K extraction in the ddtree path.
         find_package(OpenMP)
         if(OpenMP_CXX_FOUND)

--- a/dflash/docs/MIXED_BACKEND.md
+++ b/dflash/docs/MIXED_BACKEND.md
@@ -1,0 +1,86 @@
+# CUDA/HIP mixed backend placement
+
+This guide covers the bench/runtime harness paths for placing PFlash and
+DFlash work across separate CUDA and HIP builds. The mixed-backend boundary is
+kept at host-data or process boundaries:
+
+- PFlash phase split passes compressed token/text data from `pflash_daemon` to
+  the target run.
+- DFlash draft split can run the draft model in a separate backend process and
+  feed a target process through host IPC.
+- Target layer split remains inside one backend binary; cross-backend target
+  layer split is intentionally out of scope.
+
+## Build CUDA and HIP binaries
+
+```bash
+cmake -S . -B build-cuda -DCMAKE_BUILD_TYPE=Release \
+  -DDFLASH27B_GPU_BACKEND=cuda
+cmake --build build-cuda --target pflash_daemon test_dflash -j
+
+cmake -S . -B build-hip -DCMAKE_BUILD_TYPE=Release \
+  -DDFLASH27B_GPU_BACKEND=hip \
+  -DDFLASH27B_HIP_ARCHITECTURES=<your-gfx-arch>
+cmake --build build-hip --target pflash_daemon test_dflash -j
+```
+
+## PFlash phase split
+
+PFlash targets the prefill side of long-context requests. The phase-split
+harness keeps the PFlash drafter resident in `pflash_daemon`, then can launch a
+separate target generation pass on another backend.
+
+- `--pflash-backend cuda|hip` and `--pflash-visible-devices` select the
+  backend/device set used by `pflash_daemon`.
+- `--run-target` launches `test_dflash` after compression.
+- `--target-backend cuda|hip` and `--target-visible-devices` select the target
+  backend/device environment.
+- Reports include compressed token/text output, PFlash timing, target timing,
+  target return code, and GPU resource summaries for both sides.
+
+Example: HIP PFlash drafter followed by CUDA target layer split:
+
+```bash
+python scripts/phase_split_dual_gpu.py bench-niah \
+  --build-dir build-hip \
+  --pflash-backend hip \
+  --pflash-visible-devices 0 \
+  --run-target \
+  --target-bin build-cuda/test_dflash \
+  --target-backend cuda \
+  --target-visible-devices 0,1 \
+  --target-gpus 0,1 \
+  --target-layer-split 1,1 \
+  --target-gen-tokens 8 \
+  --contexts 4096 \
+  --local-files-only \
+  --report-dir reports/pflash_hybrid_hip_drafter_cuda_target
+```
+
+Compress a real prompt without running target generation:
+
+```bash
+python scripts/phase_split_dual_gpu.py run-prompt \
+  --build-dir build-cuda \
+  --prompt-file /path/to/prompt.txt \
+  --local-files-only \
+  --report-dir reports/pflash_phase_split_prompt
+```
+
+## DFlash draft split
+
+For DFlash, the target process can launch a separate draft IPC daemon from a
+different backend build. The target process keeps target execution and any
+target layer split inside its own backend binary.
+
+Use these `test_dflash` options for the target process:
+
+- `--draft-ipc-bin <path>` points to the other backend's `test_dflash` binary.
+- `--draft-ipc-gpu <id>` selects the draft daemon device in that backend's
+  visible-device namespace.
+- `--draft-ipc-work-dir <path>` selects where temporary IPC payload files are
+  written.
+- `--draft-ipc-ring-cap <n>` controls the remote draft feature-ring capacity.
+
+`scripts/bench_he.py` passes these options through for HumanEval-style
+validation runs.

--- a/dflash/docs/SPEC_PREFILL.md
+++ b/dflash/docs/SPEC_PREFILL.md
@@ -51,78 +51,11 @@ DFLASH_FP_PROFILE=1    # log mean/score/select/forward stage timings
 
 See `src/flashprefill.h` for the full list and defaults.
 
-## Hybrid PFlash phase split
+## Mixed backend placement
 
-PFlash targets the prefill side of long-context requests. The dual-GPU phase
-split harness is an opt-in benchmark/runtime path for measuring the PFlash
-prefill phase as its own resident process. It can now place the PFlash drafter
-phase and the later target generation phase on different ggml GPU backends:
-
-- `pflash_daemon` keeps the Qwen3-0.6B PFlash drafter resident.
-- `scripts/phase_split_dual_gpu.py` sends counted token IDs to the daemon.
-- `--pflash-backend cuda|hip` and `--pflash-visible-devices` select the
-  backend/device set used for the PFlash phase.
-- `--run-target` can launch `test_dflash` afterward with
-  `--target-backend cuda|hip` and `--target-visible-devices`.
-- The report records compressed token/text outputs, PFlash timing, target
-  generation timing, return code, and GPU resource peaks for the PFlash worker.
-
-The cross-backend boundary is host-side token/text data: the PFlash daemon
-returns compressed drafter-token IDs, the harness decodes them to text, and
-the target tokenizer re-encodes that text for `test_dflash`. This keeps the
-hybrid path compatible with the existing PFlash phase split, DFlash target/draft
-split, and DFlash target layer split harnesses without adding cross-vendor GPU
-activation transfers.
-
-Target layer split remains inside one backend binary. For example, use HIP
-PFlash on an AMD card with CUDA target layer split across two NVIDIA cards, or
-CUDA PFlash on an NVIDIA card with HIP target layer split across AMD cards.
-Cross-backend target layer split is intentionally out of scope for this phase.
-
-Build:
-
-```
-cmake -S . -B build-cuda -DCMAKE_BUILD_TYPE=Release \
-  -DDFLASH27B_GPU_BACKEND=cuda
-cmake --build build-cuda --target pflash_daemon test_dflash -j
-
-cmake -S . -B build-hip -DCMAKE_BUILD_TYPE=Release \
-  -DDFLASH27B_GPU_BACKEND=hip \
-  -DDFLASH27B_HIP_ARCHITECTURES=<your-gfx-arch>
-cmake --build build-hip --target pflash_daemon test_dflash -j
-```
-
-Run a HIP PFlash drafter followed by CUDA target layer split:
-
-```
-python scripts/phase_split_dual_gpu.py bench-niah \
-  --build-dir build-hip \
-  --pflash-backend hip \
-  --pflash-visible-devices 0 \
-  --run-target \
-  --target-bin build-cuda/test_dflash \
-  --target-backend cuda \
-  --target-visible-devices 0,1 \
-  --target-gpus 0,1 \
-  --target-layer-split 1,1 \
-  --target-gen-tokens 8 \
-  --contexts 4096 \
-  --local-files-only \
-  --report-dir reports/pflash_hybrid_hip_drafter_cuda_target
-```
-
-Compress a real prompt:
-
-```
-python scripts/phase_split_dual_gpu.py run-prompt \
-  --build-dir build \
-  --prompt-file /path/to/prompt.txt \
-  --local-files-only \
-  --report-dir reports/pflash_phase_split_prompt
-```
-
-The reports include source token count, compressed token count, compression
-ratio, PFlash timing, and GPU resource peaks.
+CUDA/HIP mixed backend placement uses separate CUDA and HIP builds at the
+PFlash phase or DFlash draft-process boundary. See
+[`MIXED_BACKEND.md`](MIXED_BACKEND.md) for the build and harness instructions.
 
 ## Performance
 

--- a/dflash/docs/SPEC_PREFILL.md
+++ b/dflash/docs/SPEC_PREFILL.md
@@ -51,36 +51,64 @@ DFLASH_FP_PROFILE=1    # log mean/score/select/forward stage timings
 
 See `src/flashprefill.h` for the full list and defaults.
 
-## Dual-GPU PFlash phase split
+## Hybrid PFlash phase split
 
 PFlash targets the prefill side of long-context requests. The dual-GPU phase
 split harness is an opt-in benchmark/runtime path for measuring the PFlash
-prefill phase as its own resident CUDA process:
+prefill phase as its own resident process. It can now place the PFlash drafter
+phase and the later target generation phase on different ggml GPU backends:
 
 - `pflash_daemon` keeps the Qwen3-0.6B PFlash drafter resident.
 - `scripts/phase_split_dual_gpu.py` sends counted token IDs to the daemon.
-- `--pflash-gpu` selects the CUDA GPU used for the PFlash phase.
-- The report records compressed token/text outputs, PFlash timing, and GPU
-  resource peaks for the PFlash worker.
+- `--pflash-backend cuda|hip` and `--pflash-visible-devices` select the
+  backend/device set used for the PFlash phase.
+- `--run-target` can launch `test_dflash` afterward with
+  `--target-backend cuda|hip` and `--target-visible-devices`.
+- The report records compressed token/text outputs, PFlash timing, target
+  generation timing, return code, and GPU resource peaks for the PFlash worker.
 
-The harness produces the compressed prompt artifact used by later target
-prefill experiments. It does not measure or modify decode.
+The cross-backend boundary is host-side token/text data: the PFlash daemon
+returns compressed drafter-token IDs, the harness decodes them to text, and
+the target tokenizer re-encodes that text for `test_dflash`. This keeps the
+hybrid path compatible with the existing PFlash phase split, DFlash target/draft
+split, and DFlash target layer split harnesses without adding cross-vendor GPU
+activation transfers.
+
+Target layer split remains inside one backend binary. For example, use HIP
+PFlash on an AMD card with CUDA target layer split across two NVIDIA cards, or
+CUDA PFlash on an NVIDIA card with HIP target layer split across AMD cards.
+Cross-backend target layer split is intentionally out of scope for this phase.
 
 Build:
 
 ```
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-cmake --build build --target pflash_daemon -j
+cmake -S . -B build-cuda -DCMAKE_BUILD_TYPE=Release \
+  -DDFLASH27B_GPU_BACKEND=cuda
+cmake --build build-cuda --target pflash_daemon test_dflash -j
+
+cmake -S . -B build-hip -DCMAKE_BUILD_TYPE=Release \
+  -DDFLASH27B_GPU_BACKEND=hip \
+  -DDFLASH27B_HIP_ARCHITECTURES=<your-gfx-arch>
+cmake --build build-hip --target pflash_daemon test_dflash -j
 ```
 
-Run a synthetic NIAH sweep:
+Run a HIP PFlash drafter followed by CUDA target layer split:
 
 ```
 python scripts/phase_split_dual_gpu.py bench-niah \
-  --build-dir build \
-  --contexts 4096,8192,16384 \
+  --build-dir build-hip \
+  --pflash-backend hip \
+  --pflash-visible-devices 0 \
+  --run-target \
+  --target-bin build-cuda/test_dflash \
+  --target-backend cuda \
+  --target-visible-devices 0,1 \
+  --target-gpus 0,1 \
+  --target-layer-split 1,1 \
+  --target-gen-tokens 8 \
+  --contexts 4096 \
   --local-files-only \
-  --report-dir reports/pflash_phase_split_context_sweep
+  --report-dir reports/pflash_hybrid_hip_drafter_cuda_target
 ```
 
 Compress a real prompt:

--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -330,6 +330,14 @@ def main():
                     help="Load the draft alongside the target layer-split harness")
     ap.add_argument("--target-split-dflash", action="store_true",
                     help="Run chain DFlash decode through the target layer-split harness")
+    ap.add_argument("--draft-ipc-bin", default=None,
+                    help="Path to a different-backend test_dflash used as the remote draft daemon")
+    ap.add_argument("--draft-ipc-gpu", type=int, default=None,
+                    help="GPU id passed to the remote draft daemon")
+    ap.add_argument("--draft-ipc-work-dir", default=None,
+                    help="Work directory for host-file IPC with the remote draft daemon")
+    ap.add_argument("--draft-ipc-ring-cap", type=int, default=None,
+                    help="Feature-ring capacity for the remote draft daemon")
     ap.add_argument("--max-ctx", type=int, default=None,
                     help="Forward --max-ctx=N to test_dflash")
     ap.add_argument("--prefill-ubatch", type=int, default=None,
@@ -393,6 +401,14 @@ def main():
         extra_args.append("--target-split-load-draft")
     if args.target_split_dflash:
         extra_args.append("--target-split-dflash")
+    if args.draft_ipc_bin:
+        extra_args.append(f"--draft-ipc-bin={args.draft_ipc_bin}")
+    if args.draft_ipc_gpu is not None:
+        extra_args.append(f"--draft-ipc-gpu={args.draft_ipc_gpu}")
+    if args.draft_ipc_work_dir:
+        extra_args.append(f"--draft-ipc-work-dir={args.draft_ipc_work_dir}")
+    if args.draft_ipc_ring_cap is not None:
+        extra_args.append(f"--draft-ipc-ring-cap={args.draft_ipc_ring_cap}")
     if args.max_ctx is not None:
         extra_args.append(f"--max-ctx={args.max_ctx}")
 

--- a/dflash/scripts/phase_split_dual_gpu.py
+++ b/dflash/scripts/phase_split_dual_gpu.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""Run the PFlash prefill phase through a persistent CUDA daemon.
+"""Run PFlash prefill through a persistent daemon, optionally followed by target generation.
 
 This phase-split harness is intentionally PFlash-only. It keeps the Qwen3-0.6B
-PFlash drafter resident in `pflash_daemon`, optionally on a different CUDA GPU
-from the later target run, and writes compressed token/text outputs plus timing
-and GPU resource reports. It measures the PFlash/prefill side only; decode is
-outside this harness.
+PFlash drafter resident in `pflash_daemon`, optionally on a different CUDA or
+HIP backend from the later target run. The cross-backend boundary is host-side
+token/text data; target layer split remains inside one backend binary.
 """
 
 from __future__ import annotations
@@ -35,6 +34,9 @@ def env_path(name: str, default: Path) -> Path:
 DEFAULT_BUILD = env_path("PFLASH_PHASE_BUILD_DIR", ROOT / "build")
 DEFAULT_DRAFTER = env_path("PFLASH_PHASE_DRAFTER", ROOT / "models" / "Qwen3-0.6B-BF16.gguf")
 DEFAULT_TOKENIZER = os.environ.get("PFLASH_PHASE_TOKENIZER", "Qwen/Qwen3-0.6B")
+DEFAULT_TARGET = env_path("DFLASH_TARGET", ROOT / "models" / "Qwen3.6-27B-Q4_K_M.gguf")
+DEFAULT_TARGET_DRAFT = env_path("DFLASH_DRAFT", ROOT / "models" / "draft")
+DEFAULT_TARGET_TOKENIZER = os.environ.get("PFLASH_PHASE_TARGET_TOKENIZER", "Qwen/Qwen3.6-27B")
 
 
 def write_counted_i32(path: Path, ids: Iterable[int]) -> None:
@@ -43,6 +45,22 @@ def write_counted_i32(path: Path, ids: Iterable[int]) -> None:
         f.write(struct.pack("<I", len(values)))
         if values:
             f.write(struct.pack("<" + "i" * len(values), *values))
+
+
+def write_raw_i32(path: Path, ids: Iterable[int]) -> None:
+    values = [int(x) for x in ids]
+    with path.open("wb") as f:
+        if values:
+            f.write(struct.pack("<" + "i" * len(values), *values))
+
+
+def read_raw_i32(path: Path) -> list[int]:
+    raw = path.read_bytes()
+    if len(raw) % 4 != 0:
+        raise RuntimeError(f"raw int32 file has odd byte length: {path}")
+    if not raw:
+        return []
+    return list(struct.unpack("<" + "i" * (len(raw) // 4), raw))
 
 
 def read_stream_until_sentinel(r_fd: int) -> list[int]:
@@ -91,11 +109,14 @@ class ProcessLog:
 
 
 class PFlashDaemon:
-    def __init__(self, *, binary: Path, drafter: Path, gpu: int, log_path: Path,
+    def __init__(self, *, binary: Path, drafter: Path, gpu: int, backend: str,
+                 visible_devices: str | None, log_path: Path,
                  env: dict[str, str]) -> None:
         self.binary = binary
         self.drafter = drafter
         self.gpu = gpu
+        self.backend = backend
+        self.visible_devices = visible_devices
         self.log = ProcessLog(log_path)
         self.env = env
         self.proc: subprocess.Popen[bytes] | None = None
@@ -105,7 +126,14 @@ class PFlashDaemon:
         r_fd, w_fd = os.pipe()
         env = os.environ.copy()
         env.update(self.env)
-        env["CUDA_VISIBLE_DEVICES"] = str(self.gpu)
+        visible = self.visible_devices or str(self.gpu)
+        if self.backend == "cuda":
+            env["CUDA_VISIBLE_DEVICES"] = visible
+        elif self.backend == "hip":
+            env["HIP_VISIBLE_DEVICES"] = visible
+            env["ROCR_VISIBLE_DEVICES"] = visible
+        else:
+            raise RuntimeError(f"unknown PFlash backend: {self.backend}")
         cmd = [str(self.binary), str(self.drafter), f"--stream-fd={w_fd}"]
         t0 = time.perf_counter()
         self.proc = subprocess.Popen(
@@ -164,8 +192,9 @@ class PFlashDaemon:
 
 
 class GpuMonitor:
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, backend: str) -> None:
         self.path = path
+        self.backend = backend
         self.phase = "init"
         self._lock = threading.Lock()
         self._stop = threading.Event()
@@ -181,26 +210,41 @@ class GpuMonitor:
                 return self.phase
 
         def loop() -> None:
-            fields = "index,temperature.gpu,fan.speed,power.draw,power.limit,memory.used,memory.total,utilization.gpu"
             with self.path.open("w") as f:
-                f.write("ts,phase,index,temp_c,fan_pct,power_w,power_limit_w,mem_used_mib,mem_total_mib,util_pct\n")
+                if self.backend == "cuda":
+                    f.write("ts,phase,index,temp_c,fan_pct,power_w,power_limit_w,mem_used_mib,mem_total_mib,util_pct\n")
+                else:
+                    f.write("ts,phase,card,temp_edge_c,temp_junction_c,temp_memory_c,power_w,gpu_use_pct,vram_pct,vram_activity_pct,mem_activity\n")
                 f.flush()
                 while not self._stop.is_set():
                     ts = time.time()
                     try:
-                        out = subprocess.check_output(
-                            ["nvidia-smi", f"--query-gpu={fields}", "--format=csv,noheader,nounits"],
-                            text=True,
-                            stderr=subprocess.DEVNULL,
-                            timeout=2,
-                        )
-                        for line in out.strip().splitlines():
-                            parts = [p.strip() for p in line.split(",")]
-                            if len(parts) == 8:
-                                f.write(",".join([f"{ts:.3f}", phase()] + parts) + "\n")
+                        if self.backend == "cuda":
+                            fields = "index,temperature.gpu,fan.speed,power.draw,power.limit,memory.used,memory.total,utilization.gpu"
+                            out = subprocess.check_output(
+                                ["nvidia-smi", f"--query-gpu={fields}", "--format=csv,noheader,nounits"],
+                                text=True,
+                                stderr=subprocess.DEVNULL,
+                                timeout=2,
+                            )
+                            for line in out.strip().splitlines():
+                                parts = [p.strip() for p in line.split(",")]
+                                if len(parts) == 8:
+                                    f.write(",".join([f"{ts:.3f}", phase()] + parts) + "\n")
+                        else:
+                            out = subprocess.check_output(
+                                ["rocm-smi", "--showuse", "--showmemuse", "--showpower", "--showtemp", "--csv"],
+                                text=True,
+                                stderr=subprocess.DEVNULL,
+                                timeout=2,
+                            )
+                            for line in out.strip().splitlines()[1:]:
+                                parts = [p.strip() for p in line.split(",")]
+                                if len(parts) >= 9:
+                                    f.write(",".join([f"{ts:.3f}", phase()] + parts[:9]) + "\n")
                         f.flush()
                     except Exception as exc:
-                        f.write(f"{ts:.3f},{phase()},ERR,,,,,,,{type(exc).__name__}\n")
+                        f.write(f"{ts:.3f},{phase()},ERR,{type(exc).__name__}\n")
                         f.flush()
                     self._stop.wait(1.0)
 
@@ -212,25 +256,46 @@ class GpuMonitor:
         if self._thread:
             self._thread.join(timeout=3)
 
-    def summarize_gpu(self, gpu: int) -> dict[str, float | int | None]:
+    def summarize_gpu(self, gpu: int, *, target_phase: bool | None = None) -> dict[str, float | int | None]:
         rows: list[dict[str, float | int]] = []
         if not self.path.exists():
             return {"samples": 0}
         for line in self.path.read_text().splitlines()[1:]:
             parts = line.split(",")
-            if len(parts) != 10 or parts[2] == "ERR":
+            if len(parts) < 3:
+                continue
+            is_target_phase = parts[1].endswith("_target")
+            if target_phase is not None and is_target_phase != target_phase:
+                continue
+            if parts[2] == "ERR":
                 continue
             try:
-                idx = int(parts[2])
-                if idx != gpu:
-                    continue
-                rows.append({
-                    "temp": float(parts[3]),
-                    "fan": float(parts[4]),
-                    "power": float(parts[5]),
-                    "mem": float(parts[7]),
-                    "util": float(parts[9]),
-                })
+                if self.backend == "cuda":
+                    if len(parts) != 10:
+                        continue
+                    idx = int(parts[2])
+                    if idx != gpu:
+                        continue
+                    rows.append({
+                        "temp": float(parts[3]),
+                        "fan": float(parts[4]),
+                        "power": float(parts[5]),
+                        "mem": float(parts[7]),
+                        "util": float(parts[9]),
+                    })
+                else:
+                    if len(parts) < 11:
+                        continue
+                    idx = int(parts[2].replace("card", ""))
+                    if idx != gpu:
+                        continue
+                    rows.append({
+                        "temp": float(parts[4]),
+                        "fan": 0.0,
+                        "power": float(parts[6]),
+                        "mem": float(parts[8]),
+                        "util": float(parts[7]),
+                    })
             except ValueError:
                 pass
         if not rows:
@@ -247,6 +312,24 @@ class GpuMonitor:
         }
 
 
+def parse_device_list(value: str | None, default: list[int]) -> list[int]:
+    if not value:
+        return default
+    out: list[int] = []
+    for item in value.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        out.append(int(item))
+    return out or default
+
+
+def summarize_devices(monitor: GpuMonitor, devices: list[int], *,
+                      target_phase: bool | None = None) -> dict[str, dict[str, float | int | None]]:
+    return {str(gpu): monitor.summarize_gpu(gpu, target_phase=target_phase)
+            for gpu in devices}
+
+
 @dataclass
 class CompressionCase:
     name: str
@@ -257,6 +340,10 @@ class CompressionCase:
     compression_ratio: float
     retained_key: bool | None = None
     retained_answer: bool | None = None
+    target_input_tokens: int | None = None
+    target_output_tokens: int | None = None
+    target_wall_s: float | None = None
+    target_returncode: int | None = None
 
 
 def load_tokenizer(args):
@@ -267,6 +354,103 @@ def load_tokenizer(args):
         trust_remote_code=True,
         local_files_only=bool(args.local_files_only),
     )
+
+
+def load_target_tokenizer(args):
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(
+        args.target_tokenizer,
+        trust_remote_code=True,
+        local_files_only=bool(args.local_files_only),
+    )
+
+
+def resolve_target_draft(path: Path) -> Path:
+    if path.is_file():
+        return path
+    for candidate in path.rglob("model.safetensors"):
+        return candidate
+    raise SystemExit(f"target draft safetensors not found at {path}")
+
+
+def parse_env_overrides(values: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for item in values:
+        if "=" not in item:
+            raise SystemExit(f"bad env override {item!r}; expected NAME=VALUE")
+        name, value = item.split("=", 1)
+        if not name:
+            raise SystemExit(f"bad env override {item!r}; empty name")
+        out[name] = value
+    return out
+
+
+def target_env(args) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(parse_env_overrides(args.target_env))
+    visible = args.target_visible_devices
+    if visible:
+        if args.target_backend == "cuda":
+            env["CUDA_VISIBLE_DEVICES"] = visible
+        else:
+            env["HIP_VISIBLE_DEVICES"] = visible
+            env["ROCR_VISIBLE_DEVICES"] = visible
+    return env
+
+
+def run_target_generation(args, case_dir: Path, compressed_text: str,
+                          target_tokenizer) -> dict[str, float | int | str]:
+    target_ids = target_tokenizer.encode(compressed_text, add_special_tokens=False)
+    if not target_ids:
+        raise RuntimeError("compressed prompt is empty after target tokenization")
+    prompt_path = case_dir / "target_prompt.bin"
+    out_path = case_dir / "target_out.bin"
+    log_path = case_dir / "target.log"
+    write_raw_i32(prompt_path, target_ids)
+
+    cmd = [
+        str(args.target_bin),
+        str(args.target),
+        str(args.target_draft),
+        str(prompt_path),
+        str(args.target_gen_tokens),
+        str(out_path),
+        f"--max-ctx={args.target_max_ctx}",
+    ]
+    if args.target_gpus:
+        cmd += ["--target-gpus", args.target_gpus]
+    if args.target_layer_split:
+        cmd += ["--target-layer-split", args.target_layer_split]
+    if args.target_split_load_draft:
+        cmd.append("--target-split-load-draft")
+    if args.target_split_dflash:
+        cmd.append("--target-split-dflash")
+
+    t0 = time.perf_counter()
+    with log_path.open("wb") as log:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(ROOT),
+            env=target_env(args),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    wall_s = time.perf_counter() - t0
+    out_tokens = []
+    if proc.returncode == 0 and out_path.exists():
+        out_tokens = read_raw_i32(out_path)
+    return {
+        "target_backend": args.target_backend,
+        "target_input_tokens": len(target_ids),
+        "target_output_tokens": max(0, len(out_tokens) - len(target_ids)),
+        "target_wall_s": wall_s,
+        "target_returncode": proc.returncode,
+        "target_log": str(log_path),
+        "target_prompt_bin": str(prompt_path),
+        "target_out_bin": str(out_path),
+    }
 
 
 def make_niah_text(tokenizer, token_count: int, case_idx: int, needle_fraction: float) -> tuple[str, str, str, int]:
@@ -314,21 +498,38 @@ def fmt(value, nd: int = 2) -> str:
     return f"{float(value):.{nd}f}"
 
 
+def set_monitor_phase(monitors: list[GpuMonitor], phase: str) -> None:
+    for monitor in monitors:
+        monitor.set_phase(phase)
+
+
 def run_cases(args, cases: list[tuple[str, str, str | None, str | None]]) -> None:
     args.report_dir.mkdir(parents=True, exist_ok=True)
     tokenizer = load_tokenizer(args)
-    monitor = GpuMonitor(args.report_dir / "gpu_monitor.csv")
+    target_tokenizer = load_target_tokenizer(args) if args.run_target else None
+    pflash_monitor = GpuMonitor(args.report_dir / f"pflash_gpu_monitor_{args.pflash_backend}.csv",
+                                args.pflash_backend)
+    target_monitor = (
+        GpuMonitor(args.report_dir / f"target_gpu_monitor_{args.target_backend}.csv",
+                   args.target_backend)
+        if args.run_target else None
+    )
+    monitors = [pflash_monitor] + ([target_monitor] if target_monitor else [])
     daemon = PFlashDaemon(
         binary=args.pflash_bin,
         drafter=args.pflash_drafter,
         gpu=args.pflash_gpu,
+        backend=args.pflash_backend,
+        visible_devices=args.pflash_visible_devices,
         log_path=args.report_dir / "pflash_daemon.log",
         env=make_pflash_env(args),
     )
     results: list[CompressionCase] = []
+    target_failures: list[dict[str, int | str]] = []
     try:
-        monitor.start()
-        monitor.set_phase("pflash_load")
+        for monitor in monitors:
+            monitor.start()
+        set_monitor_phase(monitors, "pflash_load")
         ready_s = daemon.start()
         for name, text, key, answer in cases:
             case_dir = args.report_dir / name
@@ -338,7 +539,7 @@ def run_cases(args, cases: list[tuple[str, str, str | None, str | None]]) -> Non
             counted = case_dir / "prompt_counted.bin"
             write_counted_i32(counted, ids)
 
-            monitor.set_phase(name)
+            set_monitor_phase(monitors, name)
             kept, wall_s = daemon.compress(
                 counted,
                 keep_ratio=args.keep_ratio,
@@ -346,9 +547,29 @@ def run_cases(args, cases: list[tuple[str, str, str | None, str | None]]) -> Non
                 chunk_size=args.chunk_size,
                 pool_kernel=args.pool_kernel,
             )
+            if not kept:
+                raise RuntimeError(
+                    f"PFlash compression returned no tokens; see {args.report_dir / 'pflash_daemon.log'}")
             compressed_text = tokenizer.decode(kept, skip_special_tokens=True)
             (case_dir / "compressed.txt").write_text(compressed_text, encoding="utf-8")
             write_counted_i32(case_dir / "compressed_counted.bin", kept)
+
+            target_result: dict[str, float | int | str] | None = None
+            if args.run_target:
+                set_monitor_phase(monitors, f"{name}_target")
+                assert target_tokenizer is not None
+                target_result = run_target_generation(
+                    args, case_dir, compressed_text, target_tokenizer)
+
+            target_input_tokens = None
+            target_output_tokens = None
+            target_wall_s = None
+            target_returncode = None
+            if target_result is not None:
+                target_input_tokens = int(target_result["target_input_tokens"])
+                target_output_tokens = int(target_result["target_output_tokens"])
+                target_wall_s = float(target_result["target_wall_s"])
+                target_returncode = int(target_result["target_returncode"])
 
             results.append(CompressionCase(
                 name=name,
@@ -359,14 +580,44 @@ def run_cases(args, cases: list[tuple[str, str, str | None, str | None]]) -> Non
                 compression_ratio=(len(kept) / len(ids)) if ids else 0.0,
                 retained_key=(key in compressed_text) if key else None,
                 retained_answer=(answer in compressed_text) if answer else None,
+                target_input_tokens=target_input_tokens,
+                target_output_tokens=target_output_tokens,
+                target_wall_s=target_wall_s,
+                target_returncode=target_returncode,
             ))
+            if target_result is not None:
+                (case_dir / "target_result.json").write_text(
+                    json.dumps(target_result, indent=2), encoding="utf-8")
+                if target_returncode != 0:
+                    target_failures.append({
+                        "case": name,
+                        "returncode": target_returncode,
+                        "log": str(case_dir / "target.log"),
+                    })
 
-        monitor.set_phase("cleanup")
-        resource_summary = monitor.summarize_gpu(args.pflash_gpu)
+        set_monitor_phase(monitors, "cleanup")
+        pflash_monitor_devices = parse_device_list(args.pflash_visible_devices,
+                                                   [args.pflash_gpu])
+        target_monitor_devices = parse_device_list(
+            args.target_visible_devices,
+            parse_device_list(args.target_gpus, [0]),
+        ) if args.run_target else []
+        pflash_resource_summary = summarize_devices(
+            pflash_monitor, pflash_monitor_devices, target_phase=False)
+        target_resource_summary = (
+            summarize_devices(target_monitor, target_monitor_devices, target_phase=True)
+            if target_monitor else {}
+        )
+        resource_summary = (
+            pflash_resource_summary.get(str(pflash_monitor_devices[0]), {"samples": 0})
+            if pflash_monitor_devices else {"samples": 0}
+        )
         summary = {
             "date": time.strftime("%Y-%m-%d"),
-            "mode": "dual_gpu_pflash_phase_split",
+            "mode": "hybrid_pflash_phase_split" if args.run_target else "pflash_phase_split",
+            "pflash_backend": args.pflash_backend,
             "pflash_gpu": args.pflash_gpu,
+            "pflash_visible_devices": args.pflash_visible_devices,
             "pflash_daemon_ready_s": ready_s,
             "pflash_drafter": str(args.pflash_drafter),
             "tokenizer": args.tokenizer,
@@ -375,67 +626,114 @@ def run_cases(args, cases: list[tuple[str, str, str | None, str | None]]) -> Non
             "chunk_size": args.chunk_size,
             "pool_kernel": args.pool_kernel,
             "pflash_k_type": args.pflash_k_type or "compute",
+            "target": {
+                "enabled": bool(args.run_target),
+                "backend": args.target_backend,
+                "bin": str(args.target_bin) if args.target_bin else None,
+                "model": str(args.target),
+                "draft": str(args.target_draft) if args.target_draft else None,
+                "gpus": args.target_gpus,
+                "layer_split": args.target_layer_split,
+                "visible_devices": args.target_visible_devices,
+                "max_ctx": args.target_max_ctx,
+                "gen_tokens": args.target_gen_tokens,
+                "tokenizer": args.target_tokenizer,
+            },
+            "target_failures": target_failures,
             "cases": [asdict(c) for c in results],
+            "pflash_monitor_gpus": pflash_monitor_devices,
+            "target_monitor_gpus": target_monitor_devices,
+            "pflash_resource_summary": pflash_resource_summary,
+            "target_resource_summary": target_resource_summary,
             "resource_summary": resource_summary,
             "logs": {
                 "pflash": str(args.report_dir / "pflash_daemon.log"),
-                "monitor": str(args.report_dir / "gpu_monitor.csv"),
+                "pflash_monitor": str(pflash_monitor.path),
+                "target_monitor": str(target_monitor.path) if target_monitor else None,
             },
         }
         (args.report_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
         write_markdown(args.report_dir / "summary.md", summary)
         print(json.dumps(summary, indent=2))
+        if target_failures:
+            first = target_failures[0]
+            raise RuntimeError(
+                f"target generation failed for {len(target_failures)} case(s); "
+                f"first={first['case']} rc={first['returncode']} log={first['log']}")
     finally:
-        monitor.stop()
+        for monitor in monitors:
+            monitor.stop()
         daemon.stop()
 
 
 def write_markdown(path: Path, summary: dict) -> None:
     lines = [
-        "# Dual-GPU PFlash Phase-Split Report",
+        "# Hybrid PFlash Phase-Split Report",
         "",
+        f"- PFlash backend: `{summary.get('pflash_backend', 'cuda')}`",
         f"- PFlash GPU: `{summary['pflash_gpu']}`",
         f"- PFlash daemon ready: `{fmt(summary['pflash_daemon_ready_s'])} s`",
         f"- keep ratio: `{summary['keep_ratio']}`",
         f"- lookahead: `{summary['lookahead']}`",
         f"- PFlash K cache: `{summary.get('pflash_k_type', 'compute')}`",
         "",
-        "## Resource Peak",
+        "## PFlash Resource Peak",
         "",
-        "| gpu | samples | peak mem MiB | peak temp C | avg power W | peak power W | avg util % | peak util % |",
+        "| gpu | samples | peak mem MiB/% | peak temp C | avg power W | peak power W | avg util % | peak util % |",
         "|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
-    res = summary.get("resource_summary") or {}
-    lines.append(
-        "| {gpu} | {samples} | {mem} | {temp} | {pavg} | {pmax} | {uavg} | {umax} |".format(
-            gpu=summary["pflash_gpu"],
-            samples=res.get("samples", 0),
-            mem=fmt(res.get("mem_max_mib")),
-            temp=fmt(res.get("temp_max_c")),
-            pavg=fmt(res.get("power_avg_w")),
-            pmax=fmt(res.get("power_max_w")),
-            uavg=fmt(res.get("util_avg_pct")),
-            umax=fmt(res.get("util_max_pct")),
-        )
-    )
+    def append_resource_rows(resources: dict) -> None:
+        if not resources:
+            lines.append("| n/a | 0 | n/a | n/a | n/a | n/a | n/a | n/a |")
+            return
+        for gpu, res in resources.items():
+            lines.append(
+                "| {gpu} | {samples} | {mem} | {temp} | {pavg} | {pmax} | {uavg} | {umax} |".format(
+                    gpu=gpu,
+                    samples=res.get("samples", 0),
+                    mem=fmt(res.get("mem_max_mib")),
+                    temp=fmt(res.get("temp_max_c")),
+                    pavg=fmt(res.get("power_avg_w")),
+                    pmax=fmt(res.get("power_max_w")),
+                    uavg=fmt(res.get("util_avg_pct")),
+                    umax=fmt(res.get("util_max_pct")),
+                )
+            )
+
+    append_resource_rows(summary.get("pflash_resource_summary") or {
+        str(summary["pflash_gpu"]): summary.get("resource_summary") or {}
+    })
+    if summary.get("target", {}).get("enabled"):
+        lines.extend([
+            "",
+            "## Target Resource Peak",
+            "",
+            "| gpu | samples | peak mem MiB/% | peak temp C | avg power W | peak power W | avg util % | peak util % |",
+            "|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ])
+        append_resource_rows(summary.get("target_resource_summary") or {})
     lines.extend([
         "",
         "## Cases",
         "",
-        "| case | source tokens | compressed tokens | ratio | PFlash s | PFlash tok/s | key retained | answer retained |",
-        "|---|---:|---:|---:|---:|---:|:---:|:---:|",
+        "| case | source tokens | compressed tokens | ratio | PFlash s | PFlash tok/s | target input | target output | target s | target rc | key retained | answer retained |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|:---:|",
     ])
     for case in summary["cases"]:
         key = case.get("retained_key")
         answer = case.get("retained_answer")
         lines.append(
-            "| {name} | {source} | {compressed} | {ratio} | {secs} | {tps} | {key} | {answer} |".format(
+            "| {name} | {source} | {compressed} | {ratio} | {secs} | {tps} | {tin} | {tout} | {twall} | {trc} | {key} | {answer} |".format(
                 name=case["name"],
                 source=case["source_tokens"],
                 compressed=case["compressed_tokens"],
                 ratio=fmt(case["compression_ratio"], 4),
                 secs=fmt(case["compress_wall_s"]),
                 tps=fmt(case["compress_tok_s"]),
+                tin=case.get("target_input_tokens") if case.get("target_input_tokens") is not None else "n/a",
+                tout=case.get("target_output_tokens") if case.get("target_output_tokens") is not None else "n/a",
+                twall=fmt(case.get("target_wall_s")) if case.get("target_wall_s") is not None else "n/a",
+                trc=case.get("target_returncode") if case.get("target_returncode") is not None else "n/a",
                 key="n/a" if key is None else ("yes" if key else "no"),
                 answer="n/a" if answer is None else ("yes" if answer else "no"),
             )
@@ -483,7 +781,10 @@ def add_common_args(ap: argparse.ArgumentParser) -> None:
     ap.add_argument("--pflash-bin", type=Path, default=None)
     ap.add_argument("--pflash-drafter", type=Path, default=DEFAULT_DRAFTER)
     ap.add_argument("--tokenizer", default=DEFAULT_TOKENIZER)
+    ap.add_argument("--pflash-backend", choices=["cuda", "hip"], default="cuda")
     ap.add_argument("--pflash-gpu", type=int, default=0)
+    ap.add_argument("--pflash-visible-devices", default=None,
+                    help="Visible device list for pflash_daemon. Defaults to --pflash-gpu.")
     ap.add_argument("--local-files-only", action=argparse.BooleanOptionalAction, default=False)
     ap.add_argument("--keep-ratio", type=float, default=0.05)
     ap.add_argument("--lookahead", type=int, default=2)
@@ -495,6 +796,29 @@ def add_common_args(ap: argparse.ArgumentParser) -> None:
                     choices=["f16", "bf16", "q8_0", "q4_0", "q4_1"],
                     help="persistent PFlash drafter K cache type; default follows drafter compute type")
     ap.add_argument("--report-dir", type=Path, default=Path("reports/pflash_phase_split"))
+    ap.add_argument("--run-target", action="store_true",
+                    help="After PFlash compression, run test_dflash target generation.")
+    ap.add_argument("--target-bin", type=Path, default=None,
+                    help="Path to the target test_dflash binary. Required with --run-target.")
+    ap.add_argument("--target-backend", choices=["cuda", "hip"], default="cuda")
+    ap.add_argument("--target-visible-devices", default=None,
+                    help="Visible device list for the target binary, e.g. 0,1.")
+    ap.add_argument("--target", type=Path, default=DEFAULT_TARGET)
+    ap.add_argument("--target-draft", type=Path, default=DEFAULT_TARGET_DRAFT,
+                    help="DFlash draft path required by test_dflash, file or directory.")
+    ap.add_argument("--target-tokenizer", default=DEFAULT_TARGET_TOKENIZER)
+    ap.add_argument("--target-gpus", default=None,
+                    help="Comma-separated target device ids passed to --target-gpus.")
+    ap.add_argument("--target-layer-split", default=None,
+                    help="Comma-separated layer split weights for target layer split.")
+    ap.add_argument("--target-max-ctx", type=int, default=4096)
+    ap.add_argument("--target-gen-tokens", type=int, default=32)
+    ap.add_argument("--target-env", action="append", default=[],
+                    help="Extra NAME=VALUE environment entries for target generation.")
+    ap.add_argument("--target-split-load-draft", action="store_true",
+                    help="Also load DFlash draft in the target split harness for regression.")
+    ap.add_argument("--target-split-dflash", action="store_true",
+                    help="Run DFlash target-split decode instead of AR target decode.")
 
 
 def main() -> None:
@@ -518,6 +842,25 @@ def main() -> None:
     for path in (args.pflash_bin, args.pflash_drafter):
         if not Path(path).exists():
             raise SystemExit(f"missing required path: {path}")
+    args.build_dir = args.build_dir.resolve()
+    args.report_dir = args.report_dir.resolve()
+    args.pflash_bin = args.pflash_bin.resolve()
+    args.pflash_drafter = args.pflash_drafter.resolve()
+    if args.run_target:
+        if args.target_bin is None:
+            args.target_bin = args.build_dir / "test_dflash"
+        if not args.target_bin.exists():
+            raise SystemExit(f"missing required path: {args.target_bin}")
+        if not args.target.exists():
+            raise SystemExit(f"missing required path: {args.target}")
+        args.target_draft = resolve_target_draft(args.target_draft)
+        args.target_bin = args.target_bin.resolve()
+        args.target = args.target.resolve()
+        args.target_draft = args.target_draft.resolve()
+        if args.target_gen_tokens <= 0:
+            raise SystemExit("--target-gen-tokens must be > 0")
+        if args.target_split_dflash:
+            args.target_split_load_draft = True
     args.func(args)
 
 

--- a/dflash/src/flashprefill.h
+++ b/dflash/src/flashprefill.h
@@ -56,20 +56,22 @@ int flash_prefill_forward_bf16(
     float scale,
     const FlashPrefillConfig & cfg);
 
-// ggml flash_attn_ext-based implementation. Works on all SM targets (75+).
+// ggml flash_attn_ext-based implementation for CUDA/HIP builds supported by
+// the selected ggml backend and GPU architecture.
 // Same interface as flash_prefill_forward_bf16 but uses ggml's FA internally
-// (chunked causal attention). Accepts BF16/F16 Q/K/V tensors stored in the
-// same [B, S, H, D] contiguous layout. No custom WMMA kernels needed.
+// (chunked causal attention). Accepts BF16/F16/F32 Q/K/V tensors stored in the
+// same [B, S, H, D] contiguous layout. The caller must pass the real ggml type;
+// F16 and BF16 are both 2-byte values but are not bit-compatible.
 //
-// On SM < 80 this is the only available path (BF16 WMMA doesn't exist).
-// On SM >= 80 callers may prefer flash_prefill_forward_bf16 for the
-// block-sparse selection + custom WMMA kernel path.
+// Builds without CUDA BF16 WMMA support use this as the available FlashPrefill
+// path. CUDA builds with the custom WMMA kernels may prefer
+// flash_prefill_forward_bf16 for block-sparse selection.
 int flash_prefill_forward_q8(
     ggml_backend_t backend,
     const void * Q, const void * K, const void * V, void * O,
     int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
     float scale,
-    int elem_size,
+    ggml_type qkv_type,
     const FlashPrefillConfig & cfg);
 
 #ifdef DFLASH27B_HAVE_BSA

--- a/dflash/src/flashprefill_q8.cpp
+++ b/dflash/src/flashprefill_q8.cpp
@@ -1,8 +1,10 @@
 // ggml flash_attn_ext-based FlashPrefill implementation.
 //
 // Provides flash_prefill_forward_q8() — a portable alternative to the custom
-// BF16 WMMA flashprefill kernels. Uses ggml's built-in flash_attn_ext which
-// works on all SM targets (75+) with FP16/BF16/Q8_0 K/V support.
+// BF16 WMMA flashprefill kernels. Uses ggml's built-in flash_attn_ext. The
+// ggml CUDA/HIP FA kernels require F32 Q/output while still supporting half
+// K/V, so this path widens Q and the temporary attention output inside the
+// graph and copies the result back to the caller's half/F32 output buffer.
 //
 // The attention is run in chunks (CHUNK_S tokens per pass) to keep the
 // causal mask small and the ggml graph allocation bounded. Each chunk
@@ -31,7 +33,7 @@ int flash_prefill_forward_q8(
     const void * Q, const void * K, const void * V, void * O,
     int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
     float scale,
-    int elem_size,
+    ggml_type qkv_type,
     const FlashPrefillConfig & cfg)
 {
     (void)cfg;  // block-sparse selection not used in this path
@@ -43,15 +45,13 @@ int flash_prefill_forward_q8(
     const int Hk = n_k_heads;
     const int D  = head_dim;
 
-    // Determine the ggml type from element size.
-    // The caller passes Q/K/V as raw pointers with a known element size.
-    ggml_type qkv_type;
-    if      (elem_size == 2) qkv_type = GGML_TYPE_BF16;  // or F16 — FA handles both
-    else if (elem_size == 4) qkv_type = GGML_TYPE_F32;
-    else {
-        std::fprintf(stderr, "[flashprefill_q8] unsupported elem_size=%d\n", elem_size);
+    if (qkv_type != GGML_TYPE_F16 && qkv_type != GGML_TYPE_BF16
+        && qkv_type != GGML_TYPE_F32) {
+        std::fprintf(stderr, "[flashprefill_q8] unsupported qkv_type=%s\n",
+                     ggml_type_name(qkv_type));
         return -1;
     }
+    const int elem_size = (int)ggml_type_size(qkv_type);
 
     ggml_gallocr_t galloc = ggml_gallocr_new(
         ggml_backend_get_default_buffer_type(backend));
@@ -99,11 +99,17 @@ int flash_prefill_forward_q8(
         ggml_set_name(O_full, "O_ext");
         ggml_set_output(O_full);
 
-        // Q chunk: [D, H, cl] view, then permute → [D, cl, H] for FA
+        // Q chunk: [D, H, cl] view, then permute -> [D, cl, H] for FA.
+        // ggml-cuda/hip flash_attn_ext requires F32 Q.
         ggml_tensor * Q_chunk = ggml_view_3d(ctx, Q_full, D, H, cl,
                                              esz * D, esz * D * H,
                                              (size_t)cs * esz * D * H);
-        ggml_tensor * Q_fa = ggml_cont(ctx, ggml_permute(ctx, Q_chunk, 0, 2, 1, 3));
+        ggml_tensor * Q_perm = ggml_cont(ctx, ggml_permute(ctx, Q_chunk, 0, 2, 1, 3));
+        ggml_tensor * Q_fa = Q_perm;
+        if (qkv_type != GGML_TYPE_F32) {
+            Q_fa = ggml_cpy(ctx, Q_perm,
+                            ggml_new_tensor_3d(ctx, GGML_TYPE_F32, D, cl, H));
+        }
 
         // K/V: [D, Hk, kv_len] view, then permute → [D, kv_len, Hk] for FA
         ggml_tensor * K_view = ggml_view_3d(ctx, K_full, D, Hk, kv_len,
@@ -119,8 +125,9 @@ int flash_prefill_forward_q8(
         ggml_set_input(mask);
 
         ggml_tensor * attn = ggml_flash_attn_ext(ctx, Q_fa, K_fa, V_fa,
-                                                  mask, scale, 0.0f, 0.0f);
-        // FA output: [D, H, cl] (permuted). Copy to O_full at chunk offset.
+                                                 mask, scale, 0.0f, 0.0f);
+        // FA output is F32 [D, H, cl] (permuted). Copy/cast to O_full at
+        // chunk offset so the caller can keep compact half persistent buffers.
         ggml_tensor * O_dst = ggml_view_3d(ctx, O_full, D, H, cl,
                                            esz * D, esz * D * H,
                                            (size_t)cs * esz * D * H);

--- a/dflash/src/gpu_compat.h
+++ b/dflash/src/gpu_compat.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// Minimal CUDA/HIP runtime compatibility for dflash harness code that already
+// uses cuda* names. ggml exposes the HIP backend through ggml-cuda.h-compatible
+// APIs, so keeping the call sites unchanged avoids touching the hot-path logic.
+
+#if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+
+#include <hip/hip_runtime.h>
+
+#define cudaDeviceCanAccessPeer hipDeviceCanAccessPeer
+#define cudaDeviceEnablePeerAccess hipDeviceEnablePeerAccess
+#define cudaDeviceSynchronize hipDeviceSynchronize
+#define cudaErrorPeerAccessAlreadyEnabled hipErrorPeerAccessAlreadyEnabled
+#define cudaErrorPeerAccessNotEnabled hipErrorPeerAccessNotEnabled
+#define cudaError_t hipError_t
+#define cudaFree hipFree
+#define cudaGetDeviceCount hipGetDeviceCount
+#define cudaGetErrorString hipGetErrorString
+#define cudaGetLastError hipGetLastError
+#define cudaMalloc hipMalloc
+#define cudaMemcpy2DAsync hipMemcpy2DAsync
+#define cudaMemcpyAsync hipMemcpyAsync
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemcpyKind hipMemcpyKind
+#define cudaMemcpyPeerAsync hipMemcpyPeerAsync
+#define cudaMemset hipMemset
+#define cudaSetDevice hipSetDevice
+#define cudaStreamSynchronize hipStreamSynchronize
+#define cudaStream_t hipStream_t
+#define cudaSuccess hipSuccess
+
+#else
+
+#include <cuda_runtime.h>
+
+#endif

--- a/dflash/src/gpu_runtime_compat.h
+++ b/dflash/src/gpu_runtime_compat.h
@@ -1,8 +1,9 @@
 #pragma once
 
 // Minimal CUDA/HIP runtime compatibility for dflash harness code that already
-// uses cuda* names. ggml exposes the HIP backend through ggml-cuda.h-compatible
-// APIs, so keeping the call sites unchanged avoids touching the hot-path logic.
+// uses cuda* names. This is not a HIP-only shim: CUDA builds include the CUDA
+// runtime through this header, while HIP builds map the existing cuda* runtime
+// spellings to hip*.
 
 #if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
 

--- a/dflash/src/hip_compat/cuda_fp16.h
+++ b/dflash/src/hip_compat/cuda_fp16.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Compatibility include for vendored ggml sources compiled through HIP.
+// Some submodule snapshots include <cuda_fp16.h> in shared CUDA/HIP sources;
+// on AMD HIP builds that must resolve to hip_fp16 instead of the CUDA SDK.
+
+#include <hip/hip_fp16.h>

--- a/dflash/src/qwen3_0p6b_graph.cpp
+++ b/dflash/src/qwen3_0p6b_graph.cpp
@@ -34,7 +34,7 @@
 #include "internal.h"
 #include "flashprefill.h"
 
-#if DFLASH27B_MIN_SM >= 80
+#ifdef DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL
 #include <cuda_runtime.h>
 #endif
 
@@ -146,9 +146,10 @@ bool forward_qwen3_0p6b_drafter(
         int64_t d_ql[]  = {(int64_t)D, (int64_t)H,  (int64_t)n_lookahead};
         int64_t d_p[]   = {(int64_t)S};
         int64_t d_mt[]  = {(int64_t)S, (int64_t)n_lookahead};
-        // Use BF16 on Ampere+ (native tensor core support), F16 on Turing.
+        // Use BF16 only when the CUDA WMMA fastpath is compiled. Other CUDA
+        // arches and HIP use F16 with ggml flash_attn_ext for the portable path.
         const ggml_type half_type =
-#if DFLASH27B_MIN_SM >= 80
+#ifdef DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL
             GGML_TYPE_BF16;
 #else
             GGML_TYPE_F16;
@@ -323,18 +324,19 @@ bool forward_qwen3_0p6b_drafter(
 
         // ── Attention dispatch ──
         // Use the ggml FA path (flash_prefill_forward_q8) when:
-        //   - SM < 80 (BF16 WMMA unavailable), OR
-        //   - The drafter's persistent buffers are not BF16 (e.g. F16 on Turing)
-        // Use the custom BF16 WMMA path on SM >= 80 with BF16 buffers.
+        //   - the CUDA BF16 WMMA kernels were not compiled, OR
+        //   - the drafter's persistent buffers are not BF16
+        // Use the custom CUDA BF16 WMMA path only when it is compiled and the
+        // buffers are BF16.
         auto tF0 = std::chrono::steady_clock::now();
         const bool use_bf16_fp = (Q_buf.t->type == GGML_TYPE_BF16)
-#if DFLASH27B_MIN_SM >= 80
+#ifdef DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL
                                  && true;
 #else
                                  && false;  // WMMA kernels not compiled
 #endif
         if (use_bf16_fp) {
-#if DFLASH27B_MIN_SM >= 80
+#ifdef DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL
             int rc = flashprefill::flash_prefill_forward_bf16(
                 Q_buf.t->data,
                 K_curr_v[il].t->data,
@@ -360,7 +362,7 @@ bool forward_qwen3_0p6b_drafter(
                 V_curr_v[il].t->data,
                 attn_out_buf.t->data,
                 1, S, H, Hk, D, scale,
-                (int)ggml_element_size(Q_buf.t),
+                Q_buf.t->type,
                 fp_cfg);
             if (rc != 0) {
                 set_last_error("flash_prefill_forward_q8 failed at layer " + std::to_string(il));

--- a/dflash/src/safetensors_draft.cpp
+++ b/dflash/src/safetensors_draft.cpp
@@ -325,22 +325,17 @@ static void bf16_to_f16_array(const uint16_t * src, uint16_t * dst, size_t n) {
     }
 }
 
-// Returns true if the current CUDA device has native BF16 tensor core support
-// (Ampere SM 8.0+). On Turing (SM 7.5) cuBLAS BF16 GEMM falls back to slow
-// CUDA cores instead of tensor cores. Uses ggml's CUDA backend info at runtime.
-static bool cuda_has_native_bf16() {
-    // Check at runtime: link against ggml-cuda's device info if available,
-    // otherwise fall back to env var DFLASH27B_DRAFT_FP16 for manual override.
+// Returns true when this build should keep draft projection weights as BF16.
+// CUDA builds keep BF16 only when built for native BF16 tensor-core support;
+// all other builds convert to F16 unless explicitly overridden.
+static bool build_prefers_bf16_projection() {
     const char * env = std::getenv("DFLASH27B_DRAFT_FP16");
     if (env && std::atoi(env) != 0) return false;  // force fp16
 
-    // Probe via ggml_backend_cuda device properties (compiled-in at build time).
-    // The CMAKE_CUDA_ARCHITECTURES list tells us the minimum supported arch.
-    // If the smallest arch is < 80, return false.
-#if defined(DFLASH27B_MIN_SM) && DFLASH27B_MIN_SM < 80
-    return false;
-#else
+#if defined(DFLASH27B_BACKEND_CUDA) && defined(DFLASH27B_CUDA_MIN_SM) && DFLASH27B_CUDA_MIN_SM >= 80
     return true;
+#else
+    return false;
 #endif
 }
 
@@ -398,12 +393,12 @@ bool load_draft_safetensors(const std::string & path,
 
     // ── 4. Create named tensors in the context ───────────────────
     //
-    // Norms (rms_norm weights) are loaded as F32 because ggml's CUDA
+    // Norms (rms_norm weights) are loaded as F32 because ggml's GPU
     // elementwise ops require F32/F16 operands. Projection weights stay bf16
-    // on Ampere+ (native tensor core support) or are converted to fp16 on
-    // Turing (SM 7.5) where cuBLAS BF16 GEMM falls back to slow CUDA cores.
+    // only when the selected CUDA arch has native tensor-core BF16 support;
+    // otherwise they are converted to fp16 for the portable path.
     const ggml_type NORM_GT = GGML_TYPE_F32;
-    const bool native_bf16 = cuda_has_native_bf16();
+    const bool native_bf16 = build_prefers_bf16_projection();
     const ggml_type PROJ_GT = native_bf16 ? GGML_TYPE_COUNT : GGML_TYPE_F16;
 
     out.fc          = alloc_tensor(out.ctx, st, "fc.weight",           {HIDDEN, FC_IN},  "BF16", PROJ_GT);
@@ -440,7 +435,7 @@ bool load_draft_safetensors(const std::string & path,
     // Walk the tensors in the context and upload their bytes.
     // For tensors whose ggml type differs from the safetensors dtype (i.e.
     // BF16-on-disk, F32-in-ggml for norms, or BF16-on-disk, F16-in-ggml for
-    // projection weights on Turing), convert on the fly via scratch buffers.
+    // projection weights without native BF16), convert on the fly via scratch buffers.
     std::vector<float>    scratch_f32;
     std::vector<uint16_t> scratch_f16;
     for (ggml_tensor * t = ggml_get_first_tensor(out.ctx); t != nullptr;

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -22,7 +22,7 @@
 #include "internal.h"
 #include "dflash_graph.h"
 #include "qwen3_drafter.h"
-#include "gpu_compat.h"
+#include "gpu_runtime_compat.h"
 
 #include "ggml.h"
 #include "ggml-alloc.h"

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -22,13 +22,12 @@
 #include "internal.h"
 #include "dflash_graph.h"
 #include "qwen3_drafter.h"
+#include "gpu_compat.h"
 
 #include "ggml.h"
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
 #include "ggml-cuda.h"
-
-#include <cuda_runtime.h>
 
 // ggml-cuda dequantize: Q8_0/F16/BF16 → F32. Replaces the custom
 // f16_convert.cu kernels with ggml's built-in converter dispatch.
@@ -58,14 +57,18 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type);
 #endif
 #else
 #include <unistd.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 #endif
 
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <queue>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -1250,6 +1253,274 @@ static bool parse_float_list(const char * text, std::vector<double> & out) {
     return !out.empty();
 }
 
+static bool write_binary_file(const std::string & path, const void * data, size_t bytes) {
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return false;
+    if (bytes > 0) f.write((const char *)data, (std::streamsize)bytes);
+    return (bool)f;
+}
+
+static bool read_binary_file_exact(const std::string & path, void * data, size_t bytes) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+    if (bytes > 0) f.read((char *)data, (std::streamsize)bytes);
+    return (bool)f;
+}
+
+static std::string read_line_tail(std::istringstream & iss) {
+    std::string tail;
+    std::getline(iss, tail);
+    const size_t first = tail.find_first_not_of(" \t");
+    if (first == std::string::npos) return {};
+    if (first > 0) tail.erase(0, first);
+    return tail;
+}
+
+#if !defined(_WIN32)
+static bool read_exact_fd(int fd, void * data, size_t bytes) {
+    char * p = (char *)data;
+    size_t done = 0;
+    while (done < bytes) {
+        ssize_t n = ::read(fd, p + done, bytes - done);
+        if (n == 0) return false;
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        done += (size_t)n;
+    }
+    return true;
+}
+
+static bool write_exact_fd(int fd, const void * data, size_t bytes) {
+    const char * p = (const char *)data;
+    size_t done = 0;
+    while (done < bytes) {
+        ssize_t n = ::write(fd, p + done, bytes - done);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        done += (size_t)n;
+    }
+    return true;
+}
+#endif
+
+class DFlashDraftIpcClient {
+public:
+    DFlashDraftIpcClient() = default;
+    DFlashDraftIpcClient(const DFlashDraftIpcClient &) = delete;
+    DFlashDraftIpcClient & operator=(const DFlashDraftIpcClient &) = delete;
+    ~DFlashDraftIpcClient() { close(); }
+
+    bool start(const std::string & bin,
+               const std::string & draft_path,
+               int draft_gpu,
+               int ring_cap,
+               const std::string & work_dir) {
+#if defined(_WIN32)
+        (void)bin; (void)draft_path; (void)draft_gpu; (void)ring_cap; (void)work_dir;
+        std::fprintf(stderr, "DFlash draft IPC is only implemented on POSIX hosts\n");
+        return false;
+#else
+        close();
+        if (bin.empty() || draft_path.empty() || ring_cap <= 0) return false;
+        if (!init_work_dir(work_dir)) return false;
+
+        int cmd_pipe[2] = {-1, -1};
+        int stream_pipe[2] = {-1, -1};
+        if (::pipe(cmd_pipe) != 0 || ::pipe(stream_pipe) != 0) {
+            std::fprintf(stderr, "draft-ipc pipe failed: %s\n", std::strerror(errno));
+            if (cmd_pipe[0] >= 0) ::close(cmd_pipe[0]);
+            if (cmd_pipe[1] >= 0) ::close(cmd_pipe[1]);
+            if (stream_pipe[0] >= 0) ::close(stream_pipe[0]);
+            if (stream_pipe[1] >= 0) ::close(stream_pipe[1]);
+            return false;
+        }
+
+        pid_ = ::fork();
+        if (pid_ < 0) {
+            std::fprintf(stderr, "draft-ipc fork failed: %s\n", std::strerror(errno));
+            ::close(cmd_pipe[0]); ::close(cmd_pipe[1]);
+            ::close(stream_pipe[0]); ::close(stream_pipe[1]);
+            pid_ = -1;
+            return false;
+        }
+        if (pid_ == 0) {
+            ::dup2(cmd_pipe[0], STDIN_FILENO);
+            ::close(cmd_pipe[0]);
+            ::close(cmd_pipe[1]);
+            ::close(stream_pipe[0]);
+
+            const std::string cap_arg = "--ring-cap=" + std::to_string(ring_cap);
+            const std::string gpu_arg = "--draft-gpu=" + std::to_string(std::max(0, draft_gpu));
+            const std::string fd_arg = "--stream-fd=" + std::to_string(stream_pipe[1]);
+            ::execl(bin.c_str(), bin.c_str(),
+                    "--draft-ipc-daemon", draft_path.c_str(),
+                    cap_arg.c_str(), gpu_arg.c_str(), fd_arg.c_str(),
+                    (char *)nullptr);
+            std::fprintf(stderr, "draft-ipc exec failed: %s: %s\n",
+                         bin.c_str(), std::strerror(errno));
+            _exit(127);
+        }
+
+        ::close(cmd_pipe[0]);
+        ::close(stream_pipe[1]);
+        stream_fd_ = stream_pipe[0];
+        cmd_ = ::fdopen(cmd_pipe[1], "w");
+        if (!cmd_) {
+            std::fprintf(stderr, "draft-ipc fdopen failed: %s\n", std::strerror(errno));
+            ::close(cmd_pipe[1]);
+            close();
+            return false;
+        }
+        int32_t status = -1;
+        if (!read_exact_fd(stream_fd_, &status, sizeof(status)) || status != 0) {
+            std::fprintf(stderr, "draft-ipc daemon did not become ready (status=%d)\n", status);
+            close();
+            return false;
+        }
+        ring_cap_ = ring_cap;
+        active_ = true;
+        std::printf("[draft-ipc] ready bin=%s gpu=%d ring_cap=%d work_dir=%s\n",
+                    bin.c_str(), draft_gpu, ring_cap, work_dir_.c_str());
+        return true;
+#endif
+    }
+
+    bool send_feature_slice(int capture_idx,
+                            int start_pos,
+                            int n_tokens,
+                            const std::vector<float> & slice) {
+#if defined(_WIN32)
+        (void)capture_idx; (void)start_pos; (void)n_tokens; (void)slice;
+        return false;
+#else
+        if (!active_ || !cmd_ || n_tokens <= 0) return false;
+        const size_t expected = (size_t)n_tokens * DFLASH27B_TARGET_HIDDEN;
+        if (slice.size() != expected) return false;
+        const std::string path = next_path("feature");
+        if (!write_binary_file(path, slice.data(), slice.size() * sizeof(float))) {
+            std::fprintf(stderr, "draft-ipc write feature failed: %s\n", path.c_str());
+            return false;
+        }
+        std::fprintf(cmd_, "feature_slice %d %d %d %s\n",
+                     capture_idx, start_pos, n_tokens, path.c_str());
+        std::fflush(cmd_);
+        int32_t status = -1;
+        const bool ok = read_exact_fd(stream_fd_, &status, sizeof(status)) && status == 0;
+        std::remove(path.c_str());
+        if (!ok) {
+            std::fprintf(stderr, "draft-ipc feature_slice failed status=%d\n", status);
+        }
+        return ok;
+#endif
+    }
+
+    bool propose(int committed,
+                 int ctx_len,
+                 const std::vector<float> & noise_embed,
+                 std::vector<float> & hidden_out) {
+#if defined(_WIN32)
+        (void)committed; (void)ctx_len; (void)noise_embed; (void)hidden_out;
+        return false;
+#else
+        if (!active_ || !cmd_ || ctx_len <= 0) return false;
+        const size_t noise_expected =
+            (size_t)DFLASH27B_TARGET_HIDDEN * DFLASH27B_DRAFT_BLOCK_SIZE;
+        if (noise_embed.size() != noise_expected) return false;
+        const std::string path = next_path("noise");
+        if (!write_binary_file(path, noise_embed.data(), noise_embed.size() * sizeof(float))) {
+            std::fprintf(stderr, "draft-ipc write noise failed: %s\n", path.c_str());
+            return false;
+        }
+        std::fprintf(cmd_, "propose %d %d %s\n", committed, ctx_len, path.c_str());
+        std::fflush(cmd_);
+        int32_t status = -1;
+        bool ok = read_exact_fd(stream_fd_, &status, sizeof(status)) && status == 0;
+        if (ok) {
+            hidden_out.assign(noise_expected, 0.0f);
+            ok = read_exact_fd(stream_fd_, hidden_out.data(),
+                               hidden_out.size() * sizeof(float));
+        }
+        std::remove(path.c_str());
+        if (!ok) {
+            std::fprintf(stderr, "draft-ipc propose failed status=%d\n", status);
+        }
+        return ok;
+#endif
+    }
+
+    bool active() const { return active_; }
+    int ring_cap() const { return ring_cap_; }
+
+    void close() {
+#if !defined(_WIN32)
+        if (cmd_) {
+            std::fclose(cmd_);
+            cmd_ = nullptr;
+        }
+        if (stream_fd_ >= 0) {
+            ::close(stream_fd_);
+            stream_fd_ = -1;
+        }
+        if (pid_ > 0) {
+            int status = 0;
+            ::waitpid(pid_, &status, 0);
+            pid_ = -1;
+        }
+        if (owns_work_dir_ && !work_dir_.empty()) {
+            ::rmdir(work_dir_.c_str());
+        }
+#endif
+        active_ = false;
+        ring_cap_ = 0;
+    }
+
+private:
+#if !defined(_WIN32)
+    bool init_work_dir(const std::string & requested) {
+        if (!requested.empty()) {
+            work_dir_ = requested;
+            owns_work_dir_ = false;
+            if (::mkdir(work_dir_.c_str(), 0700) != 0 && errno != EEXIST) {
+                std::fprintf(stderr, "draft-ipc mkdir failed: %s: %s\n",
+                             work_dir_.c_str(), std::strerror(errno));
+                return false;
+            }
+            return true;
+        }
+        const char * tmp = std::getenv("TMPDIR");
+        std::string templ = std::string(tmp && *tmp ? tmp : "/tmp") +
+                            "/dflash-draft-ipc-XXXXXX";
+        std::vector<char> buf(templ.begin(), templ.end());
+        buf.push_back('\0');
+        char * dir = ::mkdtemp(buf.data());
+        if (!dir) {
+            std::fprintf(stderr, "draft-ipc mkdtemp failed: %s\n", std::strerror(errno));
+            return false;
+        }
+        work_dir_ = dir;
+        owns_work_dir_ = true;
+        return true;
+    }
+
+    std::string next_path(const char * prefix) {
+        return work_dir_ + "/" + prefix + "_" + std::to_string(seq_++) + ".bin";
+    }
+
+    pid_t pid_ = -1;
+    FILE * cmd_ = nullptr;
+    int stream_fd_ = -1;
+    std::string work_dir_;
+    int seq_ = 0;
+    bool owns_work_dir_ = false;
+#endif
+    bool active_ = false;
+    int ring_cap_ = 0;
+};
+
 static int inspect_target_layer_count(const char * target_path) {
     ggml_context * meta_ctx = nullptr;
     gguf_init_params gip{};
@@ -1339,6 +1610,35 @@ static bool copy_capture_slice_to_draft_ring(
     return cudaDeviceSynchronize() == cudaSuccess;
 }
 
+static bool copy_capture_slice_to_remote_draft(
+        DFlashDraftIpcClient & remote,
+        int capture_idx,
+        const ggml_tensor * act_out,
+        ggml_backend_t src_backend,
+        int chunk_start,
+        int start_pos,
+        int n_tokens) {
+    if (!remote.active() || !act_out || capture_idx < 0 || n_tokens <= 0) return true;
+    const int hidden = DFLASH27B_TARGET_HIDDEN;
+    const size_t row_bytes = (size_t)hidden * sizeof(float);
+    const size_t src_stride = act_out->nb[1];
+    std::vector<float> host((size_t)n_tokens * hidden);
+    ggml_backend_synchronize(src_backend);
+    if (src_stride == row_bytes) {
+        ggml_backend_tensor_get(act_out, host.data(),
+                                (size_t)chunk_start * src_stride,
+                                row_bytes * (size_t)n_tokens);
+    } else {
+        for (int i = 0; i < n_tokens; i++) {
+            ggml_backend_tensor_get(act_out,
+                                    host.data() + (size_t)i * hidden,
+                                    (size_t)(chunk_start + i) * src_stride,
+                                    row_bytes);
+        }
+    }
+    return remote.send_feature_slice(capture_idx, start_pos, n_tokens, host);
+}
+
 static bool copy_feature_ring_range_to_tensor(
         const DraftFeatureMirror & feature_ring,
         ggml_tensor * dst,
@@ -1378,6 +1678,194 @@ static bool copy_feature_ring_range_to_tensor(
         done += run;
     }
     return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+static bool stream_status(int stream_fd, int32_t status) {
+#if defined(_WIN32)
+    (void)stream_fd; (void)status;
+    return false;
+#else
+    return write_exact_fd(stream_fd, &status, sizeof(status));
+#endif
+}
+
+static int run_dflash_draft_ipc_daemon(const char * draft_path,
+                                       int ring_cap,
+                                       int draft_gpu,
+                                       int stream_fd) {
+#if defined(_WIN32)
+    (void)draft_path; (void)ring_cap; (void)draft_gpu; (void)stream_fd;
+    std::fprintf(stderr, "DFlash draft IPC daemon is only implemented on POSIX hosts\n");
+    return 2;
+#else
+    if (!draft_path || ring_cap <= 0 || stream_fd < 0) {
+        std::fprintf(stderr, "usage: test_dflash --draft-ipc-daemon <draft> --ring-cap=N --stream-fd=FD [--draft-gpu=N]\n");
+        return 2;
+    }
+
+    ggml_backend_t backend = ggml_backend_cuda_init(std::max(0, draft_gpu));
+    if (!backend) {
+        std::fprintf(stderr, "[draft-ipc-daemon] backend init failed gpu=%d\n", draft_gpu);
+        stream_status(stream_fd, -1);
+        return 1;
+    }
+
+    DraftWeights draft_weights;
+    std::string dp(draft_path);
+    bool draft_ok = false;
+    if (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf") {
+        draft_ok = load_draft_gguf(draft_path, backend, draft_weights);
+    } else {
+        draft_ok = load_draft_safetensors(draft_path, backend, draft_weights);
+    }
+    if (!draft_ok) {
+        std::fprintf(stderr, "[draft-ipc-daemon] draft load failed: %s\n",
+                     dflash27b_last_error());
+        stream_status(stream_fd, -1);
+        ggml_backend_free(backend);
+        return 1;
+    }
+
+    DraftFeatureMirror feature_ring;
+    if (!draft_feature_mirror_init(feature_ring, backend, draft_gpu, draft_gpu, ring_cap)) {
+        std::fprintf(stderr, "[draft-ipc-daemon] feature ring init failed cap=%d gpu=%d\n",
+                     ring_cap, draft_gpu);
+        stream_status(stream_fd, -1);
+        free_draft_weights(draft_weights);
+        ggml_backend_free(backend);
+        return 1;
+    }
+
+    std::fprintf(stderr, "[draft-ipc-daemon] ready gpu=%d ring_cap=%d\n",
+                 draft_gpu, ring_cap);
+    stream_status(stream_fd, 0);
+
+    const int hidden = DFLASH27B_TARGET_HIDDEN;
+    const int q_len = DFLASH27B_DRAFT_BLOCK_SIZE;
+    StepGraph draft_sg;
+    std::vector<float> noise_embed((size_t)hidden * q_len);
+    std::vector<int32_t> pos_q(q_len);
+    std::vector<int32_t> pos_k;
+    std::vector<float> hidden_out((size_t)hidden * q_len);
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        std::istringstream iss(line);
+        std::string cmd;
+        iss >> cmd;
+        if (cmd == "quit" || cmd == "exit") {
+            break;
+        }
+        if (cmd == "feature_slice") {
+            int capture_idx = -1;
+            int start_pos = -1;
+            int n_tokens = 0;
+            iss >> capture_idx >> start_pos >> n_tokens;
+            std::string path = read_line_tail(iss);
+            if (capture_idx < 0 || capture_idx >= DFLASH27B_DRAFT_N_TARGET_LAYERS ||
+                start_pos < 0 || n_tokens <= 0 || path.empty()) {
+                std::fprintf(stderr, "[draft-ipc-daemon] bad feature_slice: %s\n",
+                             line.c_str());
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            std::vector<float> slice((size_t)n_tokens * hidden);
+            if (!read_binary_file_exact(path, slice.data(), slice.size() * sizeof(float))) {
+                std::fprintf(stderr, "[draft-ipc-daemon] read feature_slice failed: %s\n",
+                             path.c_str());
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            const size_t dst_stride = feature_ring.target_feat->nb[1];
+            const size_t slice_offset =
+                (size_t)capture_idx * (size_t)hidden * sizeof(float);
+            for (int i = 0; i < n_tokens; i++) {
+                const int slot = (start_pos + i) % feature_ring.cap;
+                const size_t dst_off = (size_t)slot * dst_stride + slice_offset;
+                ggml_backend_tensor_set(feature_ring.target_feat,
+                                        slice.data() + (size_t)i * hidden,
+                                        dst_off,
+                                        (size_t)hidden * sizeof(float));
+            }
+            ggml_backend_synchronize(backend);
+            stream_status(stream_fd, 0);
+            continue;
+        }
+        if (cmd == "propose") {
+            int committed = -1;
+            int ctx_len = 0;
+            iss >> committed >> ctx_len;
+            std::string path = read_line_tail(iss);
+            if (committed < 0 || ctx_len <= 0 || ctx_len > feature_ring.cap || path.empty()) {
+                std::fprintf(stderr, "[draft-ipc-daemon] bad propose: %s\n",
+                             line.c_str());
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            if (!read_binary_file_exact(path, noise_embed.data(),
+                                        noise_embed.size() * sizeof(float))) {
+                std::fprintf(stderr, "[draft-ipc-daemon] read noise failed: %s\n",
+                             path.c_str());
+                stream_status(stream_fd, -1);
+                continue;
+            }
+
+            int mirror_slot0 = 0;
+            const bool use_mirror_view =
+                draft_feature_mirror_can_view(feature_ring, committed, ctx_len, mirror_slot0);
+            if (!build_draft_step(draft_sg, draft_weights, nullptr, backend,
+                                  ctx_len, use_mirror_view ? &feature_ring : nullptr,
+                                  committed)) {
+                std::fprintf(stderr, "[draft-ipc-daemon] draft build failed\n");
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            if (!use_mirror_view &&
+                !copy_feature_ring_range_to_tensor(feature_ring,
+                                                   draft_sg.target_hidden_cat,
+                                                   committed - ctx_len,
+                                                   ctx_len)) {
+                std::fprintf(stderr, "[draft-ipc-daemon] feature copy failed\n");
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
+                                    noise_embed.size() * sizeof(float));
+            pos_k.resize((size_t)ctx_len + q_len);
+            for (int i = 0; i < q_len; i++) pos_q[i] = ctx_len + i;
+            for (int i = 0; i < ctx_len + q_len; i++) pos_k[i] = i;
+            ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
+                                    pos_q.size() * sizeof(int32_t));
+            ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
+                                    pos_k.size() * sizeof(int32_t));
+            auto st = ggml_backend_graph_compute(backend, draft_sg.gf);
+            if (st != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr, "[draft-ipc-daemon] draft compute failed status=%d\n",
+                             (int)st);
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            ggml_backend_tensor_get(draft_sg.hidden_states, hidden_out.data(), 0,
+                                    hidden_out.size() * sizeof(float));
+            if (!stream_status(stream_fd, 0) ||
+                !write_exact_fd(stream_fd, hidden_out.data(),
+                                hidden_out.size() * sizeof(float))) {
+                std::fprintf(stderr, "[draft-ipc-daemon] stream write failed\n");
+                break;
+            }
+            continue;
+        }
+        std::fprintf(stderr, "[draft-ipc-daemon] unknown command: %s\n", line.c_str());
+        stream_status(stream_fd, -1);
+    }
+
+    step_graph_destroy(draft_sg);
+    draft_feature_mirror_free(feature_ring);
+    free_draft_weights(draft_weights);
+    ggml_backend_free(backend);
+    std::fprintf(stderr, "[draft-ipc-daemon] stopped\n");
+    return 0;
+#endif
 }
 
 static bool compute_target_split_argmax(
@@ -1431,7 +1919,8 @@ static bool run_target_layer_split_forward(
         int & last_tok,
         DraftFeatureMirror * feature_ring = nullptr,
         std::vector<int32_t> * argmax_out = nullptr,
-        std::vector<float> * logits_out = nullptr) {
+        std::vector<float> * logits_out = nullptr,
+        DFlashDraftIpcClient * remote_draft = nullptr) {
     if (shards.empty() || tokens.empty()) return false;
     const int hidden = DFLASH27B_TARGET_HIDDEN;
     const int vocab = DFLASH27B_TARGET_VOCAB;
@@ -1532,12 +2021,23 @@ static bool run_target_layer_split_forward(
                 activation_pair_free(acts);
                 return false;
             }
-            if (feature_ring && capture_idx >= 0) {
-                if (!copy_capture_slice_to_draft_ring(*feature_ring, capture_idx,
+            if ((feature_ring || remote_draft) && capture_idx >= 0) {
+                if (feature_ring &&
+                    !copy_capture_slice_to_draft_ring(*feature_ring, capture_idx,
                                                       act_out, shard->gpu,
                                                       start, base_pos + start, n)) {
                     std::fprintf(stderr,
                                  "target-split capture copy failed layer=%d capture=%d gpu=%d\n",
+                                 il, capture_idx, shard->gpu);
+                    activation_pair_free(acts);
+                    return false;
+                }
+                if (remote_draft &&
+                    !copy_capture_slice_to_remote_draft(*remote_draft, capture_idx,
+                                                        act_out, shard->backend,
+                                                        start, base_pos + start, n)) {
+                    std::fprintf(stderr,
+                                 "target-split remote capture failed layer=%d capture=%d gpu=%d\n",
                                  il, capture_idx, shard->gpu);
                     activation_pair_free(acts);
                     return false;
@@ -1584,8 +2084,10 @@ static bool run_target_layer_split_dflash_decode(
         const std::vector<int32_t> & prompt,
         int n_gen,
         int last_tok,
-        const char * out_path) {
-    if (shards.empty() || !feature_ring.target_feat) return false;
+        const char * out_path,
+        DFlashDraftIpcClient * remote_draft = nullptr) {
+    const bool use_remote_draft = remote_draft && remote_draft->active();
+    if (shards.empty() || (!use_remote_draft && !feature_ring.target_feat)) return false;
     const int hidden = DFLASH27B_TARGET_HIDDEN;
     const int vocab = DFLASH27B_TARGET_VOCAB;
     const int q_len = DFLASH27B_DRAFT_BLOCK_SIZE;
@@ -1608,7 +2110,7 @@ static bool run_target_layer_split_dflash_decode(
 
     auto sync_all = [&]() {
         for (auto & shard : shards) ggml_backend_synchronize(shard.backend);
-        ggml_backend_synchronize(draft_backend);
+        if (!use_remote_draft && draft_backend) ggml_backend_synchronize(draft_backend);
     };
 
     auto t_dec0 = std::chrono::steady_clock::now();
@@ -1626,42 +2128,54 @@ static bool run_target_layer_split_dflash_decode(
         }
 
         constexpr int DRAFT_CTX_MAX = 2048;
-        const int draft_ctx = std::min(committed, std::min(feature_ring.cap, DRAFT_CTX_MAX));
+        const int ring_cap = use_remote_draft ? remote_draft->ring_cap() : feature_ring.cap;
+        const int draft_ctx = std::min(committed, std::min(ring_cap, DRAFT_CTX_MAX));
         const int draft_start = committed - draft_ctx;
         int mirror_slot0 = 0;
         const bool use_mirror_view =
+            !use_remote_draft &&
             draft_feature_mirror_can_view(feature_ring, committed, draft_ctx, mirror_slot0);
-        if (!build_draft_step(draft_sg, draft_weights, nullptr, draft_backend,
-                              draft_ctx, use_mirror_view ? &feature_ring : nullptr,
-                              committed)) {
-            std::fprintf(stderr, "target-split-dflash draft build failed\n");
-            step_graph_destroy(draft_sg);
-            step_graph_destroy(proj_sg);
-            return false;
-        }
-        if (!use_mirror_view &&
-            !copy_feature_ring_range_to_tensor(feature_ring, draft_sg.target_hidden_cat,
-                                               draft_start, draft_ctx)) {
-            std::fprintf(stderr, "target-split-dflash draft feature copy failed\n");
-            step_graph_destroy(draft_sg);
-            step_graph_destroy(proj_sg);
-            return false;
-        }
-        ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
-                                sizeof(float) * noise_embed.size());
-        pos_k.resize((size_t)draft_ctx + q_len);
-        for (int i = 0; i < q_len; i++) pos_q[i] = draft_ctx + i;
-        for (int i = 0; i < draft_ctx + q_len; i++) pos_k[i] = i;
-        ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
-                                sizeof(int32_t) * pos_q.size());
-        ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
-                                sizeof(int32_t) * pos_k.size());
-        auto st = ggml_backend_graph_compute(draft_backend, draft_sg.gf);
-        if (st != GGML_STATUS_SUCCESS) {
-            std::fprintf(stderr, "target-split-dflash draft compute %d\n", (int)st);
-            step_graph_destroy(draft_sg);
-            step_graph_destroy(proj_sg);
-            return false;
+        std::vector<float> remote_hidden;
+        if (use_remote_draft) {
+            if (!remote_draft->propose(committed, draft_ctx, noise_embed, remote_hidden)) {
+                std::fprintf(stderr, "target-split-dflash remote draft propose failed\n");
+                step_graph_destroy(draft_sg);
+                step_graph_destroy(proj_sg);
+                return false;
+            }
+        } else {
+            if (!build_draft_step(draft_sg, draft_weights, nullptr, draft_backend,
+                                  draft_ctx, use_mirror_view ? &feature_ring : nullptr,
+                                  committed)) {
+                std::fprintf(stderr, "target-split-dflash draft build failed\n");
+                step_graph_destroy(draft_sg);
+                step_graph_destroy(proj_sg);
+                return false;
+            }
+            if (!use_mirror_view &&
+                !copy_feature_ring_range_to_tensor(feature_ring, draft_sg.target_hidden_cat,
+                                                   draft_start, draft_ctx)) {
+                std::fprintf(stderr, "target-split-dflash draft feature copy failed\n");
+                step_graph_destroy(draft_sg);
+                step_graph_destroy(proj_sg);
+                return false;
+            }
+            ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
+                                    sizeof(float) * noise_embed.size());
+            pos_k.resize((size_t)draft_ctx + q_len);
+            for (int i = 0; i < q_len; i++) pos_q[i] = draft_ctx + i;
+            for (int i = 0; i < draft_ctx + q_len; i++) pos_k[i] = i;
+            ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
+                                    sizeof(int32_t) * pos_q.size());
+            ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
+                                    sizeof(int32_t) * pos_k.size());
+            auto st = ggml_backend_graph_compute(draft_backend, draft_sg.gf);
+            if (st != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr, "target-split-dflash draft compute %d\n", (int)st);
+                step_graph_destroy(draft_sg);
+                step_graph_destroy(proj_sg);
+                return false;
+            }
         }
 
         if (!proj_sg.gf || !proj_sg.hidden_input || proj_sg.hidden_input->ne[1] != q_len) {
@@ -1673,18 +2187,23 @@ static bool run_target_layer_split_dflash_decode(
                 return false;
             }
         }
-        const size_t hidden_bytes = ggml_nbytes(draft_sg.hidden_states);
-        if (!copy_peer_async(proj_sg.hidden_input->data, output_gpu,
-                             draft_sg.hidden_states->data, draft_gpu,
-                             hidden_bytes)) {
-            std::fprintf(stderr, "target-split-dflash hidden peer copy failed\n");
-            step_graph_destroy(draft_sg);
-            step_graph_destroy(proj_sg);
-            return false;
+        if (use_remote_draft) {
+            ggml_backend_tensor_set(proj_sg.hidden_input, remote_hidden.data(), 0,
+                                    remote_hidden.size() * sizeof(float));
+        } else {
+            const size_t hidden_bytes = ggml_nbytes(draft_sg.hidden_states);
+            if (!copy_peer_async(proj_sg.hidden_input->data, output_gpu,
+                                 draft_sg.hidden_states->data, draft_gpu,
+                                 hidden_bytes)) {
+                std::fprintf(stderr, "target-split-dflash hidden peer copy failed\n");
+                step_graph_destroy(draft_sg);
+                step_graph_destroy(proj_sg);
+                return false;
+            }
+            cudaSetDevice(output_gpu);
+            cudaDeviceSynchronize();
         }
-        cudaSetDevice(output_gpu);
-        cudaDeviceSynchronize();
-        st = ggml_backend_graph_compute(output_backend, proj_sg.gf);
+        auto st = ggml_backend_graph_compute(output_backend, proj_sg.gf);
         if (st != GGML_STATUS_SUCCESS) {
             std::fprintf(stderr, "target-split-dflash projection compute %d\n", (int)st);
             step_graph_destroy(draft_sg);
@@ -1701,7 +2220,7 @@ static bool run_target_layer_split_dflash_decode(
         if (!run_target_layer_split_forward(shards, shards.front().weights,
                                             draft_tok, committed, q_len,
                                             verify_last_tok, &feature_ring,
-                                            &target_tok)) {
+                                            &target_tok, nullptr, remote_draft)) {
             std::fprintf(stderr, "target-split-dflash verify failed\n");
             step_graph_destroy(draft_sg);
             step_graph_destroy(proj_sg);
@@ -1729,7 +2248,8 @@ static bool run_target_layer_split_dflash_decode(
         int replay_last_tok = -1;
         if (!run_target_layer_split_forward(shards, shards.front().weights,
                                             replay_tok, committed, commit_n,
-                                            replay_last_tok, &feature_ring)) {
+                                            replay_last_tok, &feature_ring,
+                                            nullptr, nullptr, remote_draft)) {
             std::fprintf(stderr, "target-split-dflash replay failed\n");
             step_graph_destroy(draft_sg);
             step_graph_destroy(proj_sg);
@@ -1778,7 +2298,11 @@ static int run_target_layer_split_harness(
         bool run_draft_smoke,
         bool run_dflash,
         int max_ctx,
-        int max_verify_tokens) {
+        int max_verify_tokens,
+        const char * draft_ipc_bin = nullptr,
+        int draft_ipc_gpu = 0,
+        const char * draft_ipc_work_dir = nullptr,
+        int draft_ipc_ring_cap = 0) {
     if (!prompt_path || !out_path) {
         std::fprintf(stderr, "target layer split requires prompt/n_gen/out positional args\n");
         return 2;
@@ -1848,53 +2372,66 @@ static int run_target_layer_split_harness(
     ggml_backend_t draft_backend = nullptr;
     DraftWeights draft_weights;
     DraftFeatureMirror feature_ring;
+    DFlashDraftIpcClient remote_draft;
     bool draft_backend_owned = false;
+    const bool use_remote_draft = draft_ipc_bin && *draft_ipc_bin;
     if (load_draft) {
-        for (auto & shard : shards) {
-            if (shard.gpu == draft_gpu) {
-                draft_backend = shard.backend;
-                break;
-            }
-        }
-        if (!draft_backend) {
-            draft_backend = ggml_backend_cuda_init(draft_gpu);
-            if (!draft_backend) {
-                std::fprintf(stderr, "target-split draft cuda init failed for gpu %d\n", draft_gpu);
+        const int cap = draft_ipc_ring_cap > 0
+            ? std::min(draft_ipc_ring_cap, max_ctx)
+            : std::min(max_ctx, 4096);
+        if (use_remote_draft) {
+            if (!remote_draft.start(draft_ipc_bin, draft_path, draft_ipc_gpu,
+                                    cap, draft_ipc_work_dir ? draft_ipc_work_dir : "")) {
+                std::fprintf(stderr, "target-split remote draft start failed\n");
                 free_target_layer_split_shards(shards);
                 return 1;
             }
-            draft_backend_owned = true;
-        }
-        std::string dp(draft_path);
-        bool draft_ok = false;
-        if (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf") {
-            draft_ok = load_draft_gguf(draft_path, draft_backend, draft_weights);
         } else {
-            draft_ok = load_draft_safetensors(draft_path, draft_backend, draft_weights);
+            for (auto & shard : shards) {
+                if (shard.gpu == draft_gpu) {
+                    draft_backend = shard.backend;
+                    break;
+                }
+            }
+            if (!draft_backend) {
+                draft_backend = ggml_backend_cuda_init(draft_gpu);
+                if (!draft_backend) {
+                    std::fprintf(stderr, "target-split draft cuda init failed for gpu %d\n", draft_gpu);
+                    free_target_layer_split_shards(shards);
+                    return 1;
+                }
+                draft_backend_owned = true;
+            }
+            std::string dp(draft_path);
+            bool draft_ok = false;
+            if (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf") {
+                draft_ok = load_draft_gguf(draft_path, draft_backend, draft_weights);
+            } else {
+                draft_ok = load_draft_safetensors(draft_path, draft_backend, draft_weights);
+            }
+            if (!draft_ok) {
+                std::fprintf(stderr, "target-split draft load gpu=%d: %s\n",
+                             draft_gpu, dflash27b_last_error());
+                free_draft_weights(draft_weights);
+                if (draft_backend_owned) ggml_backend_free(draft_backend);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            std::printf("[target-split] draft loaded on gpu=%d format=%s\n",
+                        draft_gpu,
+                        (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf")
+                            ? "gguf" : "safetensors");
+            if (!draft_feature_mirror_init(feature_ring, draft_backend,
+                                           draft_gpu, draft_gpu, cap)) {
+                std::fprintf(stderr, "target-split feature ring init failed on gpu=%d\n", draft_gpu);
+                draft_feature_mirror_free(feature_ring);
+                free_draft_weights(draft_weights);
+                if (draft_backend_owned) ggml_backend_free(draft_backend);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            std::printf("[target-split] draft feature ring cap=%d gpu=%d\n", cap, draft_gpu);
         }
-        if (!draft_ok) {
-            std::fprintf(stderr, "target-split draft load gpu=%d: %s\n",
-                         draft_gpu, dflash27b_last_error());
-            free_draft_weights(draft_weights);
-            if (draft_backend_owned) ggml_backend_free(draft_backend);
-            free_target_layer_split_shards(shards);
-            return 1;
-        }
-        std::printf("[target-split] draft loaded on gpu=%d format=%s\n",
-                    draft_gpu,
-                    (dp.size() >= 5 && dp.substr(dp.size() - 5) == ".gguf")
-                        ? "gguf" : "safetensors");
-        const int cap = std::min(max_ctx, 4096);
-        if (!draft_feature_mirror_init(feature_ring, draft_backend,
-                                       draft_gpu, draft_gpu, cap)) {
-            std::fprintf(stderr, "target-split feature ring init failed on gpu=%d\n", draft_gpu);
-            draft_feature_mirror_free(feature_ring);
-            free_draft_weights(draft_weights);
-            if (draft_backend_owned) ggml_backend_free(draft_backend);
-            free_target_layer_split_shards(shards);
-            return 1;
-        }
-        std::printf("[target-split] draft feature ring cap=%d gpu=%d\n", cap, draft_gpu);
     }
 
     auto prompt = read_int32_file(prompt_path);
@@ -1927,7 +2464,9 @@ static int run_target_layer_split_harness(
     auto t_pf0 = std::chrono::steady_clock::now();
     if (!run_target_layer_split_forward(shards, shards.front().weights,
                                         prompt, 0, ubatch, last_tok,
-                                        load_draft ? &feature_ring : nullptr)) {
+                                        (load_draft && !use_remote_draft) ? &feature_ring : nullptr,
+                                        nullptr, nullptr,
+                                        (load_draft && use_remote_draft) ? &remote_draft : nullptr)) {
         std::fprintf(stderr, "target-split prefill failed\n");
         draft_feature_mirror_free(feature_ring);
         free_draft_weights(draft_weights);
@@ -1943,79 +2482,99 @@ static int run_target_layer_split_harness(
     if (run_draft_smoke) {
         const int hidden = DFLASH27B_TARGET_HIDDEN;
         const int q_len = DFLASH27B_DRAFT_BLOCK_SIZE;
-        const int draft_ctx = std::min((int)prompt.size(), feature_ring.cap);
+        const int ring_cap = use_remote_draft ? remote_draft.ring_cap() : feature_ring.cap;
+        const int draft_ctx = std::min((int)prompt.size(), ring_cap);
         const int draft_start = (int)prompt.size() - draft_ctx;
-        StepGraph draft_sg;
-        int mirror_slot0 = 0;
-        const bool use_mirror_view =
-            draft_feature_mirror_can_view(feature_ring, (int)prompt.size(),
-                                          draft_ctx, mirror_slot0);
-        if (!build_draft_step(draft_sg, draft_weights, nullptr, draft_backend,
-                              draft_ctx, use_mirror_view ? &feature_ring : nullptr,
-                              (int)prompt.size())) {
-            std::fprintf(stderr, "target-split draft smoke build failed\n");
-            step_graph_destroy(draft_sg);
-            draft_feature_mirror_free(feature_ring);
-            free_draft_weights(draft_weights);
-            if (draft_backend_owned) ggml_backend_free(draft_backend);
-            free_target_layer_split_shards(shards);
-            return 1;
-        }
-        if (!use_mirror_view &&
-            !copy_feature_ring_range_to_tensor(feature_ring,
-                                               draft_sg.target_hidden_cat,
-                                               draft_start, draft_ctx)) {
-            std::fprintf(stderr, "target-split draft smoke feature copy failed\n");
-            step_graph_destroy(draft_sg);
-            draft_feature_mirror_free(feature_ring);
-            free_draft_weights(draft_weights);
-            if (draft_backend_owned) ggml_backend_free(draft_backend);
-            free_target_layer_split_shards(shards);
-            return 1;
-        }
         std::vector<int32_t> noise_ids(q_len, DFLASH27B_DRAFT_MASK_TOKEN_ID);
         noise_ids[0] = last_tok;
         std::vector<float> noise_embed((size_t)hidden * q_len);
         if (!shards.front().weights.embedder.embed(noise_ids.data(), q_len, noise_embed.data())) {
             std::fprintf(stderr, "target-split draft smoke embed failed\n");
-            step_graph_destroy(draft_sg);
             draft_feature_mirror_free(feature_ring);
             free_draft_weights(draft_weights);
             if (draft_backend_owned) ggml_backend_free(draft_backend);
             free_target_layer_split_shards(shards);
             return 1;
         }
-        ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
-                                sizeof(float) * noise_embed.size());
-        std::vector<int32_t> pos_q(q_len), pos_k(draft_ctx + q_len);
-        for (int i = 0; i < q_len; i++) pos_q[i] = draft_ctx + i;
-        for (int i = 0; i < draft_ctx + q_len; i++) pos_k[i] = i;
-        ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
-                                sizeof(int32_t) * pos_q.size());
-        ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
-                                sizeof(int32_t) * pos_k.size());
-        auto t_ds0 = std::chrono::steady_clock::now();
-        auto st = ggml_backend_graph_compute(draft_backend, draft_sg.gf);
-        auto t_ds1 = std::chrono::steady_clock::now();
-        if (st != GGML_STATUS_SUCCESS) {
-            std::fprintf(stderr, "target-split draft smoke compute failed status=%d\n", (int)st);
+        if (use_remote_draft) {
+            std::vector<float> hidden_out;
+            auto t_ds0 = std::chrono::steady_clock::now();
+            const bool ok = remote_draft.propose((int)prompt.size(), draft_ctx,
+                                                 noise_embed, hidden_out);
+            auto t_ds1 = std::chrono::steady_clock::now();
+            if (!ok) {
+                std::fprintf(stderr, "target-split remote draft smoke failed\n");
+                draft_feature_mirror_free(feature_ring);
+                free_draft_weights(draft_weights);
+                if (draft_backend_owned) ggml_backend_free(draft_backend);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            std::printf("[target-split] remote draft smoke ctx=%d q=%d time=%.3f ms\n",
+                        draft_ctx, q_len,
+                        std::chrono::duration<double, std::milli>(t_ds1 - t_ds0).count());
+        } else {
+            StepGraph draft_sg;
+            int mirror_slot0 = 0;
+            const bool use_mirror_view =
+                draft_feature_mirror_can_view(feature_ring, (int)prompt.size(),
+                                              draft_ctx, mirror_slot0);
+            if (!build_draft_step(draft_sg, draft_weights, nullptr, draft_backend,
+                                  draft_ctx, use_mirror_view ? &feature_ring : nullptr,
+                                  (int)prompt.size())) {
+                std::fprintf(stderr, "target-split draft smoke build failed\n");
+                step_graph_destroy(draft_sg);
+                draft_feature_mirror_free(feature_ring);
+                free_draft_weights(draft_weights);
+                if (draft_backend_owned) ggml_backend_free(draft_backend);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            if (!use_mirror_view &&
+                !copy_feature_ring_range_to_tensor(feature_ring,
+                                                   draft_sg.target_hidden_cat,
+                                                   draft_start, draft_ctx)) {
+                std::fprintf(stderr, "target-split draft smoke feature copy failed\n");
+                step_graph_destroy(draft_sg);
+                draft_feature_mirror_free(feature_ring);
+                free_draft_weights(draft_weights);
+                if (draft_backend_owned) ggml_backend_free(draft_backend);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
+                                    sizeof(float) * noise_embed.size());
+            std::vector<int32_t> pos_q(q_len), pos_k(draft_ctx + q_len);
+            for (int i = 0; i < q_len; i++) pos_q[i] = draft_ctx + i;
+            for (int i = 0; i < draft_ctx + q_len; i++) pos_k[i] = i;
+            ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
+                                    sizeof(int32_t) * pos_q.size());
+            ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
+                                    sizeof(int32_t) * pos_k.size());
+            auto t_ds0 = std::chrono::steady_clock::now();
+            auto st = ggml_backend_graph_compute(draft_backend, draft_sg.gf);
+            auto t_ds1 = std::chrono::steady_clock::now();
+            if (st != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr, "target-split draft smoke compute failed status=%d\n", (int)st);
+                step_graph_destroy(draft_sg);
+                draft_feature_mirror_free(feature_ring);
+                free_draft_weights(draft_weights);
+                if (draft_backend_owned) ggml_backend_free(draft_backend);
+                free_target_layer_split_shards(shards);
+                return 1;
+            }
+            std::printf("[target-split] draft smoke ctx=%d q=%d time=%.3f ms\n",
+                        draft_ctx, q_len,
+                        std::chrono::duration<double, std::milli>(t_ds1 - t_ds0).count());
             step_graph_destroy(draft_sg);
-            draft_feature_mirror_free(feature_ring);
-            free_draft_weights(draft_weights);
-            if (draft_backend_owned) ggml_backend_free(draft_backend);
-            free_target_layer_split_shards(shards);
-            return 1;
         }
-        std::printf("[target-split] draft smoke ctx=%d q=%d time=%.3f ms\n",
-                    draft_ctx, q_len,
-                    std::chrono::duration<double, std::milli>(t_ds1 - t_ds0).count());
-        step_graph_destroy(draft_sg);
     }
 
     if (run_dflash) {
         const bool ok = run_target_layer_split_dflash_decode(
             shards, draft_weights, draft_backend, draft_gpu, feature_ring,
-            prompt, n_gen, last_tok, out_path);
+            prompt, n_gen, last_tok, out_path,
+            use_remote_draft ? &remote_draft : nullptr);
         draft_feature_mirror_free(feature_ring);
         free_draft_weights(draft_weights);
         if (draft_backend_owned) ggml_backend_free(draft_backend);
@@ -2031,7 +2590,9 @@ static int run_target_layer_split_harness(
         int next_tok = -1;
         if (!run_target_layer_split_forward(shards, shards.front().weights,
                                             one, (int)out_all.size(), 1, next_tok,
-                                            load_draft ? &feature_ring : nullptr)) {
+                                            (load_draft && !use_remote_draft) ? &feature_ring : nullptr,
+                                            nullptr, nullptr,
+                                            (load_draft && use_remote_draft) ? &remote_draft : nullptr)) {
             std::fprintf(stderr, "target-split decode failed at %d\n", generated);
             draft_feature_mirror_free(feature_ring);
             free_draft_weights(draft_weights);
@@ -2064,9 +2625,42 @@ static SamplerCfg     g_sampler;
 static std::mt19937_64 g_sampler_rng{std::random_device{}()};
 
 int main(int argc, char ** argv) {
+    if (argc >= 2 && std::strcmp(argv[1], "--draft-ipc-daemon") == 0) {
+        if (argc < 3) {
+            std::fprintf(stderr,
+                "usage: %s --draft-ipc-daemon <draft.safetensors|draft.gguf> --ring-cap=N --stream-fd=FD [--draft-gpu=N]\n",
+                argv[0]);
+            return 2;
+        }
+        const char * ipc_draft_path = argv[2];
+        int ipc_ring_cap = 4096;
+        int ipc_draft_gpu = 0;
+        int ipc_stream_fd = -1;
+        for (int i = 3; i < argc; i++) {
+            if (std::strncmp(argv[i], "--ring-cap=", 11) == 0) {
+                ipc_ring_cap = std::atoi(argv[i] + 11);
+            } else if (std::strcmp(argv[i], "--ring-cap") == 0) {
+                if (i + 1 < argc) ipc_ring_cap = std::atoi(argv[++i]);
+            } else if (std::strncmp(argv[i], "--draft-gpu=", 12) == 0) {
+                ipc_draft_gpu = std::max(0, std::atoi(argv[i] + 12));
+            } else if (std::strcmp(argv[i], "--draft-gpu") == 0) {
+                if (i + 1 < argc) ipc_draft_gpu = std::max(0, std::atoi(argv[++i]));
+            } else if (std::strncmp(argv[i], "--stream-fd=", 12) == 0) {
+                ipc_stream_fd = std::atoi(argv[i] + 12);
+            } else if (std::strcmp(argv[i], "--stream-fd") == 0) {
+                if (i + 1 < argc) ipc_stream_fd = std::atoi(argv[++i]);
+            }
+        }
+        return run_dflash_draft_ipc_daemon(ipc_draft_path,
+                                           ipc_ring_cap,
+                                           ipc_draft_gpu,
+                                           ipc_stream_fd);
+    }
     if (argc < 3) {
         std::fprintf(stderr,
-            "usage: %s <target.gguf> <draft.safetensors> [<prompt_ids.bin> <n_gen> <out_ids.bin>] [--daemon] [-ctk <type>] [-ctv <type>] ...\n", argv[0]);
+            "usage: %s <target.gguf> <draft.safetensors> [<prompt_ids.bin> <n_gen> <out_ids.bin>] [--daemon] [-ctk <type>] [-ctv <type>] ...\n"
+            "       %s --draft-ipc-daemon <draft.safetensors|draft.gguf> --ring-cap=N --stream-fd=FD [--draft-gpu=N]\n",
+            argv[0], argv[0]);
         return 2;
     }
     // TurboQuant FA kernel requires kv_len aligned to FATTN_KQ_STRIDE=256.
@@ -2112,6 +2706,10 @@ int main(int argc, char ** argv) {
     bool  target_split_dflash = false;
     int   target_gpu = 0;
     int   draft_gpu = 0;
+    const char * draft_ipc_bin = nullptr;
+    const char * draft_ipc_work_dir = nullptr;
+    int   draft_ipc_gpu = 0;
+    int   draft_ipc_ring_cap = 0;
     std::vector<int> target_gpus;
     std::vector<double> target_split_weights;
     if (const char * s = std::getenv("DFLASH_TARGET_GPU")) {
@@ -2119,6 +2717,18 @@ int main(int argc, char ** argv) {
     }
     if (const char * s = std::getenv("DFLASH_DRAFT_GPU")) {
         draft_gpu = std::max(0, std::atoi(s));
+    }
+    if (const char * s = std::getenv("DFLASH_DRAFT_IPC_BIN")) {
+        draft_ipc_bin = s;
+    }
+    if (const char * s = std::getenv("DFLASH_DRAFT_IPC_GPU")) {
+        draft_ipc_gpu = std::max(0, std::atoi(s));
+    }
+    if (const char * s = std::getenv("DFLASH_DRAFT_IPC_WORK_DIR")) {
+        draft_ipc_work_dir = s;
+    }
+    if (const char * s = std::getenv("DFLASH_DRAFT_IPC_RING_CAP")) {
+        draft_ipc_ring_cap = std::max(0, std::atoi(s));
     }
     if (const char * s = std::getenv("DFLASH_TARGET_GPUS")) {
         if (!parse_int_list(s, target_gpus)) {
@@ -2197,6 +2807,30 @@ int main(int argc, char ** argv) {
         else if (std::strcmp(argv[i], "--draft-gpu") == 0) {
             if (i + 1 < argc) draft_gpu = std::max(0, std::atoi(argv[++i]));
         }
+        else if (std::strncmp(argv[i], "--draft-ipc-bin=", 16) == 0) {
+            draft_ipc_bin = argv[i] + 16;
+        }
+        else if (std::strcmp(argv[i], "--draft-ipc-bin") == 0) {
+            if (i + 1 < argc) draft_ipc_bin = argv[++i];
+        }
+        else if (std::strncmp(argv[i], "--draft-ipc-gpu=", 16) == 0) {
+            draft_ipc_gpu = std::max(0, std::atoi(argv[i] + 16));
+        }
+        else if (std::strcmp(argv[i], "--draft-ipc-gpu") == 0) {
+            if (i + 1 < argc) draft_ipc_gpu = std::max(0, std::atoi(argv[++i]));
+        }
+        else if (std::strncmp(argv[i], "--draft-ipc-work-dir=", 21) == 0) {
+            draft_ipc_work_dir = argv[i] + 21;
+        }
+        else if (std::strcmp(argv[i], "--draft-ipc-work-dir") == 0) {
+            if (i + 1 < argc) draft_ipc_work_dir = argv[++i];
+        }
+        else if (std::strncmp(argv[i], "--draft-ipc-ring-cap=", 21) == 0) {
+            draft_ipc_ring_cap = std::max(0, std::atoi(argv[i] + 21));
+        }
+        else if (std::strcmp(argv[i], "--draft-ipc-ring-cap") == 0) {
+            if (i + 1 < argc) draft_ipc_ring_cap = std::max(0, std::atoi(argv[++i]));
+        }
         else if (std::strcmp(argv[i], "--profile-scaling") == 0) {
             profile_scaling = true;
         }
@@ -2254,10 +2888,24 @@ int main(int argc, char ** argv) {
     if (target_split_dflash) target_split_load_draft = true;
     if (target_gpus.empty()) target_gpus.push_back(target_gpu);
     if (target_gpus.size() == 1) target_gpu = target_gpus[0];
+    if (draft_ipc_bin && target_gpus.size() <= 1) {
+        std::fprintf(stderr,
+                     "--draft-ipc-bin currently applies to --target-gpus layer-split DFlash only\n");
+        return 2;
+    }
+    if (draft_ipc_bin && !target_split_load_draft) {
+        std::fprintf(stderr,
+                     "--draft-ipc-bin requires --target-split-dflash or --target-split-load-draft\n");
+        return 2;
+    }
     std::printf("[cfg] seq_verify=%d fast_rollback=%d ddtree=%d budget=%d temp=%.2f chain_seed=%d fa_window=%d draft_feature_mirror=%d target_gpu=%d draft_gpu=%d\n",
                 (int)seq_verify, (int)fast_rollback, (int)ddtree_mode,
                 ddtree_budget, ddtree_temp, (int)ddtree_chain_seed, g_fa_window,
                 (int)draft_feature_mirror, target_gpu, draft_gpu);
+    if (draft_ipc_bin) {
+        std::printf("[cfg] draft_ipc_bin=%s draft_ipc_gpu=%d draft_ipc_ring_cap=%d\n",
+                    draft_ipc_bin, draft_ipc_gpu, draft_ipc_ring_cap);
+    }
 
     int cuda_device_count = 0;
     cudaGetDeviceCount(&cuda_device_count);
@@ -2268,7 +2916,8 @@ int main(int argc, char ** argv) {
             return 2;
         }
     }
-    if (target_gpu >= cuda_device_count || draft_gpu >= cuda_device_count) {
+    if (target_gpu >= cuda_device_count ||
+        (!draft_ipc_bin && draft_gpu >= cuda_device_count)) {
         std::fprintf(stderr, "bad gpu ids target=%d draft=%d device_count=%d\n",
                      target_gpu, draft_gpu, cuda_device_count);
         return 2;
@@ -2288,10 +2937,14 @@ int main(int argc, char ** argv) {
                                              target_split_load_draft,
                                              target_split_load_draft && !target_split_dflash,
                                              target_split_dflash,
-                                             g_max_ctx_override > 0 ? g_max_ctx_override : 4096,
-                                             ddtree_mode
-                                                 ? std::max<int>(DFLASH27B_DRAFT_BLOCK_SIZE, ddtree_budget + 1)
-                                                 : DFLASH27B_DRAFT_BLOCK_SIZE);
+                                                 g_max_ctx_override > 0 ? g_max_ctx_override : 4096,
+                                                 ddtree_mode
+                                                     ? std::max<int>(DFLASH27B_DRAFT_BLOCK_SIZE, ddtree_budget + 1)
+                                                     : DFLASH27B_DRAFT_BLOCK_SIZE,
+                                                 draft_ipc_bin,
+                                                 draft_ipc_gpu,
+                                                 draft_ipc_work_dir,
+                                                 draft_ipc_ring_cap);
     }
 
     const bool split_gpus = target_gpu != draft_gpu;


### PR DESCRIPTION
# bench(dflash,pflash): add CUDA/HIP mixed backend placement

## Summary

Add CUDA/HIP mixed backend placement support for PFlash and DFlash bench harness execution.

This PR makes the PFlash/DFlash harness split paths backend-portable instead of CUDA-only or multi-GPU-specific. The same implementation can be built as separate CUDA or HIP binaries, then combined by the harness when CUDA/HIP mixed backend placement is needed:

- single backend / single device, where the split path still runs inside one selected GPU backend;
- single backend / multiple devices, where target execution may use the existing target layer split;
- CUDA/HIP mixed backend, where PFlash phase split or DFlash draft split crosses a host-data/process boundary.

This PR keeps mixed placement in the bench/runtime harnesses first, so the multi-device and multi-backend behavior can be validated directly before the OpenAI-compatible server path is integrated in a follow-up PR.

## Changes

- Add `DFLASH27B_GPU_BACKEND=cuda|hip` to the DFlash CMake build.
- Link DFlash runtime/test targets against the selected ggml backend (`ggml-cuda` or `ggml-hip`).
- Add a small HIP compatibility shim for the current vendored ggml HIP snapshot.
- Route non-CUDA-WMMA PFlash execution through ggml `flash_attn_ext`.
- Pass the real Q/K/V `ggml_type` into the portable PFlash path so F16 and BF16 are not inferred from byte size.
- Make draft projection weight type selection backend-aware instead of using a CUDA-only SM macro.
- Extend `phase_split_dual_gpu.py` with:
  - `--pflash-backend cuda|hip`
  - `--pflash-visible-devices`
  - `--target-backend cuda|hip`
  - `--target-visible-devices`
  - optional target generation after PFlash compression
  - separate CUDA/HIP GPU resource monitoring
- Add DFlash draft IPC support to `test_dflash`:
  - `--draft-ipc-daemon`
  - `--draft-ipc-bin`
  - `--draft-ipc-gpu`
  - `--draft-ipc-work-dir`
  - `--draft-ipc-ring-cap`
- Extend `bench_he.py` so HumanEval-style DFlash runs can pass through the draft IPC binary/options used for mixed-backend draft split validation.
- Document CUDA/HIP mixed backend placement in `dflash/docs/MIXED_BACKEND.md` and keep `SPEC_PREFILL.md` focused on the spec-prefill daemon reference.

## CUDA/HIP Mixed Backend Design

PFlash and DFlash already have flexible split flows. This PR makes those flows explicit backend-placement points across separate CUDA/HIP builds instead of tying the harness to one GPU vendor or one fixed topology.

The mixed-backend boundary stays at phase/model/process level:

- PFlash phase split can place the PFlash drafter and target generation on different backends, or keep both on one backend.
- DFlash draft split can place the draft model in a separate backend process and feed a target process through host IPC.
- Target execution can remain single-device or use same-backend target layer split.

These split boundaries do not require moving GPU activations directly across vendors, so backend placement can be selected through build-time backend binaries plus runtime harness placement while cross-vendor target layer execution stays outside the design.

For PFlash, the boundary is host-side token/text data:

1. The PFlash daemon returns compressed drafter-token IDs.
2. The harness decodes those IDs to text.
3. The target tokenizer re-encodes that text for target generation.

For DFlash, the boundary is a separate draft process:

1. The target split path captures target-side feature slices.
2. The feature/noise inputs are passed through host IPC to the draft daemon.
3. The draft daemon returns hidden states to the target process for projection and verification.

This keeps mixed backend support compatible with single-device target runs and existing same-backend target layer split behavior while avoiding cross-vendor target layer execution.

## Validation

Validation used mixed CUDA/HIP hardware to cover the cross-backend case. CUDA-only, HIP-only, single-device, and same-backend multi-device placements use the same CMake backend selector and harness plumbing, but the table below focuses on the cases that prove both backend directions:

- CUDA side: RTX 2080 Ti (`sm_75`), NVIDIA driver `595.58.03`, CUDA toolkit `12.0.140` (`nvidia-smi` reports CUDA driver capability `13.2`).
- HIP side: AMD Radeon Pro VII (`gfx906`), ROCm `7.2.1`, HIP `7.2.53211`.

| Path | Direction | Draft/PFlash side | Target side | Model | Test | Result |
|---|---|---|---|---|---|---|
| PFlash phase split | HIP -> CUDA | HIP on 1x Pro VII (`gfx906`) | CUDA target split on 2x RTX 2080 Ti (`sm_75`) | Qwen3.6-27B-Q8_0 | NIAH 4K / 8K / 16K | Passed, key and answer retained, kept-token ratio 4.4-4.8% |
| PFlash phase split | CUDA -> HIP | CUDA on 1x RTX 2080 Ti (`sm_75`) | HIP target split on 2x Pro VII (`gfx906`) | Qwen3.6-27B-Q8_0 | NIAH 4K / 8K / 16K | Passed, key and answer retained, kept-token ratio 4.4-4.8% |
| DFlash draft split | HIP -> CUDA | HIP draft IPC daemon on 1x Pro VII (`gfx906`) | CUDA target split on 2x RTX 2080 Ti (`sm_75`) | Qwen3.6-27B-Q8_0 | HumanEval 10 prompts, n_gen=256 | Passed, mean AL 8.88, accept 50.8%, decode 35.68 tok/s |
| DFlash draft split | CUDA -> HIP | CUDA draft IPC daemon on 1x RTX 2080 Ti (`sm_75`) | HIP target split on 2x Pro VII (`gfx906`) | Qwen3.6-27B-Q8_0 | HumanEval 10 prompts, n_gen=256 | Passed, mean AL 8.69, accept 49.6%, decode 20.86 tok/s |

Additional checks:

- CUDA build passed for the mixed-backend branch.
- HIP build passed for the mixed-backend branch.
- `phase_split_dual_gpu.py` was exercised in both backend directions.
- `bench_he.py` was exercised with mixed-backend DFlash draft IPC in both backend directions.