### PR TITLE
feat(dflash): add sparse flash-attention adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j$(nproc)
 
+      - name: Build sparse FA adapter (sm_86)
+        run: |
+          cd dflash
+          cmake -B build-sm86 \
+            -DCMAKE_CUDA_ARCHITECTURES="86" \
+            -DDFLASH27B_ENABLE_BSA=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-sm86 --target test_flash_attn_sparse -j$(nproc)
+
       - name: Install megakernel Python deps
         run: pip install torch --index-url https://download.pytorch.org/whl/cu126
 

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -240,7 +240,8 @@ if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
     string(REGEX REPLACE "[^0-9]" "" _dflash27b_cuda_min_sm "${_dflash27b_cuda_min_sm}")
     target_compile_definitions(dflash27b PRIVATE
         DFLASH27B_BACKEND_CUDA=1
-        DFLASH27B_CUDA_MIN_SM=${_dflash27b_cuda_min_sm})
+        DFLASH27B_CUDA_MIN_SM=${_dflash27b_cuda_min_sm}
+        DFLASH27B_MIN_SM=${_dflash27b_cuda_min_sm})
 elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
     set_target_properties(dflash27b PROPERTIES HIP_ARCHITECTURES "${_dflash27b_archs}")
     target_compile_definitions(dflash27b PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
@@ -283,7 +284,8 @@ elseif(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash27b_cuda_min_sm GREATER_
     target_sources(dflash27b PRIVATE
         src/flashprefill_kernels.cu
         src/flashprefill_select.cpp
-        src/flashprefill.cpp)
+        src/flashprefill.cpp
+        src/pflash_ggml_adapter.cpp)
     target_compile_definitions(dflash27b PRIVATE DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL=1)
 endif()
 
@@ -525,5 +527,14 @@ if(DFLASH27B_TESTS)
             target_link_libraries(${_t} PRIVATE CUDA::cudart)
         endif()
     endforeach()
+
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flash_attn_sparse.cpp")
+        add_executable(test_flash_attn_sparse test/test_flash_attn_sparse.cpp)
+        target_link_libraries(test_flash_attn_sparse PRIVATE dflash27b ggml ggml-cuda ggml-base)
+        target_include_directories(test_flash_attn_sparse PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src
+            ${DFLASH27B_SRC_INCLUDE_DIRS})
+    endif()
     endif()
 endif()

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -528,7 +528,11 @@ if(DFLASH27B_TESTS)
         endif()
     endforeach()
 
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flash_attn_sparse.cpp")
+    # Gated on the same condition as src/pflash_ggml_adapter.cpp (see line ~291):
+    # the adapter is only compiled into dflash27b on CUDA + sm>=80, so the test
+    # that calls pflash_register_ggml_kernel() can only link there too.
+    if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash27b_cuda_min_sm GREATER_EQUAL 80
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flash_attn_sparse.cpp")
         add_executable(test_flash_attn_sparse test/test_flash_attn_sparse.cpp)
         target_link_libraries(test_flash_attn_sparse PRIVATE dflash27b ggml ggml-cuda ggml-base)
         target_include_directories(test_flash_attn_sparse PRIVATE

--- a/dflash/src/pflash_ggml_adapter.cpp
+++ b/dflash/src/pflash_ggml_adapter.cpp
@@ -1,0 +1,33 @@
+#include "flashprefill.h"
+
+// Forward-declare the registration function from ggml-cuda (defined in fattn-sparse.cu).
+// No extern "C" — nvcc compiles .cu as C++ and the symbol has C++ linkage.
+void ggml_cuda_flash_attn_sparse_set_kernel(
+    int (*fn)(const void*, const void*, const void*, void*,
+              int, int, int, int, int, float, float));
+
+static int pflash_adapter(
+    const void * Q, const void * K, const void * V, void * O,
+    int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
+    float scale, float alpha)
+{
+    dflash27b::flashprefill::FlashPrefillConfig cfg;
+    if (alpha >= 1.0f) {
+        // alpha >= 1.0 means "select all blocks" — configure for dense attention
+        cfg.alpha          = 0.0f;
+        cfg.attention_sink = seq_len;  // all blocks are "sinks"
+        cfg.window         = seq_len;  // window covers everything
+        cfg.last_n_full    = seq_len;  // all query blocks attend fully
+    } else {
+        cfg.alpha = alpha;
+    }
+    return dflash27b::flashprefill::flash_prefill_forward_bf16(
+        Q, K, V, O,
+        batch, seq_len, n_q_heads, n_k_heads, head_dim,
+        scale, cfg);
+}
+
+// Call this once at init time before running any ggml_flash_attn_sparse graphs.
+void pflash_register_ggml_kernel() {
+    ggml_cuda_flash_attn_sparse_set_kernel(&pflash_adapter);
+}

--- a/dflash/src/pflash_ggml_adapter.h
+++ b/dflash/src/pflash_ggml_adapter.h
@@ -1,0 +1,2 @@
+#pragma once
+void pflash_register_ggml_kernel();

--- a/dflash/test/test_flash_attn_sparse.cpp
+++ b/dflash/test/test_flash_attn_sparse.cpp
@@ -111,7 +111,7 @@ static bool test_sparse_matches_dense(ggml_backend_t backend, int S, int H, int 
 
     ggml_gallocr_free(alloc);
     ggml_free(ctx);
-    return max_diff < 1.0f && !any_nonfinite;
+    return max_diff < 1e-3f && !any_nonfinite;
 }
 
 // Sanity-check sparse attention at alpha < 1.0:

--- a/dflash/test/test_flash_attn_sparse.cpp
+++ b/dflash/test/test_flash_attn_sparse.cpp
@@ -104,14 +104,15 @@ static bool test_sparse_matches_dense(ggml_backend_t backend, int S, int H, int 
         if (diff > max_diff) max_diff = diff;
     }
 
+    const bool pass = max_diff < 1e-3f && !any_nonfinite;
     printf("[test] S=%d H=%d Hk=%d D=%d max_diff=%.6f nonfinite=%s %s\n",
            S, H, Hk, D, max_diff,
            any_nonfinite ? "YES" : "no",
-           (max_diff < 1.0f && !any_nonfinite) ? "PASS" : "FAIL");
+           pass ? "PASS" : "FAIL");
 
     ggml_gallocr_free(alloc);
     ggml_free(ctx);
-    return max_diff < 1e-3f && !any_nonfinite;
+    return pass;
 }
 
 // Sanity-check sparse attention at alpha < 1.0:

