### PR TITLE
Add scored full-cache eviction on-disk prefix cache

### DIFF
--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -744,6 +744,13 @@ class PrefixCache:
                 continue
         return total
 
+    @staticmethod
+    def _read_full_meta_int(meta: dict, key: str, *, default: int | None = None) -> int | None:
+        value = meta.get(key, default)
+        if value is None or isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value
+
     def _recompute_full_next_slot(self) -> None:
         if getattr(self, "_full_disabled", True) or self._full_cap <= 0:
             self._full_next_slot = 0
@@ -856,18 +863,18 @@ class PrefixCache:
 
             if not isinstance(meta, dict):
                 continue
-            version = int(meta.get("version", 0) or 0)
+            version = self._read_full_meta_int(meta, "version", default=0)
+            if version is None:
+                continue
             if version not in (1, self.FULL_META_VERSION):
                 continue
             if meta.get("kv_k_type") != self.kv_k_type:
                 continue
-            if int(meta.get("fa_window", -1)) != fa_window:
+            meta_fa_window = self._read_full_meta_int(meta, "fa_window", default=-1)
+            if meta_fa_window != fa_window:
                 continue
 
             key_hex = meta.get("key_hex")
-            cur_ids_len = meta.get("cur_ids_len")
-            raw_prompt_len = meta.get("raw_prompt_len", cur_ids_len)
-            last_used_ns = meta.get("last_used_ns", 0)
             if not isinstance(key_hex, str):
                 continue
             try:
@@ -876,11 +883,14 @@ class PrefixCache:
                 continue
             if len(key) != 16:
                 continue
-            if not isinstance(cur_ids_len, int) or cur_ids_len < 0:
+            cur_ids_len = self._read_full_meta_int(meta, "cur_ids_len")
+            if cur_ids_len is None or cur_ids_len < 0:
                 continue
-            if not isinstance(raw_prompt_len, int) or raw_prompt_len < 0:
+            raw_prompt_len = self._read_full_meta_int(meta, "raw_prompt_len", default=cur_ids_len)
+            if raw_prompt_len is None or raw_prompt_len < 0:
                 continue
-            if not isinstance(last_used_ns, int):
+            last_used_ns = self._read_full_meta_int(meta, "last_used_ns", default=0)
+            if last_used_ns is None:
                 continue
 
             bin_path = self._full_bin_path(key)

--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -54,9 +54,11 @@ Option 3 — full-compress-result cache:
 """
 import asyncio
 import hashlib
+import json
 import os
 import shutil
 import struct
+import time
 from collections import OrderedDict
 from pathlib import Path
 
@@ -425,6 +427,8 @@ class PrefixCache:
     # configured cap > this is silently clamped down — exceeding it would
     # cause silent SNAPSHOT failures on slots ≥ 8.
     DAEMON_MAX_SLOTS = 8
+    FULL_META_VERSION = 1
+    FULL_META_SUFFIX = ".meta.json"
 
     def __init__(self, *, daemon_stdin, await_reply, daemon_lock,
                  tokenizer, kv_k_type: str, fa_window: int,
@@ -674,6 +678,140 @@ class PrefixCache:
               f"slots=[{self._full_slot_base},{self._full_slot_base + full_cap}) "
               f"dir={cache_dir_path}", flush=True)
 
+    def _full_bin_path(self, key: bytes) -> Path:
+        return self._full_cache_dir / f"{key.hex()}.bin"
+
+    def _full_meta_path(self, key: bytes) -> Path:
+        return self._full_cache_dir / f"{key.hex()}{self.FULL_META_SUFFIX}"
+
+    def _write_json_atomic(self, path: Path, payload: dict) -> None:
+        tmp_path = Path(f"{path}.tmp")
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, sort_keys=True)
+        os.replace(tmp_path, path)
+
+    def _persist_full_metadata(self, key: bytes, cur_ids_len: int,
+                               *, last_used_ns: int | None = None) -> None:
+        if getattr(self, "_full_disabled", True):
+            return
+        meta = {
+            "version": self.FULL_META_VERSION,
+            "key_hex": key.hex(),
+            "kv_k_type": self.kv_k_type,
+            "fa_window": int(self.fa_window or 0),
+            "cur_ids_len": int(cur_ids_len),
+            "last_used_ns": int(time.time_ns() if last_used_ns is None else last_used_ns),
+        }
+        try:
+            self._write_json_atomic(self._full_meta_path(key), meta)
+        except OSError as exc:
+            print(f"{self.log_prefix} full-cache: failed to write metadata for "
+                  f"{key.hex()[:8]}: {exc}", flush=True)
+
+    def _drop_full_metadata(self, key: bytes) -> None:
+        if getattr(self, "_full_disabled", True):
+            return
+        try:
+            self._full_meta_path(key).unlink(missing_ok=True)
+        except OSError as exc:
+            print(f"{self.log_prefix} full-cache: failed to remove metadata for "
+                  f"{key.hex()[:8]}: {exc}", flush=True)
+
+    def _load_persisted_full_entries(self) -> list[tuple[bytes, str, int, int]]:
+        """Return persisted full-cache entries sorted from LRU → MRU."""
+        if getattr(self, "_full_disabled", True):
+            return []
+
+        entries_by_key: dict[bytes, tuple[bytes, str, int, int]] = {}
+        fa_window = int(self.fa_window or 0)
+        for meta_path in self._full_cache_dir.glob(f"*{self.FULL_META_SUFFIX}"):
+            try:
+                with meta_path.open("r", encoding="utf-8") as f:
+                    meta = json.load(f)
+            except (OSError, ValueError, TypeError):
+                continue
+
+            if not isinstance(meta, dict):
+                continue
+            if meta.get("version") != self.FULL_META_VERSION:
+                continue
+            if meta.get("kv_k_type") != self.kv_k_type:
+                continue
+            if int(meta.get("fa_window", -1)) != fa_window:
+                continue
+
+            key_hex = meta.get("key_hex")
+            cur_ids_len = meta.get("cur_ids_len")
+            last_used_ns = meta.get("last_used_ns", 0)
+            if not isinstance(key_hex, str):
+                continue
+            try:
+                key = bytes.fromhex(key_hex)
+            except ValueError:
+                continue
+            if len(key) != 16:
+                continue
+            if not isinstance(cur_ids_len, int) or cur_ids_len < 0:
+                continue
+            if not isinstance(last_used_ns, int):
+                continue
+
+            bin_path = self._full_bin_path(key)
+            if not bin_path.exists():
+                continue
+
+            prev = entries_by_key.get(key)
+            record = (key, str(bin_path), cur_ids_len, last_used_ns)
+            if prev is None or record[3] >= prev[3]:
+                entries_by_key[key] = record
+
+        return sorted(entries_by_key.values(), key=lambda item: (item[3], item[0].hex()))
+
+    async def rehydrate_full_cache(self, replay_entry) -> int:
+        """Restore persisted full-cache entries into fresh daemon slots.
+
+        ``replay_entry`` must be an async callable accepting
+        ``(slot, cur_bin_path, cur_ids_len)`` and return ``True`` on success.
+        """
+        if getattr(self, "_full_disabled", True):
+            return 0
+
+        persisted = self._load_persisted_full_entries()
+        if not persisted:
+            self.full_entries.clear()
+            self._full_next_slot = 0
+            return 0
+
+        if len(persisted) > self._full_cap:
+            persisted = persisted[-self._full_cap:]
+
+        self.full_entries.clear()
+        self._full_pending_evict_key = None
+        self._full_pending_evict_path = None
+
+        restored = 0
+        async with self.lock:
+            for key, cur_bin_path, cur_ids_len, _last_used_ns in persisted:
+                slot = self._full_slot_base + restored
+                try:
+                    ok = await replay_entry(slot, cur_bin_path, cur_ids_len)
+                except Exception as exc:
+                    print(f"{self.log_prefix} full-cache: restore failed for "
+                          f"{Path(cur_bin_path).name}: {exc}", flush=True)
+                    ok = False
+                if not ok:
+                    continue
+                self.full_entries[key] = (slot, cur_bin_path, cur_ids_len)
+                restored += 1
+                if restored >= self._full_cap:
+                    break
+
+        self._full_next_slot = restored % self._full_cap if self._full_cap > 0 else 0
+        if restored:
+            print(f"{self.log_prefix} full-cache restored {restored} entries "
+                  f"from disk", flush=True)
+        return restored
+
     def lookup_full(self, prompt_ids: list[int]) -> tuple[int, str, int] | None:
         """Exact-match on full prompt_ids hash (keyed on raw, pre-compression ids).
 
