### PR TITLE
Support Chat Completions `max_completion_tokens`

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -483,6 +483,7 @@ class ChatRequest(BaseModel):
     messages: list[ChatMessage]
     stream: bool = False
     max_tokens: int = 512
+    max_completion_tokens: int | None = None
     temperature: float | None = None   # 0 = greedy, >0 = sample
     seed: int | None = None             # rng seed for sampling
     top_p: float | None = None         # nucleus, applied when temperature > 0
@@ -1094,6 +1095,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     def _gen_len_for(prompt_len: int, max_tokens: int) -> int:
         return min(max_tokens, max_ctx - prompt_len - 20)
 
+    def _max_tokens_for(req) -> int:
+        return getattr(req, "max_completion_tokens", None) or req.max_tokens
+
     # ── /v1/chat/completions ────────────────────────────────────────────────
 
     @app.post("/v1/chat/completions")
@@ -1109,9 +1113,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         n_tools = len(req.tools) if req.tools else 0
         log.info(
             "chat %s  stream=%s  msgs=%d %s  tools=%d  "
-            "prompt_tokens=%d  max_tokens=%d  max_ctx=%d  model=%s",
+            "prompt_tokens=%d  max_tokens=%d  max_completion_tokens=%s  "
+            "effective_max_tokens=%d  max_ctx=%d  model=%s",
             completion_id, req.stream, len(req.messages), dict(role_counts),
-            n_tools, prompt_len, req.max_tokens, max_ctx, req.model,
+            n_tools, prompt_len, req.max_tokens, req.max_completion_tokens,
+            _max_tokens_for(req), max_ctx, req.model,
         )
         t0 = time.monotonic()
 
@@ -1129,7 +1135,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         cur_bin = Path(cached_cur_bin)
                         prompt_len = cached_cur_ids_len
                         started_in_thinking = False  # cached: no think prefill
-                        gen_len = _gen_len_for(prompt_len, req.max_tokens)
+                        gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                         if gen_len <= 0:
                             try: prompt_bin.unlink()
                             except Exception: pass
@@ -1148,7 +1154,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             req.chat_template_kwargs)
                         timing["compress"] = time.monotonic() - t_compress
                         prompt_len = len(cur_ids)
-                        gen_len = _gen_len_for(prompt_len, req.max_tokens)
+                        gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                         if gen_len <= 0:
                             try: cur_bin.unlink()
                             except Exception: pass
@@ -1383,7 +1389,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cur_bin = Path(cached_cur_bin)
                 cur_ids = None
                 prompt_len = cached_cur_ids_len
-                gen_len = _gen_len_for(prompt_len, req.max_tokens)
+                gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                 if gen_len <= 0:
                     try: prompt_bin.unlink()
                     except Exception: pass
@@ -1398,7 +1404,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             req.chat_template_kwargs)
                 timing["compress"] = time.monotonic() - t_compress
                 prompt_len = len(cur_ids)
-                gen_len = _gen_len_for(prompt_len, req.max_tokens)
+                gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                 if gen_len <= 0:
                     try: cur_bin.unlink()
                     except Exception: pass
@@ -1516,7 +1522,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         cur_bin = Path(cached_cur_bin)
                         cur_ids = None
                         prompt_len = cached_cur_ids_len
-                        gen_len = min(req.max_tokens, max_ctx - prompt_len - 20)
+                        gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                         if gen_len <= 0:
                             try: prompt_bin.unlink()
                             except Exception: pass
@@ -1533,7 +1539,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             req.chat_template_kwargs)
                         timing["compress"] = time.monotonic() - t_compress
                         prompt_len = len(cur_ids)
-                        gen_len = min(req.max_tokens, max_ctx - prompt_len - 20)
+                        gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                         if gen_len <= 0:
                             try: cur_bin.unlink()
                             except Exception: pass
@@ -1642,7 +1648,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cur_bin = Path(cached_cur_bin)
                 cur_ids = None
                 prompt_len = cached_cur_ids_len
-                gen_len = min(req.max_tokens, max_ctx - prompt_len - 20)
+                gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                 if gen_len <= 0:
                     try: prompt_bin.unlink()
                     except Exception: pass
@@ -1658,7 +1664,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             req.chat_template_kwargs)
                 timing["compress"] = time.monotonic() - t_compress
                 prompt_len = len(cur_ids)
