### PR TITLE
feat(dflash): --prefill-skip-park for 32 GB+ GPUs

### DIFF
--- a/dflash/scripts/_prefill_hook.py
+++ b/dflash/scripts/_prefill_hook.py
@@ -59,6 +59,7 @@ class PrefillConfig:
     keep_ratio: float                                  # 0.015..0.125
     drafter_gguf: Optional[Path]                       # drafter weights (Qwen3-0.6B BF16 GGUF)
     drafter_tokenizer_id: str                          # HF repo ID for drafter vocab
+    skip_park: bool = False                            # skip park/unpark on >=32 GB GPUs
 
     @property
     def enabled(self) -> bool:
@@ -92,6 +93,11 @@ def add_cli_flags(ap) -> None:
     ap.add_argument("--prefill-drafter-tokenizer", default="Qwen/Qwen3-0.6B",
                     help="HF repo ID for the drafter tokenizer "
                          "(default Qwen/Qwen3-0.6B).")
+    ap.add_argument("--prefill-skip-park", action="store_true", default=False,
+                    help="Skip park/unpark/free-drafter on GPUs with enough VRAM "
+                         "to hold target + draft + scorer simultaneously (e.g. "
+                         "RTX 5090 32 GB). Keeps scorer resident for fast "
+                         "subsequent compressions.")
 
 
 def config_from_args(args) -> PrefillConfig:
@@ -109,6 +115,7 @@ def config_from_args(args) -> PrefillConfig:
         keep_ratio=args.prefill_keep_ratio,
         drafter_gguf=args.prefill_drafter,
         drafter_tokenizer_id=args.prefill_drafter_tokenizer,
+        skip_park=getattr(args, 'prefill_skip_park', False),
     )
 
 
