### PR TITLE
feat: disable Qwen3 thinking by default + NIAH bench QoL flags

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -277,8 +277,13 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
 
         ``template_kwargs`` is passed through to ``apply_chat_template`` so callers
         can toggle template knobs like ``enable_thinking`` per-request.
+
+        Thinking is disabled by default (enable_thinking=False) because Qwen3.6's
+        think mode wrecks DFlash acceptance rates. Clients can opt in by sending
+        ``"chat_template_kwargs": {"enable_thinking": true}`` in the request.
         """
-        tpl_kwargs: dict = {"tokenize": False, "add_generation_prompt": True}
+        tpl_kwargs: dict = {"tokenize": False, "add_generation_prompt": True,
+                            "enable_thinking": False}
         tpl_kwargs.update(
             {k: v for k, v in (template_kwargs or {}).items() if k in _ALLOWED_TEMPLATE_KWARGS}
         )

--- a/pflash/tests/bench_niah_cpp.py
+++ b/pflash/tests/bench_niah_cpp.py
@@ -54,6 +54,12 @@ def main():
                          "DFLASH_FP_ALPHA env var when unset. Validate per "
                          "setup; e.g. alpha=0.85 fails 2/10 NIAH at 117K on "
                          "Qwen3.6-27B / RTX 5090.")
+    ap.add_argument("--no-thinking", action="store_true",
+                    help="Pass enable_thinking=False to the target chat "
+                         "template. Required for Qwen3.6: thinking mode "
+                         "consumes n_gen budget on a chain-of-thought "
+                         "rollout instead of answering, breaking NIAH "
+                         "validation.")
     args = ap.parse_args()
 
     # Resolve BSA + alpha so the daemon subprocess inherits a consistent env.
@@ -139,9 +145,11 @@ def main():
         # Decode compressed ids with DRAFTER tokenizer, re-encode with TARGET + chat template.
         comp_text = drafter_tok.decode(compressed_ids, skip_special_tokens=True)
         user_msg = comp_text + "\n\nAnswer the user question based on the above context."
+        chat_kwargs = {"tokenize": False, "add_generation_prompt": True}
+        if args.no_thinking:
+            chat_kwargs["enable_thinking"] = False
         chat = target_tok.apply_chat_template(
-            [{"role": "user", "content": user_msg}],
-            tokenize=False, add_generation_prompt=True)
+            [{"role": "user", "content": user_msg}], **chat_kwargs)
         target_ids = target_tok(chat, return_tensors="pt")["input_ids"][0].tolist()
 
         # Free drafter (1.2GB), restore target+spec_draft for target gen.

--- a/pflash/tests/niah_gen.py
+++ b/pflash/tests/niah_gen.py
@@ -103,6 +103,10 @@ def main():
     ap.add_argument("--n", type=int, default=10)
     ap.add_argument("--ctx", type=_positive_int, default=8192)
     ap.add_argument("--out", required=True)
+    ap.add_argument("--seed-base", type=int, default=42,
+                    help="Base seed for case generation (default 42). "
+                         "Vary this to produce different needle key/value "
+                         "pairs without changing --n.")
     # Default matches bench_niah_cpp.py's --drafter-tokenizer, since that is
     # the tokenizer the downstream NIAH bench uses to size case["prompt"]
     # for the drafter forward. Override for any other harness.
@@ -118,7 +122,7 @@ def main():
         with open(tmp_path, "w") as f:
             for i in range(args.n):
                 try:
-                    ex = gen_one(seed=42 + i, target_tokens=args.ctx, tokenizer=tok)
+                    ex = gen_one(seed=args.seed_base + i, target_tokens=args.ctx, tokenizer=tok)
                 except ValueError as e:
                     sys.exit(f"[error] case {i}: {e}")
                 assert ex["n_tokens"] <= args.ctx, (


### PR DESCRIPTION
Three small, related changes around Qwen3.x thinking-mode handling and the NIAH harness.

server.py: default `enable_thinking=False`

The OpenAI-compatible endpoint applied the tokenizer chat template with no `enable_thinking` kwarg, which falls through to the Qwen3.x template default of `True`. With thinking on, every reply burns its `n_gen` budget on a chain-of-thought rollout that DFlash's drafter cannot predict, collapsing acceptance rate (typically ~60% -> single digits) and frequently exhausting `max_tokens` before the answer block starts.

The default flips to `False`. Clients keep full control by sending `"chat_template_kwargs": {"enable_thinking": true}` per request, which the existing template-kwargs passthrough merges in. This repo only serves Qwen3.5/3.6, so the default is safe; the kwarg is silently ignored by tokenizers whose templates do not reference it.

bench_niah_cpp.py: `--no-thinking` flag

The NIAH bench builds its own chat prompt (independent of the server path) and hit the same problem at 117K context: Qwen3.6 spent the full generation budget thinking and never reached the answer. Adds a `--no-thinking` flag that injects `enable_thinking=False` into the target's `apply_chat_template` call. Default is off, so existing invocations are unchanged.

niah_gen.py: `--seed-base` flag

Replaces the hardcoded `seed=42 + i` with a `--seed-base` argument (default 42). Lets you generate independent case sets without changing `--n`, e.g. for held-out validation passes.