### PR TITLE
refactor(scripts): extract backend-device placement helper

### DIFF
--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -16,6 +16,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from placement.backend_device import apply_backend_visible_devices, TestDflashLaunchArgs
+
 
 ROOT = Path(__file__).resolve().parent.parent
 BIN_SUFFIX = ".exe" if os.name == "nt" else ""
@@ -388,37 +390,29 @@ def main():
     print(f"{'prompt':28s}  {'steps':>6s} {'AL':>6s} {'pct%':>6s} {'prefill':>8s} {'decode':>8s}")
     print("-" * 72)
 
-    extra_args = []
-    if args.draft_feature_mirror:
-        extra_args.append("--draft-feature-mirror")
-    if args.peer_access:
-        extra_args.append("--peer-access")
-    if args.target_gpu is not None:
-        extra_args.append(f"--target-gpu={args.target_gpu}")
-    if args.draft_gpu is not None:
-        extra_args.append(f"--draft-gpu={args.draft_gpu}")
-    if args.target_gpus:
-        extra_args.append(f"--target-gpus={args.target_gpus}")
-    if args.target_layer_split:
-        extra_args.append(f"--target-layer-split={args.target_layer_split}")
-    if args.target_split_load_draft:
-        extra_args.append("--target-split-load-draft")
-    if args.target_split_dflash:
-        extra_args.append("--target-split-dflash")
-    if args.draft_ipc_bin:
-        extra_args.append(f"--draft-ipc-bin={args.draft_ipc_bin}")
-    if args.draft_ipc_gpu is not None:
-        extra_args.append(f"--draft-ipc-gpu={args.draft_ipc_gpu}")
-    if args.draft_ipc_work_dir:
-        extra_args.append(f"--draft-ipc-work-dir={args.draft_ipc_work_dir}")
-    if args.draft_ipc_ring_cap is not None:
-        extra_args.append(f"--draft-ipc-ring-cap={args.draft_ipc_ring_cap}")
-    if args.max_ctx is not None:
-        extra_args.append(f"--max-ctx={args.max_ctx}")
+    extra_args = TestDflashLaunchArgs(
+        draft_feature_mirror=args.draft_feature_mirror,
+        peer_access=args.peer_access,
+        target_gpu=args.target_gpu,
+        draft_gpu=args.draft_gpu,
+        target_gpus=args.target_gpus,
+        target_layer_split=args.target_layer_split,
+        target_split_load_draft=args.target_split_load_draft,
+        target_split_dflash=args.target_split_dflash,
+        draft_ipc_bin=args.draft_ipc_bin,
+        draft_ipc_gpu=args.draft_ipc_gpu,
+        draft_ipc_work_dir=args.draft_ipc_work_dir,
+        draft_ipc_ring_cap=args.draft_ipc_ring_cap,
+        max_ctx=args.max_ctx,
+    ).to_cli_args()
 
     extra_env = {}
     if args.cuda_visible_devices:
-        extra_env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+        extra_env = apply_backend_visible_devices(
+            "cuda",
+            visible_devices=args.cuda_visible_devices,
+            base_env=extra_env,
+        )
     if args.prefill_ubatch is not None:
         extra_env["DFLASH27B_PREFILL_UBATCH"] = str(args.prefill_ubatch)
 

--- a/dflash/scripts/phase_split_dual_gpu.py
+++ b/dflash/scripts/phase_split_dual_gpu.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from statistics import mean
 from typing import Iterable
 
+from placement.backend_device import apply_backend_visible_devices, TestDflashLaunchArgs
+
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -124,16 +126,12 @@ class PFlashDaemon:
 
     def start(self) -> float:
         r_fd, w_fd = os.pipe()
