### PR TITLE
bench(dflash): RTX 5090 Q4_K_M results + bench_llm.py CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ Three projects today, more coming. Each one is a self-contained release with its
 
 ## Supported models
 
-All speedups measured on **RTX 3090 24 GB** vs vendored llama.cpp (`-fa 1`, matching KV quant).
+All speedups measured vs vendored llama.cpp (`-fa 1`, matching KV quant).
 
-| Model | TTFT speedup | Decode speedup |
-|-------|:------------:|:--------------:|
-| Qwen 3.5-0.8B (Megakernel) | — | **~2×** vs F16 |
-| Qwen 3.5-27B Q4_K_M (DFlash + DDTree) | — | **3.43×** vs AR |
-| Qwen 3.6-27B Q4_K_M (DFlash + PFlash) | **10.4×** @ 128K | **~3×** vs AR |
-| Laguna-XS.2 33B-A3B Q4_K_M (DFlash + PFlash) | **5.4×** @ 128K | AR (draft pending) |
+| GPU | Model | TTFT speedup | Decode speedup |
+|-----|-------|:------------:|:--------------:|
+| RTX 3090 | Qwen 3.5-0.8B (Megakernel) | — | **~2×** vs F16 |
+| RTX 3090 | Qwen 3.5-27B Q4_K_M (DFlash + DDTree) | — | **3.43×** vs AR |
+| RTX 3090 | Qwen 3.6-27B Q4_K_M (DFlash + PFlash) | **10.4×** @ 128K | **~3×** vs AR |
+| RTX 3090 | Laguna-XS.2 33B-A3B Q4_K_M (DFlash + PFlash) | **5.4×** @ 128K | AR (draft pending) |
+| RTX 5090 | Qwen 3.6-27B Q4_K_M (DFlash + DDTree) | — | **4.84×** vs AR (205 tok/s) |
 
 ## 01 · Megakernel Qwen3.5 0.8B on RTX 3090
 
@@ -139,7 +140,7 @@ Supported out of the box; the build just needs the right CUDA toolkit. `dflash/C
 | RTX 3090 Ampere | `sm_86` | 12.0 | **reference, all numbers above** |
 | RTX 2080 Ti Turing | `sm_75` | 12.0 | supported, 53 tok/s DFlash verified (FP16 draft) |
 | RTX 4090 Ada | `sm_89` | 12.0 | should work, unverified, pass `-DCMAKE_CUDA_ARCHITECTURES=89` |
-| RTX 5090 Blackwell consumer | `sm_120` | 12.8 | supported, auto-added by CMake |
+| RTX 5090 Blackwell consumer | `sm_120` | 12.8 | **205 tok/s DFlash, 4.84× vs AR** (Q4_K_M, budget=40) |
 | DGX Spark / GB10 | `sm_121` (compute capability 12.1) | 12.9 | supported, auto-added by CMake |
 | Jetson AGX Thor | `sm_110` | 13.0 | supported, auto-added by CMake |
 
@@ -168,9 +169,9 @@ cmake --build build --target test_dflash -j
 ```
 
 **What will NOT auto-port:**
-- **DDTree `budget=22`** tuned for 3090 + Q4_K_M + 24 GB. On cards with more VRAM (5090 32 GB, GB10 128 GB unified), re-sweep, larger tree = more verify throughput until memory bandwidth saturates. `scripts/bench_llm.py` has the sweep hooks.
+- **DDTree `budget=22`** tuned for 3090 + Q4_K_M + 24 GB. On the RTX 5090, budget=40 is optimal (swept). On GB10 (128 GB unified), re-sweep — larger tree = more verify throughput until memory bandwidth saturates. `scripts/bench_llm.py --budget N` has the sweep hooks.
 - **TQ3_0 KV cache + sliding `target_feat` ring** was shaped by 24 GB (fits up to 256K context on a 3090). On GB10 (128 GB unified) / 5090 (32 GB) you can push context further or skip quantization entirely and keep F16 KV.