@@ -693,8 +831,10 @@ class PrefixCache:
         # Verify the cached file still exists (could have been deleted externally).
         if not Path(cur_bin_path).exists():
             self.full_entries.pop(key, None)
+            self._drop_full_metadata(key)
             return None
         self.full_entries.move_to_end(key)  # mark fresh in LRU
+        self._persist_full_metadata(key, cur_ids_len)
         print(f"{self.log_prefix} full-cache hit slot={slot} "
               f"cur_ids_len={cur_ids_len} key={key.hex()[:8]}", flush=True)
         return slot, cur_bin_path, cur_ids_len
@@ -744,7 +884,7 @@ class PrefixCache:
             return
 
         key = hash_prefix(prompt_ids, self.kv_k_type, self.fa_window)
-        dest = self._full_cache_dir / (key.hex() + ".bin")
+        dest = self._full_bin_path(key)
 
         try:
             shutil.copy2(str(cur_bin_src), str(dest))
@@ -759,13 +899,16 @@ class PrefixCache:
         # Atomically evict the reserved entry (if any) and insert new one.
         if self._full_pending_evict_key is not None:
             evicted_path = self._full_pending_evict_path
-            self.full_entries.pop(self._full_pending_evict_key, None)
+            evicted_key = self._full_pending_evict_key
+            self.full_entries.pop(evicted_key, None)
             if evicted_path:
                 Path(evicted_path).unlink(missing_ok=True)
+            self._drop_full_metadata(evicted_key)
             self._full_pending_evict_key = None
             self._full_pending_evict_path = None
 
         self.full_entries[key] = (slot, str(dest), cur_ids_len)
+        self._persist_full_metadata(key, cur_ids_len)
         print(f"{self.log_prefix} full-cache committed slot={slot} "
               f"cur_ids_len={cur_ids_len} key={key.hex()[:8]}", flush=True)
 

--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -60,6 +60,7 @@ import shutil
 import struct
 import time
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -129,6 +130,16 @@ class DaemonStdoutBus:
             # remove ourselves so _waiters doesn't grow without bound.
             try: self._waiters.remove(entry)
             except ValueError: pass
+
+
+@dataclass
+class FullCacheEntry:
+    slot: int
+    cur_bin_path: str
+    cur_ids_len: int
+    raw_prompt_len: int
+    last_used_ns: int
+    hits: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -427,7 +438,7 @@ class PrefixCache:
     # configured cap > this is silently clamped down — exceeding it would
     # cause silent SNAPSHOT failures on slots ≥ 8.
     DAEMON_MAX_SLOTS = 8
-    FULL_META_VERSION = 1
+    FULL_META_VERSION = 2
     FULL_META_SUFFIX = ".meta.json"
 
     def __init__(self, *, daemon_stdin, await_reply, daemon_lock,
@@ -625,7 +636,8 @@ class PrefixCache:
     # ------------------------------------------------------------------
 
     def init_full_cache(self, full_cap: int,
-                        cache_dir: str | None = None) -> None:
+                        cache_dir: str | None = None,
+                        budget_bytes: int = 0) -> None:
         """Initialise the full-cache pool.  Must be called once after __init__
         if you want Option 3 to be active.  Idempotent if called again with
         the same parameters.
@@ -637,7 +649,7 @@ class PrefixCache:
             prefix_cap (self.cap) + full_cap must not exceed DAEMON_MAX_SLOTS.
         cache_dir:
             Directory to persist cur_bin files across requests.
-            Defaults to /tmp/dflash-pflash-cache/.
+            Defaults to /tmp/prefix/.
         """
         if self.disabled or full_cap <= 0:
             self._full_cap = 0
@@ -662,21 +674,24 @@ class PrefixCache:
 
         self._full_cap = full_cap
         self._full_disabled = False
+        self._full_budget_bytes = max(0, int(budget_bytes or 0))
         # Slots used by the full-cache start AFTER the prefix-cache slots.
         self._full_slot_base = self.cap
         self._full_next_slot = 0  # relative; absolute = _full_slot_base + _full_next_slot
-        # LRU map: prompt_ids_hash -> (absolute_slot, cached_cur_bin_path, cur_ids_len)
-        self.full_entries: OrderedDict[bytes, tuple[int, str, int]] = OrderedDict()
+        # Access-ordered map: prompt_ids_hash -> full-cache entry metadata.
+        self.full_entries: OrderedDict[bytes, FullCacheEntry] = OrderedDict()
         # Pending eviction: the LRU entry reserved for the next confirm.
         self._full_pending_evict_key: bytes | None = None
         self._full_pending_evict_path: str | None = None
 
-        cache_dir_path = Path(cache_dir) if cache_dir else Path("/tmp/dflash-pflash-cache")
+        cache_dir_path = Path(cache_dir) if cache_dir else Path("/tmp/prefix")
         cache_dir_path.mkdir(parents=True, exist_ok=True)
         self._full_cache_dir = cache_dir_path
+        budget_msg = (f" budget={self._full_budget_bytes}"
+                      if self._full_budget_bytes > 0 else "")
         print(f"{self.log_prefix} full-cache enabled: cap={full_cap} "
               f"slots=[{self._full_slot_base},{self._full_slot_base + full_cap}) "
-              f"dir={cache_dir_path}", flush=True)
+              f"dir={cache_dir_path}{budget_msg}", flush=True)
 
     def _full_bin_path(self, key: bytes) -> Path:
         return self._full_cache_dir / f"{key.hex()}.bin"