-        env = os.environ.copy()
-        env.update(self.env)
-        visible = self.visible_devices or str(self.gpu)
-        if self.backend == "cuda":
-            env["CUDA_VISIBLE_DEVICES"] = visible
-        elif self.backend == "hip":
-            env["HIP_VISIBLE_DEVICES"] = visible
-            env["ROCR_VISIBLE_DEVICES"] = visible
-        else:
-            raise RuntimeError(f"unknown PFlash backend: {self.backend}")
+        env = apply_backend_visible_devices(
+            self.backend,
+            visible_devices=self.visible_devices,
+            fallback_device=self.gpu,
+            base_env={**os.environ, **self.env},
+        )
         cmd = [str(self.binary), str(self.drafter), f"--stream-fd={w_fd}"]
         t0 = time.perf_counter()
         self.proc = subprocess.Popen(
@@ -387,16 +385,11 @@ def parse_env_overrides(values: list[str]) -> dict[str, str]:
 
 
 def target_env(args) -> dict[str, str]:
-    env = os.environ.copy()
-    env.update(parse_env_overrides(args.target_env))
-    visible = args.target_visible_devices
-    if visible:
-        if args.target_backend == "cuda":
-            env["CUDA_VISIBLE_DEVICES"] = visible
-        else:
-            env["HIP_VISIBLE_DEVICES"] = visible
-            env["ROCR_VISIBLE_DEVICES"] = visible
-    return env
+    return apply_backend_visible_devices(
+        args.target_backend,
+        visible_devices=args.target_visible_devices,
+        base_env={**os.environ, **parse_env_overrides(args.target_env)},
+    )
 
 
 def run_target_generation(args, case_dir: Path, compressed_text: str,
@@ -416,16 +409,14 @@ def run_target_generation(args, case_dir: Path, compressed_text: str,
         str(prompt_path),
         str(args.target_gen_tokens),
         str(out_path),
-        f"--max-ctx={args.target_max_ctx}",
     ]
-    if args.target_gpus:
-        cmd += ["--target-gpus", args.target_gpus]
-    if args.target_layer_split:
-        cmd += ["--target-layer-split", args.target_layer_split]
-    if args.target_split_load_draft:
-        cmd.append("--target-split-load-draft")
-    if args.target_split_dflash:
-        cmd.append("--target-split-dflash")
+    cmd.extend(TestDflashLaunchArgs(
+        target_gpus=args.target_gpus,
+        target_layer_split=args.target_layer_split,
+        target_split_load_draft=args.target_split_load_draft,
+        target_split_dflash=args.target_split_dflash,
+        max_ctx=args.target_max_ctx,
+    ).to_cli_args())
 
     t0 = time.perf_counter()
     with log_path.open("wb") as log:

--- a/dflash/scripts/placement/__init__.py
+++ b/dflash/scripts/placement/__init__.py
@@ -1,0 +1,1 @@
+"""Script-side backend/device placement helpers."""

--- a/dflash/scripts/placement/backend_device.py
+++ b/dflash/scripts/placement/backend_device.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Shared backend/device placement plumbing for script-side test_dflash launchers."""
+
+import os
+from dataclasses import dataclass
+
+
+def resolve_visible_devices(visible_devices: str | None,
+                            fallback_device: int | None = None) -> str | None:
+    if visible_devices:
+        return visible_devices
+    if fallback_device is None:
+        return None
+    return str(fallback_device)
+
+
+def apply_backend_visible_devices(backend: str,
+                                  *,
+                                  visible_devices: str | None = None,
+                                  fallback_device: int | None = None,
+                                  base_env: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ if base_env is None else base_env)
+    resolved = resolve_visible_devices(visible_devices, fallback_device)
+    if resolved is None:
+        return env
+    if backend == "cuda":
+        env["CUDA_VISIBLE_DEVICES"] = resolved
+        return env
+    if backend == "hip":
+        env["HIP_VISIBLE_DEVICES"] = resolved
+        env["ROCR_VISIBLE_DEVICES"] = resolved
+        return env
+    raise ValueError(f"unknown backend: {backend!r}")
+
+
+@dataclass(frozen=True)
+class TestDflashLaunchArgs:
+    draft_feature_mirror: bool = False
+    peer_access: bool = False
+    target_gpu: int | None = None
+    draft_gpu: int | None = None
+    target_gpus: str | None = None
+    target_layer_split: str | None = None
+    target_split_load_draft: bool = False
+    target_split_dflash: bool = False
+    draft_ipc_bin: str | None = None
+    draft_ipc_gpu: int | None = None
+    draft_ipc_work_dir: str | None = None
+    draft_ipc_ring_cap: int | None = None
+    max_ctx: int | None = None
+
+    def to_cli_args(self) -> list[str]:
+        out: list[str] = []
+        if self.draft_feature_mirror:
+            out.append("--draft-feature-mirror")
+        if self.peer_access:
+            out.append("--peer-access")
+        if self.target_gpu is not None:
+            out.append(f"--target-gpu={self.target_gpu}")
+        if self.draft_gpu is not None:
+            out.append(f"--draft-gpu={self.draft_gpu}")
+        if self.target_gpus:
+            out.append(f"--target-gpus={self.target_gpus}")
+        if self.target_layer_split:
+            out.append(f"--target-layer-split={self.target_layer_split}")
+        if self.target_split_load_draft:
+            out.append("--target-split-load-draft")
+        if self.target_split_dflash:
+            out.append("--target-split-dflash")
+        if self.draft_ipc_bin:
+            out.append(f"--draft-ipc-bin={self.draft_ipc_bin}")
+        if self.draft_ipc_gpu is not None:
+            out.append(f"--draft-ipc-gpu={self.draft_ipc_gpu}")
+        if self.draft_ipc_work_dir:
+            out.append(f"--draft-ipc-work-dir={self.draft_ipc_work_dir}")
+        if self.draft_ipc_ring_cap is not None:
+            out.append(f"--draft-ipc-ring-cap={self.draft_ipc_ring_cap}")
+        if self.max_ctx is not None:
+            out.append(f"--max-ctx={self.max_ctx}")
+        return out

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -40,6 +40,7 @@ from _prefill_hook import (
     PrefillConfig, add_cli_flags, config_from_args,
     compress_text_via_daemon, _drain_until_sentinel,
 )
+from placement.backend_device import TestDflashLaunchArgs
 from prefix_cache import DaemonStdoutBus, PrefixCache
 from tool_memory import ToolMemory
 
@@ -2409,23 +2410,26 @@ def main():
         drafter_tokenizer = AutoTokenizer.from_pretrained(
             prefill_cfg.drafter_tokenizer_id, trust_remote_code=True)
 
-    extra_daemon: list[str] = []
-    if args.draft_feature_mirror:
-        extra_daemon.append("--draft-feature-mirror")
-    if args.peer_access:
-        extra_daemon.append("--peer-access")
+    extra_daemon_cfg = TestDflashLaunchArgs(
+        draft_feature_mirror=args.draft_feature_mirror,
+        peer_access=args.peer_access,
+    )
     if args.target_gpus:
-        extra_daemon.append(f"--target-gpus={args.target_gpus}")
-        if args.target_layer_split:
-            extra_daemon.append(f"--target-layer-split={args.target_layer_split}")
-        # Keep sharded daemon behavior aligned with the single-GPU server path.
-        extra_daemon.append("--target-split-load-draft")
-        extra_daemon.append("--target-split-dflash")
+        extra_daemon_cfg = TestDflashLaunchArgs(
+            draft_feature_mirror=args.draft_feature_mirror,
+            peer_access=args.peer_access,
+            target_gpus=args.target_gpus,
+            target_layer_split=args.target_layer_split,
+            # Keep sharded daemon behavior aligned with the single-GPU server path.
+            target_split_load_draft=True,
+            target_split_dflash=True,
+        )
         # Multi-GPU daemon mode currently does not implement SNAPSHOT/RESTORE.
         if args.prefix_cache_slots > 0 or args.prefill_cache_slots > 0:
             print("  [cfg] target-gpus daemon mode disables prefix/full cache slots (snapshot protocol unsupported)")
             args.prefix_cache_slots = 0
             args.prefill_cache_slots = 0
+    extra_daemon = extra_daemon_cfg.to_cli_args()
 
     app = build_app(args.target, draft, args.bin, args.budget, args.max_ctx,
                     tokenizer, stop_ids,


### PR DESCRIPTION
## Summary

This PR extracts a small shared backend/device placement helper for the script-side `test_dflash` launchers.

It is a behavior-preserving refactor. It does not add new backend combinations, change server behavior, or change the existing CLI surface. The goal is to make the current CUDA/HIP and device-placement wiring easier to reuse before the next server integration PRs.

## Problem

The current mixed-backend and multi-GPU paths are orchestrated mostly from `dflash/scripts`:

- PFlash phase split starts a drafter daemon on one backend/device set and can run target generation on another.
- DFlash target/draft split and target layer split are driven through `test_dflash` flags and process environment setup.

Before this PR, the same placement plumbing was repeated in several entrypoints:

- `phase_split_dual_gpu.py` had local CUDA/HIP visible-device env mapping for both daemon and target launch paths.
- `server.py` manually assembled sharded target daemon placement arguments.
- `bench_he.py` manually assembled nearly the same placement/split arguments and its own visible-device override.

That made the placement boundary real in practice, but implicit and duplicated.

## Changes

This PR adds `dflash/scripts/placement/` as a small script-side placement package.

Added `dflash/scripts/placement/backend_device.py`:

- `resolve_visible_devices()` centralizes visible-device resolution:
  - use the explicit visible-device list when provided
  - otherwise fall back to the single device id
- `apply_backend_visible_devices()` centralizes backend-specific environment setup:
  - CUDA sets `CUDA_VISIBLE_DEVICES`
  - HIP sets both `HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES`
- `TestDflashLaunchArgs` centralizes shared `test_dflash` placement/split argv serialization. It covers the existing launcher flags for:
  - draft feature mirror and peer access
  - target/draft GPU ids
  - target GPU list and target layer split
  - target split load/dflash flags
  - remote draft IPC binary, GPU, work directory, and ring capacity
  - max context

Updated `dflash/scripts/phase_split_dual_gpu.py`:

- The PFlash daemon launch path now uses `apply_backend_visible_devices()` instead of local CUDA/HIP env mapping.
- The target generation env path now uses the same helper.
- Target generation placement args now use `TestDflashLaunchArgs(...).to_cli_args()` instead of locally appending target split flags.

Updated `dflash/scripts/server.py`:

- Daemon placement args now use `TestDflashLaunchArgs`.
- Existing sharded-daemon behavior is preserved:
  - `target_gpus` mode still enables the existing target split load/dflash path
  - target-gpus daemon mode still disables prefix/full cache slots because that path does not support SNAPSHOT/RESTORE yet
- This keeps the server policy unchanged while moving the repeated argv construction into the shared helper.

Updated `dflash/scripts/bench_he.py`:

- Benchmark placement args now use `TestDflashLaunchArgs`.
- The CUDA visible-device override now uses `apply_backend_visible_devices("cuda", ...)`.
- The benchmark remains a bench harness; this PR does not expand it into a new backend configuration surface.

Overall, the PR keeps the same CLI flags and behavior, but moves duplicated backend/device env setup and `test_dflash` placement argv construction into one reusable script-side helper.

## Follow-up Path

This PR creates `dflash/scripts/placement/` as the script-side placement boundary.

The next PRs can extend this directory with config resolution, validation, resolved-placement logging, and later placement recommendations. Runtime kernels, model execution, and VRAM optimization should remain outside this directory.

One naming note: this PR keeps the current runner naming as-is. `TestDflashLaunchArgs` refers to the existing `test_dflash` runner binary because the current server and benchmark scripts already launch that binary for DFlash/target execution. A broader project refactor can later separate or rename that runner surface; this PR only centralizes the existing launch flags.

## Validation

Rebased onto the latest `upstream/main`; the ROCm/HIP support already merged upstream does not conflict with this script-side refactor.

Static/build checks passed after the rebase:

- `python3 -m py_compile` for the new helper and touched scripts
- helper smoke test for `TestDflashLaunchArgs` serialization and CUDA/HIP env mapping
- CUDA build: `test_dflash` and `pflash_daemon`
- HIP build: `test_dflash` and `pflash_daemon`

End-to-end regression checks passed on this branch:

- CUDA target layer split, target-only:
  - `--target-gpus=0,1 --target-layer-split=1,1`
- CUDA DFlash target/draft split:
  - `--target-gpu=0 --draft-gpu=1`
- CUDA target layer split + local DFlash:
  - `--target-gpus=0,1 --target-layer-split=1,1 --target-split-dflash`
- HIP -> CUDA mixed-backend PFlash phase split:
  - HIP `pflash_daemon`
  - CUDA `test_dflash` target generation with target layer split
- HIP remote draft IPC -> CUDA target layer split DFlash:
  - CUDA target process with target layer split
  - HIP remote draft daemon via `--draft-ipc-bin`