--- a/dflash/test/test_flash_attn_sparse.cpp
+++ b/dflash/test/test_flash_attn_sparse.cpp
@@ -1,0 +1,201 @@
+#include "ggml.h"
+#include "ggml-cuda.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "../src/pflash_ggml_adapter.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <cassert>
+
+// Compare dense FA output vs sparse FA output
+// At alpha=1.0 (select all blocks), sparse should match dense exactly.
+static bool test_sparse_matches_dense(ggml_backend_t backend, int S, int H, int Hk, int D) {
+    // Use no_alloc=true so tensors are NOT pre-allocated in CPU memory.
+    // The gallocr will allocate them in the CUDA backend buffer instead,
+    // which is required for ggml_backend_tensor_set/get to work.
+    const size_t ctx_size = 256 * 1024 * 1024;
+    ggml_init_params params = { ctx_size, nullptr, /*no_alloc=*/true };
+    ggml_context * ctx = ggml_init(params);
+
+    // Q must be F32: the CUDA FA kernel asserts Q->type == GGML_TYPE_F32
+    // K and V can be F16; the kernel converts them internally if needed
+    // ggml FA convention: ne[0]=D, ne[1]=S, ne[2]=H
+    ggml_tensor * Q = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, D, S, H);
+    // K [D, S, Hk]
+    ggml_tensor * K = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+    // V [D, S, Hk]
+    ggml_tensor * V = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+
+    // Mark Q, K, V as graph inputs so gallocr allocates persistent backend buffers for them
+    ggml_set_input(Q);
+    ggml_set_input(K);
+    ggml_set_input(V);
+
+    // Causal mask for dense FA: ne[0]=KV_len, ne[1]=Q_len.
+    // The kernel indexes it as mask[q * ne[0] + kv], so mask[q][kv] = (kv <= q) ? 0 : -inf.
+    // pFlash applies causal masking at block granularity, so we give dense FA the same mask.
+    ggml_tensor * mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, S, S);
+    ggml_set_input(mask);
+
+    // Dense FA
+    ggml_tensor * dense_out = ggml_flash_attn_ext(ctx, Q, K, V, mask, 1.0f/sqrtf((float)D), 0.0f, 0.0f);
+
+    // Sparse FA (alpha=1.0 = select all blocks = should match dense)
+    ggml_tensor * sparse_out = ggml_flash_attn_sparse(ctx, Q, K, V, 1.0f/sqrtf((float)D), 1.0f);
+
+    // Mark outputs so gallocr never frees/overwrites them before readback
+    ggml_set_output(dense_out);
+    ggml_set_output(sparse_out);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, dense_out);
+    ggml_build_forward_expand(gf, sparse_out);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    ggml_gallocr_alloc_graph(alloc, gf);
+
+    // Fill Q (F32), K (F16), V (F16) with random data
+    srand(42);
+
+    std::vector<float> q_buf(D * S * H);
+    for (auto & x : q_buf) x = (float)(rand() % 1000 - 500) / 500.0f;
+    ggml_backend_tensor_set(Q, q_buf.data(), 0, ggml_nbytes(Q));
+
+    std::vector<ggml_fp16_t> buf(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(K, buf.data(), 0, ggml_nbytes(K));
+
+    buf.resize(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(V, buf.data(), 0, ggml_nbytes(V));
+
+    // Fill causal mask: mask[q * S + kv] = (kv <= q) ? 0.0f : -INFINITY
+    {
+        std::vector<ggml_fp16_t> mask_data(S * S);
+        for (int q = 0; q < S; q++) {
+            for (int kv = 0; kv < S; kv++) {
+                float val = (kv <= q) ? 0.0f : -INFINITY;
+                mask_data[q * S + kv] = ggml_fp32_to_fp16(val);
+            }
+        }
+        ggml_backend_tensor_set(mask, mask_data.data(), 0, S * S * sizeof(ggml_fp16_t));
+    }
+
+    ggml_backend_graph_compute(backend, gf);
+
+    // Compare outputs (dense_out is GGML_TYPE_F32, use ggml_nelements for element count)
+    const size_t n_elems   = ggml_nelements(dense_out);
+    const size_t out_bytes = n_elems * sizeof(float);
+    std::vector<float> dense_data(n_elems);
+    std::vector<float> sparse_data(n_elems);
+    ggml_backend_tensor_get(dense_out, dense_data.data(), 0, out_bytes);
+    ggml_backend_tensor_get(sparse_out, sparse_data.data(), 0, out_bytes);
+
+    float max_diff = 0.0f;
+    bool any_nonfinite = false;
+    for (size_t i = 0; i < dense_data.size(); i++) {
+        if (!std::isfinite(sparse_data[i]) || !std::isfinite(dense_data[i])) {
+            any_nonfinite = true;
+            break;
+        }
+        float diff = fabsf(dense_data[i] - sparse_data[i]);
+        if (diff > max_diff) max_diff = diff;
+    }
+
+    printf("[test] S=%d H=%d Hk=%d D=%d max_diff=%.6f nonfinite=%s %s\n",
+           S, H, Hk, D, max_diff,
+           any_nonfinite ? "YES" : "no",
+           (max_diff < 1.0f && !any_nonfinite) ? "PASS" : "FAIL");
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return max_diff < 1.0f && !any_nonfinite;
+}
+
+// Sanity-check sparse attention at alpha < 1.0:
+// The output should not be all zeros (basic liveness check).
+// With alpha < 1.0 outputs will differ from dense FA — that is expected and not tested here.
+static bool test_sparse_alpha(ggml_backend_t backend, int S, int H, int Hk, int D, float alpha) {
+    const size_t ctx_size = 256 * 1024 * 1024;
+    ggml_init_params params = { ctx_size, nullptr, /*no_alloc=*/true };
+    ggml_context * ctx = ggml_init(params);
+
+    // ggml FA convention: ne[0]=D, ne[1]=S, ne[2]=H
+    ggml_tensor * Q = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, D, S, H);
+    ggml_tensor * K = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+    ggml_tensor * V = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+
+    ggml_set_input(Q);
+    ggml_set_input(K);
+    ggml_set_input(V);
+
+    ggml_tensor * sparse_out = ggml_flash_attn_sparse(ctx, Q, K, V, 1.0f/sqrtf((float)D), alpha);
+    ggml_set_output(sparse_out);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, sparse_out);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    ggml_gallocr_alloc_graph(alloc, gf);
+
+    srand(42);
+
+    std::vector<float> q_buf(D * S * H);
+    for (auto & x : q_buf) x = (float)(rand() % 1000 - 500) / 500.0f;
+    ggml_backend_tensor_set(Q, q_buf.data(), 0, ggml_nbytes(Q));
+
+    std::vector<ggml_fp16_t> buf(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(K, buf.data(), 0, ggml_nbytes(K));
+
+    buf.resize(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(V, buf.data(), 0, ggml_nbytes(V));
+
+    ggml_backend_graph_compute(backend, gf);
+
+    const size_t n_elems   = ggml_nelements(sparse_out);
+    const size_t out_bytes = n_elems * sizeof(float);
+    std::vector<float> out_data(n_elems);
+    ggml_backend_tensor_get(sparse_out, out_data.data(), 0, out_bytes);
+
+    // Basic sanity: output must not be all zeros
+    float max_abs = 0.0f;
+    for (size_t i = 0; i < out_data.size(); i++) {
+        float v = fabsf(out_data[i]);
+        if (v > max_abs) max_abs = v;
+    }
+
+    bool pass = max_abs > 1e-6f;
+    printf("[test_sparse_alpha] alpha=%.2f S=%d H=%d Hk=%d D=%d max_abs=%.6f %s\n",
+           alpha, S, H, Hk, D, max_abs, pass ? "PASS" : "FAIL (all zeros)");
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return pass;
+}
+
+int main() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        fprintf(stderr, "CUDA backend not available\n");
+        return 1;
+    }
+
+    pflash_register_ggml_kernel();
+
+    bool ok = true;
+    ok &= test_sparse_matches_dense(backend, 256, 16, 8, 128);   // small
+    ok &= test_sparse_matches_dense(backend, 1024, 16, 8, 128);  // medium
+    ok &= test_sparse_matches_dense(backend, 4096, 16, 8, 128);  // large
+
+    // Alpha < 1.0: pFlash kernel with moderate and aggressive sparsity
+    ok &= test_sparse_alpha(backend, 1024, 16, 8, 128, 0.5f);   // moderate sparsity
+    ok &= test_sparse_alpha(backend, 4096, 16, 8, 128, 0.12f);  // aggressive sparsity (default alpha)
+
+    ggml_backend_free(backend);
+    printf("\n%s\n", ok ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Purpose

Expose the sparse flash-attention operation from the updated llama.cpp submodule (bumped in #169) through a thin parent-repo adapter and one generic test. The adapter (`pflash_ggml_adapter.cpp`) registers a pflash kernel with ggml-cuda's sparse FA dispatch hook; the header exposes a single registration function; the test exercises the adapter path generically without any Gemma4-specific setup.

## Scope

Four files changed:
- `dflash/src/pflash_ggml_adapter.cpp` — thin kernel-registration adapter
- `dflash/src/pflash_ggml_adapter.h` — single-function public header
- `dflash/test/test_flash_attn_sparse.cpp` — generic sparse FA test
- `dflash/CMakeLists.txt` — adds `src/pflash_ggml_adapter.cpp` to `dflash27b`, adds `DFLASH27B_MIN_SM` compile definition, adds `test_flash_attn_sparse` build target

## Dependencies

Depends on #169 (llama.cpp substrate bump) which depends on #168 (repo hygiene). Stacks on `split/gemma4-02-llama-substrate`; until those merge, this diff includes their commits.

## Risk: Medium

## Review checklist

- [ ] Adapter is thin and encodes no Gemma4-specific behavior
- [ ] Test is generic sparse FA coverage, not a Gemma4 integration test
- [ ] No new public API beyond the single `pflash_register_ggml_kernel()` entry point

## Validation

Skipped: no CUDA build environment available in this context (WSL2, no GPU). The `test_flash_attn_sparse` CMake target is guarded by `EXISTS` so it does not break non-CUDA builds.