### PR TITLE
fix(server): default snapshot slots to 1/0 to fit on 24 GB GPUs

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -2300,8 +2300,19 @@ def main():
     ap.add_argument("--verbose-daemon", action="store_true",
                     help="Print all daemon stdout lines, including suppressed "
                          "timing and per-step diagnostics.")
-    ap.add_argument("--prefix-cache-slots", type=int, default=4)
-    ap.add_argument("--prefill-cache-slots", type=int, default=4)
+    # Defaults sized for 24 GB consumer GPUs (RTX 3090/4090).
+    # Each snapshot slot allocates a full max_ctx-sized KV mirror in F16:
+    # ~570 MiB at max_ctx=16000, ~1.85 GiB rollback alloc on first long prompt.
+    # On a 3090 the headroom after weights + main KV + verify/rollback buffers
+    # is ~1-3 GiB, so the previous default of 4+4 = 8 slots reliably OOMed (#114).
+    # Set higher manually if you have an A6000/A100 or are running a smaller model.
+    ap.add_argument("--prefix-cache-slots", type=int, default=1,
+                    help="Snapshot slots for system-prompt prefix cache. "
+                         "Default 1 fits 24 GB GPUs; raise on bigger cards.")
+    ap.add_argument("--prefill-cache-slots", type=int, default=0,
+                    help="Snapshot slots for full-prompt prefill cache (pFlash). "
+                         "Default 0 = disabled to keep VRAM headroom; raise if you "
+                         "have spare VRAM and want pFlash full-prompt caching.")
     ap.add_argument("--prefill-cache-bytes", type=int, default=0,
                     help="Disk budget in bytes for persisted full-cache artifacts. "
                          "0 disables budget trimming.")


### PR DESCRIPTION
## Summary

- Previous defaults `--prefix-cache-slots=4 --prefill-cache-slots=4` reliably OOM on RTX 3090s (#114). Each snapshot slot allocates a full `max_ctx`-sized KV mirror in F16 (~570 MiB at `max_ctx=16000`); plus the F16 rollback-cache migration that fires on the first long prompt (~1.85 GiB) lives in the same pool.
- After weights (~15 GiB) + main KV + verify/rollback buffers, a 3090 has only ~1-3 GiB of headroom. 8 snapshot slots overshoot by ~3 GiB.
- New defaults: `--prefix-cache-slots 1` keeps the system-prompt snapshot (the highest-hit case); `--prefill-cache-slots 0` disables the full-prefill pFlash pool. Users on bigger cards can opt back in explicitly.

## Why this matters

Repo tagline is "hand-tuned LLM inference, built for specific consumer hardware" — i.e., 3090-class. Defaults that OOM on the stated target hardware are the wrong defaults. Two users (#114) and a third commenter all hit this within a few hours of trying the server.

## Test plan

- [ ] `python scripts/server.py --tokenizer Qwen/Qwen3.6-27B --port 8000 --max-ctx 16000 --fa-window 2048 --daemon` runs without OOM on RTX 3090 (the #114 repro).
- [ ] System-prompt cache hit still works on second request (slot 0 lookup).
- [ ] Users who want the old behavior can pass `--prefix-cache-slots 4 --prefill-cache-slots 4` explicitly.

Closes #114

🧙 Built with [WOZCODE](https://wozcode.com)