### PR TITLE
fix(dflash): daemon-mode OOM resilience (refs #114)

### DIFF
--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -86,6 +86,13 @@ class DaemonStdoutBus:
         self._suppress_prefixes = () if verbose else self._DEFAULT_SUPPRESS_PREFIXES
         self._waiters: list[tuple[str, asyncio.Future]] = []
         self._task: asyncio.Task | None = None
+        # Issue #114: side-channel callbacks for daemon-emitted events.
+        # Keys = line prefix, values = zero-arg callable invoked on match.
+        self._line_callbacks: dict[str, callable] = {}
+
+    def register_line_callback(self, prefix: str, cb) -> None:
+        """Invoke ``cb()`` whenever the daemon emits a stdout line starting with ``prefix``."""
+        self._line_callbacks[prefix] = cb
 
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         self._task = loop.create_task(self._run())
@@ -102,6 +109,15 @@ class DaemonStdoutBus:
                 self._waiters.clear()
                 return
             decoded = line.decode("utf-8", errors="replace").rstrip()
+
+            # Issue #114: side-channel callbacks (e.g. PrefixCache invalidation
+            # on ``[snap] all-cleared``) run before waiter dispatch so cache
+            # state is consistent for any caller awaiting a reply.
+            for _cb_prefix, _cb in self._line_callbacks.items():
+                if decoded.startswith(_cb_prefix):
+                    try: _cb()
+                    except Exception as _cbe:
+                        print(f"  [bus] callback for {_cb_prefix!r} raised: {_cbe}", flush=True)
 
             # Try to satisfy a waiter first.
             matched = False
@@ -524,6 +540,22 @@ class PrefixCache:
             print(f"{self.log_prefix} lookup hit slot={best[0]} prefix_len={best[1]} "
                   f"(of {len(prompt_ids)} total)", flush=True)
         return best
+
+    def mark_all_cleared(self) -> None:
+        """Drop every LRU entry after the daemon emits ``[snap] all-cleared``.
+
+        Issue #114: when the daemon hits an OOM during prefill it frees every
+        prefix snapshot slot to recover VRAM. Without this hook the Python LRU
+        keeps entries pointing at freed slots, and the next request triggers
+        ``RESTORE bad args or empty slot`` and streams nothing back.
+        """
+        if self.disabled:
+            return
+        n = len(self.entries)
+        self.entries.clear()
+        self.next_slot = 0
+        self._pending_evict_key = None
+        print(f"{self.log_prefix} all-cleared — dropped {n} LRU entries", flush=True)
 
     def prepare_inline_snap(self, prompt_ids: list[int]) -> tuple[int, int] | None:
         """Pick a target boundary + slot for inline snapshot during the next

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -698,6 +698,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     )
     if prefill_cfg is not None and prefill_cache_slots > 0:
         prefix_cache.init_full_cache(prefill_cache_slots)
+
+    # Issue #114: invalidate the Python LRU whenever the daemon frees every
+    # prefix snapshot slot during OOM recovery. Without this the next request
+    # would RESTORE a freed slot and stream nothing back.
+    bus.register_line_callback("[snap] all-cleared", prefix_cache.mark_all_cleared)
+
     tool_memory = ToolMemory(
         max_entries=int(os.environ.get("DFLASH_TOOL_MEMORY_MAX_ENTRIES", "50000")),
         max_bytes=int(os.environ.get("DFLASH_TOOL_MEMORY_MAX_BYTES", str(64 * 1024 * 1024))),

--- a/dflash/test/test_dflash.cpp
+++ b/dflash/test/test_dflash.cpp
@@ -4293,7 +4293,13 @@ int main(int argc, char ** argv) {
                                 /*capture_delta_intermediate=*/false,
                                 /*fa_window=*/g_fa_window,
                                 /*last_token_logits_only=*/true)) {
-            std::fprintf(stderr, "prefill gallocr pre-reserve failed\n"); return 1;
+            // Issue #114: gallocr OOM. Free all prefix snapshots so the next
+            // request has VRAM headroom; abort this request cleanly in daemon
+            // mode instead of killing the process.
+            std::fprintf(stderr, "prefill gallocr pre-reserve failed (OOM)\n");
+            for (int _i = 0; _i < PREFIX_CACHE_SLOTS; _i++) free_prefix_snapshot(prefix_snapshots[_i]);
+            std::printf("[snap] all-cleared\n"); std::fflush(stdout);
+            if (daemon_mode) { stream_emit(-1); continue; } else return 1;
         }
         // gallocr is now reserved at peak size; subsequent builds will reuse it.
     }
@@ -4338,11 +4344,17 @@ int main(int argc, char ** argv) {
                                 /*capture_delta_intermediate=*/false,
                                 /*fa_window=*/g_fa_window,
                                 /*last_token_logits_only=*/true)) {
-            std::fprintf(stderr, "prefill build @%d\n", start); return 1;
+            std::fprintf(stderr, "prefill build @%d failed (OOM)\n", start);
+            for (int _i = 0; _i < PREFIX_CACHE_SLOTS; _i++) free_prefix_snapshot(prefix_snapshots[_i]);
+            std::printf("[snap] all-cleared\n"); std::fflush(stdout);
+            if (daemon_mode) { stream_emit(-1); goto _req_aborted_oom; } else return 1;
         }
 
         pf_embed_buf.assign((size_t)hidden * n_tokens, 0.0f);
-        if (!w.embedder.embed(prompt.data() + start, n_tokens, pf_embed_buf.data())) return 1;
+        if (!w.embedder.embed(prompt.data() + start, n_tokens, pf_embed_buf.data())) {
+            std::fprintf(stderr, "prefill embed @%d failed\n", start);
+            if (daemon_mode) { stream_emit(-1); goto _req_aborted_oom; } else return 1;
+        }
         ggml_backend_tensor_set(sg.inp_embed, pf_embed_buf.data(), 0,
                                 sizeof(float) * pf_embed_buf.size());
 
@@ -4374,7 +4386,12 @@ int main(int argc, char ** argv) {
         }
 
         auto st = ggml_backend_graph_compute(backend, sg.gf);
-        if (st != GGML_STATUS_SUCCESS) { std::fprintf(stderr, "prefill compute @%d\n", start); return 1; }
+        if (st != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "prefill compute @%d failed (OOM)\n", start);
+            for (int _i = 0; _i < PREFIX_CACHE_SLOTS; _i++) free_prefix_snapshot(prefix_snapshots[_i]);
+            std::printf("[snap] all-cleared\n"); std::fflush(stdout);
+            if (daemon_mode) { stream_emit(-1); goto _req_aborted_oom; } else return 1;
+        }
 
         // Logits are [vocab, 1] (last_token_logits_only), read from offset 0.
         pf_logits_buf.assign(vocab, 0.0f);
@@ -4404,6 +4421,12 @@ int main(int argc, char ** argv) {
             // the for-loop does start += PREFILL_UBATCH, so back-adjust.
             start = committed - PREFILL_UBATCH;
         }
+    }
+    // Issue #114: in-loop prefill OOM lands here, then re-enters the daemon
+    // read loop without killing the process. No-op when daemon_mode=false.
+    if (false) {
+    _req_aborted_oom:
+        continue;
     }
     auto t_pf1 = std::chrono::steady_clock::now();
     // If prefill was a no-op due to a snapshot RESTORE (cache.cur_pos already


### PR DESCRIPTION
## Summary

Refs #114. Reduces the daemon-death symptom: daemon now survives transient cudaMalloc OOM during prefill instead of dying and taking every subsequent request with it. **Does not auto-close #114** — the underlying VRAM pressure at `max_ctx=65536` on 24 GB is still real; this PR is defense in depth + a documented workaround config that fits hermes-agent. Maintainers can close the issue when they consider it resolved.

## Failure mode

At `max_ctx=65536` on a 24 GB card, target weights (~15 GB) + KV reservations + a single prefix-cache snapshot leave ~1-1.5 GB headroom. The prefill gallocr pre-reserve needs ~1.2 GB of scratch; once a snap is committed it pushes us into a regime where one transient `cudaMalloc(1216 MiB)` fails. The daemon's three OOM-fatal sites in token-segmented prefill (`prefill gallocr pre-reserve failed`, `prefill build @N`, `prefill compute @N`) all `return 1;` from `main()` — the process dies. Next chat completion hits `BrokenPipe` writing to daemon stdin.

## What this PR changes (65 lines)

| File | Change |
|---|---|
| `dflash/test/test_dflash.cpp` | Three OOM-fatal sites: free every prefix snapshot to recover VRAM, emit `[snap] all-cleared` on stdout, `stream_emit(-1)` + abort the current request via `continue` (gallocr site) or `goto _req_aborted_oom` (in-loop sites that need to escape the prefill for-loop). One-shot CLI mode (`daemon_mode=false`) keeps fail-fast `return 1` semantics unchanged. |
| `dflash/scripts/prefix_cache.py` | `DaemonStdoutBus.register_line_callback(prefix, cb)` invokes `cb()` whenever the daemon emits a stdout line starting with `prefix`. `PrefixCache.mark_all_cleared()` drops every LRU entry + resets `next_slot`/`_pending_evict_key`. |
| `dflash/scripts/server.py` | Wire `bus.register_line_callback(\"[snap] all-cleared\", prefix_cache.mark_all_cleared)` after the cache is built. |

## Validation

NousResearch/hermes-agent (31 tools, ~17K-token prompts) on RTX 3090 + Qwen3.6-27B Q4_K_M, `--max-ctx 65536`:

| Stack | Before | After |
|---|---|---|
| Tasks completed | 0-1 then daemon dies | **10/10** |
| OOM events | 1 → fatal | recovered, daemon alive |
| Per-task `api_calls` | 3 retries then fallback | **1 clean call** |
| VRAM end-state | 0 (process dead) | stable |

## Recommended low-VRAM serving config

For users hitting #114 on a single 3090 with hermes-agent's mandatory 64K context floor:

```bash
DFLASH27B_KV_TQ3=1 DFLASH27B_PREFILL_UBATCH=128 \\
  python3 scripts/server.py \\
    --tokenizer Qwen/Qwen3.6-27B --port 8000 \\
    --max-ctx 65536 --fa-window 1024 \\
    --prefix-cache-slots 1 --budget 8 --daemon
```

The critical lever is `--budget 8` (vs default 22): a smaller DDTree spec-verify tree halves the prefill gallocr scratch and avoids the OOM in the first place. The patch is defense-in-depth for users who push past their VRAM budget.

## Test plan

- [x] hermes-agent 10-task multi-turn loop on RTX 3090, max_ctx=65536 — all green
- [x] CUDA build clean, `cmake --build build --target test_dflash` succeeds
- [ ] Reviewer: validate non-daemon CLI mode (`./test_dflash target.gguf draft.safetensors prompt.bin 256 out.bin`) still fail-fasts on OOM
- [ ] Reviewer: HIP/gfx1151 daemon path (patches are platform-agnostic but only CUDA was hands-on tested)

🧙 Built with [WOZCODE](https://wozcode.com)