### PR TITLE
fix(dflash): pad KV mask to 256 when TQ3_0 is selected via -ctk/-ctv

### DIFF
--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -60,6 +60,7 @@ to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type);
 #include <unistd.h>
 #endif
 
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -2231,6 +2232,22 @@ int main(int argc, char ** argv) {
         else if (std::strncmp(argv[i], "-ctv=", 5) == 0) {
             setenv("DFLASH27B_KV_V", argv[i] + 5, 1);
         }
+    }
+
+    // The KV type may also have been chosen via -ctk/-ctv, which sets
+    // DFLASH27B_KV_K / DFLASH27B_KV_V during the argv loop above. Re-check
+    // for TQ3 here so g_kq_stride_pad matches the chunked-FA driver's
+    // align_up(kv_len, 256); otherwise the host-built mask is short and the
+    // kernel reads past its end.
+    auto kv_env_is_tq3 = [](const char * name) {
+        const char * s = std::getenv(name);
+        if (!s) return false;
+        std::string lc;
+        for (const char * p = s; *p; ++p) lc += (char)std::tolower((unsigned char)*p);
+        return lc.rfind("tq3", 0) == 0;
+    };
+    if (kv_env_is_tq3("DFLASH27B_KV_K") || kv_env_is_tq3("DFLASH27B_KV_V")) {
+        g_kq_stride_pad = 256;
     }
 
     if (!daemon_mode && !test_window_mode && (!prompt_path || !out_path)) {


### PR DESCRIPTION
Tried using TQ3_0 KV cache on a 32 GB RTX 5090 to free VRAM for a larger context window. Server came up clean, but every reply past a short prompt was a single "!" token followed by an empty response. Short prompts worked. Output was non-deterministic across runs, so the prime suspect was uninitialized memory.

Testing across ubatch sizes showed the failure wasn't a simple threshold, it hit specific values clustered around multiples of 32 ({26-32, 63-64, 95-96, 128, 160, 192, 224, 320, 384}) while powers of 2 at or above 256 passed cleanly. Instrumenting the chunked flash-attention path traced the NaN to the softmax kernel reading the causal mask out of bounds: the mask tensor was (384, 384) when the kernel expected (512, 384). The read at mask[383*384 + 442] landed past the buffer end into adjacent GPU memory, where stray fp16 bits like 0xfe19 decoded as NaN and poisoned the softmax.

The stride bump from 32 to 256 already existed for the legacy DFLASH27B_KV_TQ3=1 env path, but the newer -ctk/-ctv flags (which set DFLASH27B_KV_K / DFLASH27B_KV_V) never triggered it.

Fix: re-check DFLASH27B_KV_K / DFLASH27B_KV_V after argv parsing and bump g_kq_stride_pad to 256 if either starts with "tq3". The legacy path is left in place; this is purely additive.

Reproducer: -ctk tq3_0 -ctv tq3_0 with any prompt long enough to hit PREFILL_UBATCH > 25 (default switches at 2048 tokens) returns "!" before this fix and correct output after.

The bug is not architecture-specific, it affects any GPU when TQ3_0 is selected via the newer -ctk/-ctv flags rather than the legacy DFLASH27B_KV_TQ3=1 env. It was caught on an RTX 5090 but would reproduce identically on a 3090 under the same flag path.