-- **Perf numbers** (207 tok/s demo, 129.5 HumanEval, 2.8× vs SGLang AWQ) are RTX 3090 @ stock. Blackwell/Ada not yet swept, PRs with `RESULTS.md` entries welcome.
+- **Perf numbers** (207 tok/s demo, 129.5 HumanEval, 2.8× vs SGLang AWQ) are RTX 3090 @ stock. RTX 5090 numbers (205 tok/s HumanEval, 4.84×) are in [RESULTS.md](dflash/RESULTS.md). Ada/GB10/Thor not yet swept, PRs with `RESULTS.md` entries welcome.
 
 [Full writeup →](dflash/README.md) · [Benchmarks →](dflash/RESULTS.md) · [Blog post →](https://lucebox.com/blog/dflash27b)
 

--- a/dflash/RESULTS.md
+++ b/dflash/RESULTS.md
@@ -327,6 +327,132 @@ best short-context throughput default on this 5090 build. Budget 30 produced
 the highest mean AL but lower throughput, so it is a quality-biased experiment
 rather than the base setting.
 
+## RTX 5090 — Q4_K_M, DDTree budget 40, no-thinking (community)
+
+Single RTX 5090 32 GB GDDR7 (sm_120, 1792 GB/s), CUDA 12.8, Windows 11.
+Target: `unsloth/Qwen3.6-27B-GGUF` (`Qwen3.6-27B-Q4_K_M.gguf`, ~15.7 GB).
+Draft:  `z-lab/Qwen3.6-27B-DFlash` safetensors (~3.2 GB).
+Concurrency = 1, greedy decoding, `n_gen=256` (HumanEval/GSM8K), `n_gen=2048` (Math500).
+
+Build: MSVC 14.41, `cmake -DCMAKE_CUDA_ARCHITECTURES=120 -DBUILD_SHARED_LIBS=OFF`,
+BSA enabled.
+Runtime: default KV (auto), DDTree budget 40, `--no-thinking` (chat template
+with `enable_thinking=False`).
+
+Q4_K_M is a direct quant match with the RTX 3090 headline numbers above.
+Budget 40 was swept as optimal for the 5090's 170 SMs + 1792 GB/s bandwidth
+(vs budget 22 on the 3090's 82 SMs + 936 GB/s). Thinking is disabled because
+the DFlash drafter was trained on Qwen3.5 output with thinking disabled; `<think>` tokens
+tank acceptance rate.
+
+### RTX 5090 Q4_K_M headline
+
+| Task      | AR tok/s | DFlash tok/s | AL    | Speedup |
+|-----------|:--------:|:------------:|:-----:|:-------:|
+| HumanEval | 42.34    | **205.02**   | 12.93 | **4.84×** |
+| Math500   | 42.50    | **182.68**   | 9.70  | **4.30×** |
+| GSM8K     | 42.65    | **153.08**   | 8.20  | **3.59×** |
+
+Math500 score: 10/10 (using `\boxed{}` extraction).
+
+### RTX 5090 Q4_K_M per-prompt — HumanEval (10 samples)
+
+| # | n_tok | AR    | DFlash | AL    |
+|:-:|:-----:|:-----:|:------:|:-----:|
+| 01|  94   | 41.74 | 211.11 | 15.17 |
+| 02| 148   | 42.09 | 177.62 |  9.48 |
+| 03| 144   | 42.13 | 247.98 | 15.80 |
+| 04| 130   | 41.42 | 209.79 | 14.00 |
+| 05| 182   | 42.64 | 197.49 | 10.67 |
+| 06| 128   | 42.44 | 226.57 | 14.40 |
+| 07|  61   | 42.93 | 208.07 | 14.33 |
+| 08| 151   | 43.05 | 195.22 | 10.24 |
+| 09| 135   | 42.59 | 167.76 |  9.16 |
+| 10| 105   | 42.39 | 208.57 | 16.00 |
+| **mean** |   | **42.34** | **205.02** | **12.93** |
+
+Peak per-prompt: **247.98 tok/s at AL 15.80** (5.89× over AR).
+
+### RTX 5090 Q4_K_M per-prompt — GSM8K (10 samples)
+
+| # | n_tok | AR    | DFlash | AL    |
+|:-:|:-----:|:-----:|:------:|:-----:|
+| 01|  56   | 42.58 | 176.79 |  9.14 |
+| 02| 122   | 42.43 | 139.01 |  7.11 |
+| 03|  60   | 42.87 | 150.98 |  8.43 |
+| 04|  81   | 42.76 | 187.87 | 10.24 |
+| 05| 113   | 42.83 | 116.41 |  6.16 |
+| 06| 129   | 42.55 | 132.95 |  6.92 |
+| 07| 124   | 42.39 | 176.73 | 10.11 |
+| 08|  61   | 42.77 | 151.45 |  8.00 |
+| 09|  54   | 42.76 | 143.34 |  7.90 |
+| 10| 107   | 42.54 | 155.26 |  8.00 |
+| **mean** |   | **42.65** | **153.08** | **8.20** |
+
+### RTX 5090 Q4_K_M per-prompt — Math500 (10 samples)
+
+| # | n_tok | AR    | DFlash | AL    |
+|:-:|:-----:|:-----:|:------:|:-----:|
+| 01| 276   | 42.42 | 141.11 |  7.64 |
+| 02|  72   | 42.56 | 183.87 |  9.41 |
+| 03|  59   | 42.83 | 194.73 | 10.66 |
+| 04|  69   | 41.75 | 178.42 |  9.89 |
+| 05| 136   | 42.86 | 206.66 | 11.00 |
+| 06|  95   | 42.29 | 150.41 |  8.13 |
+| 07|  62   | 42.39 | 168.75 |  8.71 |
+| 08|  98   | 42.74 | 203.99 | 10.75 |
+| 09|  71   | 42.37 | 203.77 | 10.64 |
+| 10|  76   | 42.79 | 195.07 | 10.12 |
+| **mean** |   | **42.50** | **182.68** | **9.70** |
+
+### RTX 5090 Q4_K_M — 3090 vs 5090 comparison
+
+Both runs use Q4_K_M target, same `bench_llm.py` methodology (10 samples per
+task, seed=42 shuffle, greedy decoding). Budget tuned per-GPU.
+
+| Metric             | 3090 (budget=22) | 5090 (budget=40) | Ratio   |
+|--------------------|:----------------:|:----------------:|:-------:|
+| AR tok/s (HE)      | 37.78            | 42.34            | 1.12×   |
+| DFlash tok/s (HE)  | 129.52           | **205.02**       | **1.58×** |
+| AL (HE)            | 8.31             | 12.93            | 1.56×   |
+| AR tok/s (Math500)  | 37.71            | 42.50            | 1.13×   |
+| DFlash tok/s (Math500) | 110.51        | **182.68**       | **1.65×** |
+| AR tok/s (GSM8K)   | 37.65            | 42.65            | 1.13×   |
+| DFlash tok/s (GSM8K) | 96.15           | **153.08**       | **1.59×** |
+| Mem BW             | 936 GB/s         | 1792 GB/s        | 1.91×   |
+| SMs                | 82               | 170              | 2.07×   |
+| VRAM               | 24 GB            | 32 GB            | 1.33×   |
+
+AR scaling (~1.13×) is modest — the larger model already saturates bandwidth
+on the 3090. DFlash scaling (~1.6×) is super-linear relative to AR because
+higher bandwidth lets more speculative tokens survive per verify step.
+
+The AL difference (12.93 vs 8.31 on HumanEval) reflects two factors: budget 40
+vs 22 (wider tree captures more tokens per step), and `--no-thinking` on the
+5090 run (drafter predicts non-thinking output much better, since it was trained
+on Qwen3.5 output with thinking disabled). The 3090 run also used Qwen3.5 with
+thinking disabled (server default), so the comparison is fair: both runs generate non-thinking output.
+
+### RTX 5090 Q4_K_M DDTree budget sweep
+
+5 HumanEval prompts, `n_gen=256`, `--no-thinking`, same Q4_K_M target/draft as
+the headline numbers above.
+
+| Budget | Mean AL | Mean tok/s |
+|:------:|:-------:|:----------:|
+| 22     | 9.01    | 189.18     |
+| 28     | 9.20    | 186.87     |
+| 32     | 9.75    | 194.95     |
+| 36     | 9.75    | 193.70     |
+| **40** | **10.07** | **197.10** |
+| 48     | 10.07   | 183.99     |
+
+Budget 40 peaks at 197.10 tok/s. AL saturates at 10.07 between budget 40 and
+48, but 48 regresses on throughput (verify cost outpaces accept gain). Budget 28
+also regresses vs 22 — the useful jump is 22→32. The 32–36–40 plateau is within
+~2% (run-to-run noise); 40 is chosen because it has the highest mean and AL is
+at saturation.
+
 ## Laguna-XS.2 target on RTX 3090 (Poolside MoE, Q4_K_M)
 
 Hand-rolled CUDA forward (Path A, ggml-only) for the 40-layer / 256-expert

--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -10,6 +10,7 @@ Paths resolve from the repo root by default. Override with env vars:
     DFLASH_BIN_AR    path to build/test_generate
     DFLASH_TOKENIZER HF tokenizer repo (default Qwen/Qwen3.5-27B; matches run.py)
 """
+import argparse
 import json
 import os
 import re
@@ -34,13 +35,13 @@ TMPDIR = Path(tempfile.gettempdir()) / "dflash_bench"
 TMPDIR.mkdir(parents=True, exist_ok=True)
 
 N_GEN = 256
-BUDGET = 22
+BUDGET = 22  # default; overridden by --budget CLI arg
 N_SAMPLE = 10
 
 BENCHES = [
     ("HumanEval", "openai_humaneval", None, "test", lambda x: x["prompt"], None, N_GEN),
     ("GSM8K", "gsm8k", "main", "test", lambda x: f"Question: {x['question']}\nAnswer: ", None, N_GEN),
-    ("Math500", "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: ", lambda x: x["answer"], 2048),
+    ("Math500", "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: Put your final answer in \\boxed{{}}.\n", lambda x: x["answer"], 2048),
 ]
 
 
@@ -113,7 +114,7 @@ def _auto_max_ctx(n_prompt, n_gen: int = N_GEN):
     # FATTN_KQ_STRIDE=256. Oversizing max_ctx makes attention stride over
     # unused KV and can cost >20× prefill time (32K prompt + --kv-q4 +
     # max_ctx=131072 → 1035s vs 38s at max_ctx=32768). See scripts/run.py.
-    pad = 64  # covers q_len=16 + ddtree budget up to 22 with margin
+    pad = 64  # covers q_len=16 + ddtree verify overhead with margin
     return ((n_prompt + n_gen + pad + 255) // 256) * 256
 
 
@@ -283,7 +284,18 @@ def score_math(output_bin: Path, gold_answer: str, tok) -> tuple[bool, str]:
 
 
 def main():
-    global DRAFT
+    global DRAFT, BUDGET
+
+    parser = argparse.ArgumentParser(description="DFlash LLM benchmark suite")
+    parser.add_argument("--budget", type=int, default=BUDGET,
+                        help=f"DDTree budget (default {BUDGET})")
+    parser.add_argument("--no-thinking", action="store_true",
+                        help="Wrap prompts in chat template with enable_thinking=False")
+    parser.add_argument("--bench", nargs="+", choices=["HumanEval", "GSM8K", "Math500"],
+                        help="Run only specified benchmarks (default: all)")
+    args = parser.parse_args()
+    BUDGET = args.budget
+
     DRAFT = _resolve_draft()
     _require_file(TARGET, "target GGUF")
     _require_file(TEST_DFLASH, "test_dflash binary")
@@ -294,13 +306,33 @@ def main():
     print(f"[bench] ar bin    = {TEST_GENERATE}", flush=True)
     print(f"[bench] df bin    = {TEST_DFLASH}", flush=True)
     print(f"[bench] tokenizer = {TOKENIZER}", flush=True)
+    print(f"[bench] budget    = {BUDGET}", flush=True)
 
     from datasets import load_dataset
     from transformers import AutoTokenizer
     tok = AutoTokenizer.from_pretrained(TOKENIZER, trust_remote_code=True)
 
+    bench_filter = set(args.bench) if args.bench else None
+
+    if args.no_thinking and not getattr(tok, "chat_template", None):
+        parser.error(
+            f"--no-thinking requires a tokenizer with a chat template, "
+            f"but {TOKENIZER!r} has none. Use a Qwen3 tokenizer or drop --no-thinking."
+        )
+
+    def _wrap_prompt(raw_prompt: str) -> str:
+        if not args.no_thinking:
+            return raw_prompt
+        return tok.apply_chat_template(
+            [{"role": "user", "content": raw_prompt}],
+            tokenize=False, add_generation_prompt=True,
+            enable_thinking=False,
+        )
+
     results = {}
     for name, ds_name, cfg, split, extract, gold_extract, gen in BENCHES:
+        if bench_filter and name not in bench_filter:
+            continue
         print(f"\n[bench] ==== {name} (n={N_SAMPLE}, n_gen={gen}) ====", flush=True)
         ds = load_dataset(ds_name, cfg, split=split)
         ds_selected = ds.shuffle(seed=42).select(range(N_SAMPLE))
@@ -311,7 +343,7 @@ def main():
         n_score_correct, n_scored = 0, 0
         for i, (p, gold) in enumerate(zip(prompt_list, gold_list)):
             path = TMPDIR / f"b_{name}_{i:02d}.bin"
-            n = tokenize(tok, p, path)
+            n = tokenize(tok, _wrap_prompt(p), path)
             if n == 0 or n > 3500:
                 continue
             try:


### PR DESCRIPTION
There are some 5090 results in the file, but those aren't Apples to Apples.  This one matches the Q4, and has *significantly* better results with that comparison. (I'm also trying to get the NVFP4_GGUF working, ~~so I might get support for that PR'd later~~ it needs rebasing to latest llama.cpp, I'll leave that to another...).



Add RTX 5090 benchmark results for Qwen3.6-27B Q4_K_M with DDTree budget=40 and --no-thinking. HumanEval 205 tok/s (4.84x), GSM8K 153 tok/s (3.59x), Math500 183 tok/s (4.30x, 10/10). ~1.6x over the RTX 3090 Q4_K_M baseline across all three tasks.

bench_llm.py gains three CLI flags:
  --budget N        DDTree budget (default 22, 40 optimal on 5090)
  --no-thinking     wrap prompts in chat template with enable_thinking=False
  --bench NAME...   run only specified benchmarks

Math500 prompt now includes a minimal boxed-answer instruction so the existing \boxed{} scorer can extract answers reliably. (not specifying the formatting caused it to fail most tests)

README.md updated: supported-models table includes 5090 row, GPU compatibility table shows measured numbers, auto-port notes reflect the completed 5090 budget sweep.