@@ -690,17 +705,20 @@ class PrefixCache:
             json.dump(payload, f, sort_keys=True)
         os.replace(tmp_path, path)
 
-    def _persist_full_metadata(self, key: bytes, cur_ids_len: int,
+    def _persist_full_metadata(self, key: bytes, entry: FullCacheEntry,
                                *, last_used_ns: int | None = None) -> None:
         if getattr(self, "_full_disabled", True):
             return
+        used_ns = int(entry.last_used_ns if last_used_ns is None else last_used_ns)
+        entry.last_used_ns = used_ns
         meta = {
             "version": self.FULL_META_VERSION,
             "key_hex": key.hex(),
             "kv_k_type": self.kv_k_type,
             "fa_window": int(self.fa_window or 0),
-            "cur_ids_len": int(cur_ids_len),
-            "last_used_ns": int(time.time_ns() if last_used_ns is None else last_used_ns),
+            "cur_ids_len": int(entry.cur_ids_len),
+            "raw_prompt_len": int(entry.raw_prompt_len),
+            "last_used_ns": used_ns,
         }
         try:
             self._write_json_atomic(self._full_meta_path(key), meta)
@@ -717,12 +735,86 @@ class PrefixCache:
             print(f"{self.log_prefix} full-cache: failed to remove metadata for "
                   f"{key.hex()[:8]}: {exc}", flush=True)
 
-    def _load_persisted_full_entries(self) -> list[tuple[bytes, str, int, int]]:
+    def _full_entry_artifact_size(self, key: bytes, entry: FullCacheEntry) -> int:
+        total = 0
+        for path in (Path(entry.cur_bin_path), self._full_meta_path(key)):
+            try:
+                total += path.stat().st_size
+            except OSError:
+                continue
+        return total
+
+    def _full_entry_score(self, key: bytes, entry: FullCacheEntry,
+                          live_prompt_ids: list[int] | None = None) -> float:
+        file_size = self._full_entry_artifact_size(key, entry)
+        if file_size <= 0:
+            return 0.0
+        tokens = entry.raw_prompt_len if entry.raw_prompt_len > 0 else entry.cur_ids_len
+        score = ((float(entry.hits) + 1.0) * float(tokens)) / float(file_size)
+        if live_prompt_ids and self._is_live_prefix_entry(key, entry, live_prompt_ids):
+            depth = float(tokens) / float(len(live_prompt_ids))
+            score *= 0.25 if entry.hits else 0.02
+            score *= depth
+        return score
+
+    def _is_live_prefix_entry(self, key: bytes, entry: FullCacheEntry,
+                              live_prompt_ids: list[int]) -> bool:
+        plen = int(entry.raw_prompt_len or 0)
+        if plen <= 0 or plen >= len(live_prompt_ids):
+            return False
+        live_key = hash_prefix(live_prompt_ids[:plen], self.kv_k_type, self.fa_window)
+        return live_key == key
+
+    def _select_full_victim_from_entries(
+            self,
+            entries: OrderedDict[bytes, FullCacheEntry],
+            live_prompt_ids: list[int] | None = None) -> tuple[bytes, FullCacheEntry] | None:
+        victim: tuple[bytes, FullCacheEntry] | None = None
+        victim_score = 0.0
+        for key, entry in entries.items():
+            score = self._full_entry_score(key, entry, live_prompt_ids)
+            if (victim is None
+                    or score < victim_score
+                    or (score == victim_score and entry.last_used_ns < victim[1].last_used_ns)):
+                victim = (key, entry)
+                victim_score = score
+        return victim
+
+    def _retire_full_entry(self, key: bytes, entry: FullCacheEntry,
+                           *, remove_files: bool = True) -> None:
+        self.full_entries.pop(key, None)
+        if remove_files:
+            try:
+                Path(entry.cur_bin_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+            self._drop_full_metadata(key)
+
+    def _enforce_full_budget(self, live_prompt_ids: list[int] | None = None) -> None:
+        budget = int(getattr(self, "_full_budget_bytes", 0) or 0)
+        if budget <= 0 or not self.full_entries:
+            return
+        total = sum(self._full_entry_artifact_size(key, entry)
+                    for key, entry in self.full_entries.items())
+        while total > budget and self.full_entries:
+            victim = self._select_full_victim_from_entries(self.full_entries, live_prompt_ids)
+            if victim is None:
+                break
+            victim_key, victim_entry = victim
+            victim_size = self._full_entry_artifact_size(victim_key, victim_entry)
+            victim_score = self._full_entry_score(victim_key, victim_entry, live_prompt_ids)
+            self._retire_full_entry(victim_key, victim_entry, remove_files=True)
+            print(f"{self.log_prefix} full-cache retired key={victim_key.hex()[:8]} "
+                  f"score={victim_score:.6f} "
+                  f"size={victim_size}", flush=True)
+            total = total - victim_size if total >= victim_size else 0
+
+    def _load_persisted_full_entries(self) -> list[tuple[bytes, FullCacheEntry]]:
         """Return persisted full-cache entries sorted from LRU → MRU."""
         if getattr(self, "_full_disabled", True):
             return []
 
-        entries_by_key: dict[bytes, tuple[bytes, str, int, int]] = {}
+        entries_by_key: dict[bytes, FullCacheEntry] = {}
         fa_window = int(self.fa_window or 0)
         for meta_path in self._full_cache_dir.glob(f"*{self.FULL_META_SUFFIX}"):
             try:
@@ -733,7 +825,8 @@ class PrefixCache:
 
             if not isinstance(meta, dict):
                 continue
-            if meta.get("version") != self.FULL_META_VERSION:
+            version = int(meta.get("version", 0) or 0)
+            if version not in (1, self.FULL_META_VERSION):
                 continue
             if meta.get("kv_k_type") != self.kv_k_type:
                 continue
@@ -742,6 +835,7 @@ class PrefixCache:
 
             key_hex = meta.get("key_hex")
             cur_ids_len = meta.get("cur_ids_len")
+            raw_prompt_len = meta.get("raw_prompt_len", cur_ids_len)
             last_used_ns = meta.get("last_used_ns", 0)
             if not isinstance(key_hex, str):
                 continue
@@ -753,6 +847,8 @@ class PrefixCache:
                 continue
             if not isinstance(cur_ids_len, int) or cur_ids_len < 0:
                 continue
+            if not isinstance(raw_prompt_len, int) or raw_prompt_len < 0:
+                continue
             if not isinstance(last_used_ns, int):
                 continue
 
@@ -761,11 +857,26 @@ class PrefixCache:
                 continue
 
             prev = entries_by_key.get(key)
-            record = (key, str(bin_path), cur_ids_len, last_used_ns)
-            if prev is None or record[3] >= prev[3]:
+            record = FullCacheEntry(
+                slot=-1,
+                cur_bin_path=str(bin_path),
+                cur_ids_len=cur_ids_len,
+                raw_prompt_len=raw_prompt_len,
+                last_used_ns=last_used_ns,
+                hits=0,
+            )
+            if prev is None or record.last_used_ns >= prev.last_used_ns:
                 entries_by_key[key] = record
 
-        return sorted(entries_by_key.values(), key=lambda item: (item[3], item[0].hex()))
+        if entries_by_key and getattr(self, "_full_budget_bytes", 0):
+            self.full_entries = OrderedDict(
+                sorted(entries_by_key.items(), key=lambda item: (item[1].last_used_ns, item[0].hex()))
+            )
+            self._enforce_full_budget()
+            entries_by_key = dict(self.full_entries)
+            self.full_entries.clear()
+
+        return sorted(entries_by_key.items(), key=lambda item: (item[1].last_used_ns, item[0].hex()))
 
     async def rehydrate_full_cache(self, replay_entry) -> int:
         """Restore persisted full-cache entries into fresh daemon slots.
@@ -791,17 +902,18 @@ class PrefixCache:
 
         restored = 0
         async with self.lock:
-            for key, cur_bin_path, cur_ids_len, _last_used_ns in persisted:
+            for key, entry in persisted:
                 slot = self._full_slot_base + restored
                 try:
-                    ok = await replay_entry(slot, cur_bin_path, cur_ids_len)
+                    ok = await replay_entry(slot, entry.cur_bin_path, entry.cur_ids_len)
                 except Exception as exc:
                     print(f"{self.log_prefix} full-cache: restore failed for "
-                          f"{Path(cur_bin_path).name}: {exc}", flush=True)
+                          f"{Path(entry.cur_bin_path).name}: {exc}", flush=True)
                     ok = False
                 if not ok:
                     continue
-                self.full_entries[key] = (slot, cur_bin_path, cur_ids_len)
+                entry.slot = slot
+                self.full_entries[key] = entry
                 restored += 1
                 if restored >= self._full_cap:
                     break
@@ -827,14 +939,16 @@ class PrefixCache:
         entry = self.full_entries.get(key)
         if entry is None:
             return None
-        slot, cur_bin_path, cur_ids_len = entry
+        slot, cur_bin_path, cur_ids_len = entry.slot, entry.cur_bin_path, entry.cur_ids_len
         # Verify the cached file still exists (could have been deleted externally).
         if not Path(cur_bin_path).exists():
             self.full_entries.pop(key, None)
             self._drop_full_metadata(key)
             return None
+        entry.hits += 1
+        entry.last_used_ns = time.time_ns()
         self.full_entries.move_to_end(key)  # mark fresh in LRU
-        self._persist_full_metadata(key, cur_ids_len)
+        self._persist_full_metadata(key, entry)
         print(f"{self.log_prefix} full-cache hit slot={slot} "
               f"cur_ids_len={cur_ids_len} key={key.hex()[:8]}", flush=True)
         return slot, cur_bin_path, cur_ids_len
@@ -856,11 +970,13 @@ class PrefixCache:
 
         # Pick a slot, deferring eviction until confirm succeeds.
         if len(self.full_entries) >= self._full_cap:
-            old_key = next(iter(self.full_entries))
-            old_slot, old_path, _ = self.full_entries[old_key]
+            victim = self._select_full_victim_from_entries(self.full_entries, prompt_ids)
+            if victim is None:
+                return None
+            old_key, old_entry = victim
             self._full_pending_evict_key = old_key
-            self._full_pending_evict_path = old_path
-            abs_slot = old_slot
+            self._full_pending_evict_path = old_entry.cur_bin_path
+            abs_slot = old_entry.slot
         else:
             abs_slot = self._full_slot_base + self._full_next_slot
             self._full_next_slot = (self._full_next_slot + 1) % self._full_cap
@@ -907,8 +1023,17 @@ class PrefixCache:
             self._full_pending_evict_key = None
             self._full_pending_evict_path = None
 
-        self.full_entries[key] = (slot, str(dest), cur_ids_len)
-        self._persist_full_metadata(key, cur_ids_len)
+        entry = FullCacheEntry(
+            slot=slot,
+            cur_bin_path=str(dest),
+            cur_ids_len=cur_ids_len,
+            raw_prompt_len=len(prompt_ids),
+            last_used_ns=time.time_ns(),
+            hits=0,
+        )
+        self.full_entries[key] = entry
+        self._persist_full_metadata(key, entry)
+        self._enforce_full_budget(prompt_ids)
         print(f"{self.log_prefix} full-cache committed slot={slot} "
               f"cur_ids_len={cur_ids_len} key={key.hex()[:8]}", flush=True)
 

--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -744,6 +744,35 @@ class PrefixCache:
                 continue
         return total
 
+    def _recompute_full_next_slot(self) -> None:
+        if getattr(self, "_full_disabled", True) or self._full_cap <= 0:
+            self._full_next_slot = 0
+            return
+        occupied = {
+            entry.slot - self._full_slot_base
+            for entry in self.full_entries.values()
+            if self._full_slot_base <= entry.slot < self._full_slot_base + self._full_cap
+        }
+        for offset in range(self._full_cap):
+            idx = (self._full_next_slot + offset) % self._full_cap
+            if idx not in occupied:
+                self._full_next_slot = idx
+                return
+        self._full_next_slot = 0
+
+    def _reserve_next_free_full_slot(self) -> int | None:
+        if getattr(self, "_full_disabled", True) or self._full_cap <= 0:
+            return None
+        self._recompute_full_next_slot()
+        occupied = {entry.slot for entry in self.full_entries.values()}
+        for offset in range(self._full_cap):
+            idx = (self._full_next_slot + offset) % self._full_cap
+            abs_slot = self._full_slot_base + idx
+            if abs_slot not in occupied:
+                self._full_next_slot = (idx + 1) % self._full_cap
+                return abs_slot
+        return None
+
     def _full_entry_score(self, key: bytes, entry: FullCacheEntry,
                           live_prompt_ids: list[int] | None = None) -> float:
         file_size = self._full_entry_artifact_size(key, entry)
@@ -789,6 +818,7 @@ class PrefixCache:
             except OSError:
                 pass
             self._drop_full_metadata(key)
+        self._recompute_full_next_slot()
 
     def _enforce_full_budget(self, live_prompt_ids: list[int] | None = None) -> None:
         budget = int(getattr(self, "_full_budget_bytes", 0) or 0)
@@ -808,6 +838,7 @@ class PrefixCache:
                   f"score={victim_score:.6f} "
                   f"size={victim_size}", flush=True)
             total = total - victim_size if total >= victim_size else 0
+        self._recompute_full_next_slot()
 
     def _load_persisted_full_entries(self) -> list[tuple[bytes, FullCacheEntry]]:
         """Return persisted full-cache entries sorted from LRU → MRU."""
@@ -918,7 +949,7 @@ class PrefixCache:
                 if restored >= self._full_cap:
                     break
 
-        self._full_next_slot = restored % self._full_cap if self._full_cap > 0 else 0
+        self._recompute_full_next_slot()
         if restored:
             print(f"{self.log_prefix} full-cache restored {restored} entries "
                   f"from disk", flush=True)
@@ -978,8 +1009,9 @@ class PrefixCache:
             self._full_pending_evict_path = old_entry.cur_bin_path
             abs_slot = old_entry.slot
         else:
-            abs_slot = self._full_slot_base + self._full_next_slot
-            self._full_next_slot = (self._full_next_slot + 1) % self._full_cap
+            abs_slot = self._reserve_next_free_full_slot()
+            if abs_slot is None:
+                return None
             self._full_pending_evict_key = None
             self._full_pending_evict_path = None
 

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -677,6 +677,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     async def _startup():
         bus.start(asyncio.get_running_loop())
         await prefix_cache.startup_sync()
+        if not getattr(prefix_cache, "_full_disabled", True):
+            restored = await prefix_cache.rehydrate_full_cache(
+                _rehydrate_full_cache_entry)
+            if restored:
+                log.info("full-cache restored %d entries from disk", restored)
         if lazy_draft:
             log.info("lazy-draft: parking decode draft at startup to free ~3.3 GB")
             daemon_proc.stdin.write(b"park draft\n")
@@ -926,6 +931,33 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         daemon_proc.stdin.flush()
         if timing is not None:
             timing["t_cmd_sent"] = time.monotonic()
+
+    async def _rehydrate_full_cache_entry(slot: int, cur_bin_path: str,
+                                          cur_ids_len: int) -> bool:
+        cmd_line = f"{cur_bin_path} 0 snap={cur_ids_len}:{slot}\n"
+        loop = asyncio.get_running_loop()
+        sent = False
+        try:
+            _write_cmd(cmd_line)
+            sent = True
+            await bus.await_reply(f"[snap] inline slot={slot} ", timeout=120.0)
+            await loop.run_in_executor(None, _drain_until_sentinel, r_pipe)
+            return True
+        except Exception as exc:
+            log.warning("full-cache restore failed for slot=%d path=%s: %s",
+                        slot, cur_bin_path, exc)
+            if sent:
+                try:
+                    await loop.run_in_executor(None, _drain_until_sentinel, r_pipe)
+                except Exception:
+                    pass
+                try:
+                    daemon_proc.stdin.write(f"FREE_SNAPSHOT {slot}\n".encode("utf-8"))
+                    daemon_proc.stdin.flush()
+                    await bus.await_reply(f"[snap] freed slot={slot}", timeout=5.0)
+                except Exception:
+                    pass
+            return False
 
     def _park_draft_if_lazy(timing=None):
         """Park decode draft to free ~3.3 GB VRAM. Call after tokens consumed."""

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -579,6 +579,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
               drafter_tokenizer: AutoTokenizer | None = None,
               prefix_cache_slots: int = 4,
               prefill_cache_slots: int = 4,
+              prefill_cache_bytes: int = 0,
               arch: str = "qwen35",
               lazy_draft: bool = False,
               verbose_daemon: bool = False) -> FastAPI:
@@ -671,7 +672,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         cap=prefix_cache_slots,
     )
     if prefill_cfg is not None and prefill_cache_slots > 0:
-        prefix_cache.init_full_cache(prefill_cache_slots)
+        prefix_cache.init_full_cache(prefill_cache_slots, budget_bytes=prefill_cache_bytes)
 
     @app.on_event("startup")
     async def _startup():
@@ -2232,6 +2233,9 @@ def main():
                          "timing and per-step diagnostics.")
     ap.add_argument("--prefix-cache-slots", type=int, default=4)
     ap.add_argument("--prefill-cache-slots", type=int, default=4)
+    ap.add_argument("--prefill-cache-bytes", type=int, default=0,
+                    help="Disk budget in bytes for persisted full-cache artifacts. "
+                         "0 disables budget trimming.")
     ap.add_argument("--daemon", action="store_true")
     add_cli_flags(ap)
     args = ap.parse_args()
@@ -2298,6 +2302,7 @@ def main():
                     drafter_tokenizer=drafter_tokenizer,
                     prefix_cache_slots=args.prefix_cache_slots,
                     prefill_cache_slots=args.prefill_cache_slots,
+                    prefill_cache_bytes=args.prefill_cache_bytes,
                     arch=arch,
                     lazy_draft=args.lazy_draft,
                     verbose_daemon=args.verbose_daemon)

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -205,15 +205,18 @@ def parse_reasoning(
     so the generated text contains only the reasoning body + ``</think>``.
     Returns (cleaned_content, reasoning_content).
     """
+    def _strip_leading_think_closers(value: str) -> str:
+        return re.sub(r"^(?:\s*</think>\s*)+", "", value).strip()
+
     parts = text.partition(THINK_OPEN_TAG)
     saw_open_tag = bool(parts[1])
     rest = parts[2] if saw_open_tag else parts[0]
     if THINK_CLOSE_TAG not in rest:
         if thinking_enabled and (started_in_thinking or saw_open_tag):
             return "", (rest.strip() or None)
-        return rest.strip(), None
+        return _strip_leading_think_closers(rest), None
     reasoning, _, content = rest.partition(THINK_CLOSE_TAG)
-    return content.strip(), (reasoning.strip() or None)
+    return _strip_leading_think_closers(content), (reasoning.strip() or None)
 
 
 def _find_tool_properties(tools, function_name):
@@ -1202,9 +1205,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
                                 else:  # mode == "content"
                                     think_idx = window.find(THINK_OPEN_TAG)
+                                    think_close_idx = window.find(THINK_CLOSE_TAG)
                                     tool_idx  = window.find(TOOL_OPEN_TAG)
                                     hits = [(i, t) for i, t in
-                                            ((think_idx, "think"), (tool_idx, "tool")) if i != -1]
+                                            ((think_idx, "think"),
+                                             (think_close_idx, "think_close"),
+                                             (tool_idx, "tool")) if i != -1]
                                     if hits:
                                         hits.sort()
                                         idx, which = hits[0]
@@ -1214,6 +1220,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                         if which == "think":
                                             window = window[idx + len(THINK_OPEN_TAG):]
                                             mode = "reasoning"
+                                        elif which == "think_close":
+                                            window = window[idx + len(THINK_CLOSE_TAG):]
                                         else:
                                             tool_buffer = window[idx:]
                                             window = ""
@@ -2045,9 +2053,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
                             else:  # content
                                 think_idx = window.find(THINK_OPEN_TAG)
+                                think_close_idx = window.find(THINK_CLOSE_TAG)
                                 tool_idx = window.find(TOOL_OPEN_TAG)
                                 hits = [(i, t) for i, t in
-                                        ((think_idx, "think"), (tool_idx, "tool")) if i != -1]
+                                        ((think_idx, "think"),
+                                         (think_close_idx, "think_close"),
+                                         (tool_idx, "tool")) if i != -1]
                                 if hits:
                                     hits.sort()
                                     idx, which = hits[0]
