### PR TITLE
Add tolerant OpenAI tool-call parsing for chat completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ MANIFEST
 # virtualenvs
 venv/
 .venv/
+.conda/
 env/
 .env
 
@@ -64,6 +65,7 @@ checkpoints/
 *.safetensors
 *.bin
 .cache/
+fix-plan.md
 
 # Secrets
 .env.local

--- a/dflash/CODEX.md
+++ b/dflash/CODEX.md
@@ -1,0 +1,157 @@
+# Using DFlash with OpenAI Codex CLI
+
+This guide covers installing Codex CLI, configuring it to use the local
+DFlash server, and common usage patterns.
+
+## Prerequisites
+
+- **DFlash server** built and model files downloaded (see [DEVELOPER.md](DEVELOPER.md))
+- **Node.js ≥ 18**
+
+## 1. Install Codex CLI
+
+```bash
+npm install -g @openai/codex
+codex --version          # should print 0.1xx.x
+```
+
+> If you get a permission error, use a user-level prefix:
+> ```bash
+> mkdir -p ~/.npm-global && npm config set prefix ~/.npm-global
+> export PATH=~/.npm-global/bin:$PATH   # add to ~/.bashrc
+> npm install -g @openai/codex
+> ```
+
+## 2. Start the DFlash Server
+
+```bash
+cd dflash
+python scripts/server.py \
+  --draft models/draft/draft-Qwen3.6-27B.gguf \
+  --port 8080
+```
+
+Wait until you see:
+
+```
+INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
+```
+
+### Quick smoke test
+
+```bash
+curl -s http://localhost:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"luce-dflash","input":"Say hi","max_output_tokens":32}' \
+  | python3 -m json.tool
+```
+
+## 3. Configure Codex
+
+Create or edit `~/.codex/config.toml`:
+
+```toml
+model = "luce-dflash"
+model_provider = "dflash"
+
+[model_providers.dflash]
+name = "DFlash"
+base_url = "http://localhost:8080/v1"
+wire_api = "responses"
+supports_websockets = false
+```
+
+Key points:
+
+| Field | Why |
+|---|---|
+| `name` | **Required** — Codex rejects providers with an empty name |
+| `wire_api = "responses"` | Codex only supports the Responses API |
+| `supports_websockets = false` | DFlash serves HTTP only |
+| No `env_key` | Local server needs no auth token |
+
+## 4. Using Codex
+
+### Interactive mode
+
+```bash
+codex                               # opens the TUI
+```
+
+### Non-interactive (exec)
+
+```bash
+# Simple question
+codex exec "What is 2+2?"
+
+# Coding task in a repo
+cd /path/to/your/project
+codex exec "Add input validation to the login handler"
+
+# Code review
+codex exec review
+```
+
+### Approval policies
+
+```bash
+codex --approval-policy suggest ...   # suggest commands, ask before running
+codex --approval-policy auto-edit ... # auto-approve file edits, ask for shell
+codex --approval-policy full-auto ... # auto-approve everything
+```
+
+### Reasoning effort
+
+The server maps reasoning effort to Qwen's thinking mode:
+
+- `low` (default) — thinking disabled, fastest responses
+- `medium` / `high` — thinking enabled (`<think>` tags)
+
+```bash
+codex -c 'model_reasoning_effort="medium"' exec "Refactor this module"
+```
+
+## 5. Troubleshooting
+
+### "provider name must not be empty"
+
+Add `name = "DFlash"` (or any non-empty string) to `[model_providers.dflash]`.
+
+### "Reconnecting… 1/5" loop
+
+The server is returning an error. Check:
+
+1. **Server is running** — `curl http://localhost:8080/health`
+2. **Port matches config** — `base_url` must match `--port`
+3. **Server logs** — look at the terminal where `server.py` is running
+
+Common causes:
+
+- Server not started yet (daemon still loading model)
+- Port mismatch between config and server
+- Proxy intercepting localhost (set `no_proxy=localhost`)
+
+### "Unknown model luce-dflash"
+
+This warning is normal — Codex doesn't recognize custom model names but
+uses fallback metadata. It does not affect functionality.
+
+### Slow first response
+
+The first request triggers model loading into GPU memory. Subsequent
+requests reuse the loaded model and are much faster.
+
+## 6. Server CLI Reference
+
+```
+python scripts/server.py [OPTIONS]
+
+Options:
+  --host HOST           Bind address (default: 0.0.0.0)
+  --port PORT           Bind port (default: 8080)
+  --target PATH         Target model GGUF (default: models/Qwen3.6-27B-Q4_K_M.gguf)
+  --draft PATH          Draft model for speculative decoding
+  --budget N            Speculation budget (default: 22)
+  --max-ctx N           Max context length (default: model-dependent)
+  --tokenizer NAME      HuggingFace tokenizer (auto-detected from model)
+```