-                gen_len = min(req.max_tokens, max_ctx - prompt_len - 20)
+                gen_len = _gen_len_for(prompt_len, _max_tokens_for(req))
                 if gen_len <= 0:
                     try: cur_bin.unlink()
                     except Exception: pass

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -359,6 +359,42 @@ def test_chat_completions_non_streaming(mock_os_read, mock_pipe, mock_tokenizer,
 
 @patch("server.os.pipe")
 @patch("server.os.read")
+@patch("server.subprocess.Popen")
+def test_chat_completions_uses_max_completion_tokens(
+        mock_popen, mock_os_read, mock_pipe, mock_tokenizer):
+    mock_popen.return_value.poll.return_value = None
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    app = build_app(
+        target=Path("target.gguf"),
+        draft=Path("draft.safetensors"),
+        bin_path=Path("test_dflash"),
+        budget=22,
+        max_ctx=131072,
+        tokenizer=mock_tokenizer,
+        stop_ids={2},
+    )
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 2,
+        "max_completion_tokens": 7,
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    writes = [
+        call.args[0].decode("utf-8")
+        for call in mock_popen.return_value.stdin.write.call_args_list
+    ]
+    command = next(write for write in writes if write.strip().endswith(" 7"))
+    assert command.strip().split()[1] == "7"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
 def test_chat_completions_non_streaming_with_tool_call(mock_os_read, mock_pipe,
                                                         mock_tokenizer, app):
     """Non-streaming chat returns tool_calls when model outputs <tool_call>."""


### PR DESCRIPTION
This PR fixes an OpenAI Chat Completions compatibility gap for clients that send `max_completion_tokens`.

dflash accepted `max_tokens`, but ignored `max_completion_tokens`. When clients requested a larger output budget using `max_completion_tokens`, dflash still used its local `max_tokens` default of 512. On long-running agent workflows this can cause repeated truncation/continuation loops even though the client asked for enough output room.

## User-Visible Failure

Hermes hit repeated length truncation during a heavier terminal/tool workflow:

```text
● yes run it
────────────────────────────────────────

  ┊ 💻 preparing terminal…
  ┊ 💻 $         cd ~/Projects/gpu-cpu-hybrid && ./scripts/rebuild_and_deploy_ik_llama.sh --local-path ~/Projects/ik_llama.cpp  60.5s [error]
⚠️  Response truncated (finish_reason='length') - model hit max output tokens
⚠️  Response truncated (finish_reason='length') - model hit max output tokens
⚠️  Response truncated (finish_reason='length') - model hit max output tokens
 ─  ⚕ Hermes  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

     Error: Response remained truncated after 3 continuation attempts

 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ⚕ luce-dflash │ 55.6K/65.5K │ [████████░░] 85% │ 12h 30m │ ⏲ 6m 50s
```

The server log showed the request included a larger `max_completion_tokens`, but the effective generation cap was still 512 before this fix.

Related upstream user report:

- https://github.com/Luce-Org/lucebox-hub/issues/157#issuecomment-4436186211 reports WebUI answering with decent speed, "but only 512 tokens, then cut off."

## Root Cause

The Chat Completions request model only included:

```python
max_tokens: int = 512
```

So Pydantic ignored `max_completion_tokens` from OpenAI-compatible clients. Generation length was then computed from `req.max_tokens`, often the default 512, instead of the larger requested completion budget.

## What Changed

- `ChatRequest` now accepts `max_completion_tokens`.
- Chat generation length uses `max_completion_tokens` when present, otherwise falls back to `max_tokens`.
- Chat request logging now reports:
  - `max_tokens`
  - `max_completion_tokens`
  - effective max tokens used for generation
- Added a regression test proving `max_completion_tokens` overrides `max_tokens` when constructing the daemon command.

## Validation

Unit tests:

```bash
./.conda/bin/python -m pytest dflash/scripts/test_server.py -q
```


Live smoke test against local dflash:

```text
stream=True  msgs=15 {'system': 1, 'user': 3, 'assistant': 6, 'tool': 5}  tools=22  prompt_tokens=29323  max_tokens=512  max_completion_tokens=16384  effective_max_tokens=16384  max_ctx=65536  model=luce-dflash
```

The request used the client-provided `max_completion_tokens=16384` instead of falling back to 512.