@@ -2060,6 +2071,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                     if which == "think":
                                         window = window[idx + len(THINK_OPEN_TAG):]
                                         mode = "reasoning"
+                                    elif which == "think_close":
+                                        window = window[idx + len(THINK_CLOSE_TAG):]
                                     else:
                                         tool_buffer = window[idx:]
                                         window = ""

--- a/dflash/scripts/test_prefix_cache.py
+++ b/dflash/scripts/test_prefix_cache.py
@@ -97,6 +97,32 @@ def test_rehydrate_full_cache_skips_stale_metadata(tmp_path):
     assert cache.full_entries == {}
 
 
+def test_rehydrate_full_cache_skips_malformed_integer_metadata(tmp_path):
+    cache = make_cache(tmp_path)
+    bad_key = b"\x02" * 16
+    good_prompt = [7, 7, 7]
+    good_key = hash_prefix(good_prompt, cache.kv_k_type, cache.fa_window)
+    cache._full_bin_path(bad_key).write_bytes(b"bad")
+    cache._full_meta_path(bad_key).write_text(json.dumps({
+        "version": [],
+        "key_hex": bad_key.hex(),
+        "kv_k_type": cache.kv_k_type,
+        "fa_window": "oops",
+        "cur_ids_len": 5,
+        "raw_prompt_len": 5,
+        "last_used_ns": 1,
+    }), encoding="utf-8")
+    cache._full_bin_path(good_key).write_bytes(b"good")
+    write_meta(cache, good_key, cur_ids_len=6, raw_prompt_len=len(good_prompt), last_used_ns=2)
+
+    replay = AsyncMock(return_value=True)
+    restored = asyncio.run(cache.rehydrate_full_cache(replay))
+
+    assert restored == 1
+    replay.assert_awaited_once_with(cache._full_slot_base, str(cache._full_bin_path(good_key)), 6)
+    assert list(cache.full_entries.keys()) == [good_key]
+
+
 def test_rehydrate_full_cache_keeps_most_recent_entries_within_cap(tmp_path):
     cache = make_cache(tmp_path, full_cap=2)
     keys = [bytes([i]) * 16 for i in range(1, 4)]

