### PR TITLE
docs(pflash): clarify drafter dtype in operator notes benchmark

### DIFF
--- a/pflash/README.md
+++ b/pflash/README.md
@@ -266,7 +266,12 @@ simultaneously on a 24 GB GPU.
 
 Reproducible comparison vs Ollama native `/api/chat` on the same
 64K unique-prompt summary task, RTX 6000 Ada sm_89,
-Qwen3.6-27B-Q4_K_M, FP16 drafter, FA_WINDOW=0:
+Qwen3.6-27B-Q4_K_M, FA_WINDOW=0. Drafter setup: Qwen3-0.6B BF16
+GGUF for the PFlash compress path (see "Drafter selection" above);
+the larger DFlash drafter on the dflash daemon side ran as FP16
+safetensors during decode-after-unpark on this run. Feel free to
+substitute either drafter side with the format you have on disk —
+the speedup comes from the compress path, not the dtype:
 
 | Backend                                      | TTFT @ 64K |
 |----------------------------------------------|------------|


### PR DESCRIPTION
docs(pflash): clarify drafter dtype in operator notes benchmark

Follow-up to #136 (merged). The benchmark section described the
target as "Qwen3.6-27B-Q4_K_M, FP16 drafter" while the "Drafter
selection" section above it recommends Qwen3-0.6B **BF16** for
PFlash compress. cubic-dev-ai flagged this as ambiguous and harder
to reproduce.

The real setup of the measurement was:
  - PFlash compress drafter: Qwen3-0.6B BF16 GGUF (the recommended
    one).
  - DFlash drafter on the daemon side (decode after unpark):
    FP16 safetensors on this particular run.

This commit clarifies that in the benchmark paragraph, makes it
explicit that the speedup comes from the compress path itself
(not the drafter dtype), and tells the reader they can substitute
either drafter side with the format they have on disk.

No code or kernel change. Docs only.

Author: Javier Pazo <xabicasa@gmail.com>
