### PR TITLE
feat(dflash): wire caller-provided SWA mask through draft graph

### DIFF
--- a/dflash/src/dflash_graph.h
+++ b/dflash/src/dflash_graph.h
@@ -1,6 +1,9 @@
 // Shared inputs/outputs for the DFlash draft graph builder.
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 #include "ggml.h"
 
 namespace dflash27b {
@@ -13,11 +16,15 @@ struct DraftGraphInputs {
     ggml_tensor * target_hidden_cat;// [5*hidden, ctx_len, 1] f32
     ggml_tensor * positions_q;      // [q_len] i32   values [ctx_len..ctx_len+q_len-1]
     ggml_tensor * positions_k;      // [ctx_len+q_len] i32   values [0..ctx_len+q_len-1]
+    // Optional SWA mask for long-context sliding-attention layers.
+    // Shape [kv_len, q_len] or padded [kv_pad, q_pad], type F16, values
+    // 0 for visible positions and -inf for masked positions.
+    ggml_tensor * attn_mask = nullptr;
     // Optional: if non-null, the graph projects final hidden states through
     // this LM head (shape [hidden, vocab]) and returns logits instead of
     // hidden states. Used for DFlash integration where the draft shares the
     // target's lm_head.
-    ggml_tensor * lm_head;
+    ggml_tensor * lm_head = nullptr;
 };
 
 struct DraftGraphOutputs {
@@ -29,5 +36,11 @@ DraftGraphOutputs build_draft_graph(
     ggml_context *            ctx,
     const DraftWeights &      w,
     const DraftGraphInputs &  in);
+
+bool draft_graph_needs_swa_mask(const DraftWeights & w, int ctx_len);
+void build_draft_swa_mask(std::vector<uint16_t> & out,
+                          int ctx_len,
+                          int q_len,
+                          int swa_window);
 
 } // namespace dflash27b

--- a/dflash/src/qwen3_dflash_graph.cpp
+++ b/dflash/src/qwen3_dflash_graph.cpp
@@ -31,9 +31,45 @@
 #include "internal.h"
 #include "dflash_graph.h"
 
+#include <algorithm>
 #include <cmath>
+#include <cstdio>
 
 namespace dflash27b {
+
+bool draft_graph_needs_swa_mask(const DraftWeights & w, int ctx_len) {
+    if (w.swa_window <= 0) {
+        return false;
+    }
+    const int total_k = ctx_len + DFLASH27B_DRAFT_BLOCK_SIZE;
+    if (total_k <= w.swa_window) {
+        return false;
+    }
+    for (int il = 0; il < w.n_layer; ++il) {
+        if (w.layers[il].is_swa) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void build_draft_swa_mask(std::vector<uint16_t> & out,
+                          int ctx_len,
+                          int q_len,
+                          int swa_window) {
+    static constexpr uint16_t F16_ZERO = 0x0000;
+    static constexpr uint16_t F16_NEG_INF = 0xFC00;
+
+    const int total_k = ctx_len + q_len;
+    out.assign((size_t)total_k * q_len, F16_NEG_INF);
+    for (int q = 0; q < q_len; ++q) {
+        const int abs_q = ctx_len + q;
+        const int min_k = std::max(0, abs_q - swa_window);
+        for (int k = min_k; k < total_k; ++k) {
+            out[(size_t)q * total_k + k] = F16_ZERO;
+        }
+    }
+}
 
 DraftGraphOutputs build_draft_graph(
     ggml_context *            ctx,
@@ -118,8 +154,36 @@ DraftGraphOutputs build_draft_graph(
         V = ggml_cont   (ctx, V);
 
         // ── 2f. Non-causal flash attention; GQA broadcast handled internally.
+        //   For SWA layers (Qwen3.6 draft): apply sliding window mask
+        //   limiting context K/V to the last `swa_window` positions.
         const float scale = 1.0f / std::sqrt((float)head_dim);
-        ggml_tensor * attn = ggml_flash_attn_ext(ctx, Q, K, V, /*mask=*/nullptr,
+        ggml_tensor * attn_mask = nullptr;
+        if (L.is_swa && w.swa_window > 0 && total_k > w.swa_window) {
+            if (!in.attn_mask) {
+                set_last_error("build_draft_graph: SWA layer requires a non-null attn_mask");
+                return {};
+            }
+            if (in.attn_mask->type != GGML_TYPE_F16) {
+                char buf[128];
+                std::snprintf(buf, sizeof(buf),
+                              "build_draft_graph: SWA attn_mask must be F16, got %s",
+                              ggml_type_name(in.attn_mask->type));
+                set_last_error(buf);
+                return {};
+            }
+            if (in.attn_mask->ne[0] < total_k || in.attn_mask->ne[1] < q_len) {
+                char buf[160];
+                std::snprintf(buf, sizeof(buf),
+                              "build_draft_graph: SWA attn_mask too small (%lld x %lld, need >= %d x %d)",
+                              (long long)in.attn_mask->ne[0],
+                              (long long)in.attn_mask->ne[1],
+                              total_k, q_len);
+                set_last_error(buf);
+                return {};
+            }
+            attn_mask = in.attn_mask;
+        }
+        ggml_tensor * attn = ggml_flash_attn_ext(ctx, Q, K, V, attn_mask,
                                                  scale, /*max_bias=*/0.0f,
                                                  /*logit_softcap=*/0.0f);
         // attn result: [n_embd_v=head_dim, n_head, n_batch=q_len, 1]

--- a/dflash/test/smoke_draft_graph.cpp
+++ b/dflash/test/smoke_draft_graph.cpp
@@ -85,6 +85,12 @@ int main(int argc, char ** argv) {
     ggml_tensor * target_hid  = ggml_new_tensor_3d(gctx, GGML_TYPE_F32, fc_in, ctx_len, 1);
     ggml_tensor * pos_q       = ggml_new_tensor_1d(gctx, GGML_TYPE_I32,  q_len);
     ggml_tensor * pos_k       = ggml_new_tensor_1d(gctx, GGML_TYPE_I32,  ctx_len + q_len);
+    ggml_tensor * attn_mask   = nullptr;
+    if (draft_graph_needs_swa_mask(w, ctx_len)) {
+        attn_mask = ggml_new_tensor_2d(gctx, GGML_TYPE_F16, ctx_len + q_len, q_len);
+        ggml_set_name(attn_mask, "draft_swa_mask");
+        ggml_set_input(attn_mask);
+    }
     ggml_set_name(noise_embed, "noise_embed");
     ggml_set_name(target_hid,  "target_hidden_cat");
     ggml_set_name(pos_q,       "positions_q");
@@ -101,6 +107,7 @@ int main(int argc, char ** argv) {
     gi.target_hidden_cat = target_hid;
     gi.positions_q       = pos_q;
     gi.positions_k       = pos_k;
+    gi.attn_mask         = attn_mask;
 
     DraftGraphOutputs go = build_draft_graph(gctx, w, gi);
     if (!go.hidden_states) { std::fprintf(stderr, "build_draft_graph returned null\n"); return 1; }
@@ -140,6 +147,11 @@ int main(int argc, char ** argv) {
         std::vector<int32_t> pk(ctx_len + q_len);
         for (int i = 0; i < ctx_len + q_len; i++) pk[i] = i;
         ggml_backend_tensor_set(pos_k, pk.data(), 0, sizeof(int32_t) * pk.size());
+    }
+    if (attn_mask) {
+        std::vector<uint16_t> mask;
+        build_draft_swa_mask(mask, ctx_len, q_len, w.swa_window);
+        ggml_backend_tensor_set(attn_mask, mask.data(), 0, sizeof(uint16_t) * mask.size());
     }
 
     // ── 7. Compute

--- a/dflash/test/test_vs_oracle.cpp
+++ b/dflash/test/test_vs_oracle.cpp
@@ -117,6 +117,12 @@ int main(int argc, char ** argv) {
     ggml_tensor * target_hid  = ggml_new_tensor_3d(gctx, GGML_TYPE_F32, m.fc_in, m.ctx_len, 1);
     ggml_tensor * pos_q       = ggml_new_tensor_1d(gctx, GGML_TYPE_I32, m.q_len);
     ggml_tensor * pos_k       = ggml_new_tensor_1d(gctx, GGML_TYPE_I32, m.ctx_len + m.q_len);
+    ggml_tensor * attn_mask   = nullptr;
+    if (draft_graph_needs_swa_mask(w, m.ctx_len)) {
+        attn_mask = ggml_new_tensor_2d(gctx, GGML_TYPE_F16, m.ctx_len + m.q_len, m.q_len);
+        ggml_set_name(attn_mask, "draft_swa_mask");
+        ggml_set_input(attn_mask);
+    }
     ggml_set_name(noise_embed, "noise_embed");
     ggml_set_name(target_hid,  "target_hidden_cat");
     ggml_set_name(pos_q,       "positions_q");
@@ -132,6 +138,7 @@ int main(int argc, char ** argv) {
     gi.target_hidden_cat = target_hid;
     gi.positions_q = pos_q;
     gi.positions_k = pos_k;
+    gi.attn_mask = attn_mask;
     DraftGraphOutputs go = build_draft_graph(gctx, w, gi);
     if (!go.hidden_states) return 1;
     ggml_set_output(go.hidden_states);
@@ -154,6 +161,11 @@ int main(int argc, char ** argv) {
     for (int i = 0; i < m.ctx_len + m.q_len; i++) pk[i] = i;
     ggml_backend_tensor_set(pos_q, pq.data(), 0, sizeof(int32_t) * pq.size());
     ggml_backend_tensor_set(pos_k, pk.data(), 0, sizeof(int32_t) * pk.size());
+    if (attn_mask) {
+        std::vector<uint16_t> mask;
+        build_draft_swa_mask(mask, m.ctx_len, m.q_len, w.swa_window);
+        ggml_backend_tensor_set(attn_mask, mask.data(), 0, sizeof(uint16_t) * mask.size());
+    }
 
     // Compute
     auto status = ggml_backend_graph_compute(backend, gf);


### PR DESCRIPTION
feat(dflash): wire caller-provided SWA mask through draft graph

When the Qwen3.6 draft graph is built for a context that exceeds
the SWA window, the caller-provided sliding-window attention mask
must reach `ggml_flash_attn_ext` on the SWA layers.

Previously the mask was constructed and then nullified
post-construction in qwen3_dflash_graph, so SWA layers ran without
the intended visibility constraint at long contexts.

This change makes the wiring explicit and pinable as a contract:

  * `dflash_graph.h` — `DraftGraphInputs` gains an optional
    `attn_mask` field. Documented as caller-owned, type F16, with
    shape `[kv_len, q_len]` (or padded `[kv_pad, q_pad]`), values
    `0` for visible positions and `-inf` for masked positions.
    Two helpers added so callers do not reimplement the same logic:

      bool draft_graph_needs_swa_mask(const DraftWeights & w,
                                      int ctx_len);
      void build_draft_swa_mask(std::vector<uint16_t> & out,
                                int ctx_len, int q_len,
                                int swa_window);

    `lm_head` is normalised to a default-null member at the same
    time (small consistency fix; layout unchanged).

  * `qwen3_dflash_graph.cpp` — when `total_k > swa_window` on a SWA
    layer, the graph wires the caller-provided mask through to
    `ggml_flash_attn_ext` and stops nullifying it. Layers that are
    not SWA still ignore the mask, as before.

  * `smoke_draft_graph.cpp` and `test_vs_oracle.cpp` — small
    alignment so the existing tests can build / fill the draft SWA
    mask when `ctx_len + q_len > swa_window`. No new test scaffolding
    is added in this commit; the focused regression test lives in a
    separate PR (`test(dflash): contract test for draft SWA mask
    wiring`) so each PR keeps one concern.

Validation:

  * Built and ran `smoke_draft_graph` and `test_vs_oracle` on
    RTX 6000 Ada (sm_89), Heretic Q4_K_M target, FP16 safetensors
    drafter, FA_WINDOW=0. Both tests pass before and after; the
    behaviour at ctx_len <= swa_window is unchanged (mask not
    needed and not consumed).
  * At long context the SWA layers now respect the caller mask.

Verification vs existing community PRs:

  COMP-COMPL with PR #94 (open, "support Qwen3.6-27B-DFlash draft
  (SWA layers)", Quitetall) and PR #129 (open Draft, "sliding
  window attention for Qwen3.6 draft model", howard0su).

  * PR #94 wires SWA via masks (same family as this PR).
  * PR #129 wires SWA via per-layer K/V truncation instead.

  The interface added here (caller-mask field + helpers) is small
  enough that it can survive either approach landing first. If
  PR #94 lands first, this commit should rebase cleanly because it
  formalises the mask path #94 already needs internally; if
  PR #129 lands first, the mask path here remains useful for
  callers that prefer mask semantics. Maintainers, happy to
  coordinate ordering.

Author: Javier Pazo <xabicasa@gmail.com>