--- a/dflash/scripts/test_prefix_cache.py
+++ b/dflash/scripts/test_prefix_cache.py
@@ -1,0 +1,154 @@
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from _prefill_hook import PrefillConfig
+from prefix_cache import PrefixCache, hash_prefix
+from server import build_app
+
+
+class FakeTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        mapping = {
+            "<|im_end|>": [1],
+            "<|im_start|>": [2],
+            "system": [3],
+        }
+        return mapping.get(text, [99])
+
+
+def make_cache(tmp_path: Path, *, cap: int = 2, full_cap: int = 2,
+               kv_k_type: str = "q8_0", fa_window: int = 2048) -> PrefixCache:
+    async def await_reply(prefix: str, timeout: float = 10.0) -> str:
+        return prefix
+
+    cache = PrefixCache(
+        daemon_stdin=SimpleNamespace(write=lambda *_: None, flush=lambda: None),
+        await_reply=await_reply,
+        daemon_lock=asyncio.Lock(),
+        tokenizer=FakeTokenizer(),
+        kv_k_type=kv_k_type,
+        fa_window=fa_window,
+        cap=cap,
+    )
+    cache.init_full_cache(full_cap, cache_dir=str(tmp_path))
+    return cache
+
+
+def write_meta(cache: PrefixCache, key: bytes, *, cur_ids_len: int,
+               last_used_ns: int, kv_k_type: str | None = None,
+               fa_window: int | None = None) -> None:
+    meta = {
+        "version": cache.FULL_META_VERSION,
+        "key_hex": key.hex(),
+        "kv_k_type": kv_k_type or cache.kv_k_type,
+        "fa_window": cache.fa_window if fa_window is None else fa_window,
+        "cur_ids_len": cur_ids_len,
+        "last_used_ns": last_used_ns,
+    }
+    cache._full_meta_path(key).write_text(json.dumps(meta), encoding="utf-8")
+
+
+def test_rehydrate_full_cache_restores_valid_entries(tmp_path):
+    prompt_ids = [11, 22, 33]
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"cached")
+
+    cache = make_cache(tmp_path)
+    cache.confirm_full_snap(cache._full_slot_base, prompt_ids, source_path, 7)
+
+    restored_cache = make_cache(tmp_path)
+    replay = AsyncMock(return_value=True)
+
+    restored = asyncio.run(restored_cache.rehydrate_full_cache(replay))
+
+    key = hash_prefix(prompt_ids, restored_cache.kv_k_type, restored_cache.fa_window)
+    assert restored == 1
+    replay.assert_awaited_once_with(
+        restored_cache._full_slot_base,
+        str(restored_cache._full_bin_path(key)),
+        7,
+    )
+    assert restored_cache.full_entries[key] == (
+        restored_cache._full_slot_base,
+        str(restored_cache._full_bin_path(key)),
+        7,
+    )
+
+
+def test_rehydrate_full_cache_skips_stale_metadata(tmp_path):
+    cache = make_cache(tmp_path)
+    key = b"\x01" * 16
+    cache._full_bin_path(key).write_bytes(b"stale")
+    write_meta(cache, key, cur_ids_len=5, last_used_ns=1, kv_k_type="q4_0")
+
+    replay = AsyncMock(return_value=True)
+    restored = asyncio.run(cache.rehydrate_full_cache(replay))
+
+    assert restored == 0
+    replay.assert_not_called()
+    assert cache.full_entries == {}
+
+
+def test_rehydrate_full_cache_keeps_most_recent_entries_within_cap(tmp_path):
+    cache = make_cache(tmp_path, full_cap=2)
+    keys = [bytes([i]) * 16 for i in range(1, 4)]
+    for idx, key in enumerate(keys, start=1):
+        cache._full_bin_path(key).write_bytes(f"bin-{idx}".encode())
+        write_meta(cache, key, cur_ids_len=idx, last_used_ns=idx)
+
+    replay_calls = []
+
+    async def replay(slot: int, cur_bin_path: str, cur_ids_len: int) -> bool:
+        replay_calls.append((slot, Path(cur_bin_path).name, cur_ids_len))
+        return True
+
+    restored = asyncio.run(cache.rehydrate_full_cache(replay))
+
+    assert restored == 2
+    assert replay_calls == [
+        (cache._full_slot_base, f"{keys[1].hex()}.bin", 2),
+        (cache._full_slot_base + 1, f"{keys[2].hex()}.bin", 3),
+    ]
+    assert list(cache.full_entries.keys()) == [keys[1], keys[2]]
+
+
+def test_server_startup_rehydrates_full_cache(tmp_path):
+    tokenizer = FakeTokenizer()
+    prefill_cfg = PrefillConfig(
+        mode="always",
+        threshold=1,
+        keep_ratio=0.05,
+        drafter_gguf=Path("drafter.gguf"),
+        drafter_tokenizer_id="Qwen/Qwen3-0.6B",
+    )
+
+    with patch("server.subprocess.Popen") as mock_popen, \
+            patch("server.PrefixCache.startup_sync", new_callable=AsyncMock) as mock_sync, \
+            patch("server.PrefixCache.rehydrate_full_cache",
+                  new_callable=AsyncMock, return_value=1) as mock_rehydrate:
+        mock_popen.return_value.poll.return_value = None
+        mock_popen.return_value.stdout.readline.return_value = b""
+
+        app = build_app(
+            target=Path("target.gguf"),
+            draft=Path("draft.safetensors"),
+            bin_path=Path("test_dflash"),
+            budget=22,
+            max_ctx=4096,
+            tokenizer=tokenizer,
+            stop_ids={2},
+            prefill_cfg=prefill_cfg,
+            drafter_tokenizer=tokenizer,
+            prefill_cache_slots=2,
+        )
+
+        with TestClient(app):
+            pass
+
+    mock_sync.assert_awaited_once()
+    mock_rehydrate.assert_awaited_once()

