### PR TITLE
flashprefill_q8: cast Q to F32 for ggml flash_attn_ext on sm_75

### DIFF
--- a/dflash/src/flashprefill_q8.cpp
+++ b/dflash/src/flashprefill_q8.cpp
@@ -104,6 +104,10 @@ int flash_prefill_forward_q8(
                                              esz * D, esz * D * H,
                                              (size_t)cs * esz * D * H);
         ggml_tensor * Q_fa = ggml_cont(ctx, ggml_permute(ctx, Q_chunk, 0, 2, 1, 3));
+        // ggml flash_attn_ext requires Q to be F32 on all SM targets.
+        if (qkv_type != GGML_TYPE_F32) {
+            Q_fa = ggml_cast(ctx, Q_fa, GGML_TYPE_F32);
+        }
 
         // K/V: [D, Hk, kv_len] view, then permute → [D, kv_len, Hk] for FA
         ggml_tensor * K_view = ggml_view_3d(ctx, K_full, D, Hk, kv_len,


### PR DESCRIPTION
ggml's flash_attn_ext asserts Q->type == GGML_TYPE_F32 on all SM targets. The q8 fallback path was passing BF16 Q tensors from the drafter's persistent buffers, causing an assertion failure on Turing (sm_75) GPUs during pflash drafter forward.

Add a ggml_cast(Q, F32) when the source type is not already F32.