@@ -121,11 +128,17 @@ def compress_text_via_daemon(
     drafter_tokenizer,
     cfg: PrefillConfig,
     prompt_text: str,
+    skip_park: bool = False,
 ) -> str:
     """Run the daemon's compress + memory dance, return the compressed text.
 
     Caller holds the daemon lock for the full duration. After this returns,
     the daemon has its target + draft restored and is ready for ``generate``.
+
+    When ``skip_park`` is True (e.g. on 32 GB+ GPUs where all three models
+    fit in VRAM simultaneously), the park/unpark/free-drafter steps are
+    skipped. The daemon's compress handler will keep the scorer loaded for
+    subsequent requests, avoiding the ~2s reload penalty per request.
     """
     # 1) drafter-tokenize the prompt
     drafter_ids = drafter_tokenizer(prompt_text, return_tensors=None,
@@ -140,9 +153,10 @@ def compress_text_via_daemon(
             for t in drafter_ids:
                 f.write(struct.pack("<i", int(t)))
 
-        # 3) park target + draft so drafter has VRAM headroom on a 24 GB card
-        _send_and_ack(daemon_stdin, r_pipe, "park target\n")
-        _send_and_ack(daemon_stdin, r_pipe, "park draft\n")
+        if not skip_park:
+            # 3) park target + draft so drafter has VRAM headroom on a 24 GB card
+            _send_and_ack(daemon_stdin, r_pipe, "park target\n")
+            _send_and_ack(daemon_stdin, r_pipe, "park draft\n")
 
         # 4) compress: drafter loads, FlashPrefill scoring, emit compressed ids, drafter held
         keep_x1000 = int(round(cfg.keep_ratio * 1000))
@@ -151,10 +165,11 @@ def compress_text_via_daemon(
         daemon_stdin.flush()
         compressed_ids = _drain_until_sentinel(r_pipe)
 
-        # 5) free drafter weights + BSA scratch, then restore target + draft
-        _send_and_ack(daemon_stdin, r_pipe, "free drafter\n")
-        _send_and_ack(daemon_stdin, r_pipe, "unpark target\n")
-        _send_and_ack(daemon_stdin, r_pipe, "unpark draft\n")
+        if not skip_park:
+            # 5) free drafter weights + BSA scratch, then restore target + draft
+            _send_and_ack(daemon_stdin, r_pipe, "free drafter\n")
+            _send_and_ack(daemon_stdin, r_pipe, "unpark target\n")
+            _send_and_ack(daemon_stdin, r_pipe, "unpark draft\n")
     finally:
         try: os.unlink(path)
         except Exception: pass

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -315,6 +315,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int, max_ctx: i
             drafter_tokenizer=drafter_tokenizer,
             cfg=prefill_cfg,
             prompt_text=long_text,
+            skip_park=prefill_cfg.skip_park,
         )
 
         new_msgs = list(msgs)
@@ -833,6 +834,8 @@ def main():
         os.environ.setdefault("DFLASH27B_FA_WINDOW", "0")
         os.environ.setdefault("DFLASH_FP_USE_BSA", "1")
         os.environ.setdefault("DFLASH_FP_ALPHA",   "0.85")
+        if prefill_cfg.skip_park:
+            os.environ["DFLASH_COMPRESS_NO_PARK"] = "1"
 
     if not args.bin.is_file():
         raise SystemExit(f"binary not found at {args.bin}")

--- a/dflash/scripts/server_tools.py
+++ b/dflash/scripts/server_tools.py
@@ -399,6 +399,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
             drafter_tokenizer=drafter_tokenizer,
             cfg=prefill_cfg,
             prompt_text=last_user.content,
+            skip_park=prefill_cfg.skip_park,
         )
 
         new_msgs = []
@@ -922,6 +923,7 @@ def build_app(target: Path, draft: Path, bin_path: Path, budget: int,
             drafter_tokenizer=drafter_tokenizer,
             cfg=prefill_cfg,
             prompt_text=long_text,
+            skip_park=prefill_cfg.skip_park,
         )
         new_msgs = list(msgs)
         new_msgs[last_user_idx] = {"role": "user", "content": compressed_text}

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -2741,8 +2741,12 @@ int main(int argc, char ** argv) {
                 // Park target + draft before allocating drafter context so
                 // the drafter's KV (~1.3 GB Q4_0) + scratch (~600 MB) have
                 // headroom on a 24 GB card. Restore after scoring.
-                bool restore_target = !target_parked;
-                bool restore_draft  = !draft_parked;
+                // On >=32 GB GPUs, DFLASH_COMPRESS_NO_PARK=1 skips parking
+                // so the scorer stays co-resident with target+draft.
+                const bool no_park = (std::getenv("DFLASH_COMPRESS_NO_PARK") &&
+                                      std::atoi(std::getenv("DFLASH_COMPRESS_NO_PARK")) != 0);
+                bool restore_target = !target_parked && !no_park;
+                bool restore_draft  = !draft_parked && !no_park;
                 if (restore_target) {
                     step_graph_destroy(proj_sg);
                     free_target_weights(w);


### PR DESCRIPTION
The PFlash compress flow parks the target + draft to VRAM-backed scratch before loading the drafter, then restores them after scoring. The park/restore protects 24 GB cards (target ~16 GB Q4_K_M + draft ~3 GB + drafter KV ~1.3 GB + BSA scratch ~600 MB exceeds 24 GB without it) but adds like 9 s of fixed cost per compress call.

On a 32 GB card (RTX 5090) all three models fit co-resident, so the park/restore round trip is pure overhead.

Plumbs a `skip_park` flag from CLI to daemon:

- `--prefill-skip-park` argparse flag (default off, behaviour unchanged for existing users).
- `PrefillConfig.skip_park` carries the choice through both server.py and server_tools.py compress paths.
- `compress_text_via_daemon` skips the `park target / park draft` and `free drafter / unpark target / unpark draft` round-trips when `skip_park=True`.
- Server start sets `DFLASH_COMPRESS_NO_PARK=1` in the daemon env when the flag is on; daemon `compress` handler then leaves the scorer resident, avoiding the ~2 s reload on every subsequent request.

The flag is opt-in. Users on 24 GB cards who pass it will OOM during compress; the help text calls out the 32 GB minimum.