--- a/dflash/scripts/test_prefix_cache.py
+++ b/dflash/scripts/test_prefix_cache.py
@@ -240,6 +240,36 @@ def test_budget_trim_retires_lowest_score_entry(tmp_path):
     assert not cache._full_meta_path(key_a).exists()
 
 
+def test_budget_trim_recomputes_next_free_slot(tmp_path):
+    cache = make_cache(tmp_path, full_cap=3)
+    keys = [bytes([0x51 + i]) * 16 for i in range(3)]
+    sizes = [120, 20, 20]
+    for idx, (key, size) in enumerate(zip(keys, sizes), start=1):
+        cache._full_bin_path(key).write_bytes(b"x" * size)
+        write_meta(cache, key, cur_ids_len=10 * idx, raw_prompt_len=10 * idx, last_used_ns=idx)
+        cache.full_entries[key] = FullCacheEntry(
+            slot=cache._full_slot_base + (idx - 1),
+            cur_bin_path=str(cache._full_bin_path(key)),
+            cur_ids_len=10 * idx,
+            raw_prompt_len=10 * idx,
+            last_used_ns=idx,
+            hits=0,
+        )
+    cache._full_next_slot = 0
+    cache._full_budget_bytes = sum(
+        cache._full_entry_artifact_size(key, cache.full_entries[key]) for key in keys[1:]
+    ) + 1
+
+    cache._enforce_full_budget()
+
+    remaining_slots = {entry.slot for entry in cache.full_entries.values()}
+    assert cache._full_slot_base not in remaining_slots
+    prep = cache.prepare_full_snap([9, 9, 9, 9])
+    assert prep is not None
+    slot, _ = prep
+    assert slot == cache._full_slot_base
+
+
 def test_lookup_full_updates_hits_in_memory_only(tmp_path):
     prompt_ids = [7, 8, 9, 10]
     source_path = tmp_path / "source.bin"