--- a/dflash/DEVELOPER.md
+++ b/dflash/DEVELOPER.md
@@ -1,0 +1,274 @@
+# DFlash Developer Guide
+
+## Prerequisites
+
+### Hardware
+
+| Requirement | Minimum | Recommended |
+|-------------|---------|-------------|
+| GPU | NVIDIA Turing (sm_75, e.g. RTX 2080) | Ampere+ (sm_86, e.g. RTX 3090) |
+| VRAM | 22 GB | 24 GB |
+| OS | Ubuntu 22.04 (jammy) | Ubuntu 24.04 (noble) |
+
+> **Note:** FlashPrefill and BSA (Block-Sparse Attention) require **sm_80+** (Ampere or newer).
+> On Turing (sm_75) the drafter falls back to ggml's `flash_attn_ext`.
+
+### System packages
+
+```
+build-essential  cmake  git  git-lfs  nvcc (CUDA Toolkit)
+```
+
+A setup script is provided that installs everything (run as root):
+
+```bash
+sudo bash dflash/scripts/setup_system.sh
+```
+
+This installs build tools, `huggingface-cli` (via pipx), and the CUDA Toolkit.
+
+### Python
+
+- **Python 3.11+** (tested with 3.11.2)
+- Virtual environment recommended
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+### Python packages
+
+Install the required packages:
+
+```bash
+pip install fastapi uvicorn transformers pydantic starlette
+```
+
+For running tests:
+
+```bash
+pip install pytest
+```
+
+---
+
+## Building the C++ daemon
+
+DFlash uses **CMake** with CUDA. The build produces `test_dflash`, the speculative-decoding
+daemon that the Python server drives via stdin/stdout.
+
+```bash
+cd dflash
+
+# Initialize submodules (llama.cpp/ggml, Block-Sparse-Attention)
+git submodule update --init --recursive
+
+# Configure
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+
+# Build the daemon binary
+cmake --build build --target test_dflash -j
+```
+
+The binary lands at `dflash/build/test_dflash`.
+
+### CMake options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `CMAKE_CUDA_ARCHITECTURES` | `75;86` (auto-extended) | Target GPU architectures |
+| `DFLASH27B_FA_ALL_QUANTS` | `ON` | Build all FA KV-quant pairs (3× longer compile) |
+| `DFLASH27B_ENABLE_BSA` | `ON` | Block-Sparse Attention for spec-prefill (needs sm_80+) |
+| `DFLASH27B_TESTS` | `ON` | Build C++ numerics tests |
+
+---
+
+## Model files
+
+Download models before running the server:
+
+```bash
+# Target model (Q4_K_M quantized Qwen3.6-27B)
+huggingface-cli download <repo-id> --local-dir dflash/models/
+
+# Draft model (safetensors format)
+# Place model.safetensors under dflash/models/draft/
+```
+
+Expected layout:
+
+```
+dflash/models/
+├── Qwen3.6-27B-Q4_K_M.gguf          # --target (GGUF)
+└── draft/
+    └── model.safetensors              # --draft  (safetensors)
+```
+
+The target path can also be set via the `DFLASH_TARGET` environment variable.
+
+---
+
+## Running the server
+
+```bash
+cd dflash
+python scripts/server.py
+```
+
+### Server CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Bind address |
+| `--port` | `8080` | Port |
+| `--target` | `models/Qwen3.6-27B-Q4_K_M.gguf` | Target GGUF model |
+| `--draft` | `models/draft` | Draft model directory |
+| `--bin` | `build/test_dflash` | Path to the daemon binary |
+| `--budget` | `22` | DDTree speculation budget |
+| `--max-ctx` | `16384` | Maximum context length |
+| `--kv-f16` | off | Force F16 KV cache |
+| `--cache-type-k` / `--ctk` | auto | KV cache type for keys (f16/q4_0/q8_0/tq3_0/...) |
+| `--cache-type-v` / `--ctv` | auto | KV cache type for values |
+| `--fa-window` | auto | Sliding window size for flash attention (0 = full) |
+| `--tokenizer` | auto (from GGUF) | HuggingFace tokenizer ID |
+| `--prefix-cache-slots` | `4` | Number of prefix-cache slots |
+| `--prefill-cache-slots` | `4` | Number of prefill-cache slots |
+| `--daemon` | off | Run as background daemon |
+
+### API endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Health check |
+| `GET /v1/models` | List models (OpenAI + Codex format) |
+| `POST /v1/chat/completions` | OpenAI Chat Completions API |
+| `POST /v1/responses` | OpenAI Responses API (Codex) |
+| `POST /v1/messages` | Anthropic Messages API |
+
+---
+
+## Tests
+
+### Python unit tests (must pass)
+
+These tests **do not** require a GPU or running daemon — they use mocked backends:
+
+```bash
+cd dflash/scripts
+python -m pytest test_server.py -v
+```
+
+#### Baseline tests that must always pass
+
+```bash
+# Run only the unit tests (no daemon needed)
+python -m pytest test_server.py -k "parse or codex_models or models_endpoint" -v
+```
+
+These cover:
+
+| Test | What it verifies |
+|------|------------------|
+| `test_models_endpoint` | `/v1/models` returns OpenAI-format model list |
+| `test_codex_models_endpoint` | `/v1/models?client_version=` returns Codex format |
+| `test_parse_tool_calls_basic` | Qwen3 XML tool-call parsing extracts function name + args |
+| `test_parse_tool_calls_no_tools` | Plain text passes through without tool parsing |
+| `test_parse_reasoning_with_think` | `<think>` block extraction works |
+| `test_parse_reasoning_no_think` | Text without `<think>` returned as content |
+
+The full test suite (including integration tests that talk to the daemon) requires
+a running `test_dflash` binary and GPU. Those tests will fail in mock-only mode;
+run the baseline tests above to validate code changes.
+
+### C++ tests (require GPU + model files)
+
+After building:
+
+```bash
+cd dflash/build
+
+# Numerics tests
+./test_vs_oracle --target ../models/Qwen3.6-27B-Q4_K_M.gguf \
+                 --draft ../models/draft/model.safetensors
+
+# Smoke tests
+./smoke_load_target --target ../models/Qwen3.6-27B-Q4_K_M.gguf
+./smoke_load_draft --draft ../models/draft/model.safetensors
+./smoke_draft_graph --draft ../models/draft/model.safetensors
+```
+
+### Integration tests (require running server)
+
+These scripts start their own server subprocess and need the daemon binary + models:
+
+```bash
+cd dflash/scripts
+python test_server_prefix_cache.py
+python test_multi_turn_prefix_cache.py
+python test_full_compress_cache.py
+```
+
+---
+
+## Project structure
+
+```
+dflash/
+├── CMakeLists.txt              # C++ build (cmake)
+├── include/                    # C++ headers
+├── src/                        # C++ sources (target/draft graph, KV cache, FlashPrefill)
+├── test/                       # C++ test sources (test_dflash.cpp, smoke_*, test_*)
+├── deps/
+│   ├── llama.cpp/              # Vendored ggml (submodule)
+│   └── Block-Sparse-Attention/ # BSA kernels (submodule)
+├── models/                     # Model files (not in git)
+│   ├── Qwen3.6-27B-Q4_K_M.gguf
+│   └── draft/model.safetensors
+├── scripts/
+│   ├── server.py               # Main OpenAI/Codex server
+│   ├── server_tools.py         # Legacy fork with tool calling (deprecated)
+│   ├── prefix_cache.py         # LRU prefix cache
+│   ├── _prefill_hook.py        # Speculative prefill compression
+│   ├── run.py                  # CLI text generation
+│   ├── test_server.py          # Python unit tests ← must pass
+│   ├── test_server_prefix_cache.py    # Integration test
+│   ├── test_multi_turn_prefix_cache.py # Integration test
+│   ├── test_full_compress_cache.py    # Integration test
+│   └── setup_system.sh         # System dependency installer
+├── README.md
+└── DEVELOPER.md                # This file
+```
+
+---
+
+## Using with OpenAI Codex CLI
+
+The server natively supports the **Responses API** (`/v1/responses`) used by
+[OpenAI Codex](https://github.com/openai/codex).
+
+### Configuration
+
+Create `~/.codex/config.toml`:
+
+```toml
+model = "luce-dflash"
+model_provider = "dflash"
+
+[model_providers.dflash]
+base_url = "http://localhost:8080/v1"
+wire_api = "responses"
+supports_websockets = false
+```
+
+No `env_key` is needed for local use.
+
+### Running
+
+```bash
+# Start the server
+python dflash/scripts/server.py --port 8080
+
+# In another terminal
+codex --provider dflash "Explain this codebase"
+```

--- a/dflash/DEVELOPER.md
+++ b/dflash/DEVELOPER.md
@@ -256,6 +256,7 @@ model = "luce-dflash"
 model_provider = "dflash"
 
 [model_providers.dflash]
+name = "DFlash"
 base_url = "http://localhost:8080/v1"
 wire_api = "responses"
 supports_websockets = false

--- a/dflash/README.md
+++ b/dflash/README.md
@@ -436,6 +436,7 @@ model = "luce-dflash"
 model_provider = "dflash"
 
 [model_providers.dflash]
+name = "DFlash"
 base_url = "http://localhost:8080/v1"
 wire_api = "responses"
 supports_websockets = false

--- a/dflash/README.md
+++ b/dflash/README.md
@@ -410,4 +410,52 @@ Open an issue or PR against `Luce-Org/lucebox-hub`. Good first picks:
 Apache 2.0 · [Lucebox](https://lucebox.com) · [Discord](https://discord.gg/yHfswqZmJQ)
 
 Inspired by [z-lab/DFlash](https://arxiv.org/abs/2602.06036), [liranringel/ddtree](https://github.com/liranringel/ddtree), [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp).
-l-org/llama.cpp](https://github.com/ggml-org/llama.cpp).
+
+---
+
+## Using with OpenAI Codex CLI
+
+The DFlash server natively supports the **Responses API** (`/v1/responses`), which is the
+only wire protocol used by [OpenAI Codex](https://github.com/openai/codex).
+
+### 1. Start the DFlash server
+
+```bash
+python dflash/scripts/server.py \
+  --target models/Qwen3.5-27B-Q4_K_M.gguf \
+  --draft models/Qwen3.5-3B-f16.safetensors \
+  --budget 22 --port 8080
+```
+
+### 2. Configure Codex
+
+Create or edit `~/.codex/config.toml`:
+
+```toml
+model = "luce-dflash"
+model_provider = "dflash"
+
+[model_providers.dflash]
+base_url = "http://localhost:8080/v1"
+wire_api = "responses"
+supports_websockets = false
+```
+
+No `env_key` is needed — the local server accepts any token.
+
+### 3. Run Codex
+
+```bash
+codex --provider dflash "Explain this codebase"
+```
+
+### Supported features
+
+| Feature | Status |
+|---------|--------|
+| Responses API (`POST /v1/responses`) | ✅ |
+| Function/tool calling | ✅ |
+| Streaming (SSE) | ✅ |
+| Codex models endpoint | ✅ |
+| Reasoning / thinking | ✅ (effort: low / medium) |
+| WebSockets | ❌ (not needed) |

--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -73,13 +73,14 @@ class DaemonStdoutBus:
     """
 
     # Prefixes that are too spammy to print in normal operation.
-    _SUPPRESS_PREFIXES = (
+    _DEFAULT_SUPPRESS_PREFIXES = (
         "[step ", "[timing]", "[dflash]", "[prompt]",
         "[prefill]", "[migrate]", "[dbg ", "  ",
     )
 
-    def __init__(self, stdout):
+    def __init__(self, stdout, verbose: bool = False):
         self.stdout = stdout
+        self._suppress_prefixes = () if verbose else self._DEFAULT_SUPPRESS_PREFIXES
         self._waiters: list[tuple[str, asyncio.Future]] = []
         self._task: asyncio.Task | None = None
 
@@ -110,7 +111,7 @@ class DaemonStdoutBus:
 
             if not matched:
                 # Log line — suppress very noisy prefixes.
-                if decoded and not any(decoded.startswith(p) for p in self._SUPPRESS_PREFIXES):
+                if decoded and not any(decoded.startswith(p) for p in self._suppress_prefixes):
                     print(f"  [daemon] {decoded}", flush=True)
 
     async def await_reply(self, prefix: str, timeout: float = 10.0) -> str:

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -447,7 +447,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
               prefix_cache_slots: int = 4,
               prefill_cache_slots: int = 4,
               arch: str = "qwen35",
-              lazy_draft: bool = False) -> FastAPI:
+              lazy_draft: bool = False,
+              verbose_daemon: bool = False) -> FastAPI:
     import asyncio
     app = FastAPI(title="Luce DFlash OpenAI server")
 
@@ -503,7 +504,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                        stdout=subprocess.PIPE, bufsize=0)
     os.close(w_pipe)
 
-    bus = DaemonStdoutBus(daemon_proc.stdout)
+    bus = DaemonStdoutBus(daemon_proc.stdout, verbose=verbose_daemon)
 
     def _resolve_kv_k_type():
         kv = "q8_0"
@@ -2029,6 +2030,9 @@ def main():
     ap.add_argument("--lazy-draft", action="store_true",
                     help="Park decode draft (~3.3 GB) when idle; unpark/park "
                          "around each generate to free VRAM for longer context.")
+    ap.add_argument("--verbose-daemon", action="store_true",
+                    help="Print all daemon stdout lines, including suppressed "
+                         "timing and per-step diagnostics.")
     ap.add_argument("--prefix-cache-slots", type=int, default=4)
     ap.add_argument("--prefill-cache-slots", type=int, default=4)
     ap.add_argument("--daemon", action="store_true")
@@ -2098,7 +2102,8 @@ def main():
                     prefix_cache_slots=args.prefix_cache_slots,
                     prefill_cache_slots=args.prefill_cache_slots,
                     arch=arch,
-                    lazy_draft=args.lazy_draft)
+                    lazy_draft=args.lazy_draft,
+                    verbose_daemon=args.verbose_daemon)
 
     import uvicorn
     logging.basicConfig(
@@ -2116,6 +2121,8 @@ def main():
     print(f"  tokenizer = {tokenizer_id}")
     if args.lazy_draft:
         print("  lazy_draft= ON (decode draft parked when idle)")
+    if args.verbose_daemon:
+        print("  verbose_daemon = ON")
     if prefill_cfg.enabled:
         print(f"  pflash    = {prefill_cfg.mode} · threshold={prefill_cfg.threshold} "
               f"keep={prefill_cfg.keep_ratio} drafter={prefill_cfg.drafter_gguf}")

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -410,7 +410,7 @@ class ResponsesCreateRequest(BaseModel):
     input: Any  # str or list[InputItem dicts]
     instructions: str | None = None
     tools: list[dict] | None = None
-    tool_choice: str | None = "auto"
+    tool_choice: Any | None = "auto"
     parallel_tool_calls: bool | None = None
     stream: bool | None = None
     max_output_tokens: int | None = None

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -150,6 +150,10 @@ TOOL_CALL_PARAMETER_RE = re.compile(
     r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
     re.DOTALL,
 )
+BARE_FUNCTION_XML_RE = re.compile(
+    r"<function=([A-Za-z_][\w.-]*)>(.*?)</function>(?:\s*</tool_call>)?",
+    re.DOTALL,
+)
 FUNCTION_SIGNATURE_RE = re.compile(
     r"<function=([A-Za-z_][\w.-]*)\((.*?)\)</function>", re.DOTALL)
 TOOL_CODE_RE = re.compile(r"<tool_code>(.*?)</tool_code>", re.DOTALL)
@@ -325,17 +329,7 @@ def parse_tool_calls(text: str, tools=None) -> tuple[str, list[dict]]:
         })
         removals.append((start, end))
 
-    for m in TOOL_CALL_COMPLETE_RE.finditer(text):
-        body = m.group(1)
-        fn_match = TOOL_CALL_FUNCTION_RE.search(body)
-        if not fn_match:
-            continue
-        fn_text = fn_match.group(1) or fn_match.group(2) or ""
-        end_idx = fn_text.find(">")
-        if end_idx == -1:
-            continue
-        function_name = fn_text[:end_idx].strip()
-        params_region = fn_text[end_idx + 1:]
+    def parse_xml_function(function_name: str, params_region: str) -> dict:
         param_config = _find_tool_properties(tools, function_name)
         args: dict = {}
         for match_text in TOOL_CALL_PARAMETER_RE.findall(params_region):
@@ -347,9 +341,31 @@ def parse_tool_calls(text: str, tools=None) -> tuple[str, list[dict]]:
             if v.startswith("\n"): v = v[1:]
             if v.endswith("\n"): v = v[:-1]
             args[k] = _convert_param_value(v, k, param_config, function_name)
-        add_call(function_name, args, m.start(), m.end())
+        return args
+
+    for m in TOOL_CALL_COMPLETE_RE.finditer(text):
+        body = m.group(1)
+        fn_match = TOOL_CALL_FUNCTION_RE.search(body)
+        if not fn_match:
+            continue
+        fn_text = fn_match.group(1) or fn_match.group(2) or ""
+        end_idx = fn_text.find(">")
+        if end_idx == -1:
+            continue
+        function_name = fn_text[:end_idx].strip()
+        params_region = fn_text[end_idx + 1:]
+        add_call(function_name, parse_xml_function(function_name, params_region),
+                 m.start(), m.end())
+
+    for m in BARE_FUNCTION_XML_RE.finditer(text):
+        if any(lo <= m.start() < hi for lo, hi in removals):
+            continue
+        add_call(m.group(1), parse_xml_function(m.group(1), m.group(2)),
+                 m.start(), m.end())
 
     for m in FUNCTION_SIGNATURE_RE.finditer(text):
+        if any(lo <= m.start() < hi for lo, hi in removals):
+            continue
         args = _parse_function_signature_args(m.group(2))
         if args is not None:
             add_call(m.group(1), args, m.start(), m.end())

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -687,7 +687,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             pass
         return new_bin, new_ids
 
-    def _token_stream(r, n_gen):
+    def _token_stream(r, n_gen, timing=None):
         generated = 0
         hit_stop = False
         while True:
@@ -697,6 +697,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             tok_id = struct.unpack("<i", b)[0]
             if tok_id == -1:
                 break
+            if timing and timing.get("t_first_tok") is None:
+                timing["t_first_tok"] = time.monotonic()
             if hit_stop:
                 continue
             if tok_id in stop_ids:
@@ -706,6 +708,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             yield tok_id
             if generated >= n_gen:
                 hit_stop = True
+        if timing:
+            timing["t_last_tok"] = time.monotonic()
 
     # FIX 6: _collect_tokens_sync — non-streaming paths previously called
     # list(_token_stream(...)) directly (blocking the event loop) or used
@@ -713,11 +717,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     # (risking a deadlock if the threadpool stalled). Using run_in_executor
     # offloads the blocking os.read loop to a thread without holding any
     # asyncio primitive across the thread boundary.
-    async def _collect_tokens_sync(r, n_gen) -> list[int]:
+    async def _collect_tokens_sync(r, n_gen, timing=None) -> list[int]:
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, lambda: list(_token_stream(r, n_gen)))
+        return await loop.run_in_executor(None, lambda: list(_token_stream(r, n_gen, timing)))
 
-    async def _astream_tokens(r, n_gen):
+    async def _astream_tokens(r, n_gen, timing=None):
         generated = 0
         hit_stop = False
         loop = asyncio.get_running_loop()
@@ -728,6 +732,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             tok_id = struct.unpack("<i", b)[0]
             if tok_id == -1:
                 break
+            if timing and timing.get("t_first_tok") is None:
+                timing["t_first_tok"] = time.monotonic()
             if hit_stop:
                 continue
             if tok_id in stop_ids:
@@ -737,28 +743,59 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             yield tok_id
             if generated >= n_gen:
                 hit_stop = True
+        if timing:
+            timing["t_last_tok"] = time.monotonic()
 
     # FIX 7: _write_cmd helper — centralises stdin write+flush and guards
     # against a dead daemon so callers get a clean 503 instead of a hang.
-    def _write_cmd(cmd_line: str):
+    def _write_cmd(cmd_line: str, timing=None):
         if daemon_proc.poll() is not None:
             raise RuntimeError("dflash daemon has exited unexpectedly")
         if lazy_draft:
             log.debug("lazy-draft: unpark draft before generate")
+            t = time.monotonic()
             daemon_proc.stdin.write(b"unpark draft\n")
             daemon_proc.stdin.flush()
             _drain_until_sentinel(r_pipe)
+            if timing is not None:
+                timing["unpark"] = time.monotonic() - t
         daemon_proc.stdin.write(cmd_line.encode("utf-8"))
         daemon_proc.stdin.flush()
+        if timing is not None:
+            timing["t_cmd_sent"] = time.monotonic()
 
-    def _park_draft_if_lazy():
+    def _park_draft_if_lazy(timing=None):
         """Park decode draft to free ~3.3 GB VRAM. Call after tokens consumed."""
         if not lazy_draft:
             return
         log.debug("lazy-draft: park draft after generate")
+        t = time.monotonic()
         daemon_proc.stdin.write(b"park draft\n")
         daemon_proc.stdin.flush()
         _drain_until_sentinel(r_pipe)
+        if timing is not None:
+            timing["park"] = time.monotonic() - t
+
+    def _timing_summary(timing: dict, out_tokens: int) -> str:
+        """Format timing breakdown for log lines."""
+        parts = []
+        if "compress" in timing:
+            parts.append(f"compress={timing['compress']:.1f}s")
+        if "unpark" in timing:
+            parts.append(f"unpark={timing['unpark']:.1f}s")
+        t_cmd = timing.get("t_cmd_sent")
+        t_first = timing.get("t_first_tok")
+        t_last = timing.get("t_last_tok")
+        if t_cmd and t_first:
+            parts.append(f"prefill={t_first - t_cmd:.1f}s")
+        if t_first and t_last and out_tokens > 1:
+            decode_s = t_last - t_first
+            decode_toks = out_tokens - 1  # first token is end of prefill
+            dtps = decode_toks / decode_s if decode_s > 0 else 0.0
+            parts.append(f"decode={decode_s:.1f}s({dtps:.1f}tok/s)")
+        if "park" in timing:
+            parts.append(f"park={timing['park']:.1f}s")
+        return "  ".join(parts)
 
     def _build_cmd_line(req, cur_bin, cur_ids, gen_len, prefix_cache,
                         prompt_ids, full_snap_prep_ref: list,
@@ -819,6 +856,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             async def sse() -> AsyncIterator[str]:
                 nonlocal started_in_thinking
                 async with daemon_lock:
+                    timing = {}
                     full_snap_prep_ref = [None]
                     snap_prep = None
 
@@ -841,9 +879,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             return
                         cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
                     else:
+                        t_compress = time.monotonic()
                         cur_bin, cur_ids = await asyncio.to_thread(
                             _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
                             req.chat_template_kwargs)
+                        timing["compress"] = time.monotonic() - t_compress
                         prompt_len = len(cur_ids)
                         gen_len = _gen_len_for(prompt_len, req.max_tokens)
                         if gen_len <= 0:
@@ -863,7 +903,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
                     # FIX 7: guard against dead daemon
                     try:
-                        _write_cmd(cmd_line)
+                        _write_cmd(cmd_line, timing)
                     except RuntimeError as e:
                         yield f"data: {json.dumps({'error': str(e)})}\n\n"
                         yield "data: [DONE]\n\n"
@@ -904,7 +944,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         return f"data: {json.dumps(chunk({kind: text}))}\n\n"
 
                     try:
-                        async for tok_id in _astream_tokens(r_pipe, gen_len):
+                        async for tok_id in _astream_tokens(r_pipe, gen_len, timing):
                             completion_tokens += 1
                             piece = tokenizer.decode([tok_id])
                             window += piece
@@ -982,7 +1022,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             if full_hit is None:
                                 try: cur_bin.unlink()
                                 except Exception: pass
-                            _park_draft_if_lazy()
+                            _park_draft_if_lazy(timing)
                             return
 
                         # Flush remaining
@@ -1027,7 +1067,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
                     elif snap_prep:
                         prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
-                    _park_draft_if_lazy()
+                    _park_draft_if_lazy(timing)
 
                     yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
                     if include_usage:
@@ -1043,9 +1083,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     elapsed = time.monotonic() - t0
                     tok_s = completion_tokens / elapsed if elapsed > 0 else 0.0
                     log.info(
-                        "chat DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s",
+                        "chat DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s  %s",
                         completion_id, prompt_len, completion_tokens,
                         elapsed, tok_s, finish_reason,
+                        _timing_summary(timing, completion_tokens),
                     )
                     yield "data: [DONE]\n\n"
 
@@ -1053,6 +1094,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
         # Non-streaming
         async with daemon_lock:
+            timing = {}
             full_snap_prep_ref = [None]
             snap_prep = None
 
@@ -1071,9 +1113,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         status_code=400)
                 cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
             else:
+                t_compress = time.monotonic()
                 cur_bin, cur_ids = await asyncio.to_thread(
                     _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
                             req.chat_template_kwargs)
+                timing["compress"] = time.monotonic() - t_compress
                 prompt_len = len(cur_ids)
                 gen_len = _gen_len_for(prompt_len, req.max_tokens)
                 if gen_len <= 0:
@@ -1088,12 +1132,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     prompt_ids, full_snap_prep_ref, compression_fired)
 
             try:
-                _write_cmd(cmd_line)
+                _write_cmd(cmd_line, timing)
             except RuntimeError as e:
                 return JSONResponse({"detail": str(e)}, status_code=503)
 
             # FIX 6: use run_in_executor instead of list() blocking event loop
-            tokens = await _collect_tokens_sync(r_pipe, gen_len)
+            tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
             full_snap_prep = full_snap_prep_ref[0]
             if full_snap_prep is not None:
@@ -1101,7 +1145,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
             elif snap_prep:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
-            _park_draft_if_lazy()
+            _park_draft_if_lazy(timing)
 
         if full_hit is None:
             try: cur_bin.unlink()
@@ -1142,9 +1186,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         elapsed = time.monotonic() - t0
         tok_s = len(tokens) / elapsed if elapsed > 0 else 0.0
         log.info(
-            "chat DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s",
+            "chat DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s  %s",
             completion_id, prompt_len, len(tokens),
             elapsed, tok_s, finish_reason,
+            _timing_summary(timing, len(tokens)),
         )
         return JSONResponse({
             "id": completion_id,
@@ -1184,6 +1229,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             async def sse() -> AsyncIterator[str]:
                 nonlocal started_in_thinking
                 async with daemon_lock:
+                    timing = {}
                     full_snap_prep_ref = [None]
                     snap_prep = None
 
@@ -1204,9 +1250,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             return
                         cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
                     else:
+                        t_compress = time.monotonic()
                         cur_bin, cur_ids = await asyncio.to_thread(
                             _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
                             req.chat_template_kwargs)
+                        timing["compress"] = time.monotonic() - t_compress
                         prompt_len = len(cur_ids)
                         gen_len = min(req.max_tokens, max_ctx - prompt_len - 20)
                         if gen_len <= 0:
@@ -1234,7 +1282,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     yield f"event: message_start\ndata: {json.dumps(message_start)}\n\n"
 
                     try:
-                        _write_cmd(cmd_line)
+                        _write_cmd(cmd_line, timing)
                     except RuntimeError as e:
                         yield f"event: error\ndata: {json.dumps({'type':'error','error':{'type':'server_error','message':str(e)}})}\n\n"
                         return
@@ -1250,7 +1298,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         block["text"] = ""
                     yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': block})}\n\n"
                     try:
-                        async for tok_id in _astream_tokens(r_pipe, gen_len):
+                        async for tok_id in _astream_tokens(r_pipe, gen_len, timing):
                             out_tokens += 1
                             outputs, window, mode = consume_stream_piece(
                                 window, mode, tokenizer.decode([tok_id]))
@@ -1290,7 +1338,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
                     elif snap_prep:
                         prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
-                    _park_draft_if_lazy()
+                    _park_draft_if_lazy(timing)
 
                     yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
                     msg_delta = {
@@ -1305,6 +1353,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
         # Non-streaming Anthropic
         async with daemon_lock:
+            timing = {}
             full_snap_prep_ref = [None]
             snap_prep = None
 
@@ -1324,9 +1373,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         status_code=400)
                 cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(req) + "\n"
             else:
+                t_compress = time.monotonic()
                 cur_bin, cur_ids = await asyncio.to_thread(
                     _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
                             req.chat_template_kwargs)
+                timing["compress"] = time.monotonic() - t_compress
                 prompt_len = len(cur_ids)
                 gen_len = min(req.max_tokens, max_ctx - prompt_len - 20)
                 if gen_len <= 0:
@@ -1342,13 +1393,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     prompt_ids, full_snap_prep_ref, compression_fired)
 
             try:
-                _write_cmd(cmd_line)
+                _write_cmd(cmd_line, timing)
             except RuntimeError as e:
                 return JSONResponse({"type": "error", "error": {"type": "server_error",
                                      "message": str(e)}}, status_code=503)
 
             # FIX 6: use run_in_executor — same fix as OpenAI non-streaming path
-            tokens = await _collect_tokens_sync(r_pipe, gen_len)
+            tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
             full_snap_prep = full_snap_prep_ref[0]
             if full_snap_prep is not None:
@@ -1356,7 +1407,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
             elif snap_prep:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
-            _park_draft_if_lazy()
+            _park_draft_if_lazy(timing)
 
         if full_hit is None:
             try: cur_bin.unlink()
@@ -1536,6 +1587,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             created_at, prompt_len, t0):
         """Non-streaming Responses API handler."""
         async with daemon_lock:
+            timing = {}
             full_snap_prep_ref = [None]
             snap_prep = None
 
@@ -1561,9 +1613,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     }, status_code=400)
                 cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(chat_req) + "\n"
             else:
+                t_compress = time.monotonic()
                 cur_bin, cur_ids = await asyncio.to_thread(
                     _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
                     chat_req.chat_template_kwargs)
+                timing["compress"] = time.monotonic() - t_compress
                 prompt_len = len(cur_ids)
                 gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                 if gen_len <= 0:
@@ -1584,14 +1638,14 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     prompt_ids, full_snap_prep_ref, compression_fired)
 
             try:
-                _write_cmd(cmd_line)
+                _write_cmd(cmd_line, timing)
             except RuntimeError as e:
                 return JSONResponse({
                     "type": "error",
                     "error": {"type": "server_error", "message": str(e)}
                 }, status_code=503)
 
-            tokens = await _collect_tokens_sync(r_pipe, gen_len)
+            tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
             full_snap_prep = full_snap_prep_ref[0]
             if full_snap_prep is not None:
@@ -1599,7 +1653,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
             elif snap_prep:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
-            _park_draft_if_lazy()
+            _park_draft_if_lazy(timing)
 
         if full_hit is None:
             try: cur_bin.unlink()
@@ -1642,9 +1696,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         elapsed = time.monotonic() - t0
         tok_s = len(tokens) / elapsed if elapsed > 0 else 0.0
         log.info(
-            "responses DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  output=%s  text_len=%d",
+            "responses DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  output=%s  text_len=%d  %s",
             response_id, prompt_len, len(tokens),
             elapsed, tok_s, out_types, len(cleaned),
+            _timing_summary(timing, len(tokens)),
         )
         return JSONResponse({
             "id": response_id,
@@ -1671,6 +1726,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             nonlocal prompt_len, started_in_thinking
 
             async with daemon_lock:
+                timing = {}
                 full_snap_prep_ref = [None]
                 snap_prep = None
 
@@ -1694,9 +1750,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         return
                     cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(chat_req) + "\n"
                 else:
+                    t_compress = time.monotonic()
                     cur_bin, cur_ids = await asyncio.to_thread(
                         _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
                         chat_req.chat_template_kwargs)
+                    timing["compress"] = time.monotonic() - t_compress
                     prompt_len = len(cur_ids)
                     gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                     if gen_len <= 0:
@@ -1716,7 +1774,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         prompt_ids, full_snap_prep_ref, compression_fired)
 
                 try:
-                    _write_cmd(cmd_line)
+                    _write_cmd(cmd_line, timing)
                 except RuntimeError as e:
                     yield _resp_sse("error", {
                         "error": {"type": "server_error", "message": str(e)}})
@@ -1751,7 +1809,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 tool_call_active = False
 
                 try:
-                    async for tok_id in _astream_tokens(r_pipe, gen_len):
+                    async for tok_id in _astream_tokens(r_pipe, gen_len, timing):
                         completion_tokens += 1
                         piece = tokenizer.decode([tok_id])
                         window += piece
@@ -1827,7 +1885,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
                 elif snap_prep:
                     prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
-                _park_draft_if_lazy()
+                _park_draft_if_lazy(timing)
 
                 # Build final output items
                 final_output: list[dict] = []
@@ -1902,9 +1960,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 elapsed = time.monotonic() - t0
                 tok_s = completion_tokens / elapsed if elapsed > 0 else 0.0
                 log.info(
-                    "responses DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  output=%s  text_len=%d",
+                    "responses DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  output=%s  text_len=%d  %s",
                     response_id, prompt_len, completion_tokens,
                     elapsed, tok_s, out_types, len(accumulated_text),
+                    _timing_summary(timing, completion_tokens),
                 )
                 yield _resp_sse("response.completed", {"response": shell})
 

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -15,6 +15,7 @@ Streams tokens as Server-Sent Events using the OpenAI delta format.
 """
 import argparse
 import json
+import logging
 import os
 import re
 import struct
@@ -25,6 +26,8 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, AsyncIterator
+
+log = logging.getLogger("dflash.server")
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware          # FIX 1: add CORS
@@ -778,6 +781,18 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         prompt_bin, prompt_ids, raw_msgs, started_in_thinking = _tokenize_prompt(req)
         completion_id = "chatcmpl-" + uuid.uuid4().hex[:24]
         created = int(time.time())
+        prompt_len = len(prompt_ids)
+
+        role_counts: dict[str, int] = {}
+        for m in req.messages:
+            role_counts[m.role] = role_counts.get(m.role, 0) + 1
+        n_tools = len(req.tools) if req.tools else 0
+        log.info(
+            "chat %s  stream=%s  msgs=%d %s  tools=%d  "
+            "prompt_tokens=%d  max_tokens=%d  max_ctx=%d  model=%s",
+            completion_id, req.stream, len(req.messages), dict(role_counts),
+            n_tools, prompt_len, req.max_tokens, max_ctx, req.model,
+        )
 
         if req.stream:
             async def sse() -> AsyncIterator[str]:
@@ -1450,6 +1465,20 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         prompt_bin, prompt_ids, raw_msgs, started_in_thinking = _tokenize_prompt(chat_req)
         prompt_len = len(prompt_ids)
 
+        # Summarise roles for the log line
+        role_counts: dict[str, int] = {}
+        for m in messages:
+            role_counts[m.role] = role_counts.get(m.role, 0) + 1
+        n_tools = len(tools) if tools else 0
+        log.info(
+            "responses %s  stream=%s  msgs=%d %s  tools=%d  "
+            "prompt_tokens=%d  max_output=%d  max_ctx=%d  "
+            "thinking=%s  model=%s",
+            response_id, bool(req.stream), len(messages), dict(role_counts),
+            n_tools, prompt_len, chat_req.max_tokens, max_ctx,
+            enable_thinking, chat_req.model,
+        )
+
         if req.stream:
             return await _responses_stream(
                 chat_req, prompt_bin, prompt_ids, raw_msgs,
@@ -1479,6 +1508,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 started_in_thinking = False  # cached: no think prefill
                 gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                 if gen_len <= 0:
+                    log.warning(
+                        "responses FAILED %s: prompt too long "
+                        "(prompt=%d, max_ctx=%d, cached_slot=%d)",
+                        response_id, prompt_len, max_ctx, slot)
                     try: prompt_bin.unlink()
                     except Exception: pass
                     return JSONResponse({
@@ -1494,6 +1527,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prompt_len = len(cur_ids)
                 gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                 if gen_len <= 0:
+                    log.warning(
+                        "responses FAILED %s: prompt too long "
+                        "(prompt=%d, max_ctx=%d)",
+                        response_id, prompt_len, max_ctx)
                     try: cur_bin.unlink()
                     except Exception: pass
                     return JSONResponse({
@@ -1560,6 +1597,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 "content": [{"type": "output_text", "text": cleaned, "annotations": []}],
             })
 
+        out_types = [o.get("type") for o in output]
+        log.info(
+            "responses DONE %s  in=%d out=%d  output=%s  text_len=%d",
+            response_id, prompt_len, len(tokens),
+            out_types, len(cleaned),
+        )
         return JSONResponse({
             "id": response_id,
             "object": "response",
@@ -1596,6 +1639,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     started_in_thinking = False
                     gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                     if gen_len <= 0:
+                        log.warning(
+                            "responses FAILED %s: prompt too long "
+                            "(prompt=%d, max_ctx=%d, cached_slot=%d)",
+                            response_id, prompt_len, max_ctx, slot)
                         try: prompt_bin.unlink()
                         except Exception: pass
                         yield _resp_sse("response.failed", {
@@ -1610,6 +1657,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     prompt_len = len(cur_ids)
                     gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                     if gen_len <= 0:
+                        log.warning(
+                            "responses FAILED %s: prompt too long "
+                            "(prompt=%d, max_ctx=%d)",
+                            response_id, prompt_len, max_ctx)
                         try: cur_bin.unlink()
                         except Exception: pass
                         yield _resp_sse("response.failed", {
@@ -1803,6 +1854,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     "output_tokens": completion_tokens,
                     "total_tokens": prompt_len + completion_tokens,
                 }
+                out_types = [o.get("type") for o in final_output]
+                log.info(
+                    "responses DONE %s  in=%d out=%d  output=%s  text_len=%d",
+                    response_id, prompt_len, completion_tokens,
+                    out_types, len(accumulated_text),
+                )
                 yield _resp_sse("response.completed", {"response": shell})
 
         return StreamingResponse(sse(), media_type="text/event-stream")
@@ -1919,6 +1976,11 @@ def main():
                     arch=arch)
 
     import uvicorn
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
     print(f"Luce DFlash OpenAI server on http://{args.host}:{args.port}")
     print(f"  arch      = {arch}")
     print(f"  target    = {args.target}")

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -751,6 +751,18 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     def _write_cmd(cmd_line: str, timing=None):
         if daemon_proc.poll() is not None:
             raise RuntimeError("dflash daemon has exited unexpectedly")
+        # Validate prompt .bin file before sending (catch stale/deleted files)
+        parts = cmd_line.split()
+        bin_idx = 2 if parts[0] == "RESTORE" else 0  # RESTORE <slot> <path> ...
+        if bin_idx < len(parts):
+            bin_path = Path(parts[bin_idx])
+            if bin_path.suffix == ".bin":
+                if not bin_path.exists():
+                    log.warning("prompt .bin missing before send: %s", bin_path)
+                else:
+                    sz = bin_path.stat().st_size
+                    if sz == 0:
+                        log.warning("prompt .bin is 0 bytes: %s", bin_path)
         if lazy_draft:
             log.debug("lazy-draft: unpark draft before generate")
             t = time.monotonic()
@@ -827,6 +839,28 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             if snap_prep:
                 cmd_line += f" snap={snap_prep[1]}:{snap_prep[0]}"
             return cmd_line + _samp_suffix(req) + "\n", snap_prep
+
+    def _confirm_or_abort_snap(n_tokens: int, full_snap_prep, snap_prep,
+                                  prompt_ids, cur_bin, cur_ids):
+        """Confirm prefix-cache snapshots only when the daemon actually
+        generated tokens.  When the daemon returns 0 tokens (e.g. empty
+        prompt / file read failure), confirming would register a snapshot
+        slot that was never written, corrupting future RESTORE commands."""
+        if n_tokens > 0:
+            if full_snap_prep is not None:
+                fslot, _ = full_snap_prep
+                prefix_cache.confirm_full_snap(
+                    fslot, prompt_ids, cur_bin, len(cur_ids))
+            elif snap_prep:
+                prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+        else:
+            # Abort: release the reservation without registering.
+            if full_snap_prep is not None:
+                fslot, _ = full_snap_prep
+                prefix_cache.abort_full_snap(fslot)
+            elif snap_prep:
+                prefix_cache.abort_inline_snap(snap_prep[0])
+            log.warning("0 output tokens — aborted snapshot reservation")
 
     def _gen_len_for(prompt_len: int, max_tokens: int) -> int:
         return min(max_tokens, max_ctx - prompt_len - 20)
@@ -1061,12 +1095,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             try: prompt_bin.unlink()
                             except Exception: pass
 
-                    full_snap_prep = full_snap_prep_ref[0]
-                    if full_snap_prep is not None:
-                        fslot, _ = full_snap_prep
-                        prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
-                    elif snap_prep:
-                        prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+                    _confirm_or_abort_snap(
+                        completion_tokens, full_snap_prep_ref[0], snap_prep,
+                        prompt_ids, cur_bin, cur_ids)
                     _park_draft_if_lazy(timing)
 
                     yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
@@ -1139,12 +1170,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             # FIX 6: use run_in_executor instead of list() blocking event loop
             tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
-            full_snap_prep = full_snap_prep_ref[0]
-            if full_snap_prep is not None:
-                fslot, _ = full_snap_prep
-                prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
-            elif snap_prep:
-                prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            _confirm_or_abort_snap(
+                len(tokens), full_snap_prep_ref[0], snap_prep,
+                prompt_ids, cur_bin, cur_ids)
             _park_draft_if_lazy(timing)
 
         if full_hit is None:
@@ -1332,12 +1360,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             try: prompt_bin.unlink()
                             except Exception: pass
 
-                    full_snap_prep = full_snap_prep_ref[0]
-                    if full_snap_prep is not None:
-                        fslot, _ = full_snap_prep
-                        prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
-                    elif snap_prep:
-                        prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+                    _confirm_or_abort_snap(
+                        out_tokens, full_snap_prep_ref[0], snap_prep,
+                        prompt_ids, cur_bin, cur_ids)
                     _park_draft_if_lazy(timing)
 
                     yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
@@ -1401,12 +1426,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             # FIX 6: use run_in_executor — same fix as OpenAI non-streaming path
             tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
-            full_snap_prep = full_snap_prep_ref[0]
-            if full_snap_prep is not None:
-                fslot, _ = full_snap_prep
-                prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
-            elif snap_prep:
-                prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            _confirm_or_abort_snap(
+                len(tokens), full_snap_prep_ref[0], snap_prep,
+                prompt_ids, cur_bin, cur_ids)
             _park_draft_if_lazy(timing)
 
         if full_hit is None:
@@ -1647,12 +1669,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
             tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
-            full_snap_prep = full_snap_prep_ref[0]
-            if full_snap_prep is not None:
-                fslot, _ = full_snap_prep
-                prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
-            elif snap_prep:
-                prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            _confirm_or_abort_snap(
+                len(tokens), full_snap_prep_ref[0], snap_prep,
+                prompt_ids, cur_bin, cur_ids)
             _park_draft_if_lazy(timing)
 
         if full_hit is None:
@@ -1879,12 +1898,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         try: prompt_bin.unlink()
                         except Exception: pass
 
-                full_snap_prep = full_snap_prep_ref[0]
-                if full_snap_prep is not None:
-                    fslot, _ = full_snap_prep
-                    prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
-                elif snap_prep:
-                    prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+                _confirm_or_abort_snap(
+                    completion_tokens, full_snap_prep_ref[0], snap_prep,
+                    prompt_ids, cur_bin, cur_ids)
                 _park_draft_if_lazy(timing)
 
                 # Build final output items

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -1338,9 +1338,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         """Map Responses API input → ChatMessage list + ToolDef list."""
         messages: list[ChatMessage] = []
 
-        # instructions → system message
+        # Collect all system-level content (instructions + developer messages)
+        # and merge into a single system message at position 0, since
+        # Qwen's chat template requires the system message at the beginning.
+        system_parts: list[str] = []
+
         if req.instructions:
-            messages.append(ChatMessage(role="system", content=req.instructions))
+            system_parts.append(req.instructions)
 
         # Parse input items
         input_items = req.input
@@ -1354,8 +1358,6 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
                 if item_type == "message":
                     role = item.get("role", "user")
-                    if role == "developer":
-                        role = "system"
                     content = item.get("content", "")
                     if isinstance(content, list):
                         # Extract text from content parts
@@ -1365,7 +1367,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                 if part.get("type") in ("output_text", "text", "input_text"):
                                     text_parts.append(part.get("text", ""))
                         content = "".join(text_parts)
-                    messages.append(ChatMessage(role=role, content=content))
+                    if role == "developer" or role == "system":
+                        system_parts.append(content)
+                    else:
+                        messages.append(ChatMessage(role=role, content=content))
 
                 elif item_type == "function_call":
                     tc = ToolCall(
@@ -1390,6 +1395,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
                 # Ignore reasoning, local_shell_call, etc. — we just
                 # need the message/function_call/output items for the model.
+
+        # Prepend merged system message
+        if system_parts:
+            messages.insert(0, ChatMessage(
+                role="system", content="\n\n".join(system_parts)))
 
         # Map tools
         tools: list[ToolDef] | None = None

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -43,6 +43,18 @@ from _prefill_hook import (
 from prefix_cache import DaemonStdoutBus, PrefixCache
 
 
+class OpenAICompatError(Exception):
+    def __init__(self, message: str, status_code: int = 400,
+                 error_type: str = "invalid_request_error",
+                 param: str | None = None, code: str | None = None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.error_type = error_type
+        self.param = param
+        self.code = code
+
+
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TARGET = Path(os.environ.get(
     "DFLASH_TARGET",
@@ -573,6 +585,15 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     import asyncio
     app = FastAPI(title="Luce DFlash OpenAI server")
 
+    @app.exception_handler(OpenAICompatError)
+    async def _openai_compat_error_handler(_request: Request, exc: OpenAICompatError):
+        error = {"message": exc.message, "type": exc.error_type}
+        if exc.param is not None:
+            error["param"] = exc.param
+        if exc.code is not None:
+            error["code"] = exc.code
+        return JSONResponse({"error": error}, status_code=exc.status_code)
+
     # FIX 1: CORS middleware so Open WebUI / browser frontends on other ports
     # can reach this server without being blocked by the browser.
     app.add_middleware(
@@ -739,6 +760,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         prompt = tokenizer.apply_chat_template(msgs_list, **tpl_kwargs)
         started_in_thinking = bool(re.search(r"<think>\s*$", prompt))
         ids = tokenizer.encode(prompt, add_special_tokens=False)
+        if not ids:
+            raise OpenAICompatError(
+                "Chat prompt tokenized to zero tokens",
+                param="messages")
         return _ids_to_bin(ids), ids, prompt
 
     def _tokenize_prompt(req: ChatRequest) -> tuple[Path, list[int], list[dict], bool]:

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -1448,11 +1448,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         else:
             return await _responses_non_stream(
                 chat_req, prompt_bin, prompt_ids, raw_msgs,
-                response_id, msg_item_id, created_at, prompt_len)
+                started_in_thinking, response_id, msg_item_id,
+                created_at, prompt_len)
 
     async def _responses_non_stream(
             chat_req, prompt_bin, prompt_ids, raw_msgs,
-            response_id, msg_item_id, created_at, prompt_len):
+            started_in_thinking, response_id, msg_item_id,
+            created_at, prompt_len):
         """Non-streaming Responses API handler."""
         async with daemon_lock:
             full_snap_prep_ref = [None]
@@ -1464,6 +1466,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cur_bin = Path(cached_cur_bin)
                 cur_ids = None
                 prompt_len = cached_cur_ids_len
+                started_in_thinking = False  # cached: no think prefill
                 gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
                 if gen_len <= 0:
                     try: prompt_bin.unlink()
@@ -1522,7 +1525,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         if chat_req.chat_template_kwargs:
             thinking_enabled = chat_req.chat_template_kwargs.get("enable_thinking", True)
         cleaned, tool_calls = parse_tool_calls(text, tools=chat_req.tools)
-        cleaned, reasoning = parse_reasoning(cleaned, thinking_enabled=thinking_enabled)
+        cleaned, reasoning = parse_reasoning(
+            cleaned, thinking_enabled=thinking_enabled,
+            started_in_thinking=started_in_thinking)
 
         # Build output items
         output: list[dict] = []

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -781,6 +781,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
         if req.stream:
             async def sse() -> AsyncIterator[str]:
+                nonlocal started_in_thinking
                 async with daemon_lock:
                     full_snap_prep_ref = [None]
                     snap_prep = None
@@ -1128,6 +1129,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
         if req.stream:
             async def sse() -> AsyncIterator[str]:
+                nonlocal started_in_thinking
                 async with daemon_lock:
                     full_snap_prep_ref = [None]
                     snap_prep = None

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -793,6 +793,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             completion_id, req.stream, len(req.messages), dict(role_counts),
             n_tools, prompt_len, req.max_tokens, max_ctx, req.model,
         )
+        t0 = time.monotonic()
 
         if req.stream:
             async def sse() -> AsyncIterator[str]:
@@ -1017,6 +1018,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                        "total_tokens": prompt_len + completion_tokens},
                         }
                         yield f"data: {json.dumps(usage_chunk)}\n\n"
+                    elapsed = time.monotonic() - t0
+                    tok_s = completion_tokens / elapsed if elapsed > 0 else 0.0
+                    log.info(
+                        "chat DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s",
+                        completion_id, prompt_len, completion_tokens,
+                        elapsed, tok_s, finish_reason,
+                    )
                     yield "data: [DONE]\n\n"
 
             return StreamingResponse(sse(), media_type="text/event-stream")
@@ -1108,6 +1116,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         else:
             msg["content"] = cleaned
 
+        elapsed = time.monotonic() - t0
+        tok_s = len(tokens) / elapsed if elapsed > 0 else 0.0
+        log.info(
+            "chat DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s",
+            completion_id, prompt_len, len(tokens),
+            elapsed, tok_s, finish_reason,
+        )
         return JSONResponse({
             "id": completion_id,
             "object": "chat.completion",
@@ -1483,17 +1498,17 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             return await _responses_stream(
                 chat_req, prompt_bin, prompt_ids, raw_msgs,
                 started_in_thinking, response_id, msg_item_id,
-                created_at, prompt_len)
+                created_at, prompt_len, time.monotonic())
         else:
             return await _responses_non_stream(
                 chat_req, prompt_bin, prompt_ids, raw_msgs,
                 started_in_thinking, response_id, msg_item_id,
-                created_at, prompt_len)
+                created_at, prompt_len, time.monotonic())
 
     async def _responses_non_stream(
             chat_req, prompt_bin, prompt_ids, raw_msgs,
             started_in_thinking, response_id, msg_item_id,
-            created_at, prompt_len):
+            created_at, prompt_len, t0):
         """Non-streaming Responses API handler."""
         async with daemon_lock:
             full_snap_prep_ref = [None]
@@ -1598,10 +1613,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             })
 
         out_types = [o.get("type") for o in output]
+        elapsed = time.monotonic() - t0
+        tok_s = len(tokens) / elapsed if elapsed > 0 else 0.0
         log.info(
-            "responses DONE %s  in=%d out=%d  output=%s  text_len=%d",
+            "responses DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  output=%s  text_len=%d",
             response_id, prompt_len, len(tokens),
-            out_types, len(cleaned),
+            elapsed, tok_s, out_types, len(cleaned),
         )
         return JSONResponse({
             "id": response_id,
@@ -1621,7 +1638,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     async def _responses_stream(
             chat_req, prompt_bin, prompt_ids, raw_msgs,
             started_in_thinking, response_id, msg_item_id,
-            created_at, prompt_len):
+            created_at, prompt_len, t0):
         """Streaming Responses API handler — emits Responses SSE events."""
 
         async def sse() -> AsyncIterator[str]:
@@ -1855,10 +1872,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     "total_tokens": prompt_len + completion_tokens,
                 }
                 out_types = [o.get("type") for o in final_output]
+                elapsed = time.monotonic() - t0
+                tok_s = completion_tokens / elapsed if elapsed > 0 else 0.0
                 log.info(
-                    "responses DONE %s  in=%d out=%d  output=%s  text_len=%d",
+                    "responses DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  output=%s  text_len=%d",
                     response_id, prompt_len, completion_tokens,
-                    out_types, len(accumulated_text),
+                    elapsed, tok_s, out_types, len(accumulated_text),
                 )
                 yield _resp_sse("response.completed", {"response": shell})
 

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -843,6 +843,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 break
             tok_id = struct.unpack("<i", b)[0]
             if tok_id == -1:
+                if timing is not None:
+                    timing["daemon_done"] = True
                 break
             if timing and timing.get("t_first_tok") is None:
                 timing["t_first_tok"] = time.monotonic()
@@ -878,6 +880,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 break
             tok_id = struct.unpack("<i", b)[0]
             if tok_id == -1:
+                if timing is not None:
+                    timing["daemon_done"] = True
                 break
             if timing and timing.get("t_first_tok") is None:
                 timing["t_first_tok"] = time.monotonic()
@@ -1200,7 +1204,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                                           "total_tokens": prompt_len + completion_tokens}}
                                 yield f"data: {json.dumps(usage_chunk)}\n\n"
                             yield "data: [DONE]\n\n"
-                            if full_hit is None:
+                            if timing.get("daemon_done") and full_hit is None:
                                 try: cur_bin.unlink()
                                 except Exception: pass
                             _park_draft_if_lazy(timing)
@@ -1235,12 +1239,17 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                 out = emit_delta(tool_buffer, "content")
                                 if out: yield out
                     finally:
-                        if full_hit is None:
-                            try: cur_bin.unlink()
-                            except Exception: pass
+                        if timing.get("daemon_done"):
+                            if full_hit is None:
+                                try: cur_bin.unlink()
+                                except Exception: pass
+                            else:
+                                try: prompt_bin.unlink()
+                                except Exception: pass
                         else:
-                            try: prompt_bin.unlink()
-                            except Exception: pass
+                            log.warning(
+                                "stream ended before daemon sentinel; "
+                                "retaining prompt .bin for in-flight daemon read")
 
                     _confirm_or_abort_snap(
                         completion_tokens, full_snap_prep_ref[0], snap_prep,
@@ -1500,12 +1509,17 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             delta_key = "thinking" if target_kind == "thinking" else "text"
                             yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': block_index, 'delta': {'type': delta_type, delta_key: text}})}\n\n"
                     finally:
-                        if full_hit is None:
-                            try: cur_bin.unlink()
-                            except Exception: pass
+                        if timing.get("daemon_done"):
+                            if full_hit is None:
+                                try: cur_bin.unlink()
+                                except Exception: pass
+                            else:
+                                try: prompt_bin.unlink()
+                                except Exception: pass
                         else:
-                            try: prompt_bin.unlink()
-                            except Exception: pass
+                            log.warning(
+                                "stream ended before daemon sentinel; "
+                                "retaining prompt .bin for in-flight daemon read")
 
                     _confirm_or_abort_snap(
                         out_tokens, full_snap_prep_ref[0], snap_prep,
@@ -2038,12 +2052,17 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     window = ""
 
                 finally:
-                    if full_hit is None:
-                        try: cur_bin.unlink()
-                        except Exception: pass
+                    if timing.get("daemon_done"):
+                        if full_hit is None:
+                            try: cur_bin.unlink()
+                            except Exception: pass
+                        else:
+                            try: prompt_bin.unlink()
+                            except Exception: pass
                     else:
-                        try: prompt_bin.unlink()
-                        except Exception: pass
+                        log.warning(
+                            "stream ended before daemon sentinel; "
+                            "retaining prompt .bin for in-flight daemon read")
 
                 _confirm_or_abort_snap(
                     completion_tokens, full_snap_prep_ref[0], snap_prep,

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -150,6 +150,9 @@ TOOL_CALL_PARAMETER_RE = re.compile(
     r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
     re.DOTALL,
 )
+FUNCTION_SIGNATURE_RE = re.compile(
+    r"<function=([A-Za-z_][\w.-]*)\((.*?)\)</function>", re.DOTALL)
+TOOL_CODE_RE = re.compile(r"<tool_code>(.*?)</tool_code>", re.DOTALL)
 TOOL_OPEN_TAG = "<tool_call>"
 THINK_OPEN_TAG = "<think>"
 THINK_CLOSE_TAG = "</think>"
@@ -210,6 +213,18 @@ def _find_tool_properties(tools, function_name):
     return {}
 
 
+def _tool_allowed(tools, function_name: str) -> bool:
+    if not tools:
+        return True
+    for t in tools or []:
+        fn = t.function if hasattr(t, "function") else t.get("function", {})
+        if hasattr(fn, "model_dump"):
+            fn = fn.model_dump()
+        if isinstance(fn, dict) and fn.get("name") == function_name:
+            return True
+    return False
+
+
 def _convert_param_value(param_value: str, param_name: str, param_config: dict,
                          func_name: str):
     """Coerce stringified XML values to their JSON-schema type."""
@@ -246,17 +261,71 @@ def _convert_param_value(param_value: str, param_name: str, param_config: dict,
     except (ValueError, SyntaxError, TypeError): return param_value
 
 
+def _parse_function_signature_args(arg_text: str) -> dict | None:
+    """Parse `<function=name(k="v")</function>` arguments without guessing."""
+    import ast
+    try:
+        expr = ast.parse(f"_f({arg_text})", mode="eval").body
+    except SyntaxError:
+        return None
+    if not isinstance(expr, ast.Call) or expr.args:
+        return None
+    args: dict = {}
+    for kw in expr.keywords:
+        if kw.arg is None:
+            return None
+        try:
+            args[kw.arg] = ast.literal_eval(kw.value)
+        except (ValueError, SyntaxError, TypeError):
+            return None
+    return args
+
+
+def _parse_json_tool_call(obj) -> tuple[str, dict] | None:
+    """Parse OpenAI-ish JSON tool call objects."""
+    if not isinstance(obj, dict):
+        return None
+    name = obj.get("name")
+    args = obj.get("arguments")
+    if not isinstance(name, str) and isinstance(obj.get("function"), dict):
+        fn = obj["function"]
+        name = fn.get("name")
+        args = fn.get("arguments")
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except json.JSONDecodeError:
+            return None
+    if isinstance(name, str) and isinstance(args, dict):
+        return name, args
+    return None
+
+
 def parse_tool_calls(text: str, tools=None) -> tuple[str, list[dict]]:
-    """Parse Qwen3.x <tool_call> XML blocks into OpenAI tool_calls format.
+    """Parse textual tool-call shapes into OpenAI tool_calls format.
+
+    Supports Qwen XML, malformed function-call tags observed in model output,
+    bare JSON objects, and `<tool_code>{...}</tool_code>` wrappers.
 
     Returns (cleaned_content, tool_calls_list).
     """
     tool_calls: list[dict] = []
-    cleaned_parts: list[str] = []
-    cursor = 0
+    removals: list[tuple[int, int]] = []
+
+    def add_call(function_name: str, args: dict, start: int, end: int):
+        if not _tool_allowed(tools, function_name):
+            return
+        tool_calls.append({
+            "id": "call_" + uuid.uuid4().hex[:24],
+            "type": "function",
+            "function": {
+                "name": function_name,
+                "arguments": json.dumps(args, ensure_ascii=False),
+            },
+        })
+        removals.append((start, end))
+
     for m in TOOL_CALL_COMPLETE_RE.finditer(text):
-        cleaned_parts.append(text[cursor:m.start()])
-        cursor = m.end()
         body = m.group(1)
         fn_match = TOOL_CALL_FUNCTION_RE.search(body)
         if not fn_match:
@@ -278,16 +347,52 @@ def parse_tool_calls(text: str, tools=None) -> tuple[str, list[dict]]:
             if v.startswith("\n"): v = v[1:]
             if v.endswith("\n"): v = v[:-1]
             args[k] = _convert_param_value(v, k, param_config, function_name)
-        tool_calls.append({
-            "id": "call_" + uuid.uuid4().hex[:24],
-            "type": "function",
-            "function": {
-                "name": function_name,
-                "arguments": json.dumps(args, ensure_ascii=False),
-            },
-        })
-    cleaned_parts.append(text[cursor:])
-    return "".join(cleaned_parts).strip(), tool_calls
+        add_call(function_name, args, m.start(), m.end())
+
+    for m in FUNCTION_SIGNATURE_RE.finditer(text):
+        args = _parse_function_signature_args(m.group(2))
+        if args is not None:
+            add_call(m.group(1), args, m.start(), m.end())
+
+    for m in TOOL_CODE_RE.finditer(text):
+        try:
+            obj = json.loads(m.group(1).strip())
+        except json.JSONDecodeError:
+            continue
+        parsed = _parse_json_tool_call(obj)
+        if parsed is not None:
+            add_call(parsed[0], parsed[1], m.start(), m.end())
+
+    decoder = json.JSONDecoder()
+    cursor = 0
+    while cursor < len(text):
+        start = text.find("{", cursor)
+        if start == -1:
+            break
+        if any(lo <= start < hi for lo, hi in removals):
+            cursor = start + 1
+            continue
+        try:
+            obj, consumed = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            cursor = start + 1
+            continue
+        parsed = _parse_json_tool_call(obj)
+        if parsed is not None:
+            add_call(parsed[0], parsed[1], start, start + consumed)
+        cursor = start + max(consumed, 1)
+
+    if removals:
+        parts: list[str] = []
+        cursor = 0
+        for start, end in sorted(set(removals)):
+            if start < cursor:
+                continue
+            parts.append(text[cursor:start])
+            cursor = end
+        parts.append(text[cursor:])
+        text = "".join(parts)
+    return text.strip(), tool_calls
 
 
 # FIX 2: _content_to_str helper used for BOTH OpenAI and Anthropic message

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -38,7 +38,7 @@ from transformers import AutoTokenizer
 
 from _prefill_hook import (
     PrefillConfig, add_cli_flags, config_from_args,
-    compress_text_via_daemon,
+    compress_text_via_daemon, _drain_until_sentinel,
 )
 from prefix_cache import DaemonStdoutBus, PrefixCache
 
@@ -446,7 +446,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
               drafter_tokenizer: AutoTokenizer | None = None,
               prefix_cache_slots: int = 4,
               prefill_cache_slots: int = 4,
-              arch: str = "qwen35") -> FastAPI:
+              arch: str = "qwen35",
+              lazy_draft: bool = False) -> FastAPI:
     import asyncio
     app = FastAPI(title="Luce DFlash OpenAI server")
 
@@ -533,6 +534,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     async def _startup():
         bus.start(asyncio.get_running_loop())
         await prefix_cache.startup_sync()
+        if lazy_draft:
+            log.info("lazy-draft: parking decode draft at startup to free ~3.3 GB")
+            daemon_proc.stdin.write(b"park draft\n")
+            daemon_proc.stdin.flush()
+            _drain_until_sentinel(r_pipe)
 
     # FIX 4: /health endpoint — Open WebUI and many clients ping this before
     # sending requests. Without it they show a permanent "disconnected" badge.
@@ -737,8 +743,22 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     def _write_cmd(cmd_line: str):
         if daemon_proc.poll() is not None:
             raise RuntimeError("dflash daemon has exited unexpectedly")
+        if lazy_draft:
+            log.debug("lazy-draft: unpark draft before generate")
+            daemon_proc.stdin.write(b"unpark draft\n")
+            daemon_proc.stdin.flush()
+            _drain_until_sentinel(r_pipe)
         daemon_proc.stdin.write(cmd_line.encode("utf-8"))
         daemon_proc.stdin.flush()
+
+    def _park_draft_if_lazy():
+        """Park decode draft to free ~3.3 GB VRAM. Call after tokens consumed."""
+        if not lazy_draft:
+            return
+        log.debug("lazy-draft: park draft after generate")
+        daemon_proc.stdin.write(b"park draft\n")
+        daemon_proc.stdin.flush()
+        _drain_until_sentinel(r_pipe)
 
     def _build_cmd_line(req, cur_bin, cur_ids, gen_len, prefix_cache,
                         prompt_ids, full_snap_prep_ref: list,
@@ -962,6 +982,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             if full_hit is None:
                                 try: cur_bin.unlink()
                                 except Exception: pass
+                            _park_draft_if_lazy()
                             return
 
                         # Flush remaining
@@ -1006,6 +1027,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
                     elif snap_prep:
                         prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+                    _park_draft_if_lazy()
 
                     yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
                     if include_usage:
@@ -1079,6 +1101,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
             elif snap_prep:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            _park_draft_if_lazy()
 
         if full_hit is None:
             try: cur_bin.unlink()
@@ -1267,6 +1290,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
                     elif snap_prep:
                         prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+                    _park_draft_if_lazy()
 
                     yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
                     msg_delta = {
@@ -1332,6 +1356,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
             elif snap_prep:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            _park_draft_if_lazy()
 
         if full_hit is None:
             try: cur_bin.unlink()
@@ -1574,6 +1599,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
             elif snap_prep:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            _park_draft_if_lazy()
 
         if full_hit is None:
             try: cur_bin.unlink()
@@ -1801,6 +1827,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
                 elif snap_prep:
                     prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+                _park_draft_if_lazy()
 
                 # Build final output items
                 final_output: list[dict] = []
@@ -1924,6 +1951,9 @@ def main():
     ap.add_argument("--fa-window", type=int, default=None,
                     help="Sliding window for FA layers. 0 = full attention.")
     ap.add_argument("--tokenizer", type=str, default=None)
+    ap.add_argument("--lazy-draft", action="store_true",
+                    help="Park decode draft (~3.3 GB) when idle; unpark/park "
+                         "around each generate to free VRAM for longer context.")
     ap.add_argument("--prefix-cache-slots", type=int, default=4)
     ap.add_argument("--prefill-cache-slots", type=int, default=4)
     ap.add_argument("--daemon", action="store_true")
@@ -1992,7 +2022,8 @@ def main():
                     drafter_tokenizer=drafter_tokenizer,
                     prefix_cache_slots=args.prefix_cache_slots,
                     prefill_cache_slots=args.prefill_cache_slots,
-                    arch=arch)
+                    arch=arch,
+                    lazy_draft=args.lazy_draft)
 
     import uvicorn
     logging.basicConfig(
@@ -2008,6 +2039,8 @@ def main():
     print(f"  budget    = {args.budget}")
     print(f"  max_ctx   = {args.max_ctx}")
     print(f"  tokenizer = {tokenizer_id}")
+    if args.lazy_draft:
+        print("  lazy_draft= ON (decode draft parked when idle)")
     if prefill_cfg.enabled:
         print(f"  pflash    = {prefill_cfg.mode} · threshold={prefill_cfg.threshold} "
               f"keep={prefill_cfg.keep_ratio} drafter={prefill_cfg.drafter_gguf}")

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -24,7 +24,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware          # FIX 1: add CORS
@@ -134,13 +134,55 @@ def _tokenizer_id_from_gguf(gguf_path: Path) -> str:
     return default
 
 
+# ─── tool-call & reasoning parsers ─────────────────────────────────
+# Ported from server_tools.py which ports from vLLM (Apache-2.0):
+#   vllm/reasoning/qwen3_reasoning_parser.py
+#   vllm/tool_parsers/qwen3coder_tool_parser.py
+
+TOOL_CALL_COMPLETE_RE = re.compile(r"<tool_call>(.*?)</tool_call>", re.DOTALL)
+TOOL_CALL_FUNCTION_RE = re.compile(
+    r"<function=(.*?)</function>|<function=(.*)$", re.DOTALL,
+)
+TOOL_CALL_PARAMETER_RE = re.compile(
+    r"<parameter=(.*?)(?:</parameter>|(?=<parameter=)|(?=</function>)|$)",
+    re.DOTALL,
+)
+TOOL_OPEN_TAG = "<tool_call>"
+THINK_OPEN_TAG = "<think>"
+THINK_CLOSE_TAG = "</think>"
+
+
+def normalize_stop(stop) -> list[str]:
+    """Coerce OpenAI's stop field (str | list[str] | None) to list[str]."""
+    if not stop:
+        return []
+    if isinstance(stop, str):
+        return [stop]
+    return [s for s in stop if isinstance(s, str) and s]
+
+
+def first_stop_match(text: str, stops: list[str]) -> int:
+    """Return the earliest index where any stop sequence appears, or -1."""
+    best = -1
+    for s in stops:
+        i = text.find(s)
+        if i != -1 and (best == -1 or i < best):
+            best = i
+    return best
+
+
 def parse_reasoning(
     text: str,
     thinking_enabled: bool = True,
     started_in_thinking: bool = False,
 ) -> tuple[str, str | None]:
-    # Qwen chat templates can prefill `<think>\n` into the prompt, so the
-    # generated output contains only the reasoning body plus `</think>`.
+    """Extract reasoning content from Qwen3.x's <think>...</think> blocks.
+
+    Handles paired, headless, and disabled thinking flavors.
+    ``started_in_thinking`` accounts for prompts that end with ``<think>\n``
+    so the generated text contains only the reasoning body + ``</think>``.
+    Returns (cleaned_content, reasoning_content).
+    """
     parts = text.partition(THINK_OPEN_TAG)
     saw_open_tag = bool(parts[1])
     rest = parts[2] if saw_open_tag else parts[0]
@@ -152,60 +194,105 @@ def parse_reasoning(
     return content.strip(), (reasoning.strip() or None)
 
 
-def prompt_starts_in_thinking(prompt: str) -> bool:
-    return bool(re.search(r"<think>\s*$", prompt))
+def _find_tool_properties(tools, function_name):
+    """Returns the parameters dict for a given function name, or {}."""
+    for t in tools or []:
+        fn = t.function if hasattr(t, "function") else t.get("function", {})
+        if hasattr(fn, "model_dump"):
+            fn = fn.model_dump()
+        if fn.get("name") == function_name:
+            params = fn.get("parameters", {})
+            if isinstance(params, dict):
+                return params.get("properties", {})
+    return {}
 
 
-def consume_stream_piece(window: str, mode: str, piece: str):
-    outputs = []
-    holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG))
-    window += piece
-    while True:
-        if mode == "reasoning":
-            idx = window.find(THINK_CLOSE_TAG)
-            if idx != -1:
-                pre = window[:idx]
-                if pre:
-                    outputs.append(("reasoning_content", pre))
-                window = window[idx + len(THINK_CLOSE_TAG):]
-                mode = "content"
-                continue
-            if len(window) > holdback:
-                safe = window[:-holdback]
-                if safe:
-                    outputs.append(("reasoning_content", safe))
-                window = window[-holdback:]
-            break
+def _convert_param_value(param_value: str, param_name: str, param_config: dict,
+                         func_name: str):
+    """Coerce stringified XML values to their JSON-schema type."""
+    import ast
+    if param_value.lower() == "null":
+        return None
+    if param_name not in param_config:
+        return param_value
+    cfg = param_config[param_name]
+    if isinstance(cfg, dict) and "type" in cfg:
+        ptype = str(cfg["type"]).strip().lower()
+    elif isinstance(cfg, dict) and "anyOf" in cfg:
+        ptype = "object"
+    else:
+        ptype = "string"
+    if ptype in ("string", "str", "text", "varchar", "char", "enum"):
+        return param_value
+    if any(ptype.startswith(p) for p in ("int", "uint", "long", "short", "unsigned")):
+        try: return int(param_value)
+        except (ValueError, TypeError): return param_value
+    if ptype.startswith("num") or ptype.startswith("float"):
+        try:
+            f = float(param_value)
+            return f if f - int(f) != 0 else int(f)
+        except (ValueError, TypeError):
+            return param_value
+    if ptype in ("boolean", "bool", "binary"):
+        return param_value.lower() == "true"
+    if (ptype in ("object", "array", "arr")
+            or ptype.startswith("dict") or ptype.startswith("list")):
+        try: return json.loads(param_value)
+        except (json.JSONDecodeError, TypeError, ValueError): pass
+    try: return ast.literal_eval(param_value)
+    except (ValueError, SyntaxError, TypeError): return param_value
 
-        idx = window.find(THINK_OPEN_TAG)
-        if idx != -1:
-            pre = window[:idx]
-            if pre:
-                outputs.append(("content", pre))
-            window = window[idx + len(THINK_OPEN_TAG):]
-            mode = "reasoning"
+
+def parse_tool_calls(text: str, tools=None) -> tuple[str, list[dict]]:
+    """Parse Qwen3.x <tool_call> XML blocks into OpenAI tool_calls format.
+
+    Returns (cleaned_content, tool_calls_list).
+    """
+    tool_calls: list[dict] = []
+    cleaned_parts: list[str] = []
+    cursor = 0
+    for m in TOOL_CALL_COMPLETE_RE.finditer(text):
+        cleaned_parts.append(text[cursor:m.start()])
+        cursor = m.end()
+        body = m.group(1)
+        fn_match = TOOL_CALL_FUNCTION_RE.search(body)
+        if not fn_match:
             continue
-        if len(window) > holdback:
-            safe = window[:-holdback]
-            if safe:
-                outputs.append(("content", safe))
-            window = window[-holdback:]
-        break
-
-    return outputs, window, mode
-
-
-def flush_stream_deltas(window: str, mode: str):
-    if not window:
-        return []
-    kind = "reasoning_content" if mode == "reasoning" else "content"
-    return [(kind, window)]
+        fn_text = fn_match.group(1) or fn_match.group(2) or ""
+        end_idx = fn_text.find(">")
+        if end_idx == -1:
+            continue
+        function_name = fn_text[:end_idx].strip()
+        params_region = fn_text[end_idx + 1:]
+        param_config = _find_tool_properties(tools, function_name)
+        args: dict = {}
+        for match_text in TOOL_CALL_PARAMETER_RE.findall(params_region):
+            eq_idx = match_text.find(">")
+            if eq_idx == -1:
+                continue
+            k = match_text[:eq_idx].strip()
+            v = match_text[eq_idx + 1:]
+            if v.startswith("\n"): v = v[1:]
+            if v.endswith("\n"): v = v[:-1]
+            args[k] = _convert_param_value(v, k, param_config, function_name)
+        tool_calls.append({
+            "id": "call_" + uuid.uuid4().hex[:24],
+            "type": "function",
+            "function": {
+                "name": function_name,
+                "arguments": json.dumps(args, ensure_ascii=False),
+            },
+        })
+    cleaned_parts.append(text[cursor:])
+    return "".join(cleaned_parts).strip(), tool_calls
 
 
 # FIX 2: _content_to_str helper used for BOTH OpenAI and Anthropic message
 # content fields (str | list[dict]). Previously OpenAI list[dict] content
 # was passed raw to the tokenizer and caused a crash.
-def _content_to_str(content: "str | list[dict]") -> str:
+def _content_to_str(content: "str | list[dict] | None") -> str:
+    if content is None:
+        return ""
     if isinstance(content, str):
         return content
     parts = []
@@ -215,10 +302,31 @@ def _content_to_str(content: "str | list[dict]") -> str:
     return "".join(parts)
 
 
+# ─── pydantic schemas ──────────────────────────────────────────────
+
+class ToolCallFunction(BaseModel):
+    name: str
+    arguments: str  # JSON string per OpenAI spec
+
+
+class ToolCall(BaseModel):
+    id: str | None = None
+    type: str = "function"
+    function: ToolCallFunction
+
+
 class ChatMessage(BaseModel):
     role: str
     # FIX 2 cont: accept list[dict] in the model but always stringify it
-    content: str | list[dict]
+    content: Any | None = None  # str, list, or null when tool_calls present
+    name: str | None = None
+    tool_call_id: str | None = None
+    tool_calls: list[ToolCall] | None = None
+
+
+class ToolDef(BaseModel):
+    type: str = "function"
+    function: dict  # {name, description, parameters: {...JSON schema...}}
 
 
 class ChatRequest(BaseModel):
@@ -232,7 +340,10 @@ class ChatRequest(BaseModel):
     top_k: int | None = None           # top-k, applied when temperature > 0
     frequency_penalty: float | None = None  # OAI -> rep_pen = 1 + freq_pen (sampling only)
     stop: list[str] | str | None = None  # FIX 3: accept stop field (Open WebUI sends it)
+    tools: list[ToolDef] | None = None
+    tool_choice: Any | None = None  # "auto" | "none" | {"function": {...}}
     chat_template_kwargs: dict | None = None
+    stream_options: dict | None = None  # e.g. {"include_usage": true}
 
 
 class AnthropicMessage(BaseModel):
@@ -252,6 +363,65 @@ class AnthropicMessagesRequest(BaseModel):
     frequency_penalty: float | None = None
     stop_sequences: list[str] | None = None
     chat_template_kwargs: dict | None = None
+
+
+# ─── Responses API schemas (Codex wire protocol) ──────────────────
+
+class ResponseInputMessage(BaseModel):
+    type: str = "message"
+    id: str | None = None
+    role: str = "user"
+    content: Any  # str or list[dict] content parts
+    status: str | None = None
+
+
+class ResponseFunctionCall(BaseModel):
+    type: str = "function_call"
+    id: str | None = None
+    call_id: str
+    name: str
+    arguments: str
+    status: str | None = None
+
+
+class ResponseFunctionCallOutput(BaseModel):
+    type: str = "function_call_output"
+    id: str | None = None
+    call_id: str
+    output: Any  # str or structured
+    status: str | None = None
+
+
+class ResponseToolFunction(BaseModel):
+    type: str = "function"
+    name: str
+    description: str | None = None
+    parameters: dict | None = None
+    strict: bool | None = None
+
+
+class ResponseReasoningConfig(BaseModel):
+    effort: str | None = None  # "low" | "medium" | "high"
+    summary: str | None = None  # "auto" | "concise" | "detailed" | "none"
+
+
+class ResponsesCreateRequest(BaseModel):
+    model: str = MODEL_NAME
+    input: Any  # str or list[InputItem dicts]
+    instructions: str | None = None
+    tools: list[dict] | None = None
+    tool_choice: str | None = "auto"
+    parallel_tool_calls: bool | None = None
+    stream: bool | None = None
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    reasoning: ResponseReasoningConfig | None = None
+    store: bool | None = None
+    include: list[str] | None = None
+    text: dict | None = None
+    metadata: dict | None = None
+    previous_response_id: str | None = None
 
 
 def _samp_suffix(req) -> str:
@@ -373,7 +543,26 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     # FIX 5: richer /v1/models response — Open WebUI uses `context_length` and
     # `created` to populate the model picker and context-bar correctly.
     @app.get("/v1/models")
-    def list_models():
+    def list_models(request: Request):
+        # Codex sends ?client_version= — serve the Codex-specific schema
+        if "client_version" in request.query_params:
+            return {"models": [{
+                "slug": MODEL_NAME,
+                "display_name": MODEL_NAME,
+                "description": "Local DFlash speculative-decoding server",
+                "default_reasoning_level": "low",
+                "supported_reasoning_levels": [
+                    {"effort": "low", "description": "No thinking"},
+                    {"effort": "medium", "description": "Thinking enabled"},
+                ],
+                "shell_type": "shell_command",
+                "visibility": "list",
+                "supported_in_api": True,
+                "priority": 1,
+                "context_window": max_ctx,
+                "supports_reasoning_summaries": False,
+                "supports_parallel_tool_calls": False,
+            }]}
         return {
             "object": "list",
             "data": [{
@@ -394,7 +583,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         return Path(path)
 
     def _render_messages(msgs_list: list[dict],
-                         template_kwargs: dict | None = None
+                         template_kwargs: dict | None = None,
+                         tools_arg: list[dict] | None = None,
                          ) -> tuple[Path, list[int], str]:
         """Apply chat template to msgs_list and return (bin path, ids, raw prompt).
 
@@ -413,22 +603,46 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         tpl_kwargs.update(
             {k: v for k, v in (template_kwargs or {}).items() if k in _ALLOWED_TEMPLATE_KWARGS}
         )
+        if tools_arg:
+            tpl_kwargs["tools"] = tools_arg
         prompt = tokenizer.apply_chat_template(msgs_list, **tpl_kwargs)
+        started_in_thinking = bool(re.search(r"<think>\s*$", prompt))
         ids = tokenizer.encode(prompt, add_special_tokens=False)
         return _ids_to_bin(ids), ids, prompt
 
-    def _thinking_enabled(kwargs: dict | None) -> bool:
-        if kwargs:
-            return kwargs.get("enable_thinking", True)
-        return True
-
-    # FIX 2 applied: always call _content_to_str on message content
     def _tokenize_prompt(req: ChatRequest) -> tuple[Path, list[int], list[dict], bool]:
-        msgs = [{"role": m.role, "content": _content_to_str(m.content)}
-                for m in req.messages]
-        path, ids, prompt = _render_messages(msgs, req.chat_template_kwargs)
-        think = _thinking_enabled(req.chat_template_kwargs) and prompt_starts_in_thinking(prompt)
-        return path, ids, msgs, think
+        """Returns (bin, ids, raw_msgs, started_in_thinking)."""
+        msgs: list[dict] = []
+        for m in req.messages:
+            d: dict = {"role": m.role}
+            if m.content is not None:
+                d["content"] = _content_to_str(m.content)
+            if m.name is not None:
+                d["name"] = m.name
+            if m.tool_call_id is not None:
+                d["tool_call_id"] = m.tool_call_id
+            if m.tool_calls is not None:
+                d["tool_calls"] = []
+                for tc in m.tool_calls:
+                    args = tc.function.arguments
+                    if isinstance(args, str):
+                        try: args_obj = json.loads(args)
+                        except (json.JSONDecodeError, ValueError): args_obj = {"_raw": args}
+                    else:
+                        args_obj = args
+                    d["tool_calls"].append({
+                        "id": tc.id, "type": tc.type,
+                        "function": {"name": tc.function.name, "arguments": args_obj},
+                    })
+            msgs.append(d)
+
+        tools_arg = None
+        if req.tools:
+            tools_arg = [t.model_dump() for t in req.tools]
+
+        path, ids, _prompt = _render_messages(msgs, req.chat_template_kwargs, tools_arg)
+        started_in_thinking = bool(re.search(r"<think>\s*$", _prompt))
+        return path, ids, msgs, started_in_thinking
 
     def _maybe_compress(msgs: list[dict], prompt_bin: Path, prompt_ids: list[int],
                         template_kwargs: dict | None = None
@@ -576,6 +790,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         slot, cached_cur_bin, cached_cur_ids_len = full_hit
                         cur_bin = Path(cached_cur_bin)
                         prompt_len = cached_cur_ids_len
+                        started_in_thinking = False  # cached: no think prefill
                         gen_len = _gen_len_for(prompt_len, req.max_tokens)
                         if gen_len <= 0:
                             try: prompt_bin.unlink()
@@ -627,30 +842,139 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     yield f"data: {json.dumps(head)}\n\n"
                     window, mode = "", ("reasoning" if started_in_thinking else "content")
 
+                    include_usage = bool(req.stream_options and req.stream_options.get("include_usage"))
+
+                    def chunk(delta_obj, finish=None):
+                        return {"id": completion_id, "object": "chat.completion.chunk",
+                                "created": created, "model": MODEL_NAME,
+                                "choices": [{"index": 0, "delta": delta_obj,
+                                              "finish_reason": finish}]}
+
+                    # State machine: mode ∈ {'reasoning', 'content', 'tool_buffer'}
+                    mode = "reasoning" if started_in_thinking else "content"
+                    window = ""
+                    tool_buffer = ""
+                    stops = normalize_stop(req.stop)
+                    tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
+                    stop_holdback = max((len(s) for s in stops), default=0)
+                    HOLDBACK = max(tag_holdback, stop_holdback)
+                    completion_tokens = 0
+                    stop_hit = False
+
+                    def emit_delta(text, kind):
+                        if not text:
+                            return None
+                        return f"data: {json.dumps(chunk({kind: text}))}\n\n"
+
                     try:
                         async for tok_id in _astream_tokens(r_pipe, gen_len):
-                            outputs, window, mode = consume_stream_piece(
-                                window, mode, tokenizer.decode([tok_id]))
-                            for kind, text in outputs:
-                                chunk = {
-                                    "id": completion_id,
-                                    "object": "chat.completion.chunk",
-                                    "created": created, "model": MODEL_NAME,
-                                    "choices": [{"index": 0,
-                                                 "delta": {kind: text},
-                                                 "finish_reason": None}],
-                                }
-                                yield f"data: {json.dumps(chunk)}\n\n"
-                        for kind, text in flush_stream_deltas(window, mode):
-                            chunk = {
-                                "id": completion_id,
-                                "object": "chat.completion.chunk",
-                                "created": created, "model": MODEL_NAME,
-                                "choices": [{"index": 0,
-                                             "delta": {kind: text},
-                                             "finish_reason": None}],
-                            }
-                            yield f"data: {json.dumps(chunk)}\n\n"
+                            completion_tokens += 1
+                            piece = tokenizer.decode([tok_id])
+                            window += piece
+
+                            if stops and mode != "tool_buffer":
+                                si = first_stop_match(window, stops)
+                                if si != -1:
+                                    window = window[:si]
+                                    stop_hit = True
+                                    kind = "reasoning_content" if mode == "reasoning" else "content"
+                                    out = emit_delta(window, kind)
+                                    if out: yield out
+                                    window = ""
+                                    break
+
+                            while True:
+                                if mode == "tool_buffer":
+                                    tool_buffer += window
+                                    window = ""
+                                    break
+
+                                if mode == "reasoning":
+                                    idx = window.find(THINK_CLOSE_TAG)
+                                    if idx != -1:
+                                        pre = window[:idx]
+                                        out = emit_delta(pre, "reasoning_content")
+                                        if out: yield out
+                                        window = window[idx + len(THINK_CLOSE_TAG):]
+                                        mode = "content"
+                                        continue
+                                    if len(window) > HOLDBACK:
+                                        safe = window[:-HOLDBACK]
+                                        out = emit_delta(safe, "reasoning_content")
+                                        if out: yield out
+                                        window = window[-HOLDBACK:]
+                                    break
+
+                                else:  # mode == "content"
+                                    think_idx = window.find(THINK_OPEN_TAG)
+                                    tool_idx  = window.find(TOOL_OPEN_TAG)
+                                    hits = [(i, t) for i, t in
+                                            ((think_idx, "think"), (tool_idx, "tool")) if i != -1]
+                                    if hits:
+                                        hits.sort()
+                                        idx, which = hits[0]
+                                        pre = window[:idx]
+                                        out = emit_delta(pre, "content")
+                                        if out: yield out
+                                        if which == "think":
+                                            window = window[idx + len(THINK_OPEN_TAG):]
+                                            mode = "reasoning"
+                                        else:
+                                            tool_buffer = window[idx:]
+                                            window = ""
+                                            mode = "tool_buffer"
+                                        continue
+                                    if len(window) > HOLDBACK:
+                                        safe = window[:-HOLDBACK]
+                                        out = emit_delta(safe, "content")
+                                        if out: yield out
+                                        window = window[-HOLDBACK:]
+                                    break
+
+                        if stop_hit:
+                            finish_reason = "stop"
+                            yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
+                            if include_usage:
+                                usage_chunk = {"id": completion_id, "object": "chat.completion.chunk",
+                                               "created": created, "model": MODEL_NAME, "choices": [],
+                                               "usage": {"prompt_tokens": prompt_len,
+                                                          "completion_tokens": completion_tokens,
+                                                          "total_tokens": prompt_len + completion_tokens}}
+                                yield f"data: {json.dumps(usage_chunk)}\n\n"
+                            yield "data: [DONE]\n\n"
+                            if full_hit is None:
+                                try: cur_bin.unlink()
+                                except Exception: pass
+                            return
+
+                        # Flush remaining
+                        if mode == "reasoning" and window:
+                            out = emit_delta(window, "reasoning_content")
+                            if out: yield out
+                        elif mode == "content" and window:
+                            out = emit_delta(window, "content")
+                            if out: yield out
+                        elif mode == "tool_buffer":
+                            tool_buffer += window
+                        window = ""
+
+                        finish_reason = "stop"
+                        if mode == "tool_buffer":
+                            cleaned_after, tool_calls = parse_tool_calls(tool_buffer, tools=req.tools)
+                            if tool_calls:
+                                if cleaned_after:
+                                    out = emit_delta(cleaned_after, "content")
+                                    if out: yield out
+                                tc_delta_list = [{
+                                    "index": i, "id": tc["id"], "type": "function",
+                                    "function": {"name": tc["function"]["name"],
+                                                  "arguments": tc["function"]["arguments"]},
+                                } for i, tc in enumerate(tool_calls)]
+                                yield f"data: {json.dumps(chunk({'tool_calls': tc_delta_list}))}\n\n"
+                                finish_reason = "tool_calls"
+                            else:
+                                out = emit_delta(tool_buffer, "content")
+                                if out: yield out
                     finally:
                         if full_hit is None:
                             try: cur_bin.unlink()
@@ -666,13 +990,17 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     elif snap_prep:
                         prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
 
-                    tail = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": MODEL_NAME,
-                        "choices": [{"index": 0, "delta": {},
-                                     "finish_reason": "stop"}],
-                    }
-                    yield f"data: {json.dumps(tail)}\n\n"
+                    yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
+                    if include_usage:
+                        usage_chunk = {
+                            "id": completion_id, "object": "chat.completion.chunk",
+                            "created": created, "model": MODEL_NAME,
+                            "choices": [],
+                            "usage": {"prompt_tokens": prompt_len,
+                                       "completion_tokens": completion_tokens,
+                                       "total_tokens": prompt_len + completion_tokens},
+                        }
+                        yield f"data: {json.dumps(usage_chunk)}\n\n"
                     yield "data: [DONE]\n\n"
 
             return StreamingResponse(sse(), media_type="text/event-stream")
@@ -736,14 +1064,34 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             except Exception: pass
 
         text = tokenizer.decode(tokens, skip_special_tokens=True)
+        # Stop sequences
+        stops = normalize_stop(req.stop)
+        if stops:
+            i = first_stop_match(text, stops)
+            if i != -1:
+                text = text[:i]
+        # Parse reasoning and tool calls
+        thinking_enabled = True
+        if req.chat_template_kwargs:
+            thinking_enabled = req.chat_template_kwargs.get("enable_thinking", True)
+        cleaned, tool_calls = parse_tool_calls(text, tools=req.tools)
         cleaned, reasoning = parse_reasoning(
-            text,
-            thinking_enabled=_thinking_enabled(req.chat_template_kwargs),
+            cleaned,
+            thinking_enabled=thinking_enabled,
             started_in_thinking=started_in_thinking,
         )
-        msg = {"role": "assistant", "content": cleaned}
+
+        msg: dict = {"role": "assistant"}
+        finish_reason = "stop"
         if reasoning:
             msg["reasoning_content"] = reasoning
+        if tool_calls:
+            msg["content"] = cleaned if cleaned else None
+            msg["tool_calls"] = tool_calls
+            finish_reason = "tool_calls"
+        else:
+            msg["content"] = cleaned
+
         return JSONResponse({
             "id": completion_id,
             "object": "chat.completion",
@@ -752,7 +1100,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             "choices": [{
                 "index": 0,
                 "message": msg,
-                "finish_reason": "stop",
+                "finish_reason": finish_reason,
             }],
             "usage": {"prompt_tokens": prompt_len,
                       "completion_tokens": len(tokens),
@@ -980,6 +1328,483 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             "usage": {"input_tokens": prompt_len,
                       "output_tokens": len(tokens)},
         })
+
+    # ── Responses API (Codex wire protocol) ───────────────────────────
+
+    def _map_responses_input(req: ResponsesCreateRequest
+                             ) -> tuple[list[ChatMessage], list[ToolDef] | None]:
+        """Map Responses API input → ChatMessage list + ToolDef list."""
+        messages: list[ChatMessage] = []
+
+        # instructions → system message
+        if req.instructions:
+            messages.append(ChatMessage(role="system", content=req.instructions))
+
+        # Parse input items
+        input_items = req.input
+        if isinstance(input_items, str):
+            messages.append(ChatMessage(role="user", content=input_items))
+        elif isinstance(input_items, list):
+            for item in input_items:
+                if not isinstance(item, dict):
+                    continue
+                item_type = item.get("type", "message")
+
+                if item_type == "message":
+                    role = item.get("role", "user")
+                    if role == "developer":
+                        role = "system"
+                    content = item.get("content", "")
+                    if isinstance(content, list):
+                        # Extract text from content parts
+                        text_parts = []
+                        for part in content:
+                            if isinstance(part, dict):
+                                if part.get("type") in ("output_text", "text", "input_text"):
+                                    text_parts.append(part.get("text", ""))
+                        content = "".join(text_parts)
+                    messages.append(ChatMessage(role=role, content=content))
+
+                elif item_type == "function_call":
+                    tc = ToolCall(
+                        id=item.get("call_id", "call_" + uuid.uuid4().hex[:12]),
+                        type="function",
+                        function=ToolCallFunction(
+                            name=item.get("name", ""),
+                            arguments=item.get("arguments", "{}"),
+                        ),
+                    )
+                    messages.append(ChatMessage(
+                        role="assistant", content=None, tool_calls=[tc]))
+
+                elif item_type == "function_call_output":
+                    output = item.get("output", "")
+                    if not isinstance(output, str):
+                        output = json.dumps(output)
+                    messages.append(ChatMessage(
+                        role="tool",
+                        tool_call_id=item.get("call_id", ""),
+                        content=output))
+
+                # Ignore reasoning, local_shell_call, etc. — we just
+                # need the message/function_call/output items for the model.
+
+        # Map tools
+        tools: list[ToolDef] | None = None
+        if req.tools:
+            tool_defs = []
+            for t in req.tools:
+                if not isinstance(t, dict):
+                    continue
+                if t.get("type") == "function":
+                    func_def = {
+                        "name": t.get("name", ""),
+                        "description": t.get("description", ""),
+                    }
+                    if "parameters" in t:
+                        func_def["parameters"] = t["parameters"]
+                    tool_defs.append(ToolDef(type="function", function=func_def))
+            if tool_defs:
+                tools = tool_defs
+
+        return messages, tools
+
+    @app.post("/v1/responses")
+    async def responses_create(req: ResponsesCreateRequest):
+        messages, tools = _map_responses_input(req)
+
+        # Build an internal ChatRequest
+        enable_thinking = False
+        if req.reasoning and req.reasoning.effort and req.reasoning.effort != "low":
+            enable_thinking = True
+
+        chat_req = ChatRequest(
+            model=req.model or MODEL_NAME,
+            messages=messages,
+            stream=bool(req.stream),
+            max_tokens=req.max_output_tokens or 4096,
+            temperature=req.temperature,
+            top_p=req.top_p,
+            tools=tools,
+            tool_choice=req.tool_choice,
+            chat_template_kwargs={"enable_thinking": enable_thinking},
+        )
+
+        response_id = "resp_" + uuid.uuid4().hex[:24]
+        msg_item_id = "msg_" + uuid.uuid4().hex[:24]
+        created_at = int(time.time())
+
+        # Tokenize
+        prompt_bin, prompt_ids, raw_msgs, started_in_thinking = _tokenize_prompt(chat_req)
+        prompt_len = len(prompt_ids)
+
+        if req.stream:
+            return await _responses_stream(
+                chat_req, prompt_bin, prompt_ids, raw_msgs,
+                started_in_thinking, response_id, msg_item_id,
+                created_at, prompt_len)
+        else:
+            return await _responses_non_stream(
+                chat_req, prompt_bin, prompt_ids, raw_msgs,
+                response_id, msg_item_id, created_at, prompt_len)
+
+    async def _responses_non_stream(
+            chat_req, prompt_bin, prompt_ids, raw_msgs,
+            response_id, msg_item_id, created_at, prompt_len):
+        """Non-streaming Responses API handler."""
+        async with daemon_lock:
+            full_snap_prep_ref = [None]
+            snap_prep = None
+
+            full_hit = prefix_cache.lookup_full(prompt_ids)
+            if full_hit is not None:
+                slot, cached_cur_bin, cached_cur_ids_len = full_hit
+                cur_bin = Path(cached_cur_bin)
+                cur_ids = None
+                prompt_len = cached_cur_ids_len
+                gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
+                if gen_len <= 0:
+                    try: prompt_bin.unlink()
+                    except Exception: pass
+                    return JSONResponse({
+                        "type": "error",
+                        "error": {"type": "invalid_request_error",
+                                  "message": f"Prompt too long ({prompt_len})"}
+                    }, status_code=400)
+                cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(chat_req) + "\n"
+            else:
+                cur_bin, cur_ids = await asyncio.to_thread(
+                    _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
+                    chat_req.chat_template_kwargs)
+                prompt_len = len(cur_ids)
+                gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
+                if gen_len <= 0:
+                    try: cur_bin.unlink()
+                    except Exception: pass
+                    return JSONResponse({
+                        "type": "error",
+                        "error": {"type": "invalid_request_error",
+                                  "message": f"Prompt too long ({prompt_len})"}
+                    }, status_code=400)
+                compression_fired = (cur_bin != prompt_bin)
+                cmd_line, snap_prep = _build_cmd_line(
+                    chat_req, cur_bin, cur_ids, gen_len, prefix_cache,
+                    prompt_ids, full_snap_prep_ref, compression_fired)
+
+            try:
+                _write_cmd(cmd_line)
+            except RuntimeError as e:
+                return JSONResponse({
+                    "type": "error",
+                    "error": {"type": "server_error", "message": str(e)}
+                }, status_code=503)
+
+            tokens = await _collect_tokens_sync(r_pipe, gen_len)
+
+            full_snap_prep = full_snap_prep_ref[0]
+            if full_snap_prep is not None:
+                fslot, _ = full_snap_prep
+                prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
+            elif snap_prep:
+                prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+
+        if full_hit is None:
+            try: cur_bin.unlink()
+            except Exception: pass
+        else:
+            try: prompt_bin.unlink()
+            except Exception: pass
+
+        text = tokenizer.decode(tokens, skip_special_tokens=True)
+        thinking_enabled = True
+        if chat_req.chat_template_kwargs:
+            thinking_enabled = chat_req.chat_template_kwargs.get("enable_thinking", True)
+        cleaned, tool_calls = parse_tool_calls(text, tools=chat_req.tools)
+        cleaned, reasoning = parse_reasoning(cleaned, thinking_enabled=thinking_enabled)
+
+        # Build output items
+        output: list[dict] = []
+        if tool_calls:
+            for tc in tool_calls:
+                output.append({
+                    "type": "function_call",
+                    "id": tc["id"],
+                    "status": "completed",
+                    "call_id": tc["id"],
+                    "name": tc["function"]["name"],
+                    "arguments": tc["function"]["arguments"],
+                })
+        else:
+            output.append({
+                "type": "message",
+                "id": msg_item_id,
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": cleaned, "annotations": []}],
+            })
+
+        return JSONResponse({
+            "id": response_id,
+            "object": "response",
+            "created_at": created_at,
+            "status": "completed",
+            "model": chat_req.model or MODEL_NAME,
+            "output": output,
+            "output_text": cleaned,
+            "usage": {
+                "input_tokens": prompt_len,
+                "output_tokens": len(tokens),
+                "total_tokens": prompt_len + len(tokens),
+            },
+        })
+
+    async def _responses_stream(
+            chat_req, prompt_bin, prompt_ids, raw_msgs,
+            started_in_thinking, response_id, msg_item_id,
+            created_at, prompt_len):
+        """Streaming Responses API handler — emits Responses SSE events."""
+
+        async def sse() -> AsyncIterator[str]:
+            nonlocal prompt_len, started_in_thinking
+
+            async with daemon_lock:
+                full_snap_prep_ref = [None]
+                snap_prep = None
+
+                full_hit = prefix_cache.lookup_full(prompt_ids)
+                if full_hit is not None:
+                    slot, cached_cur_bin, cached_cur_ids_len = full_hit
+                    cur_bin = Path(cached_cur_bin)
+                    prompt_len = cached_cur_ids_len
+                    started_in_thinking = False
+                    gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
+                    if gen_len <= 0:
+                        try: prompt_bin.unlink()
+                        except Exception: pass
+                        yield _resp_sse("response.failed", {
+                            "response": _resp_shell(response_id, chat_req.model, created_at,
+                                                     "failed")})
+                        return
+                    cmd_line = f"RESTORE {slot} {cached_cur_bin} {gen_len}" + _samp_suffix(chat_req) + "\n"
+                else:
+                    cur_bin, cur_ids = await asyncio.to_thread(
+                        _maybe_compress, raw_msgs, prompt_bin, prompt_ids,
+                        chat_req.chat_template_kwargs)
+                    prompt_len = len(cur_ids)
+                    gen_len = _gen_len_for(prompt_len, chat_req.max_tokens)
+                    if gen_len <= 0:
+                        try: cur_bin.unlink()
+                        except Exception: pass
+                        yield _resp_sse("response.failed", {
+                            "response": _resp_shell(response_id, chat_req.model, created_at,
+                                                     "failed")})
+                        return
+                    compression_fired = (cur_bin != prompt_bin)
+                    cmd_line, snap_prep = _build_cmd_line(
+                        chat_req, cur_bin, cur_ids, gen_len, prefix_cache,
+                        prompt_ids, full_snap_prep_ref, compression_fired)
+
+                try:
+                    _write_cmd(cmd_line)
+                except RuntimeError as e:
+                    yield _resp_sse("error", {
+                        "error": {"type": "server_error", "message": str(e)}})
+                    return
+
+                # Lifecycle: response.created
+                yield _resp_sse("response.created", {
+                    "response": _resp_shell(response_id, chat_req.model, created_at,
+                                             "in_progress")})
+
+                # Announce output item
+                yield _resp_sse("response.output_item.added", {
+                    "output_index": 0,
+                    "item": {"type": "message", "id": msg_item_id,
+                             "status": "in_progress", "role": "assistant",
+                             "content": []}})
+
+                # Announce content part
+                yield _resp_sse("response.content_part.added", {
+                    "item_id": msg_item_id, "output_index": 0,
+                    "content_index": 0,
+                    "part": {"type": "output_text", "text": "", "annotations": []}})
+
+                # Stream tokens with state machine
+                mode = "reasoning" if started_in_thinking else "content"
+                window = ""
+                tool_buffer = ""
+                accumulated_text = ""
+                tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
+                HOLDBACK = tag_holdback
+                completion_tokens = 0
+                tool_call_active = False
+
+                try:
+                    async for tok_id in _astream_tokens(r_pipe, gen_len):
+                        completion_tokens += 1
+                        piece = tokenizer.decode([tok_id])
+                        window += piece
+
+                        while True:
+                            if mode == "tool_buffer":
+                                tool_buffer += window
+                                window = ""
+                                break
+
+                            if mode == "reasoning":
+                                idx = window.find(THINK_CLOSE_TAG)
+                                if idx != -1:
+                                    window = window[idx + len(THINK_CLOSE_TAG):]
+                                    mode = "content"
+                                    continue
+                                if len(window) > HOLDBACK:
+                                    window = window[-HOLDBACK:]
+                                break
+
+                            else:  # content
+                                think_idx = window.find(THINK_OPEN_TAG)
+                                tool_idx = window.find(TOOL_OPEN_TAG)
+                                hits = [(i, t) for i, t in
+                                        ((think_idx, "think"), (tool_idx, "tool")) if i != -1]
+                                if hits:
+                                    hits.sort()
+                                    idx, which = hits[0]
+                                    pre = window[:idx]
+                                    if pre:
+                                        accumulated_text += pre
+                                        yield _resp_sse("response.output_text.delta", {
+                                            "item_id": msg_item_id, "output_index": 0,
+                                            "content_index": 0, "delta": pre})
+                                    if which == "think":
+                                        window = window[idx + len(THINK_OPEN_TAG):]
+                                        mode = "reasoning"
+                                    else:
+                                        tool_buffer = window[idx:]
+                                        window = ""
+                                        mode = "tool_buffer"
+                                    continue
+                                if len(window) > HOLDBACK:
+                                    safe = window[:-HOLDBACK]
+                                    accumulated_text += safe
+                                    yield _resp_sse("response.output_text.delta", {
+                                        "item_id": msg_item_id, "output_index": 0,
+                                        "content_index": 0, "delta": safe})
+                                    window = window[-HOLDBACK:]
+                                break
+
+                    # Flush remaining window
+                    if mode == "content" and window:
+                        accumulated_text += window
+                        yield _resp_sse("response.output_text.delta", {
+                            "item_id": msg_item_id, "output_index": 0,
+                            "content_index": 0, "delta": window})
+                    elif mode == "tool_buffer":
+                        tool_buffer += window
+                    window = ""
+
+                finally:
+                    if full_hit is None:
+                        try: cur_bin.unlink()
+                        except Exception: pass
+                    else:
+                        try: prompt_bin.unlink()
+                        except Exception: pass
+
+                full_snap_prep = full_snap_prep_ref[0]
+                if full_snap_prep is not None:
+                    fslot, _ = full_snap_prep
+                    prefix_cache.confirm_full_snap(fslot, prompt_ids, cur_bin, len(cur_ids))
+                elif snap_prep:
+                    prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+
+                # Build final output items
+                final_output: list[dict] = []
+                if mode == "tool_buffer" and tool_buffer:
+                    cleaned_after, tool_calls = parse_tool_calls(tool_buffer, tools=chat_req.tools)
+                    if tool_calls:
+                        if cleaned_after:
+                            accumulated_text += cleaned_after
+                        for tc in tool_calls:
+                            tool_call_active = True
+                            tc_item_id = tc["id"]
+                            # Emit function_call_arguments.delta for each tool call
+                            yield _resp_sse("response.function_call_arguments.delta", {
+                                "item_id": tc_item_id, "output_index": 0,
+                                "delta": tc["function"]["arguments"]})
+                            yield _resp_sse("response.function_call_arguments.done", {
+                                "item_id": tc_item_id, "output_index": 0,
+                                "arguments": tc["function"]["arguments"],
+                                "name": tc["function"]["name"]})
+                            final_output.append({
+                                "type": "function_call",
+                                "id": tc_item_id,
+                                "status": "completed",
+                                "call_id": tc_item_id,
+                                "name": tc["function"]["name"],
+                                "arguments": tc["function"]["arguments"],
+                            })
+                    else:
+                        accumulated_text += tool_buffer
+                        yield _resp_sse("response.output_text.delta", {
+                            "item_id": msg_item_id, "output_index": 0,
+                            "content_index": 0, "delta": tool_buffer})
+
+                # Finalize text output
+                yield _resp_sse("response.output_text.done", {
+                    "item_id": msg_item_id, "output_index": 0,
+                    "content_index": 0, "text": accumulated_text})
+                yield _resp_sse("response.content_part.done", {
+                    "item_id": msg_item_id, "output_index": 0,
+                    "content_index": 0,
+                    "part": {"type": "output_text", "text": accumulated_text,
+                             "annotations": []}})
+
+                if not tool_call_active:
+                    final_output.append({
+                        "type": "message",
+                        "id": msg_item_id,
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": accumulated_text,
+                                     "annotations": []}],
+                    })
+
+                yield _resp_sse("response.output_item.done", {
+                    "output_index": 0,
+                    "item": final_output[0] if final_output else {
+                        "type": "message", "id": msg_item_id,
+                        "status": "completed", "role": "assistant",
+                        "content": []}})
+
+                # response.completed
+                shell = _resp_shell(response_id, chat_req.model, created_at,
+                                     "completed")
+                shell["output"] = final_output
+                shell["output_text"] = accumulated_text
+                shell["usage"] = {
+                    "input_tokens": prompt_len,
+                    "output_tokens": completion_tokens,
+                    "total_tokens": prompt_len + completion_tokens,
+                }
+                yield _resp_sse("response.completed", {"response": shell})
+
+        return StreamingResponse(sse(), media_type="text/event-stream")
+
+    def _resp_sse(event_type: str, data: dict) -> str:
+        """Format a Responses API SSE event."""
+        data["type"] = event_type
+        return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+    def _resp_shell(resp_id: str, model: str, created_at: int,
+                    status: str) -> dict:
+        """Minimal response shell for SSE lifecycle events."""
+        return {
+            "id": resp_id,
+            "object": "response",
+            "created_at": created_at,
+            "status": status,
+            "model": model or MODEL_NAME,
+        }
 
     return app
 

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -369,6 +369,34 @@ def test_responses_non_streaming_string_input(mock_os_read, mock_pipe,
 
 @patch("server.os.pipe")
 @patch("server.os.read")
+def test_responses_non_streaming_started_in_thinking(mock_os_read, mock_pipe,
+                                                      mock_tokenizer, app):
+    """When prompt ends with <think>, reasoning without tags is not misclassified as content."""
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    # Simulate a chat template that prefills <think>\n
+    mock_tokenizer.apply_chat_template.return_value = "prompt<think>\n"
+    # Model output has no <think> tags — it's a continuation of the prefilled block
+    mock_tokenizer.decode.return_value = "internal reasoning</think>\nactual answer"
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": [{"type": "message", "role": "user", "content": "hello"}],
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+    # The "actual answer" part should be the output text, not the reasoning
+    assert "actual answer" in data["output_text"]
+    # The reasoning should NOT leak into the output text
+    assert "internal reasoning" not in data["output_text"]
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
 def test_responses_with_instructions(mock_os_read, mock_pipe,
                                       mock_tokenizer, app):
     """Instructions are mapped to system message."""

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -561,3 +561,32 @@ def test_responses_developer_role_mapped_to_system(mock_os_read, mock_pipe,
     calls = mock_tokenizer.apply_chat_template.call_args_list
     msgs = calls[-1][0][0]
     assert msgs[0]["role"] == "system"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_instructions_and_developer_merged(mock_os_read, mock_pipe,
+                                                      mock_tokenizer, app):
+    """Instructions + developer messages merge into one system message."""
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "instructions": "Top-level instructions.",
+        "input": [
+            {"type": "message", "role": "developer",
+             "content": "Developer context."},
+            {"type": "message", "role": "user", "content": "hi"},
+        ],
+    })
+
+    assert response.status_code == 200
+    calls = mock_tokenizer.apply_chat_template.call_args_list
+    msgs = calls[-1][0][0]
+    # Should be exactly one system message containing both
+    system_msgs = [m for m in msgs if m["role"] == "system"]
+    assert len(system_msgs) == 1
+    assert "Top-level instructions." in system_msgs[0]["content"]
+    assert "Developer context." in system_msgs[0]["content"]

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -454,6 +454,32 @@ def test_responses_with_tools(mock_os_read, mock_pipe, mock_tokenizer, app):
 
 @patch("server.os.pipe")
 @patch("server.os.read")
+def test_responses_object_tool_choice(mock_os_read, mock_pipe,
+                                       mock_tokenizer, app):
+    """POST /v1/responses with object-style tool_choice must not 422."""
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": [{"type": "message", "role": "user", "content": "read file.txt"}],
+        "tools": [
+            {"type": "function", "name": "read_file",
+             "description": "Read a file",
+             "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}}}
+        ],
+        "tool_choice": {"type": "function", "name": "read_file"},
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
 def test_responses_function_call_output(mock_os_read, mock_pipe,
                                          mock_tokenizer, app):
     """Responses API maps function_call + function_call_output items."""

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -382,6 +382,28 @@ def test_chat_completions_non_streaming_with_tool_call(mock_os_read, mock_pipe,
 
 @patch("server.os.pipe")
 @patch("server.os.read")
+def test_zero_token_prompt_is_rejected_before_daemon(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.encode.return_value = []
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [],
+        "stream": False,
+    })
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["error"]["type"] == "invalid_request_error"
+    assert data["error"]["param"] == "messages"
+    assert "zero tokens" in data["error"]["message"]
+    mock_os_read.assert_not_called()
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
 def test_chat_completions_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
     mock_pipe.return_value = (1, 2)
     mock_tokenizer.apply_chat_template.return_value = "<think>\n"

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -150,6 +150,29 @@ class TestParseToolCalls:
         assert args["path"] == "out.txt"
         assert args["content"] == "hello world"
 
+    def test_bare_qwen_xml_function_call(self):
+        text = (
+            '<function=read>\n'
+            '<parameter=path>\n'
+            '~/.npm-global/lib/node_modules/openclaw/skills/weather/SKILL.md\n'
+            '</parameter>\n'
+            '</function>\n'
+            '</tool_call>'
+        )
+        cleaned, calls = parse_tool_calls(text, tools=[{
+            "type": "function",
+            "function": {"name": "read", "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            }},
+        }])
+        assert cleaned == ""
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "read"
+        assert json.loads(calls[0]["function"]["arguments"]) == {
+            "path": "~/.npm-global/lib/node_modules/openclaw/skills/weather/SKILL.md"
+        }
+
     def test_tool_call_id_format(self):
         text = "<tool_call><function=f><parameter=x>1</parameter></function></tool_call>"
         _, calls = parse_tool_calls(text, tools=None)

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -8,8 +8,14 @@ from unittest.mock import patch, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-from server import build_app, MODEL_NAME, parse_tool_calls, parse_reasoning
+from server import (
+    build_app, MODEL_NAME,
+    parse_tool_calls, parse_reasoning,
+    normalize_stop, first_stop_match,
+)
 
+
+# ─── Fixtures ──────────────────────────────────────────────────────
 
 @pytest.fixture
 def mock_tokenizer():
@@ -20,116 +26,195 @@ def mock_tokenizer():
     return tokenizer
 
 
-def test_parse_reasoning_headless_think():
-    cleaned, reasoning = parse_reasoning("private chain of thought</think>\n\nvisible answer")
-    assert cleaned == "visible answer"
-    assert reasoning == "private chain of thought"
+@pytest.fixture
+def app(mock_tokenizer):
+    """Build a FastAPI app with mocked daemon."""
+    with patch("server.subprocess.Popen") as mock_popen:
+        mock_popen.return_value.poll.return_value = None  # daemon alive
+        a = build_app(
+            target=Path("target.gguf"),
+            draft=Path("draft.safetensors"),
+            bin_path=Path("test_dflash"),
+            budget=22,
+            max_ctx=131072,
+            tokenizer=mock_tokenizer,
+            stop_ids={2},
+        )
+    return a
 
 
-def test_parse_reasoning_full_think_tags():
-    cleaned, reasoning = parse_reasoning("<think>my reasoning</think>\n\nthe answer")
-    assert cleaned == "the answer"
-    assert reasoning == "my reasoning"
+@pytest.fixture
+def client(app):
+    return TestClient(app)
 
 
-def test_parse_reasoning_plain_content_when_no_think_segment_present():
-    cleaned, reasoning = parse_reasoning("visible answer only")
-    assert cleaned == "visible answer only"
-    assert reasoning is None
+# ─── parse_reasoning ───────────────────────────────────────────────
+
+class TestParseReasoning:
+    def test_full_think_tags(self):
+        cleaned, reasoning = parse_reasoning("<think>my reasoning</think>\n\nthe answer")
+        assert cleaned == "the answer"
+        assert reasoning == "my reasoning"
+
+    def test_headless_think(self):
+        """Model started in thinking — output has no <think>, just body+</think>."""
+        cleaned, reasoning = parse_reasoning("chain of thought</think>\n\nvisible")
+        assert cleaned == "visible"
+        assert reasoning == "chain of thought"
+
+    def test_no_think_tags_thinking_enabled(self):
+        """With thinking enabled but no tags and not started_in_thinking, text is content."""
+        cleaned, reasoning = parse_reasoning("all content", thinking_enabled=True)
+        assert cleaned == "all content"
+        assert reasoning is None
+
+    def test_no_think_tags_thinking_disabled(self):
+        """With thinking disabled, plain text passes through as content."""
+        cleaned, reasoning = parse_reasoning("plain answer", thinking_enabled=False)
+        assert cleaned == "plain answer"
+        assert reasoning is None
+
+    def test_started_in_thinking_no_close_tag(self):
+        """Truncated reasoning when prompt started in thinking mode."""
+        cleaned, reasoning = parse_reasoning(
+            "unfinished thought", started_in_thinking=True)
+        assert cleaned == ""
+        assert reasoning == "unfinished thought"
+
+    def test_started_in_thinking_with_close_tag(self):
+        """Full reasoning block when prompt started in thinking mode."""
+        cleaned, reasoning = parse_reasoning(
+            "thought body</think>the answer", started_in_thinking=True)
+        assert cleaned == "the answer"
+        assert reasoning == "thought body"
+
+    def test_empty_think_block(self):
+        cleaned, reasoning = parse_reasoning("<think></think>answer")
+        assert cleaned == "answer"
+        assert reasoning is None  # empty reasoning stripped to None
+
+    def test_multiline_reasoning(self):
+        text = "<think>line1\nline2\nline3</think>result"
+        cleaned, reasoning = parse_reasoning(text)
+        assert cleaned == "result"
+        assert "line1" in reasoning and "line3" in reasoning
 
 
-def test_parse_reasoning_truncated_when_prompt_started_in_thinking():
-    cleaned, reasoning = parse_reasoning(
-        "unfinished private chain of thought",
-        started_in_thinking=True,
+# ─── parse_tool_calls ─────────────────────────────────────────────
+
+class TestParseToolCalls:
+    def test_single_tool_call(self):
+        text = (
+            'Sure!\n<tool_call>'
+            '<function=read_file><parameter=path>test.py</parameter></function>'
+            '</tool_call>'
+        )
+        cleaned, calls = parse_tool_calls(text, tools=None)
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "read_file"
+        args = json.loads(calls[0]["function"]["arguments"])
+        assert args["path"] == "test.py"
+        assert cleaned.strip() == "Sure!"
+
+    def test_no_tool_tags(self):
+        text = "Just a plain answer."
+        cleaned, calls = parse_tool_calls(text, tools=None)
+        assert calls == []
+        assert cleaned == text
+
+    def test_multiple_tool_calls(self):
+        text = (
+            '<tool_call>'
+            '<function=read_file><parameter=path>a.py</parameter></function>'
+            '</tool_call>'
+            '<tool_call>'
+            '<function=read_file><parameter=path>b.py</parameter></function>'
+            '</tool_call>'
+        )
+        cleaned, calls = parse_tool_calls(text, tools=None)
+        assert len(calls) == 2
+        assert json.loads(calls[0]["function"]["arguments"])["path"] == "a.py"
+        assert json.loads(calls[1]["function"]["arguments"])["path"] == "b.py"
+
+    def test_multiple_parameters(self):
+        text = (
+            '<tool_call>'
+            '<function=write_file>'
+            '<parameter=path>out.txt</parameter>'
+            '<parameter=content>hello world</parameter>'
+            '</function></tool_call>'
+        )
+        cleaned, calls = parse_tool_calls(text, tools=None)
+        assert len(calls) == 1
+        args = json.loads(calls[0]["function"]["arguments"])
+        assert args["path"] == "out.txt"
+        assert args["content"] == "hello world"
+
+    def test_tool_call_id_format(self):
+        text = "<tool_call><function=f><parameter=x>1</parameter></function></tool_call>"
+        _, calls = parse_tool_calls(text, tools=None)
+        assert calls[0]["id"].startswith("call_")
+        assert calls[0]["type"] == "function"
+
+    def test_text_before_and_after_tool_call(self):
+        text = "Before\n<tool_call><function=f><parameter=x>1</parameter></function></tool_call>\nAfter"
+        cleaned, calls = parse_tool_calls(text, tools=None)
+        assert len(calls) == 1
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+
+# ─── normalize_stop / first_stop_match ──────────────────────────────
+
+class TestStopHelpers:
+    def test_normalize_none(self):
+        assert normalize_stop(None) == []
+
+    def test_normalize_string(self):
+        assert normalize_stop("stop") == ["stop"]
+
+    def test_normalize_list(self):
+        assert normalize_stop(["a", "b"]) == ["a", "b"]
+
+    def test_normalize_empty_string(self):
+        assert normalize_stop("") == []
+
+    def test_first_stop_match_found(self):
+        assert first_stop_match("hello world stop here", ["stop"]) == 12
+
+    def test_first_stop_match_multiple(self):
+        assert first_stop_match("ab cd ef", ["cd", "ab"]) == 0  # "ab" is earliest
+
+    def test_first_stop_match_none(self):
+        assert first_stop_match("hello world", ["xyz"]) == -1
+
+    def test_first_stop_match_empty_list(self):
+        assert first_stop_match("hello", []) == -1
+
+
+# ─── /health endpoint ─────────────────────────────────────────────
+
+def test_health_endpoint(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+# ─── CORS headers ─────────────────────────────────────────────────
+
+def test_cors_headers(client):
+    response = client.options(
+        "/v1/models",
+        headers={"Origin": "http://localhost:3000",
+                 "Access-Control-Request-Method": "GET"},
     )
-    assert cleaned == ""
-    assert reasoning == "unfinished private chain of thought"
+    assert response.status_code == 200
+    assert "access-control-allow-origin" in response.headers
 
 
-# -- consume_stream_piece / flush_stream_deltas -------------------------
+# ─── GET /v1/models ────────────────────────────────────────────────
 
-def test_consume_stream_piece_reasoning_to_content():
-    """Full transition: reasoning tokens, close tag, content tokens."""
-    window, mode = "", "reasoning"
-    assert mode == "reasoning"
-
-    all_outputs = []
-
-    # Feed reasoning text
-    outputs, window, mode = consume_stream_piece(window, mode, "deep thought")
-    all_outputs.extend(outputs)
-    assert mode == "reasoning"
-
-    # Feed close tag
-    outputs, window, mode = consume_stream_piece(window, mode, "</think>")
-    all_outputs.extend(outputs)
-    reasoning_parts = [t for k, t in all_outputs if k == "reasoning_content"]
-    assert "deep thought" in "".join(reasoning_parts)
-    assert mode == "content"
-
-    # Feed content
-    outputs, window, mode = consume_stream_piece(window, mode, "visible answer")
-    all_outputs.extend(outputs)
-    assert mode == "content"
-
-    # Flush remaining
-    flushed = flush_stream_deltas(window, mode)
-    all_content = [t for k, t in all_outputs if k == "content"] + [t for k, t in flushed if k == "content"]
-    assert "visible answer" in "".join(all_content)
-
-
-def test_consume_stream_piece_tag_split_across_pieces():
-    """The </think> tag arrives split across two pieces."""
-    window, mode = "", "reasoning"
-    all_outputs = []
-
-    outputs, window, mode = consume_stream_piece(window, mode, "thought</th")
-    all_outputs.extend(outputs)
-    # Tag not yet complete, should stay in reasoning mode
-    assert mode == "reasoning"
-
-    outputs, window, mode = consume_stream_piece(window, mode, "ink>answer")
-    all_outputs.extend(outputs)
-    # Now the tag is complete, should have transitioned
-    assert mode == "content"
-    # Collect everything emitted across both calls
-    all_reasoning = [t for k, t in all_outputs if k == "reasoning_content"]
-    all_content = [t for k, t in all_outputs if k == "content"]
-    flushed = flush_stream_deltas(window, mode)
-    all_content += [t for k, t in flushed if k == "content"]
-    assert "thought" in "".join(all_reasoning)
-    assert "answer" in "".join(all_content)
-
-
-def test_consume_stream_piece_content_mode_no_tags():
-    """Plain content with no think tags passes through."""
-    window, mode = "", "content"
-    assert mode == "content"
-
-    outputs, window, mode = consume_stream_piece(window, mode, "hello world")
-    assert mode == "content"
-    flushed = flush_stream_deltas(window, mode)
-    all_text = [t for k, t in outputs if k == "content"] + [t for k, t in flushed if k == "content"]
-    assert "hello world" in "".join(all_text)
-
-
-def test_flush_empty_window():
-    assert flush_stream_deltas("", "content") == []
-    assert flush_stream_deltas("", "reasoning") == []
-
-@patch("server.subprocess.Popen")
-def test_models_endpoint(mock_popen, mock_tokenizer):
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
-    client = TestClient(app)
+def test_models_endpoint(client):
     response = client.get("/v1/models")
     assert response.status_code == 200
     data = response.json()
@@ -137,131 +222,112 @@ def test_models_endpoint(mock_popen, mock_tokenizer):
     assert len(data["data"]) == 1
     assert data["data"][0]["id"] == MODEL_NAME
 
-@patch("server.os.pipe")
-@patch("server.subprocess.Popen")
-@patch("server.os.read")
-def test_chat_completions_non_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
-    mock_pipe.return_value = (1, 2)
-    mock_popen.return_value.poll.return_value = None  # daemon alive
-    mock_tokenizer.decode.return_value = "private chain of thought</think>\n\nvisible answer"
-    
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
-    
-    # Mock os.read to return a single token (e.g. 10) and then -1
-    mock_os_read.side_effect = [
-        struct.pack("<i", 10),
-        struct.pack("<i", -1)
-    ]
-    
-    client = TestClient(app)
-    response = client.post("/v1/chat/completions", json={
-        "model": MODEL_NAME,
-        "messages": [{"role": "user", "content": "hi"}],
-        "stream": False
-    })
-    
-    assert response.status_code == 200
-    data = response.json()
-    assert data["object"] == "chat.completion"
-    assert data["choices"][0]["message"]["content"] == "visible answer"
-    assert data["choices"][0]["message"]["reasoning_content"] == "private chain of thought"
 
-@patch("server.os.pipe")
-@patch("server.subprocess.Popen")
-@patch("server.os.read")
-def test_chat_completions_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
-    mock_pipe.return_value = (1, 2)
-    mock_popen.return_value.poll.return_value = None  # daemon alive
-    mock_tokenizer.apply_chat_template.return_value = "<think>\n"
-    mock_tokenizer.decode.side_effect = [
-        "private thought",
-        "</think>",
-        "visible answer",
-    ]
-    
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
-    
-    mock_os_read.side_effect = [
-        struct.pack("<i", 10),
-        struct.pack("<i", 11),
-        struct.pack("<i", 12),
-        struct.pack("<i", -1)
-    ]
-    
-    client = TestClient(app)
-    response = client.post("/v1/chat/completions", json={
-        "model": MODEL_NAME,
-        "messages": [{"role": "user", "content": "hi"}],
-        "stream": True
-    })
-    
-    assert response.status_code == 200
-    lines = response.text.strip().split("\n\n")
-    assert len(lines) >= 3
-    assert lines[-1] == "data: [DONE]"
-
-
-def test_codex_models_endpoint(mock_tokenizer):
+def test_codex_models_endpoint(client):
     """Codex sends ?client_version= and expects {"models":[...]} format."""
-    with patch("server.subprocess.Popen"):
-        app = build_app(
-            target=Path("target.gguf"),
-            draft=Path("draft.safetensors"),
-            bin_path=Path("test_dflash"),
-            budget=22,
-            max_ctx=131072,
-            tokenizer=mock_tokenizer,
-            stop_ids={2}
-        )
-    client = TestClient(app)
     response = client.get("/v1/models?client_version=0.1.0")
     assert response.status_code == 200
     data = response.json()
     assert "models" in data
+    assert "data" not in data  # must NOT have OpenAI format
     m = data["models"][0]
     assert m["slug"] == MODEL_NAME
     assert "context_window" in m
     assert "supported_reasoning_levels" in m
     assert m["shell_type"] == "shell_command"
+    assert m["supports_parallel_tool_calls"] is False
+
+
+# ─── POST /v1/chat/completions ─────────────────────────────────────
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_completions_non_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.decode.return_value = "chain of thought</think>\n\nvisible answer"
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "chat.completion"
+    assert data["choices"][0]["message"]["content"] == "visible answer"
+    assert data["choices"][0]["message"]["reasoning_content"] == "chain of thought"
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert data["usage"]["prompt_tokens"] > 0
+    assert data["usage"]["completion_tokens"] > 0
 
 
 @patch("server.os.pipe")
-@patch("server.subprocess.Popen")
 @patch("server.os.read")
-def test_responses_non_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
+def test_chat_completions_non_streaming_with_tool_call(mock_os_read, mock_pipe,
+                                                        mock_tokenizer, app):
+    """Non-streaming chat returns tool_calls when model outputs <tool_call>."""
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.decode.return_value = (
+        '<tool_call>'
+        '<function=read_file><parameter=path>test.py</parameter></function>'
+        '</tool_call>'
+    )
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "read test.py"}],
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["choices"][0]["finish_reason"] == "tool_calls"
+    tc = data["choices"][0]["message"]["tool_calls"]
+    assert len(tc) == 1
+    assert tc[0]["function"]["name"] == "read_file"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_completions_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.apply_chat_template.return_value = "<think>\n"
+    mock_tokenizer.decode.side_effect = ["thought", "</think>", "answer"]
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10), struct.pack("<i", 11),
+        struct.pack("<i", 12), struct.pack("<i", -1),
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    text = response.text
+    assert "data: [DONE]" in text
+    # Parse all SSE chunks
+    chunks = [json.loads(line[6:]) for line in text.strip().split("\n\n")
+              if line.startswith("data: ") and line != "data: [DONE]"]
+    assert len(chunks) >= 1
+    assert all(c["object"] == "chat.completion.chunk" for c in chunks)
+
+
+# ─── POST /v1/responses ───────────────────────────────────────────
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_non_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
     """POST /v1/responses non-streaming returns ResponsesObject."""
     mock_pipe.return_value = (1, 2)
-
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
-
-    mock_os_read.side_effect = [
-        struct.pack("<i", 10),
-        struct.pack("<i", -1)
-    ]
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
     client = TestClient(app)
     response = client.post("/v1/responses", json={
@@ -276,30 +342,61 @@ def test_responses_non_streaming(mock_os_read, mock_popen, mock_pipe, mock_token
     assert data["id"].startswith("resp_")
     assert data["output"][0]["type"] == "message"
     assert data["output"][0]["content"][0]["type"] == "output_text"
-    assert "usage" in data
+    assert data["usage"]["input_tokens"] > 0
+    assert data["usage"]["output_tokens"] > 0
+    assert data["usage"]["total_tokens"] == data["usage"]["input_tokens"] + data["usage"]["output_tokens"]
 
 
 @patch("server.os.pipe")
-@patch("server.subprocess.Popen")
 @patch("server.os.read")
-def test_responses_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
-    """POST /v1/responses streaming emits proper SSE events."""
+def test_responses_non_streaming_string_input(mock_os_read, mock_pipe,
+                                               mock_tokenizer, app):
+    """Responses API accepts a plain string as input."""
     mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": "hello world",
+    })
 
-    mock_os_read.side_effect = [
-        struct.pack("<i", 10),
-        struct.pack("<i", -1)
-    ]
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+    assert data["status"] == "completed"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_with_instructions(mock_os_read, mock_pipe,
+                                      mock_tokenizer, app):
+    """Instructions are mapped to system message."""
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": "hi",
+        "instructions": "You are a coding assistant.",
+    })
+
+    assert response.status_code == 200
+    # Verify apply_chat_template was called with system message
+    calls = mock_tokenizer.apply_chat_template.call_args_list
+    last_call = calls[-1]
+    msgs = last_call[0][0]  # first positional arg
+    assert msgs[0]["role"] == "system"
+    assert "coding assistant" in msgs[0]["content"]
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
+    """POST /v1/responses streaming emits proper SSE lifecycle events."""
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
     client = TestClient(app)
     response = client.post("/v1/responses", json={
@@ -310,45 +407,41 @@ def test_responses_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer
 
     assert response.status_code == 200
     text = response.text
-    # Must contain key SSE event types
+    # Must contain key SSE lifecycle events in order
     assert "event: response.created" in text
     assert "event: response.output_item.added" in text
     assert "event: response.content_part.added" in text
+    assert "event: response.output_text.done" in text
+    assert "event: response.content_part.done" in text
+    assert "event: response.output_item.done" in text
     assert "event: response.completed" in text
+
+    # Parse the completed event to verify structure
+    for line_block in text.split("\n\n"):
+        if "event: response.completed" in line_block:
+            data_line = [l for l in line_block.split("\n") if l.startswith("data: ")][0]
+            completed = json.loads(data_line[6:])
+            assert completed["response"]["status"] == "completed"
+            assert "usage" in completed["response"]
+            break
 
 
 @patch("server.os.pipe")
-@patch("server.subprocess.Popen")
 @patch("server.os.read")
-def test_responses_with_tools(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
+def test_responses_with_tools(mock_os_read, mock_pipe, mock_tokenizer, app):
     """POST /v1/responses with function tools maps correctly."""
     mock_pipe.return_value = (1, 2)
-
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
-
-    mock_os_read.side_effect = [
-        struct.pack("<i", 10),
-        struct.pack("<i", -1)
-    ]
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
     client = TestClient(app)
     response = client.post("/v1/responses", json={
         "model": MODEL_NAME,
-        "input": [
-            {"type": "message", "role": "user", "content": "read file.txt"},
-        ],
+        "input": [{"type": "message", "role": "user", "content": "read file.txt"}],
         "tools": [
             {"type": "function", "name": "read_file",
              "description": "Read a file",
-             "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}}
+             "parameters": {"type": "object",
+                           "properties": {"path": {"type": "string"}}}}
         ],
         "instructions": "You are a coding assistant.",
     })
@@ -360,26 +453,12 @@ def test_responses_with_tools(mock_os_read, mock_popen, mock_pipe, mock_tokenize
 
 
 @patch("server.os.pipe")
-@patch("server.subprocess.Popen")
 @patch("server.os.read")
-def test_responses_function_call_output(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
-    """Responses API maps function_call + function_call_output items correctly."""
+def test_responses_function_call_output(mock_os_read, mock_pipe,
+                                         mock_tokenizer, app):
+    """Responses API maps function_call + function_call_output items."""
     mock_pipe.return_value = (1, 2)
-
-    app = build_app(
-        target=Path("target.gguf"),
-        draft=Path("draft.safetensors"),
-        bin_path=Path("test_dflash"),
-        budget=22,
-        max_ctx=131072,
-        tokenizer=mock_tokenizer,
-        stop_ids={2}
-    )
-
-    mock_os_read.side_effect = [
-        struct.pack("<i", 10),
-        struct.pack("<i", -1)
-    ]
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
     client = TestClient(app)
     response = client.post("/v1/responses", json={
@@ -397,43 +476,34 @@ def test_responses_function_call_output(mock_os_read, mock_popen, mock_pipe, moc
     data = response.json()
     assert data["object"] == "response"
 
-
-# ─── Unit tests for parsers ────────────────────────────────────────
-
-def test_parse_tool_calls_basic():
-    """parse_tool_calls extracts Qwen XML tool calls."""
-    text = (
-        'Sure!\n<tool_call>'
-        '<function=read_file><parameter=path>test.py</parameter></function>'
-        '</tool_call>'
-    )
-    cleaned, calls = parse_tool_calls(text, tools=None)
-    assert len(calls) == 1
-    assert calls[0]["function"]["name"] == "read_file"
-    args = json.loads(calls[0]["function"]["arguments"])
-    assert args["path"] == "test.py"
-    assert cleaned.strip() == "Sure!"
+    # Verify multi-turn message mapping: user + assistant(tool_call) + tool(output)
+    calls = mock_tokenizer.apply_chat_template.call_args_list
+    msgs = calls[-1][0][0]
+    roles = [m["role"] for m in msgs]
+    assert "user" in roles
+    assert "assistant" in roles
+    assert "tool" in roles
 
 
-def test_parse_tool_calls_no_tools():
-    """parse_tool_calls returns empty list when no tool tags present."""
-    text = "Just a plain answer."
-    cleaned, calls = parse_tool_calls(text, tools=None)
-    assert calls == []
-    assert cleaned == text
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_developer_role_mapped_to_system(mock_os_read, mock_pipe,
+                                                     mock_tokenizer, app):
+    """Codex sends role=developer which maps to system."""
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": [
+            {"type": "message", "role": "developer",
+             "content": "You are helpful."},
+            {"type": "message", "role": "user", "content": "hi"},
+        ],
+    })
 
-def test_parse_reasoning_with_think():
-    """parse_reasoning extracts <think> content."""
-    text = "<think>Let me think...</think>Here is the answer."
-    cleaned, reasoning = parse_reasoning(text, thinking_enabled=True)
-    assert cleaned == "Here is the answer."
-    assert reasoning == "Let me think..."
-
-
-def test_parse_reasoning_no_think():
-    """parse_reasoning with thinking disabled returns text as content."""
-    text = "Just an answer."
-    cleaned, reasoning = parse_reasoning(text, thinking_enabled=False)
-    assert cleaned == "Just an answer."
-    assert reasoning is None
+    assert response.status_code == 200
+    calls = mock_tokenizer.apply_chat_template.call_args_list
+    msgs = calls[-1][0][0]
+    assert msgs[0]["role"] == "system"

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -8,10 +8,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-from server import (
-    build_app, MODEL_NAME, parse_reasoning,
-    consume_stream_piece, flush_stream_deltas,
-)
+from server import build_app, MODEL_NAME, parse_tool_calls, parse_reasoning
 
 
 @pytest.fixture
@@ -215,6 +212,228 @@ def test_chat_completions_streaming(mock_os_read, mock_popen, mock_pipe, mock_to
     })
     
     assert response.status_code == 200
-    assert '"reasoning_content"' in response.text
-    assert "</think>" not in response.text
-    assert "data: [DONE]" in response.text
+    lines = response.text.strip().split("\n\n")
+    assert len(lines) >= 3
+    assert lines[-1] == "data: [DONE]"
+
+
+def test_codex_models_endpoint(mock_tokenizer):
+    """Codex sends ?client_version= and expects {"models":[...]} format."""
+    with patch("server.subprocess.Popen"):
+        app = build_app(
+            target=Path("target.gguf"),
+            draft=Path("draft.safetensors"),
+            bin_path=Path("test_dflash"),
+            budget=22,
+            max_ctx=131072,
+            tokenizer=mock_tokenizer,
+            stop_ids={2}
+        )
+    client = TestClient(app)
+    response = client.get("/v1/models?client_version=0.1.0")
+    assert response.status_code == 200
+    data = response.json()
+    assert "models" in data
+    m = data["models"][0]
+    assert m["slug"] == MODEL_NAME
+    assert "context_window" in m
+    assert "supported_reasoning_levels" in m
+    assert m["shell_type"] == "shell_command"
+
+
+@patch("server.os.pipe")
+@patch("server.subprocess.Popen")
+@patch("server.os.read")
+def test_responses_non_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
+    """POST /v1/responses non-streaming returns ResponsesObject."""
+    mock_pipe.return_value = (1, 2)
+
+    app = build_app(
+        target=Path("target.gguf"),
+        draft=Path("draft.safetensors"),
+        bin_path=Path("test_dflash"),
+        budget=22,
+        max_ctx=131072,
+        tokenizer=mock_tokenizer,
+        stop_ids={2}
+    )
+
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10),
+        struct.pack("<i", -1)
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": [{"type": "message", "role": "user", "content": "hello"}],
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+    assert data["status"] == "completed"
+    assert data["id"].startswith("resp_")
+    assert data["output"][0]["type"] == "message"
+    assert data["output"][0]["content"][0]["type"] == "output_text"
+    assert "usage" in data
+
+
+@patch("server.os.pipe")
+@patch("server.subprocess.Popen")
+@patch("server.os.read")
+def test_responses_streaming(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
+    """POST /v1/responses streaming emits proper SSE events."""
+    mock_pipe.return_value = (1, 2)
+
+    app = build_app(
+        target=Path("target.gguf"),
+        draft=Path("draft.safetensors"),
+        bin_path=Path("test_dflash"),
+        budget=22,
+        max_ctx=131072,
+        tokenizer=mock_tokenizer,
+        stop_ids={2}
+    )
+
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10),
+        struct.pack("<i", -1)
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": "say hello",
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    text = response.text
+    # Must contain key SSE event types
+    assert "event: response.created" in text
+    assert "event: response.output_item.added" in text
+    assert "event: response.content_part.added" in text
+    assert "event: response.completed" in text
+
+
+@patch("server.os.pipe")
+@patch("server.subprocess.Popen")
+@patch("server.os.read")
+def test_responses_with_tools(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
+    """POST /v1/responses with function tools maps correctly."""
+    mock_pipe.return_value = (1, 2)
+
+    app = build_app(
+        target=Path("target.gguf"),
+        draft=Path("draft.safetensors"),
+        bin_path=Path("test_dflash"),
+        budget=22,
+        max_ctx=131072,
+        tokenizer=mock_tokenizer,
+        stop_ids={2}
+    )
+
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10),
+        struct.pack("<i", -1)
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": [
+            {"type": "message", "role": "user", "content": "read file.txt"},
+        ],
+        "tools": [
+            {"type": "function", "name": "read_file",
+             "description": "Read a file",
+             "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}}
+        ],
+        "instructions": "You are a coding assistant.",
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+    assert data["status"] == "completed"
+
+
+@patch("server.os.pipe")
+@patch("server.subprocess.Popen")
+@patch("server.os.read")
+def test_responses_function_call_output(mock_os_read, mock_popen, mock_pipe, mock_tokenizer):
+    """Responses API maps function_call + function_call_output items correctly."""
+    mock_pipe.return_value = (1, 2)
+
+    app = build_app(
+        target=Path("target.gguf"),
+        draft=Path("draft.safetensors"),
+        bin_path=Path("test_dflash"),
+        budget=22,
+        max_ctx=131072,
+        tokenizer=mock_tokenizer,
+        stop_ids={2}
+    )
+
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10),
+        struct.pack("<i", -1)
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": [
+            {"type": "message", "role": "user", "content": "read file.txt"},
+            {"type": "function_call", "call_id": "call_abc123",
+             "name": "read_file", "arguments": '{"path":"file.txt"}'},
+            {"type": "function_call_output", "call_id": "call_abc123",
+             "output": "file content here"},
+        ],
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+
+
+# ─── Unit tests for parsers ────────────────────────────────────────
+
+def test_parse_tool_calls_basic():
+    """parse_tool_calls extracts Qwen XML tool calls."""
+    text = (
+        'Sure!\n<tool_call>'
+        '<function=read_file><parameter=path>test.py</parameter></function>'
+        '</tool_call>'
+    )
+    cleaned, calls = parse_tool_calls(text, tools=None)
+    assert len(calls) == 1
+    assert calls[0]["function"]["name"] == "read_file"
+    args = json.loads(calls[0]["function"]["arguments"])
+    assert args["path"] == "test.py"
+    assert cleaned.strip() == "Sure!"
+
+
+def test_parse_tool_calls_no_tools():
+    """parse_tool_calls returns empty list when no tool tags present."""
+    text = "Just a plain answer."
+    cleaned, calls = parse_tool_calls(text, tools=None)
+    assert calls == []
+    assert cleaned == text
+
+
+def test_parse_reasoning_with_think():
+    """parse_reasoning extracts <think> content."""
+    text = "<think>Let me think...</think>Here is the answer."
+    cleaned, reasoning = parse_reasoning(text, thinking_enabled=True)
+    assert cleaned == "Here is the answer."
+    assert reasoning == "Let me think..."
+
+
+def test_parse_reasoning_no_think():
+    """parse_reasoning with thinking disabled returns text as content."""
+    text = "Just an answer."
+    cleaned, reasoning = parse_reasoning(text, thinking_enabled=False)
+    assert cleaned == "Just an answer."
+    assert reasoning is None

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -163,6 +163,71 @@ class TestParseToolCalls:
         assert "Before" in cleaned
         assert "After" in cleaned
 
+    def test_function_signature_tool_call(self):
+        text = '<function=web_search(query="Open Claw docs documentation")</function>'
+        cleaned, calls = parse_tool_calls(text, tools=[{
+            "type": "function",
+            "function": {"name": "web_search", "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            }},
+        }])
+        assert cleaned == ""
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "web_search"
+        assert json.loads(calls[0]["function"]["arguments"]) == {
+            "query": "Open Claw docs documentation"
+        }
+
+    @pytest.mark.parametrize("text", [
+        '{"name":"web_search","arguments":{"query":"OpenAI docs"}}',
+        '<tool_code>{"name":"web_search","arguments":{"query":"OpenAI docs"}}</tool_code>',
+    ])
+    def test_json_tool_call_shapes(self, text):
+        cleaned, calls = parse_tool_calls(text, tools=[{
+            "type": "function",
+            "function": {"name": "web_search", "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            }},
+        }])
+        assert cleaned == ""
+        assert len(calls) == 1
+        assert calls[0]["function"]["name"] == "web_search"
+        assert json.loads(calls[0]["function"]["arguments"]) == {"query": "OpenAI docs"}
+
+    def test_multiple_mixed_tool_call_shapes(self):
+        text = (
+            '<function=web_search(query="OpenAI docs")</function>'
+            '{"name":"read_file","arguments":{"path":"README.md"}}'
+        )
+        cleaned, calls = parse_tool_calls(text, tools=[
+            {"type": "function", "function": {"name": "web_search"}},
+            {"type": "function", "function": {"name": "read_file"}},
+        ])
+        assert cleaned == ""
+        assert [c["function"]["name"] for c in calls] == ["web_search", "read_file"]
+        assert json.loads(calls[0]["function"]["arguments"]) == {"query": "OpenAI docs"}
+        assert json.loads(calls[1]["function"]["arguments"]) == {"path": "README.md"}
+
+    def test_unknown_tool_name_preserved_when_tools_are_known(self):
+        text = '{"name":"unknown_tool","arguments":{"query":"OpenAI docs"}}'
+        cleaned, calls = parse_tool_calls(text, tools=[{
+            "type": "function",
+            "function": {"name": "web_search"},
+        }])
+        assert calls == []
+        assert cleaned == text
+
+    def test_malformed_function_signature_is_preserved(self):
+        text = '<function=web_search(query="unterminated"</function>'
+        cleaned, calls = parse_tool_calls(text, tools=[{
+            "type": "function",
+            "function": {"name": "web_search"},
+        }])
+        assert calls == []
+        assert cleaned == text
+
 
 # ─── normalize_stop / first_stop_match ──────────────────────────────
 


### PR DESCRIPTION
This PR improves OpenAI-compatible tool calling for `/v1/chat/completions`.

It keeps Howard's existing tool-call support https://github.com/Luce-Org/lucebox-hub/pull/132 and adds tolerant parsing for the additional textual tool-call shapes observed from agent clients and Qwen-style models. The goal is to make clients like Hermes/OpenClaw work with OpenAI Chat Completions semantics without making the implementation specific to one tool such as `web_search`.

## What Changed

- Parses multiple model-emitted tool-call formats:
  - Qwen XML tool calls
  - malformed function-signature style calls such as `<function=web_search(query="...")</function>`
  - bare JSON objects such as `{"name":"web_search","arguments":{...}}`
  - wrapped JSON such as `<tool_code>{...}</tool_code>`
- Supports multiple tool calls in one assistant turn.
- Converts valid textual tool calls into OpenAI `message.tool_calls`.
- Keeps unknown or malformed tool-call-looking output safe instead of guessing arguments.
- Preserves normal assistant text when `tool_choice: "auto"` does not require a call.
- Keeps continuation requests working when the next request includes previous `assistant.tool_calls` and `role: tool` messages without resending `tools`.

## Validation

```bash
./.conda/bin/python -m pytest dflash/scripts/test_server.py
```

Live checks performed against deployed `/v1/chat/completions`:

- no-tools chat returns normal assistant content
- `tool_choice: "required"` returns `finish_reason: "tool_calls"`
- tool continuation without resending `tools` returns normal assistant content, not HTTP 500
- streaming tool calls emit `delta.tool_calls` and finish with `finish_reason: "tool_calls"`

## NOTE:
this is based on https://github.com/Luce-Org/lucebox-hub/pull/132 assumption will be merged, so this PR is based on that tree.