--- a/dflash/scripts/test_prefix_cache.py
+++ b/dflash/scripts/test_prefix_cache.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 
 from _prefill_hook import PrefillConfig
-from prefix_cache import PrefixCache, hash_prefix
+from prefix_cache import FullCacheEntry, PrefixCache, hash_prefix
 from server import build_app
 
 
@@ -22,7 +22,8 @@ class FakeTokenizer:
 
 
 def make_cache(tmp_path: Path, *, cap: int = 2, full_cap: int = 2,
-               kv_k_type: str = "q8_0", fa_window: int = 2048) -> PrefixCache:
+               kv_k_type: str = "q8_0", fa_window: int = 2048,
+               budget_bytes: int = 0) -> PrefixCache:
     async def await_reply(prefix: str, timeout: float = 10.0) -> str:
         return prefix
 
@@ -35,12 +36,13 @@ def make_cache(tmp_path: Path, *, cap: int = 2, full_cap: int = 2,
         fa_window=fa_window,
         cap=cap,
     )
-    cache.init_full_cache(full_cap, cache_dir=str(tmp_path))
+    cache.init_full_cache(full_cap, cache_dir=str(tmp_path), budget_bytes=budget_bytes)
     return cache
 
 
 def write_meta(cache: PrefixCache, key: bytes, *, cur_ids_len: int,
-               last_used_ns: int, kv_k_type: str | None = None,
+               last_used_ns: int, raw_prompt_len: int | None = None,
+               kv_k_type: str | None = None,
                fa_window: int | None = None) -> None:
     meta = {
         "version": cache.FULL_META_VERSION,
@@ -48,6 +50,7 @@ def write_meta(cache: PrefixCache, key: bytes, *, cur_ids_len: int,
         "kv_k_type": kv_k_type or cache.kv_k_type,
         "fa_window": cache.fa_window if fa_window is None else fa_window,
         "cur_ids_len": cur_ids_len,
+        "raw_prompt_len": cur_ids_len if raw_prompt_len is None else raw_prompt_len,
         "last_used_ns": last_used_ns,
     }
     cache._full_meta_path(key).write_text(json.dumps(meta), encoding="utf-8")
@@ -73,11 +76,11 @@ def test_rehydrate_full_cache_restores_valid_entries(tmp_path):
         str(restored_cache._full_bin_path(key)),
         7,
     )
-    assert restored_cache.full_entries[key] == (
-        restored_cache._full_slot_base,
-        str(restored_cache._full_bin_path(key)),
-        7,
-    )
+    entry = restored_cache.full_entries[key]
+    assert entry.slot == restored_cache._full_slot_base
+    assert entry.cur_bin_path == str(restored_cache._full_bin_path(key))
+    assert entry.cur_ids_len == 7
+    assert entry.raw_prompt_len == len(prompt_ids)
 
 
 def test_rehydrate_full_cache_skips_stale_metadata(tmp_path):
@@ -115,6 +118,145 @@ def test_rehydrate_full_cache_keeps_most_recent_entries_within_cap(tmp_path):
         (cache._full_slot_base + 1, f"{keys[2].hex()}.bin", 3),
     ]
     assert list(cache.full_entries.keys()) == [keys[1], keys[2]]
+
+
+def test_score_victim_selector_prefers_lower_usefulness(tmp_path):
+    cache = make_cache(tmp_path)
+    low_key = b"\x10" * 16
+    high_key = b"\x20" * 16
+    cache._full_bin_path(low_key).write_bytes(b"a" * 100)
+    cache._full_meta_path(low_key).write_text("{}", encoding="utf-8")
+    cache._full_bin_path(high_key).write_bytes(b"b" * 10)
+    cache._full_meta_path(high_key).write_text("{}", encoding="utf-8")
+    cache.full_entries[low_key] = FullCacheEntry(
+        slot=cache._full_slot_base,
+        cur_bin_path=str(cache._full_bin_path(low_key)),
+        cur_ids_len=40,
+        raw_prompt_len=40,
+        last_used_ns=10,
+        hits=0,
+    )
+    cache.full_entries[high_key] = FullCacheEntry(
+        slot=cache._full_slot_base + 1,
+        cur_bin_path=str(cache._full_bin_path(high_key)),
+        cur_ids_len=80,
+        raw_prompt_len=80,
+        last_used_ns=5,
+        hits=3,
+    )
+
+    victim_key, _ = cache._select_full_victim_from_entries(cache.full_entries)
+    assert victim_key == low_key
+
+
+def test_score_victim_selector_breaks_ties_by_oldest_last_used(tmp_path):
+    cache = make_cache(tmp_path)
+    key_a = b"\x31" * 16
+    key_b = b"\x32" * 16
+    for key in (key_a, key_b):
+        cache._full_bin_path(key).write_bytes(b"x" * 20)
+        cache._full_meta_path(key).write_text("{}", encoding="utf-8")
+    cache.full_entries[key_a] = FullCacheEntry(
+        slot=cache._full_slot_base,
+        cur_bin_path=str(cache._full_bin_path(key_a)),
+        cur_ids_len=20,
+        raw_prompt_len=20,
+        last_used_ns=1,
+        hits=0,
+    )
+    cache.full_entries[key_b] = FullCacheEntry(
+        slot=cache._full_slot_base + 1,
+        cur_bin_path=str(cache._full_bin_path(key_b)),
+        cur_ids_len=20,
+        raw_prompt_len=20,
+        last_used_ns=2,
+        hits=0,
+    )
+
+    victim_key, _ = cache._select_full_victim_from_entries(cache.full_entries)
+    assert victim_key == key_a
+
+
+def test_live_prefix_penalty_makes_strict_prefix_easier_to_evict(tmp_path):
+    cache = make_cache(tmp_path)
+    prompt_a = [1, 2, 3, 4]
+    prompt_b = [1, 2, 3, 4, 5, 6]
+    key_a = hash_prefix(prompt_a, cache.kv_k_type, cache.fa_window)
+    key_b = hash_prefix(prompt_b, cache.kv_k_type, cache.fa_window)
+    for key in (key_a, key_b):
+        cache._full_bin_path(key).write_bytes(b"x" * 20)
+        cache._full_meta_path(key).write_text("{}", encoding="utf-8")
+    cache.full_entries[key_a] = FullCacheEntry(
+        slot=cache._full_slot_base,
+        cur_bin_path=str(cache._full_bin_path(key_a)),
+        cur_ids_len=4,
+        raw_prompt_len=len(prompt_a),
+        last_used_ns=10,
+        hits=0,
+    )
+    cache.full_entries[key_b] = FullCacheEntry(
+        slot=cache._full_slot_base + 1,
+        cur_bin_path=str(cache._full_bin_path(key_b)),
+        cur_ids_len=6,
+        raw_prompt_len=len(prompt_b),
+        last_used_ns=5,
+        hits=0,
+    )
+
+    victim_key, _ = cache._select_full_victim_from_entries(cache.full_entries, prompt_b)
+    assert victim_key == key_a
+
+
+def test_budget_trim_retires_lowest_score_entry(tmp_path):
+    cache = make_cache(tmp_path)
+    key_a = b"\x41" * 16
+    key_b = b"\x42" * 16
+    cache._full_bin_path(key_a).write_bytes(b"a" * 90)
+    write_meta(cache, key_a, cur_ids_len=10, raw_prompt_len=10, last_used_ns=1)
+    cache._full_bin_path(key_b).write_bytes(b"b" * 20)
+    write_meta(cache, key_b, cur_ids_len=50, raw_prompt_len=50, last_used_ns=2)
+    cache.full_entries[key_a] = FullCacheEntry(
+        slot=cache._full_slot_base,
+        cur_bin_path=str(cache._full_bin_path(key_a)),
+        cur_ids_len=10,
+        raw_prompt_len=10,
+        last_used_ns=1,
+        hits=0,
+    )
+    cache.full_entries[key_b] = FullCacheEntry(
+        slot=cache._full_slot_base + 1,
+        cur_bin_path=str(cache._full_bin_path(key_b)),
+        cur_ids_len=50,
+        raw_prompt_len=50,
+        last_used_ns=2,
+        hits=0,
+    )
+    cache._full_budget_bytes = cache._full_entry_artifact_size(key_b, cache.full_entries[key_b]) + 1
+
+    cache._enforce_full_budget()
+
+    assert list(cache.full_entries.keys()) == [key_b]
+    assert not cache._full_bin_path(key_a).exists()
+    assert not cache._full_meta_path(key_a).exists()
+
+
+def test_lookup_full_updates_hits_in_memory_only(tmp_path):
+    prompt_ids = [7, 8, 9, 10]
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"payload")
+
+    cache = make_cache(tmp_path)
+    cache.confirm_full_snap(cache._full_slot_base, prompt_ids, source_path, 5)
+    key = hash_prefix(prompt_ids, cache.kv_k_type, cache.fa_window)
+    before = json.loads(cache._full_meta_path(key).read_text(encoding="utf-8"))
+
+    hit = cache.lookup_full(prompt_ids)
+
+    assert hit is not None
+    assert cache.full_entries[key].hits == 1
+    after = json.loads(cache._full_meta_path(key).read_text(encoding="utf-8"))
+    assert "hits" not in after
+    assert after["last_used_ns"] >= before["last_used_ns"]
 
 
 def test_server_startup_rehydrates_full_cache(tmp_path):

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -99,6 +99,11 @@ class TestParseReasoning:
         assert cleaned == "result"
         assert "line1" in reasoning and "line3" in reasoning
 
+    def test_repeated_leading_think_closers_are_stripped(self):
+        cleaned, reasoning = parse_reasoning("</think>\n</think>\n8")
+        assert cleaned == "8"
+        assert reasoning is None
+
 
 # ─── parse_tool_calls ─────────────────────────────────────────────
 
@@ -430,6 +435,30 @@ def test_chat_completions_streaming(mock_os_read, mock_pipe, mock_tokenizer, app
     assert all(c["object"] == "chat.completion.chunk" for c in chunks)
 
 
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_completions_streaming_ignores_stray_think_closers(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.decode.side_effect = ["</think>", "</think>", "8"]
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10), struct.pack("<i", 11),
+        struct.pack("<i", 12), struct.pack("<i", -1),
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "4+4=?"}],
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    text = response.text
+    assert "</think>" not in text
+    assert '"content":"8"' in text or '"content": "8"' in text
+
+
 # ─── POST /v1/responses ───────────────────────────────────────────
 
 @patch("server.os.pipe")
@@ -562,6 +591,30 @@ def test_responses_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
             assert completed["response"]["status"] == "completed"
             assert "usage" in completed["response"]
             break
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_streaming_ignores_stray_think_closers(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.decode.side_effect = ["</think>", "</think>", "8"]
+    mock_os_read.side_effect = [
+        struct.pack("<i", 10), struct.pack("<i", 11),
+        struct.pack("<i", 12), struct.pack("<i", -1),
+    ]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": "4+4=?",
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    text = response.text
+    assert "</think>" not in text
+    assert '"delta":"8"' in text or '"delta": "8"' in text
 
 
 @patch("server.os.pipe")


### PR DESCRIPTION
Adopt the algorithm of evict from ds4 project:
1. Build LRU to trace the prefix cache
2. Rebuild the cache from disk when restart
3. use score based evict

Add related tests cases.