### PR TITLE
feat(dflash): add csv token output utility

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -240,7 +240,8 @@ if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
     string(REGEX REPLACE "[^0-9]" "" _dflash27b_cuda_min_sm "${_dflash27b_cuda_min_sm}")
     target_compile_definitions(dflash27b PRIVATE
         DFLASH27B_BACKEND_CUDA=1
-        DFLASH27B_CUDA_MIN_SM=${_dflash27b_cuda_min_sm})
+        DFLASH27B_CUDA_MIN_SM=${_dflash27b_cuda_min_sm}
+        DFLASH27B_MIN_SM=${_dflash27b_cuda_min_sm})
 elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
     set_target_properties(dflash27b PROPERTIES HIP_ARCHITECTURES "${_dflash27b_archs}")
     target_compile_definitions(dflash27b PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
@@ -283,7 +284,8 @@ elseif(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash27b_cuda_min_sm GREATER_
     target_sources(dflash27b PRIVATE
         src/flashprefill_kernels.cu
         src/flashprefill_select.cpp
-        src/flashprefill.cpp)
+        src/flashprefill.cpp
+        src/pflash_ggml_adapter.cpp)
     target_compile_definitions(dflash27b PRIVATE DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL=1)
 endif()
 
@@ -525,5 +527,14 @@ if(DFLASH27B_TESTS)
             target_link_libraries(${_t} PRIVATE CUDA::cudart)
         endif()
     endforeach()
+
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flash_attn_sparse.cpp")
+        add_executable(test_flash_attn_sparse test/test_flash_attn_sparse.cpp)
+        target_link_libraries(test_flash_attn_sparse PRIVATE dflash27b ggml ggml-cuda ggml-base)
+        target_include_directories(test_flash_attn_sparse PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/include
+            ${CMAKE_CURRENT_SOURCE_DIR}/deps/llama.cpp/ggml/src
+            ${DFLASH27B_SRC_INCLUDE_DIRS})
+    endif()
     endif()
 endif()

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -528,7 +528,11 @@ if(DFLASH27B_TESTS)
         endif()
     endforeach()
 
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flash_attn_sparse.cpp")
+    # Gated on the same condition as src/pflash_ggml_adapter.cpp (see line ~291):
+    # the adapter is only compiled into dflash27b on CUDA + sm>=80, so the test
+    # that calls pflash_register_ggml_kernel() can only link there too.
+    if(DFLASH27B_GPU_BACKEND STREQUAL "cuda" AND _dflash27b_cuda_min_sm GREATER_EQUAL 80
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_flash_attn_sparse.cpp")
         add_executable(test_flash_attn_sparse test/test_flash_attn_sparse.cpp)
         target_link_libraries(test_flash_attn_sparse PRIVATE dflash27b ggml ggml-cuda ggml-base)
         target_include_directories(test_flash_attn_sparse PRIVATE

--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -214,6 +214,8 @@ add_library(dflash27b STATIC
     src/laguna/laguna_target_graph.cpp
     src/laguna/laguna_daemon.cpp
     src/common/sampler.cpp
+    # Gemma4 target model loader (PR04)
+    src/gemma4_target_loader.cpp
 )
 # BSA (Block-Sparse Attention) backs the speculative-prefill drafter scoring
 # path. Default ON so prefill is fast out of the box. Turn OFF if you don't
@@ -438,6 +440,11 @@ if(DFLASH27B_TESTS)
         target_include_directories(smoke_load_target PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
         target_link_libraries(smoke_load_target PRIVATE dflash27b ggml ${DFLASH27B_GGML_BACKEND_TARGET})
     endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/gemma4/smoke_load_gemma4_target.cpp")
+        add_executable(smoke_load_gemma4_target test/gemma4/smoke_load_gemma4_target.cpp)
+        target_include_directories(smoke_load_gemma4_target PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+        target_link_libraries(smoke_load_gemma4_target PRIVATE dflash27b ggml ggml-cuda)
+    endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/smoke_load_target_laguna.cpp")
         add_executable(smoke_load_target_laguna test/smoke_load_target_laguna.cpp)
         target_include_directories(smoke_load_target_laguna PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
@@ -513,6 +520,7 @@ if(DFLASH27B_TESTS)
         smoke_draft_graph
         test_vs_oracle
         smoke_load_target
+        smoke_load_gemma4_target
         smoke_load_target_laguna
         smoke_laguna_forward
         bench_laguna_ttft

--- a/dflash/include/gemma4.h
+++ b/dflash/include/gemma4.h
@@ -1,0 +1,62 @@
+// gemma4 — standalone CUDA library for DFlash speculative decoding of
+// Gemma4 models (31B Dense and 26B-A4B MoE) with a DFlash draft model.
+
+#ifndef GEMMA4_H
+#define GEMMA4_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ─── Gemma4-31B Dense config ───────────────────────────────────────
+
+#define GEMMA4_31B_HIDDEN              4096
+#define GEMMA4_31B_LAYERS              60
+#define GEMMA4_31B_N_HEADS             32
+#define GEMMA4_31B_N_KV_HEADS          8
+#define GEMMA4_31B_HEAD_DIM            128
+#define GEMMA4_31B_INTERMEDIATE        16384
+#define GEMMA4_31B_VOCAB               262144
+#define GEMMA4_31B_SWA_WINDOW          1024
+
+// ─── Gemma4-26B-A4B MoE config ────────────────────────────────────
+
+#define GEMMA4_26B_HIDDEN              4096
+#define GEMMA4_26B_LAYERS              30
+#define GEMMA4_26B_N_HEADS             32
+#define GEMMA4_26B_N_KV_HEADS          8
+#define GEMMA4_26B_HEAD_DIM            128
+#define GEMMA4_26B_INTERMEDIATE        16384
+#define GEMMA4_26B_EXPERT_INTERMEDIATE 2048
+#define GEMMA4_26B_N_EXPERTS           128
+#define GEMMA4_26B_N_EXPERTS_USED      8
+#define GEMMA4_26B_VOCAB               262144
+#define GEMMA4_26B_SWA_WINDOW          1024
+
+// ─── Shared constants ─────────────────────────────────────────────
+
+#define GEMMA4_ROPE_THETA              1000000.0f
+#define GEMMA4_RMS_EPS                 1e-6f
+#define GEMMA4_LOGIT_SOFTCAP           30.0f
+#define GEMMA4_ATTN_SCALE              1.0f
+
+// ─── Draft model config ───────────────────────────────────────────
+
+#define GEMMA4_DRAFT_LAYERS            5
+#define GEMMA4_DRAFT_BLOCK_SIZE        16
+#define GEMMA4_DRAFT_N_TARGET_LAYERS   6
+#define GEMMA4_31B_DRAFT_MASK_TOKEN_ID 4
+#define GEMMA4_26B_DRAFT_MASK_TOKEN_ID 4
+
+// ─── Diagnostics ──────────────────────────────────────────────────
+
+const char * gemma4_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GEMMA4_H

--- a/dflash/scripts/tokenize_prompt.py
+++ b/dflash/scripts/tokenize_prompt.py
@@ -1,40 +1,92 @@
 """
-Tokenize a prompt string using the Qwen3.5 HF tokenizer (via transformers)
-and emit the token IDs as a flat int32 binary file.
+Tokenize a prompt string using a HuggingFace tokenizer (via transformers).
 
-We depend on Python only for the tokenizer — the C++ library consumes the
-int32 file directly. This keeps the standalone lib free of a BPE impl.
+Two output modes:
+  --out FILE   Write token IDs as a flat int32 little-endian binary file
+               (consumed by the C++ library directly).
+  --csv        Print comma-separated token IDs to stdout
+               (for use with the --tokens flag of test_gemma4_dflash).
 
 Usage:
-    python tokenize_prompt.py --out /tmp/prompt.bin --prompt "The capital of France is"
+    # Binary output (backward-compatible):
+    python tokenize_prompt.py --out /tmp/prompt.bin --prompt "Hello, world!"
+
+    # CSV output for --tokens flag:
+    python tokenize_prompt.py --csv --prompt "Hello, world!"
+    # -> 9259,236764,1902,236888
+
+    # Explicit model:
+    python tokenize_prompt.py --csv --model google/gemma-4-26b-a4b-it --prompt "..."
+
+    # Show token count:
+    python tokenize_prompt.py --csv --verbose --prompt "Hello, world!"
+
+Notes:
+    The Gemma4 tokenizer is cached locally at:
+      ~/.cache/huggingface/hub/models--google--gemma-4-26b-a4b-it/
+    The script tries local_files_only=True first to avoid network calls.
+    Gemma4 vocab size: 262144, BOS token id: 2, EOS token id: 1.
 """
 
 import argparse
-import os
-import sys
 import struct
+import sys
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--out", required=True)
-    ap.add_argument("--prompt", required=True)
-    ap.add_argument("--model", default="Qwen/Qwen3.5-27B",
-                    help="HF repo id whose tokenizer to use")
-    ap.add_argument("--add-bos", action="store_true", help="Prepend BOS token")
-    args = ap.parse_args()
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--prompt", required=True, help="Text to tokenize")
+    ap.add_argument("--model", default="google/gemma-4-26b-a4b-it",
+                    help="HF repo id whose tokenizer to use "
+                         "(default: google/gemma-4-26b-a4b-it)")
+    ap.add_argument("--add-bos", action="store_true",
+                    help="Prepend BOS token (add_special_tokens=True)")
+    ap.add_argument("--verbose", action="store_true",
+                    help="Print token count and first/last tokens to stderr")
+    # Output modes (at least one required)
+    out_group = ap.add_mutually_exclusive_group(required=True)
+    out_group.add_argument("--out", metavar="FILE",
+                           help="Write int32 binary token ID file")
+    out_group.add_argument("--csv", action="store_true",
+                           help="Print comma-separated token IDs to stdout")
+    return ap
 
+
+def load_tokenizer(model: str):
+    """Load tokenizer, preferring local cache to avoid network calls."""
     from transformers import AutoTokenizer
-    tok = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    try:
+        return AutoTokenizer.from_pretrained(
+            model, trust_remote_code=True, local_files_only=True
+        )
+    except Exception:
+        # Fall back to network if not cached
+        return AutoTokenizer.from_pretrained(model, trust_remote_code=True)
 
-    ids = tok.encode(args.prompt, add_special_tokens=args.add_bos)
-    print(f"tokenized {len(ids)} tokens: {ids}")
 
-    with open(args.out, "wb") as f:
-        for t in ids:
-            f.write(struct.pack("<i", int(t)))
+def tokenize(prompt: str, model: str, add_bos: bool) -> list[int]:
+    tok = load_tokenizer(model)
+    return tok.encode(prompt, add_special_tokens=add_bos)
 
-    print(f"wrote {args.out} ({len(ids) * 4} bytes)")
+
+def main() -> None:
+    args = build_parser().parse_args()
+    ids = tokenize(args.prompt, args.model, args.add_bos)
+
+    if args.verbose:
+        preview = ids[:5] + (["..."] if len(ids) > 10 else []) + ids[-5:] if len(ids) > 10 else ids
+        print(f"tokenized {len(ids)} tokens; first/last: {preview}", file=sys.stderr)
+
+    if args.csv:
+        print(",".join(str(i) for i in ids))
+    else:
+        with open(args.out, "wb") as f:
+            for t in ids:
+                f.write(struct.pack("<i", int(t)))
+        # Informational output goes to stderr so stdout stays clean
+        print(f"tokenized {len(ids)} tokens, wrote {args.out} ({len(ids) * 4} bytes)",
+              file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/dflash/src/errors.cpp
+++ b/dflash/src/errors.cpp
@@ -2,6 +2,7 @@
 // Consumed by tests and the test_dflash driver via dflash27b_last_error().
 
 #include "dflash27b.h"
+#include "gemma4.h"
 #include "internal.h"
 
 #include <mutex>
@@ -12,6 +13,7 @@ namespace dflash27b {
 namespace {
 std::mutex g_err_mu;
 std::string g_last_error;
+thread_local std::string t_err_buf;  // per-thread snapshot for safe c_str return
 }
 
 void set_last_error(std::string msg) {
@@ -23,5 +25,12 @@ void set_last_error(std::string msg) {
 
 extern "C" const char * dflash27b_last_error(void) {
     std::lock_guard<std::mutex> lk(dflash27b::g_err_mu);
-    return dflash27b::g_last_error.c_str();
+    dflash27b::t_err_buf = dflash27b::g_last_error;  // copy under lock
+    return dflash27b::t_err_buf.c_str();              // safe: thread-local
+}
+
+extern "C" const char * gemma4_last_error(void) {
+    std::lock_guard<std::mutex> lk(dflash27b::g_err_mu);
+    dflash27b::t_err_buf = dflash27b::g_last_error;
+    return dflash27b::t_err_buf.c_str();
 }

--- a/dflash/src/gemma4_target_loader.cpp
+++ b/dflash/src/gemma4_target_loader.cpp
@@ -1,0 +1,753 @@
+// Loads a Gemma4 target model (31B Dense or 26B-A4B MoE) from a GGUF file into
+// a GemmaTargetWeights struct backed by the supplied ggml backend (typically
+// CUDA).
+//
+// The expected GGUF architecture string is "gemma4". The loader supports both
+// the dense variant (60 layers, pure SwiGLU FFN) and the MoE variant (30
+// layers, sparse expert FFN on the "26B-A4B" config).
+//
+// Tensor naming follows llama.cpp's gemma4-iswa.cpp conventions:
+//
+//   Global:
+//     token_embd.weight              [n_embd, n_vocab]
+//     output_norm.weight             [n_embd]
+//     output.weight                  [n_vocab, n_embd]  (optional; falls back)
+//
+//   Per-Layer Embedding (PLE, present when n_embd_per_layer > 0):
+//     per_layer_token_embd.weight    [n_embd_per_layer * n_layer, n_vocab]
+//     per_layer_model_proj.weight    [n_embd, n_embd_per_layer * n_layer]
+//     per_layer_proj_norm.weight     [n_embd_per_layer]
+//     blk.{i}.inp_gate.weight        [n_embd, n_embd_per_layer]
+//     blk.{i}.proj.weight            [n_embd_per_layer, n_embd]
+//     blk.{i}.post_norm.weight       [n_embd]
+//
+//   Per-Layer Attention:
+//     blk.{i}.attn_norm.weight       [n_embd]
+//     blk.{i}.attn_q.weight          [n_embd, n_head * head_dim]
+//     blk.{i}.attn_k.weight          [n_embd, n_head_kv * head_dim]  (optional)
+//     blk.{i}.attn_v.weight          [n_embd, n_head_kv * head_dim]  (optional)
+//     blk.{i}.attn_output.weight     [n_head * head_dim, n_embd]
+//     blk.{i}.attn_q_norm.weight     [head_dim]
+//     blk.{i}.attn_k_norm.weight     [head_dim]                       (optional)
+//     blk.{i}.attn_post_norm.weight  [n_embd]
+//     blk.{i}.rope_freqs.weight      [head_dim/2]  (full-attn layers only)
+//     blk.{i}.out_scale.weight       [1]           (optional)
+//
+//   Per-Layer FFN (SwiGLU):
+//     blk.{i}.ffn_norm.weight        [n_embd]
+//     blk.{i}.ffn_gate.weight        [n_embd, n_ff]
+//     blk.{i}.ffn_up.weight          [n_embd, n_ff]
+//     blk.{i}.ffn_down.weight        [n_ff, n_embd]
+//     blk.{i}.ffn_post_norm.weight   [n_embd]
+//
+//   Per-Layer MoE (26B-A4B only, present when n_expert > 0):
+//     blk.{i}.ffn_gate_inp.weight    [n_embd, n_expert]
+//     blk.{i}.ffn_gate_inp.scale     [n_embd]           (optional)
+//     blk.{i}.ffn_pre_norm_2.weight  [n_embd]
+//     blk.{i}.ffn_gate_up_exps.weight [n_embd, n_ff_exp*2, n_expert]
+//     blk.{i}.ffn_down_exps.weight   [n_ff_exp, n_embd, n_expert]
+//     blk.{i}.ffn_down_exps.scale    [n_expert]         (optional)
+//     blk.{i}.ffn_post_norm_1.weight [n_embd]
+//     blk.{i}.ffn_post_norm_2.weight [n_embd]
+//
+// KV-sharing: layers with index >= (n_layer - n_kv_shared_layers) omit wk, wv,
+// k_norm. Their KV is borrowed from the last non-shared layer of the same
+// attention type. layer_to_kv_idx maps each layer to its KV cache slot;
+// layer_to_donor_kv maps shared layers to their donor layer index.
+
+#include "internal.h"
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#if !defined(_WIN32)
+#include <cerrno>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace dflash27b {
+
+namespace {
+
+// ─── Thin mmap wrapper ───────────────────────────────────────────────────────
+// Mirrors the Mmap struct from gguf_target_loader.cpp.  Ownership can be
+// transferred to a CpuEmbedder via release().
+
+struct Mmap {
+    void *  addr = nullptr;
+    size_t  len  = 0;
+#if defined(_WIN32)
+    HANDLE  hFile = INVALID_HANDLE_VALUE;
+    HANDLE  hMap  = nullptr;
+#else
+    int     fd   = -1;
+#endif
+
+    bool open_ro(const std::string & path, std::string & err) {
+#if defined(_WIN32)
+        hFile = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hFile == INVALID_HANDLE_VALUE) {
+            err = "CreateFileA: " + path + ": error " + std::to_string(GetLastError());
+            return false;
+        }
+        LARGE_INTEGER sz;
+        if (!GetFileSizeEx(hFile, &sz)) {
+            err = "GetFileSizeEx: error " + std::to_string(GetLastError());
+            return false;
+        }
+        len = (size_t)sz.QuadPart;
+        hMap = CreateFileMappingA(hFile, nullptr, PAGE_READONLY, 0, 0, nullptr);
+        if (!hMap) {
+            err = "CreateFileMappingA: error " + std::to_string(GetLastError());
+            return false;
+        }
+        addr = MapViewOfFile(hMap, FILE_MAP_READ, 0, 0, 0);
+        if (!addr) {
+            err = "MapViewOfFile: error " + std::to_string(GetLastError());
+            return false;
+        }
+#else
+        fd = ::open(path.c_str(), O_RDONLY);
+        if (fd < 0) { err = "open: " + path + ": " + std::strerror(errno); return false; }
+        struct stat st;
+        if (::fstat(fd, &st) < 0) { err = "fstat: " + std::string(std::strerror(errno)); return false; }
+        len = (size_t)st.st_size;
+        addr = ::mmap(nullptr, len, PROT_READ, MAP_PRIVATE, fd, 0);
+        if (addr == MAP_FAILED) { err = "mmap: " + std::string(std::strerror(errno)); addr = nullptr; return false; }
+#endif
+        return true;
+    }
+
+    void release() {
+        addr = nullptr;
+        len  = 0;
+#if defined(_WIN32)
+        hFile = INVALID_HANDLE_VALUE;
+        hMap  = nullptr;
+#else
+        fd = -1;
+#endif
+    }
+
+    ~Mmap() {
+#if defined(_WIN32)
+        if (addr)                          UnmapViewOfFile(addr);
+        if (hMap)                          CloseHandle(hMap);
+        if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
+#else
+        if (addr) ::munmap(addr, len);
+        if (fd >= 0) ::close(fd);
+#endif
+    }
+};
+
+// ─── GGUF metadata helpers ───────────────────────────────────────────────────
+
+static uint32_t get_u32_or(const gguf_context * g, const char * key, uint32_t fallback) {
+    int64_t id = gguf_find_key(g, key);
+    if (id < 0) return fallback;
+    return gguf_get_val_u32(g, id);
+}
+
+static float get_f32_or(const gguf_context * g, const char * key, float fallback) {
+    int64_t id = gguf_find_key(g, key);
+    if (id < 0) return fallback;
+    return gguf_get_val_f32(g, id);
+}
+
+static size_t align_up(size_t x, size_t a) {
+    if (a == 0) return x;
+    const size_t r = x % a;
+    return r == 0 ? x : x + (a - r);
+}
+
+// ─── Tensor selection filter ─────────────────────────────────────────────────
+//
+// All tensors go to GPU, including token_embd.weight which doubles as the LM
+// head (tied weights in Gemma4-26B-A4B).  The CPU embedder keeps its own
+// read-only mmap view of tok_embd for the input embedding path, so placing
+// it on GPU as well is safe and necessary for correct LM head logits.
+
+static bool is_gemma4_gpu_tensor(const char * name) {
+    (void)name;
+    return true;
+}
+
+} // namespace
+
+// ─── load_gemma4_target_gguf ─────────────────────────────────────────────────
+
+bool load_gemma4_target_gguf(const std::string & path,
+                             ggml_backend_t       backend,
+                             GemmaTargetWeights & out) {
+
+    // ── 1. Parse GGUF metadata ────────────────────────────────────────────────
+
+    ggml_context * meta_ctx = nullptr;
+    gguf_init_params gip{};
+    gip.no_alloc = true;
+    gip.ctx      = &meta_ctx;
+    gguf_context * gctx = gguf_init_from_file(path.c_str(), gip);
+    if (!gctx) {
+        set_last_error("gguf_init_from_file failed: " + path);
+        return false;
+    }
+
+    // Validate architecture string.
+    {
+        int64_t arch_id = gguf_find_key(gctx, "general.architecture");
+        if (arch_id < 0) {
+            set_last_error("missing general.architecture");
+            gguf_free(gctx);
+            return false;
+        }
+        const char * arch = gguf_get_val_str(gctx, arch_id);
+        if (std::string(arch) != "gemma4") {
+            set_last_error(std::string("unexpected arch: ") + arch + " (expected gemma4)");
+            gguf_free(gctx);
+            return false;
+        }
+    }
+
+    // Read required architecture hyperparameters.
+    const uint32_t n_embd    = get_u32_or(gctx, "gemma4.embedding_length",             0);
+    const uint32_t n_layer   = get_u32_or(gctx, "gemma4.block_count",                  0);
+    const uint32_t n_ff      = get_u32_or(gctx, "gemma4.feed_forward_length",           0);
+    const uint32_t n_head    = get_u32_or(gctx, "gemma4.attention.head_count",          0);
+    // Fix A: head_count_kv may be a per-layer INT32 array, not a scalar
+    std::vector<int> head_kv_per_layer;
+    uint32_t n_head_kv_max = 0;
+    {
+        int64_t kv_id = gguf_find_key(gctx, "gemma4.attention.head_count_kv");
+        if (kv_id >= 0) {
+            enum gguf_type kv_type = gguf_get_kv_type(gctx, kv_id);
+            if (kv_type == GGUF_TYPE_ARRAY) {
+                size_t arr_n = gguf_get_arr_n(gctx, kv_id);
+                const int32_t * arr = (const int32_t *)gguf_get_arr_data(gctx, kv_id);
+                head_kv_per_layer.resize(arr_n);
+                for (size_t i = 0; i < arr_n; i++) {
+                    head_kv_per_layer[i] = (int)arr[i];
+                    if ((uint32_t)arr[i] > n_head_kv_max) n_head_kv_max = (uint32_t)arr[i];
+                }
+            } else {
+                // Scalar fallback
+                n_head_kv_max = gguf_get_val_u32(gctx, kv_id);
+            }
+        }
+    }
+    const uint32_t n_head_kv = n_head_kv_max;
+
+    // Fix D: read both full-attn and SWA head dims
+    const uint32_t head_dim     = get_u32_or(gctx, "gemma4.attention.key_length",     0);
+    const uint32_t head_dim_swa = get_u32_or(gctx, "gemma4.attention.key_length_swa", head_dim);
+
+    // Fix B: vocab_size key may be absent — fall back to tokenizer array length
+    uint32_t n_vocab = get_u32_or(gctx, "gemma4.vocab_size", 0);
+    if (n_vocab == 0) {
+        int64_t tok_id = gguf_find_key(gctx, "tokenizer.ggml.tokens");
+        if (tok_id >= 0) n_vocab = (uint32_t)gguf_get_arr_n(gctx, tok_id);
+    }
+    const uint32_t swa_win   = get_u32_or(gctx, "gemma4.attention.sliding_window",      1024);
+    const uint32_t n_kv_shared = get_u32_or(gctx, "gemma4.attention.shared_kv_layers", 0);
+    const uint32_t n_embd_per_layer = get_u32_or(gctx, "gemma4.embedding_length_per_layer_input", 0);
+    const uint32_t n_expert   = get_u32_or(gctx, "gemma4.expert_count",                0);
+    const uint32_t n_expert_used = get_u32_or(gctx, "gemma4.expert_used_count",        0);
+    const uint32_t n_ff_exp   = get_u32_or(gctx, "gemma4.expert_feed_forward_length",  0);
+
+    const float rope_theta     = get_f32_or(gctx, "gemma4.rope.freq_base",     1000000.0f);
+    const float rope_theta_swa = get_f32_or(gctx, "gemma4.rope.freq_base_swa", 1000000.0f);
+    const float logit_softcap  = get_f32_or(gctx, "gemma4.final_logit_softcapping", 30.0f);
+
+    if (n_embd == 0 || n_layer == 0 || n_ff == 0 ||
+        n_head == 0 || n_head_kv == 0 || head_dim == 0 || n_vocab == 0) {
+        char buf[256];
+        std::snprintf(buf, sizeof(buf),
+            "missing or zero required hparams: n_embd=%u n_layer=%u n_ff=%u "
+            "n_head=%u n_head_kv=%u head_dim=%u n_vocab=%u",
+            n_embd, n_layer, n_ff, n_head, n_head_kv, head_dim, n_vocab);
+        set_last_error(buf);
+        gguf_free(gctx);
+        return false;
+    }
+
+    // ── 2. Build the per-layer SWA pattern ───────────────────────────────────
+    //
+    // swa_layers[il] != 0 → sliding-window attention; == 0 → full attention.
+    // The array is stored as GGUF_TYPE_ARRAY of INT32 or BOOL.  If absent we
+    // default to alternating: odd layers use SWA, even layers use full attn
+    // (matches Gemma4-31B's default pattern).
+
+    std::vector<bool> swa_layers(n_layer, false);
+    {
+        int64_t swa_arr_id = gguf_find_key(gctx, "gemma4.attention.sliding_window_pattern");
+        // Fix C: sliding_window_pattern may be BOOL array (1-byte), not INT32
+        if (swa_arr_id >= 0) {
+            size_t arr_n = gguf_get_arr_n(gctx, swa_arr_id);
+            enum gguf_type arr_type = gguf_get_arr_type(gctx, swa_arr_id);
+            const void * arr_data = gguf_get_arr_data(gctx, swa_arr_id);
+            for (size_t i = 0; i < arr_n && i < n_layer; i++) {
+                if (arr_type == GGUF_TYPE_BOOL || arr_type == GGUF_TYPE_INT8 || arr_type == GGUF_TYPE_UINT8) {
+                    swa_layers[i] = (((const uint8_t *)arr_data)[i] != 0);
+                } else {
+                    swa_layers[i] = (((const int32_t *)arr_data)[i] != 0);
+                }
+            }
+        } else {
+            // Fallback: odd-indexed layers → SWA, even → full attention.
+            for (uint32_t i = 0; i < n_layer; i++) {
+                swa_layers[i] = ((i % 2) == 1);
+            }
+        }
+    }
+
+    // ── 3. Build KV-sharing maps ──────────────────────────────────────────────
+    //
+    // Layers [0, n_layer - n_kv_shared_layers) own their own KV cache slot.
+    // Layers [n_layer - n_kv_shared_layers, n_layer) are KV-shared: they borrow
+    // KV from the last non-shared layer that has the same attention type (SWA
+    // or full).  layer_to_kv_idx[il] == -1 for shared layers.
+
+    const int n_non_shared = (int)n_layer - (int)n_kv_shared;
+    if (n_non_shared < 0) {
+        char buf[128];
+        std::snprintf(buf, sizeof(buf),
+            "n_kv_shared_layers=%u > n_layer=%u", n_kv_shared, n_layer);
+        set_last_error(buf);
+        gguf_free(gctx);
+        return false;
+    }
+
+    std::vector<int> layer_to_kv_idx((size_t)n_layer, -1);
+    std::vector<int> layer_to_donor_kv((size_t)n_layer, -1);
+    {
+        int kv_slot = 0;
+        for (int il = 0; il < n_non_shared; il++) {
+            layer_to_kv_idx[il] = kv_slot++;
+        }
+        // Shared layers find their donor: the last non-shared layer with the
+        // same attention type.
+        for (int il = n_non_shared; il < (int)n_layer; il++) {
+            bool is_swa = swa_layers[(size_t)il];
+            int donor = -1;
+            for (int j = n_non_shared - 1; j >= 0; j--) {
+                if (swa_layers[(size_t)j] == is_swa) { donor = j; break; }
+            }
+            layer_to_donor_kv[il] = donor;
+            // kv_idx stays -1 (no dedicated slot).
+        }
+    }
+    const int n_kv_slots = n_non_shared;  // total distinct KV cache entries
+
+    // ── 4. Populate struct metadata ──────────────────────────────────────────
+
+    out.ctx     = meta_ctx;
+    out.backend = backend;
+
+    out.n_embd              = (int)n_embd;
+    out.n_head              = (int)n_head;
+    out.n_head_kv           = (int)n_head_kv;
+    out.head_dim            = (int)head_dim;
+    out.head_dim_swa        = (int)head_dim_swa;
+    out.head_kv_per_layer   = head_kv_per_layer;
+    out.n_layer             = (int)n_layer;
+    out.n_ff             = (int)n_ff;
+    out.n_vocab          = (int)n_vocab;
+    out.n_embd_per_layer = (int)n_embd_per_layer;
+    out.swa_window       = (int)swa_win;
+    out.swa_layers       = swa_layers;
+    out.n_kv_shared_layers = (int)n_kv_shared;
+    out.n_layer_kv       = n_kv_slots;
+    out.rope_theta       = rope_theta;
+    out.rope_theta_swa   = rope_theta_swa;
+    out.n_expert         = (int)n_expert;
+    out.n_expert_used    = (int)n_expert_used;
+    out.n_ff_exp         = (int)n_ff_exp;
+    out.logit_softcap    = logit_softcap;
+
+    // BOS / EOS tokens (missing key → -1)
+    {
+        const uint32_t kMissing = 0xFFFFFFFFu;
+        const uint32_t raw_bos  = get_u32_or(gctx, "tokenizer.ggml.bos_token_id",  kMissing);
+        const uint32_t raw_eos  = get_u32_or(gctx, "tokenizer.ggml.eos_token_id",  kMissing);
+        const uint32_t raw_eot  = get_u32_or(gctx, "tokenizer.ggml.eot_token_id",  kMissing);
+        out.bos_id      = (raw_bos == kMissing) ? -1 : (int32_t)raw_bos;
+        out.eos_id      = (raw_eos == kMissing) ? -1 : (int32_t)raw_eos;
+        out.eos_chat_id = (raw_eot == kMissing) ? -1 : (int32_t)raw_eot;
+
+        // Gemma4 fallback: <end_of_turn> (107) is the chat stop token.
+        // Many GGUFs omit eot_token_id; default to 107 when missing.
+        if (out.eos_chat_id < 0) {
+            out.eos_chat_id = 107;
+        }
+
+        std::printf("[gemma4_loader] bos_id=%d eos_id=%d eos_chat_id=%d\n",
+                    out.bos_id, out.eos_id, out.eos_chat_id);
+    }
+
+    // ── 5. Compute capture_layer_ids ─────────────────────────────────────────
+    //
+    // Use hardcoded values from the DFlash draft model config.json.
+    // Fallback to evenly-spaced formula for unknown layer counts.
+    {
+        const int N = GEMMA4_DRAFT_N_TARGET_LAYERS;  // 6
+        if ((int)n_layer == 30) {
+            // Gemma4-26B-A4B — from z-lab/gemma-4-26B-A4B-it-DFlash config.json
+            const int ids[6] = {1, 6, 11, 17, 22, 27};
+            for (int k = 0; k < N; k++) out.capture_layer_ids[k] = ids[k];
+        } else if ((int)n_layer == 60) {
+            // Gemma4-31B — from z-lab/gemma-4-31B-it-DFlash config.json
+            const int ids[6] = {1, 12, 23, 35, 46, 57};
+            for (int k = 0; k < N; k++) out.capture_layer_ids[k] = ids[k];
+        } else {
+            // Fallback: evenly spaced
+            const int step = ((int)n_layer - 2) / (N - 1);
+            for (int k = 0; k < N; k++) out.capture_layer_ids[k] = 1 + k * step;
+        }
+        std::printf("[gemma4_loader] capture_layer_ids:");
+        for (int k = 0; k < N; k++) std::printf(" %d", out.capture_layer_ids[k]);
+        std::printf("\n");
+    }
+
+    // ── 6. Wire tensor pointers ───────────────────────────────────────────────
+
+    auto g = [&](const char * name) -> ggml_tensor * {
+        return ggml_get_tensor(meta_ctx, name);
+    };
+
+    out.tok_embd = g("token_embd.weight");
+    out.out_norm = g("output_norm.weight");
+    // output.weight is optional; fall back to token_embd for tied weights.
+    out.output   = g("output.weight");
+    if (!out.output) out.output = out.tok_embd;
+
+    if (!out.tok_embd || !out.out_norm) {
+        set_last_error("missing top-level tensors (token_embd.weight / output_norm.weight)");
+        gguf_free(gctx);
+        return false;
+    }
+
+    // Global PLE tensors (present only when n_embd_per_layer > 0)
+    if (n_embd_per_layer > 0) {
+        out.per_layer_tok_embd   = g("per_layer_token_embd.weight");
+        out.per_layer_model_proj = g("per_layer_model_proj.weight");
+        out.per_layer_proj_norm  = g("per_layer_proj_norm.weight");
+        if (!out.per_layer_tok_embd || !out.per_layer_model_proj || !out.per_layer_proj_norm) {
+            set_last_error("n_embd_per_layer > 0 but PLE global tensors missing");
+            gguf_free(gctx);
+            return false;
+        }
+    }
+
+    // Load global rope_freqs tensor (full-attention layers use this for proportional RoPE).
+    // Gemma4 stores one shared rope_freqs.weight (not per-layer blk.{i}.rope_freqs.weight).
+    // All full-attention layers share this single tensor, matching llama.cpp's TENSOR_DUPLICATED
+    // pattern (llama-model.cpp:4657-4658).
+    ggml_tensor * global_rope_freqs = g("rope_freqs.weight");
+
+    // Per-layer tensors.
+    out.layers.assign((size_t)n_layer, GemmaTargetLayer{});
+
+    for (int il = 0; il < (int)n_layer; il++) {
+        char name[160];
+        auto fnd = [&](const char * suffix) -> ggml_tensor * {
+            std::snprintf(name, sizeof(name), "blk.%d.%s", il, suffix);
+            return ggml_get_tensor(meta_ctx, name);
+        };
+
+        GemmaTargetLayer & L = out.layers[(size_t)il];
+
+        // ── Attention (always present) ────────────────────────────────────────
+        L.attn_norm      = fnd("attn_norm.weight");
+        L.wq             = fnd("attn_q.weight");
+        L.wo             = fnd("attn_output.weight");
+        L.q_norm         = fnd("attn_q_norm.weight");
+        // This GGUF uses "post_attention_norm.weight"; fall back to legacy name
+        L.attn_post_norm = fnd("post_attention_norm.weight");
+        if (!L.attn_post_norm) L.attn_post_norm = fnd("attn_post_norm.weight");
+
+        if (!L.attn_norm || !L.wq || !L.wo || !L.q_norm || !L.attn_post_norm) {
+            char b[128];
+            std::snprintf(b, sizeof(b), "layer %d: missing required attention tensor", il);
+            set_last_error(b);
+            gguf_free(gctx);
+            return false;
+        }
+
+        // wk, wv, k_norm — absent for KV-shared layers (il >= n_non_shared).
+        const bool is_kv_owner = (il < n_non_shared);
+        if (is_kv_owner) {
+            L.wk     = fnd("attn_k.weight");
+            L.wv     = fnd("attn_v.weight");
+            L.k_norm = fnd("attn_k_norm.weight");
+            if (!L.wk) {
+                char b[128];
+                std::snprintf(b, sizeof(b), "layer %d: expected wk (non-shared), missing", il);
+                set_last_error(b);
+                gguf_free(gctx);
+                return false;
+            }
+            // V may be absent on full-attention layers where V == K (shared K/V).
+            if (!L.wv) {
+                L.wv = L.wk;
+            }
+            // k_norm may be absent for SWA layers in some checkpoints; allow nullptr.
+        }
+
+        // Optional per-layer tensors
+        L.rope_freqs = fnd("rope_freqs.weight");
+        // Full-attention layers use proportional RoPE via rope_freqs (freq_factors).
+        // Gemma4 stores a single global rope_freqs.weight (no per-layer blk.{i} variant).
+        // Fall back to the global tensor for full-attention layers when the per-layer
+        // variant is absent (which is always the case for this GGUF format).
+        if (!L.rope_freqs && !swa_layers[(size_t)il] && global_rope_freqs) {
+            L.rope_freqs = global_rope_freqs;
+        }
+        // This GGUF uses "layer_output_scale.weight"; fall back to legacy name
+        L.out_scale  = fnd("layer_output_scale.weight");
+        if (!L.out_scale) L.out_scale = fnd("out_scale.weight");
+
+        // ── FFN (always present) ──────────────────────────────────────────────
+        L.ffn_norm      = fnd("ffn_norm.weight");
+        L.w_gate        = fnd("ffn_gate.weight");
+        L.w_up          = fnd("ffn_up.weight");
+        L.w_down        = fnd("ffn_down.weight");
+        // This GGUF uses "post_ffw_norm.weight"; fall back to legacy name
+        L.ffn_post_norm = fnd("post_ffw_norm.weight");
+        if (!L.ffn_post_norm) L.ffn_post_norm = fnd("ffn_post_norm.weight");
+
+        if (!L.ffn_norm || !L.w_gate || !L.w_up || !L.w_down || !L.ffn_post_norm) {
+            char b[128];
+            std::snprintf(b, sizeof(b), "layer %d: missing required FFN tensor", il);
+            set_last_error(b);
+            gguf_free(gctx);
+            return false;
+        }
+
+        // ── MoE (26B-A4B — present when n_expert > 0) ────────────────────────
+        if (n_expert > 0) {
+            L.ffn_gate_inp    = fnd("ffn_gate_inp.weight");
+            L.ffn_gate_inp_s  = fnd("ffn_gate_inp.scale");
+            // This GGUF uses "pre_ffw_norm_2.weight"; fall back to legacy name
+            L.ffn_pre_norm_2  = fnd("pre_ffw_norm_2.weight");
+            if (!L.ffn_pre_norm_2) L.ffn_pre_norm_2 = fnd("ffn_pre_norm_2.weight");
+            L.ffn_gate_up_exps = fnd("ffn_gate_up_exps.weight");
+            L.ffn_down_exps   = fnd("ffn_down_exps.weight");
+            L.ffn_down_exps_s = fnd("ffn_down_exps.scale");
+            // This GGUF uses "post_ffw_norm_1/2.weight"; fall back to legacy names
+            L.ffn_post_norm_1 = fnd("post_ffw_norm_1.weight");
+            if (!L.ffn_post_norm_1) L.ffn_post_norm_1 = fnd("ffn_post_norm_1.weight");
+            L.ffn_post_norm_2 = fnd("post_ffw_norm_2.weight");
+            if (!L.ffn_post_norm_2) L.ffn_post_norm_2 = fnd("ffn_post_norm_2.weight");
+
+            if (!L.ffn_gate_inp || !L.ffn_pre_norm_2 ||
+                !L.ffn_gate_up_exps || !L.ffn_down_exps ||
+                !L.ffn_post_norm_1 || !L.ffn_post_norm_2) {
+                char b[128];
+                std::snprintf(b, sizeof(b), "layer %d: MoE model but missing expert tensor", il);
+                set_last_error(b);
+                gguf_free(gctx);
+                return false;
+            }
+            // ffn_gate_inp_s, ffn_down_exps_s are optional quantization scales.
+        }
+
+        // ── Per-Layer Embedding (PLE) ─────────────────────────────────────────
+        if (n_embd_per_layer > 0) {
+            L.ple_inp_gate  = fnd("inp_gate.weight");
+            L.ple_proj      = fnd("proj.weight");
+            L.ple_post_norm = fnd("post_norm.weight");
+            if (!L.ple_inp_gate || !L.ple_proj || !L.ple_post_norm) {
+                char b[128];
+                std::snprintf(b, sizeof(b), "layer %d: PLE model but missing per-layer embedding tensor", il);
+                set_last_error(b);
+                gguf_free(gctx);
+                return false;
+            }
+        }
+    }
+
+    // ── 7. Allocate GPU buffer ────────────────────────────────────────────────
+    //
+    // Walk all GGUF tensors, skip token_embd.weight (stays CPU), accumulate
+    // aligned sizes, allocate one contiguous backend buffer, assign each tensor.
+
+    ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(backend);
+    const size_t alignment = ggml_backend_buft_get_alignment(buft);
+
+    struct TensorSlot {
+        ggml_tensor * tensor      = nullptr;
+        size_t        file_offset = 0;
+        size_t        file_size   = 0;
+        size_t        buf_offset  = 0;
+    };
+
+    std::vector<TensorSlot> slots;
+    size_t total_gpu = 0;
+    const int64_t n_tensors = gguf_get_n_tensors(gctx);
+    for (int64_t tid = 0; tid < n_tensors; tid++) {
+        const char * tname = gguf_get_tensor_name(gctx, tid);
+        if (!is_gemma4_gpu_tensor(tname)) continue;
+        ggml_tensor * t = ggml_get_tensor(meta_ctx, tname);
+        if (!t) continue;
+        total_gpu = align_up(total_gpu, alignment);
+        TensorSlot s;
+        s.tensor      = t;
+        s.file_offset = gguf_get_data_offset(gctx) + gguf_get_tensor_offset(gctx, tid);
+        s.file_size   = gguf_get_tensor_size(gctx, tid);
+        s.buf_offset  = total_gpu;
+        total_gpu    += ggml_backend_buft_get_alloc_size(buft, t);
+        slots.push_back(s);
+    }
+
+    if (slots.empty()) {
+        set_last_error("no GPU tensors found in gemma4 GGUF");
+        gguf_free(gctx);
+        return false;
+    }
+
+    // Cleanup helper: release any GPU buffer and ggml context already assigned
+    // to `out` before returning false.  Must be called on every failure path
+    // after out.buf has been (or is about to be) allocated.
+    auto cleanup_out = [&]() {
+        if (out.buf) {
+            ggml_backend_buffer_free(out.buf);
+            out.buf = nullptr;
+        }
+        // out.ctx == meta_ctx; free it so the caller doesn't leak the graph.
+        if (out.ctx) {
+            ggml_free(out.ctx);
+            out.ctx = nullptr;
+        }
+        out = GemmaTargetWeights{};
+    };
+
+    out.buf = ggml_backend_alloc_buffer(backend, total_gpu);
+    if (!out.buf) {
+        set_last_error("ggml_backend_alloc_buffer failed (gemma4 target)");
+        gguf_free(gctx);
+        cleanup_out();
+        return false;
+    }
+    ggml_backend_buffer_set_usage(out.buf, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+
+    char * base = (char *)ggml_backend_buffer_get_base(out.buf);
+    for (const TensorSlot & s : slots) {
+        if (ggml_backend_tensor_alloc(out.buf, s.tensor, base + s.buf_offset) != GGML_STATUS_SUCCESS) {
+            set_last_error("ggml_backend_tensor_alloc failed (gemma4 target)");
+            gguf_free(gctx);
+            cleanup_out();
+            return false;
+        }
+    }
+
+    // ── 8. mmap file, upload GPU tensors, keep tok_embd on CPU ───────────────
+
+    std::string err;
+    Mmap mm;
+    if (!mm.open_ro(path, err)) {
+        set_last_error(err);
+        gguf_free(gctx);
+        cleanup_out();
+        return false;
+    }
+
+    const size_t data_start = gguf_get_data_offset(gctx);
+    size_t gpu_bytes_uploaded = 0;
+    size_t tok_embd_off  = 0;
+    size_t tok_embd_sz   = 0;
+    ggml_type tok_embd_type = GGML_TYPE_COUNT;
+
+    for (int64_t tid = 0; tid < n_tensors; tid++) {
+        const char * tname = gguf_get_tensor_name(gctx, tid);
+        ggml_tensor * t    = ggml_get_tensor(meta_ctx, tname);
+        if (!t) continue;
+        const size_t off = data_start + gguf_get_tensor_offset(gctx, tid);
+        const size_t sz  = gguf_get_tensor_size(gctx, tid);
+        if (off + sz > mm.len) {
+            set_last_error(std::string("tensor '") + tname + "' overflows file");
+            gguf_free(gctx);
+            cleanup_out();
+            return false;
+        }
+        if (std::strcmp(tname, "token_embd.weight") == 0) {
+            tok_embd_off  = off;
+            tok_embd_sz   = sz;
+            tok_embd_type = gguf_get_tensor_type(gctx, tid);
+            // fall through: also upload to GPU for LM head (tied weights)
+        }
+        ggml_backend_tensor_set(t, (const uint8_t *)mm.addr + off, 0, sz);
+        gpu_bytes_uploaded += sz;
+    }
+
+    gguf_free(gctx);
+
+    if (tok_embd_off == 0 || tok_embd_type == GGML_TYPE_COUNT) {
+        set_last_error("token_embd.weight not found or invalid type");
+        cleanup_out();
+        return false;
+    }
+
+    // Fix 2: validate tok_embd_sz divisibility before computing row stride.
+    if (n_vocab == 0 || tok_embd_sz % (size_t)n_vocab != 0) {
+        set_last_error("malformed GGUF: tok_embd_sz=" + std::to_string(tok_embd_sz) +
+                       " not divisible by n_vocab=" + std::to_string(n_vocab));
+        cleanup_out();
+        return false;
+    }
+
+    // ── 9. Transfer mmap ownership to CpuEmbedder ────────────────────────────
+
+    out.embedder.mmap_addr      = mm.addr;
+    out.embedder.mmap_len       = mm.len;
+#if defined(_WIN32)
+    out.embedder.mmap_hfile     = mm.hFile;
+    out.embedder.mmap_hmap      = mm.hMap;
+#else
+    out.embedder.mmap_fd        = mm.fd;
+#endif
+    out.embedder.tok_embd_bytes = (const uint8_t *)mm.addr + tok_embd_off;
+    out.embedder.tok_embd_type  = tok_embd_type;
+    out.embedder.n_embd         = (int64_t)n_embd;
+    out.embedder.n_vocab        = (int64_t)n_vocab;
+    out.embedder.row_bytes      = tok_embd_sz / (size_t)n_vocab;
+    mm.release();
+
+    char summary[256];
+    std::snprintf(summary, sizeof(summary),
+        "gemma4 target loaded: n_layer=%u n_embd=%u n_ff=%u n_expert=%u "
+        "n_kv_slots=%d n_kv_shared=%u, %zu GPU tensors %.2f GiB, "
+        "tok_embd %.0f MiB GPU+CPU-mmap (%s, tied LM head)",
+        n_layer, n_embd, n_ff, n_expert, n_kv_slots, n_kv_shared,
+        slots.size(), (double)gpu_bytes_uploaded / (1024.0 * 1024.0 * 1024.0),
+        (double)tok_embd_sz / (1024.0 * 1024.0), ggml_type_name(tok_embd_type));
+    set_last_error(summary);
+
+    return true;
+}
+
+// ─── free_gemma4_target_weights ──────────────────────────────────────────────
+
+void free_gemma4_target_weights(GemmaTargetWeights & w) {
+    if (w.buf) { ggml_backend_buffer_free(w.buf); w.buf = nullptr; }
+    if (w.ctx) { ggml_free(w.ctx);                w.ctx = nullptr; }
+    // CpuEmbedder destructor handles the mmap automatically.
+    w.layers.clear();
+    w.tok_embd              = nullptr;
+    w.out_norm              = nullptr;
+    w.output                = nullptr;
+    w.per_layer_tok_embd    = nullptr;
+    w.per_layer_model_proj  = nullptr;
+    w.per_layer_proj_norm   = nullptr;
+    w.swa_layers.clear();
+}
+
+} // namespace dflash27b

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -610,7 +610,13 @@ void free_gemma4_target_weights(GemmaTargetWeights & w);
 } // namespace dflash27b
 
 #if defined(GGML_USE_CUDA) && !defined(GGML_USE_HIP)
-#include <cuda_runtime.h>
+// Forward-declare cudaStream_t so non-nvcc compile units that include this
+// header (e.g. smoke tests built with plain g++ and no CUDA include dirs)
+// can still parse the dflash_cuda_copy_between_devices declaration.
+// The runtime header is included only by the implementation TU
+// (src/cuda_cross_device_copy.cpp), which is nvcc-compiled.
+struct CUstream_st;
+typedef struct CUstream_st * cudaStream_t;
 // Host-staged copy between CUDA devices (no peer access required).
 // Streams are device-specific: src_stream orders the D2H leg on src_dev and
 // dst_stream orders the H2D leg on dst_dev. Null streams use each device's

--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -23,6 +23,7 @@
 #include "gguf.h"
 
 #include "dflash27b.h"
+#include "gemma4.h"
 
 namespace dflash27b {
 
@@ -506,6 +507,105 @@ ggml_tensor * build_qwen35_layer(
     int                   fa_window = 0,
     ggml_tensor *         q_tail_capture = nullptr,
     int                   q_tail_start = 0);
+
+
+// ============ Gemma4 Architecture ============
+
+struct GemmaTargetLayer {
+    // Attention (ALL layers are attention in Gemma4)
+    ggml_tensor * attn_norm      = nullptr;
+    ggml_tensor * wq             = nullptr;
+    ggml_tensor * wk             = nullptr;  // nullptr for KV-shared layers
+    ggml_tensor * wv             = nullptr;  // nullptr for KV-shared layers
+    ggml_tensor * wo             = nullptr;
+    ggml_tensor * q_norm         = nullptr;
+    ggml_tensor * k_norm         = nullptr;  // nullptr for KV-shared layers
+    ggml_tensor * attn_post_norm = nullptr;
+
+    // p-RoPE freq factors (full-attention layers only)
+    ggml_tensor * rope_freqs     = nullptr;
+
+    ggml_tensor * out_scale      = nullptr;
+
+    // FFN (SwiGLU)
+    ggml_tensor * ffn_norm       = nullptr;
+    ggml_tensor * w_gate         = nullptr;
+    ggml_tensor * w_up           = nullptr;
+    ggml_tensor * w_down         = nullptr;
+    ggml_tensor * ffn_post_norm  = nullptr;
+
+    // MoE (26B-A4B only)
+    ggml_tensor * ffn_gate_inp   = nullptr;
+    ggml_tensor * ffn_gate_inp_s = nullptr;
+    ggml_tensor * ffn_pre_norm_2 = nullptr;
+    ggml_tensor * ffn_gate_up_exps = nullptr;
+    ggml_tensor * ffn_down_exps  = nullptr;
+    ggml_tensor * ffn_down_exps_s = nullptr;
+    ggml_tensor * ffn_post_norm_1 = nullptr;
+    ggml_tensor * ffn_post_norm_2 = nullptr;
+
+    // Per-Layer Embedding (PLE)
+    ggml_tensor * ple_inp_gate   = nullptr;
+    ggml_tensor * ple_proj       = nullptr;
+    ggml_tensor * ple_post_norm  = nullptr;
+};
+
+struct GemmaTargetWeights {
+    ggml_context        * ctx     = nullptr;
+    ggml_backend_t        backend = nullptr;
+    ggml_backend_buffer_t buf     = nullptr;
+    CpuEmbedder           embedder;
+
+    ggml_tensor * tok_embd  = nullptr;
+    std::vector<GemmaTargetLayer> layers;
+    ggml_tensor * out_norm  = nullptr;
+    ggml_tensor * output    = nullptr;
+
+    // Per-Layer Embedding global tensors
+    ggml_tensor * per_layer_tok_embd   = nullptr;
+    ggml_tensor * per_layer_model_proj = nullptr;
+    ggml_tensor * per_layer_proj_norm  = nullptr;
+
+    // Architecture metadata (loaded from GGUF)
+    int n_embd           = 4096;
+    int n_head           = 32;
+    int n_head_kv        = 8;      // max n_head_kv across layers (used for cache alloc)
+    int head_dim         = 128;   // full-attention head dim
+    int head_dim_swa     = 128;   // SWA head dim (may differ from head_dim)
+    std::vector<int> head_kv_per_layer;  // per-layer n_head_kv (empty = use n_head_kv for all)
+    int n_layer          = 60;
+    int n_ff             = 16384;
+    int n_vocab          = 262144;
+    int n_embd_per_layer = 0;
+
+    int swa_window       = 1024;
+    std::vector<bool> swa_layers;
+
+    int n_kv_shared_layers = 0;
+    int n_layer_kv         = 0;
+
+    float rope_theta     = 1000000.0f;
+    float rope_theta_swa = 1000000.0f;
+
+    int n_expert         = 0;
+    int n_expert_used    = 0;
+    int n_ff_exp         = 0;
+
+    float logit_softcap  = 30.0f;
+    float attn_scale     = 1.0f;
+
+    int32_t bos_id       = -1;
+    int32_t eos_id       = -1;
+    int32_t eos_chat_id  = -1;
+
+    int n_capture_layers = GEMMA4_DRAFT_N_TARGET_LAYERS;
+    int capture_layer_ids[GEMMA4_DRAFT_N_TARGET_LAYERS] = {0};
+};
+
+// Gemma4 target loading
+bool load_gemma4_target_gguf(const std::string & path, ggml_backend_t backend,
+                             GemmaTargetWeights & out);
+void free_gemma4_target_weights(GemmaTargetWeights & w);
 
 } // namespace dflash27b
 

--- a/dflash/src/pflash_ggml_adapter.cpp
+++ b/dflash/src/pflash_ggml_adapter.cpp
@@ -1,0 +1,33 @@
+#include "flashprefill.h"
+
+// Forward-declare the registration function from ggml-cuda (defined in fattn-sparse.cu).
+// No extern "C" — nvcc compiles .cu as C++ and the symbol has C++ linkage.
+void ggml_cuda_flash_attn_sparse_set_kernel(
+    int (*fn)(const void*, const void*, const void*, void*,
+              int, int, int, int, int, float, float));
+
+static int pflash_adapter(
+    const void * Q, const void * K, const void * V, void * O,
+    int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,
+    float scale, float alpha)
+{
+    dflash27b::flashprefill::FlashPrefillConfig cfg;
+    if (alpha >= 1.0f) {
+        // alpha >= 1.0 means "select all blocks" — configure for dense attention
+        cfg.alpha          = 0.0f;
+        cfg.attention_sink = seq_len;  // all blocks are "sinks"
+        cfg.window         = seq_len;  // window covers everything
+        cfg.last_n_full    = seq_len;  // all query blocks attend fully
+    } else {
+        cfg.alpha = alpha;
+    }
+    return dflash27b::flashprefill::flash_prefill_forward_bf16(
+        Q, K, V, O,
+        batch, seq_len, n_q_heads, n_k_heads, head_dim,
+        scale, cfg);
+}
+
+// Call this once at init time before running any ggml_flash_attn_sparse graphs.
+void pflash_register_ggml_kernel() {
+    ggml_cuda_flash_attn_sparse_set_kernel(&pflash_adapter);
+}

--- a/dflash/src/pflash_ggml_adapter.h
+++ b/dflash/src/pflash_ggml_adapter.h
@@ -1,0 +1,2 @@
+#pragma once
+void pflash_register_ggml_kernel();

--- a/dflash/test/gemma4/smoke_load_gemma4_target.cpp
+++ b/dflash/test/gemma4/smoke_load_gemma4_target.cpp
@@ -1,0 +1,115 @@
+// Smoke test: load a Gemma4 target GGUF, validate metadata and tensor shapes.
+//
+// Usage: smoke_load_gemma4_target <gemma4.gguf>
+
+#include "internal.h"
+#include "gemma4.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+#include "ggml-cuda.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+using namespace dflash27b;
+
+static void fail(const char * msg) {
+    std::fprintf(stderr, "FAIL: %s\n", msg);
+    std::exit(1);
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <gemma4.gguf>\n", argv[0]);
+        return 2;
+    }
+
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) { std::fprintf(stderr, "cuda init failed\n"); return 1; }
+
+    GemmaTargetWeights w;
+    if (!load_gemma4_target_gguf(argv[1], backend, w)) {
+        std::fprintf(stderr, "load_gemma4_target_gguf failed: %s\n", dflash27b_last_error());
+        ggml_backend_free(backend);
+        return 1;
+    }
+
+    // Print architecture metadata
+    std::printf("hparams: n_layer=%d n_embd=%d n_head=%d n_head_kv=%d head_dim=%d "
+                "n_vocab=%d n_ff=%d\n",
+                w.n_layer, w.n_embd, w.n_head, w.n_head_kv, w.head_dim,
+                w.n_vocab, w.n_ff);
+
+    // Count SWA vs full-attention layers
+    int n_swa = 0, n_full = 0;
+    for (int il = 0; il < w.n_layer; il++) {
+        if (il < (int)w.swa_layers.size() && w.swa_layers[il]) n_swa++;
+        else n_full++;
+    }
+    std::printf("swa_layers: swa=%d full=%d (total=%d)\n", n_swa, n_full, w.n_layer);
+
+    // Print KV-sharing config
+    std::printf("kv_sharing: n_kv_shared_layers=%d n_layer_kv=%d\n",
+                w.n_kv_shared_layers, w.n_layer_kv);
+
+    // Print Per-Layer Embedding dimension
+    std::printf("n_embd_per_layer=%d\n", w.n_embd_per_layer);
+
+    // Print MoE config (0 for dense)
+    std::printf("moe: n_expert=%d n_expert_used=%d\n", w.n_expert, w.n_expert_used);
+
+    // Print attention config
+    std::printf("logit_softcap=%.2f attn_scale=%.4f rope_theta=%.0f\n",
+                w.logit_softcap, w.attn_scale, w.rope_theta);
+
+    // Print captured layer IDs for the DFlash draft
+    std::printf("capture_layer_ids:");
+    for (int i = 0; i < w.n_capture_layers; i++) {
+        std::printf(" %d", w.capture_layer_ids[i]);
+    }
+    std::printf("\n");
+
+    // Assertions
+    if (w.n_vocab != 262144) {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "n_vocab=%d expected 262144", w.n_vocab);
+        fail(buf);
+    }
+    if (w.logit_softcap != 30.0f) {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "logit_softcap=%.2f expected 30.0", w.logit_softcap);
+        fail(buf);
+    }
+    if (w.n_layer_kv <= 0) {
+        fail("n_layer_kv must be > 0");
+    }
+    if (w.n_layer_kv > w.n_layer) {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "n_layer_kv=%d > n_layer=%d", w.n_layer_kv, w.n_layer);
+        fail(buf);
+    }
+
+    // Spot-check layer 0 tensors
+    if (!w.layers[0].wq) fail("layers[0].wq is null");
+    if (!w.layers[0].wo) fail("layers[0].wo is null");
+    if (!w.layers[0].w_gate) fail("layers[0].w_gate is null");
+
+    // Spot-check tok_embd and output
+    if (!w.tok_embd) fail("tok_embd is null");
+    if (!w.output)   fail("output (lm_head) is null");
+    if (!w.out_norm) fail("out_norm is null");
+
+    std::printf("tok_embd: ne=[%" PRId64 ", %" PRId64 "] type=%s nbytes=%.2f MiB\n",
+                w.tok_embd->ne[0], w.tok_embd->ne[1],
+                ggml_type_name(w.tok_embd->type),
+                ggml_nbytes(w.tok_embd) / (1024.0 * 1024.0));
+
+    free_gemma4_target_weights(w);
+    ggml_backend_free(backend);
+    std::printf("PASS\n");
+    return 0;
+}

--- a/dflash/test/test_flash_attn_sparse.cpp
+++ b/dflash/test/test_flash_attn_sparse.cpp
@@ -111,7 +111,7 @@ static bool test_sparse_matches_dense(ggml_backend_t backend, int S, int H, int 
 
     ggml_gallocr_free(alloc);
     ggml_free(ctx);
-    return max_diff < 1.0f && !any_nonfinite;
+    return max_diff < 1e-3f && !any_nonfinite;
 }
 
 // Sanity-check sparse attention at alpha < 1.0:

--- a/dflash/test/test_flash_attn_sparse.cpp
+++ b/dflash/test/test_flash_attn_sparse.cpp
@@ -1,0 +1,201 @@
+#include "ggml.h"
+#include "ggml-cuda.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "../src/pflash_ggml_adapter.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <cassert>
+
+// Compare dense FA output vs sparse FA output
+// At alpha=1.0 (select all blocks), sparse should match dense exactly.
+static bool test_sparse_matches_dense(ggml_backend_t backend, int S, int H, int Hk, int D) {
+    // Use no_alloc=true so tensors are NOT pre-allocated in CPU memory.
+    // The gallocr will allocate them in the CUDA backend buffer instead,
+    // which is required for ggml_backend_tensor_set/get to work.
+    const size_t ctx_size = 256 * 1024 * 1024;
+    ggml_init_params params = { ctx_size, nullptr, /*no_alloc=*/true };
+    ggml_context * ctx = ggml_init(params);
+
+    // Q must be F32: the CUDA FA kernel asserts Q->type == GGML_TYPE_F32
+    // K and V can be F16; the kernel converts them internally if needed
+    // ggml FA convention: ne[0]=D, ne[1]=S, ne[2]=H
+    ggml_tensor * Q = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, D, S, H);
+    // K [D, S, Hk]
+    ggml_tensor * K = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+    // V [D, S, Hk]
+    ggml_tensor * V = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+
+    // Mark Q, K, V as graph inputs so gallocr allocates persistent backend buffers for them
+    ggml_set_input(Q);
+    ggml_set_input(K);
+    ggml_set_input(V);
+
+    // Causal mask for dense FA: ne[0]=KV_len, ne[1]=Q_len.
+    // The kernel indexes it as mask[q * ne[0] + kv], so mask[q][kv] = (kv <= q) ? 0 : -inf.
+    // pFlash applies causal masking at block granularity, so we give dense FA the same mask.
+    ggml_tensor * mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, S, S);
+    ggml_set_input(mask);
+
+    // Dense FA
+    ggml_tensor * dense_out = ggml_flash_attn_ext(ctx, Q, K, V, mask, 1.0f/sqrtf((float)D), 0.0f, 0.0f);
+
+    // Sparse FA (alpha=1.0 = select all blocks = should match dense)
+    ggml_tensor * sparse_out = ggml_flash_attn_sparse(ctx, Q, K, V, 1.0f/sqrtf((float)D), 1.0f);
+
+    // Mark outputs so gallocr never frees/overwrites them before readback
+    ggml_set_output(dense_out);
+    ggml_set_output(sparse_out);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, dense_out);
+    ggml_build_forward_expand(gf, sparse_out);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    ggml_gallocr_alloc_graph(alloc, gf);
+
+    // Fill Q (F32), K (F16), V (F16) with random data
+    srand(42);
+
+    std::vector<float> q_buf(D * S * H);
+    for (auto & x : q_buf) x = (float)(rand() % 1000 - 500) / 500.0f;
+    ggml_backend_tensor_set(Q, q_buf.data(), 0, ggml_nbytes(Q));
+
+    std::vector<ggml_fp16_t> buf(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(K, buf.data(), 0, ggml_nbytes(K));
+
+    buf.resize(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(V, buf.data(), 0, ggml_nbytes(V));
+
+    // Fill causal mask: mask[q * S + kv] = (kv <= q) ? 0.0f : -INFINITY
+    {
+        std::vector<ggml_fp16_t> mask_data(S * S);
+        for (int q = 0; q < S; q++) {
+            for (int kv = 0; kv < S; kv++) {
+                float val = (kv <= q) ? 0.0f : -INFINITY;
+                mask_data[q * S + kv] = ggml_fp32_to_fp16(val);
+            }
+        }
+        ggml_backend_tensor_set(mask, mask_data.data(), 0, S * S * sizeof(ggml_fp16_t));
+    }
+
+    ggml_backend_graph_compute(backend, gf);
+
+    // Compare outputs (dense_out is GGML_TYPE_F32, use ggml_nelements for element count)
+    const size_t n_elems   = ggml_nelements(dense_out);
+    const size_t out_bytes = n_elems * sizeof(float);
+    std::vector<float> dense_data(n_elems);
+    std::vector<float> sparse_data(n_elems);
+    ggml_backend_tensor_get(dense_out, dense_data.data(), 0, out_bytes);
+    ggml_backend_tensor_get(sparse_out, sparse_data.data(), 0, out_bytes);
+
+    float max_diff = 0.0f;
+    bool any_nonfinite = false;
+    for (size_t i = 0; i < dense_data.size(); i++) {
+        if (!std::isfinite(sparse_data[i]) || !std::isfinite(dense_data[i])) {
+            any_nonfinite = true;
+            break;
+        }
+        float diff = fabsf(dense_data[i] - sparse_data[i]);
+        if (diff > max_diff) max_diff = diff;
+    }
+
+    printf("[test] S=%d H=%d Hk=%d D=%d max_diff=%.6f nonfinite=%s %s\n",
+           S, H, Hk, D, max_diff,
+           any_nonfinite ? "YES" : "no",
+           (max_diff < 1.0f && !any_nonfinite) ? "PASS" : "FAIL");
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return max_diff < 1.0f && !any_nonfinite;
+}
+
+// Sanity-check sparse attention at alpha < 1.0:
+// The output should not be all zeros (basic liveness check).
+// With alpha < 1.0 outputs will differ from dense FA — that is expected and not tested here.
+static bool test_sparse_alpha(ggml_backend_t backend, int S, int H, int Hk, int D, float alpha) {
+    const size_t ctx_size = 256 * 1024 * 1024;
+    ggml_init_params params = { ctx_size, nullptr, /*no_alloc=*/true };
+    ggml_context * ctx = ggml_init(params);
+
+    // ggml FA convention: ne[0]=D, ne[1]=S, ne[2]=H
+    ggml_tensor * Q = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, D, S, H);
+    ggml_tensor * K = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+    ggml_tensor * V = ggml_new_tensor_3d(ctx, GGML_TYPE_F16, D, S, Hk);
+
+    ggml_set_input(Q);
+    ggml_set_input(K);
+    ggml_set_input(V);
+
+    ggml_tensor * sparse_out = ggml_flash_attn_sparse(ctx, Q, K, V, 1.0f/sqrtf((float)D), alpha);
+    ggml_set_output(sparse_out);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, sparse_out);
+
+    ggml_gallocr_t alloc = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    ggml_gallocr_alloc_graph(alloc, gf);
+
+    srand(42);
+
+    std::vector<float> q_buf(D * S * H);
+    for (auto & x : q_buf) x = (float)(rand() % 1000 - 500) / 500.0f;
+    ggml_backend_tensor_set(Q, q_buf.data(), 0, ggml_nbytes(Q));
+
+    std::vector<ggml_fp16_t> buf(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(K, buf.data(), 0, ggml_nbytes(K));
+
+    buf.resize(D * S * Hk);
+    for (auto & x : buf) x = ggml_fp32_to_fp16((float)(rand() % 1000 - 500) / 500.0f);
+    ggml_backend_tensor_set(V, buf.data(), 0, ggml_nbytes(V));
+
+    ggml_backend_graph_compute(backend, gf);
+
+    const size_t n_elems   = ggml_nelements(sparse_out);
+    const size_t out_bytes = n_elems * sizeof(float);
+    std::vector<float> out_data(n_elems);
+    ggml_backend_tensor_get(sparse_out, out_data.data(), 0, out_bytes);
+
+    // Basic sanity: output must not be all zeros
+    float max_abs = 0.0f;
+    for (size_t i = 0; i < out_data.size(); i++) {
+        float v = fabsf(out_data[i]);
+        if (v > max_abs) max_abs = v;
+    }
+
+    bool pass = max_abs > 1e-6f;
+    printf("[test_sparse_alpha] alpha=%.2f S=%d H=%d Hk=%d D=%d max_abs=%.6f %s\n",
+           alpha, S, H, Hk, D, max_abs, pass ? "PASS" : "FAIL (all zeros)");
+
+    ggml_gallocr_free(alloc);
+    ggml_free(ctx);
+    return pass;
+}
+
+int main() {
+    ggml_backend_t backend = ggml_backend_cuda_init(0);
+    if (!backend) {
+        fprintf(stderr, "CUDA backend not available\n");
+        return 1;
+    }
+
+    pflash_register_ggml_kernel();
+
+    bool ok = true;
+    ok &= test_sparse_matches_dense(backend, 256, 16, 8, 128);   // small
+    ok &= test_sparse_matches_dense(backend, 1024, 16, 8, 128);  // medium
+    ok &= test_sparse_matches_dense(backend, 4096, 16, 8, 128);  // large
+
+    // Alpha < 1.0: pFlash kernel with moderate and aggressive sparsity
+    ok &= test_sparse_alpha(backend, 1024, 16, 8, 128, 0.5f);   // moderate sparsity
+    ok &= test_sparse_alpha(backend, 4096, 16, 8, 128, 0.12f);  // aggressive sparsity (default alpha)
+
+    ggml_backend_free(backend);
+    printf("\n%s\n", ok ? "ALL TESTS PASSED" : "SOME TESTS FAILED");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
PR #12 of the Gemma4 split sequence. Extends `dflash/scripts/tokenize_prompt.py` with a `--csv` output mode (comma-separated token IDs to stdout) for use with the `--tokens` flag of `test_gemma4_dflash`. Binary `--out` mode is preserved and made mutually exclusive with `--csv`.

## Stack note
Originally specced to base on PR #11 (MTP runtime). PR #11 is daemon-touching and deferred until the model-agnostic daemon refactor lands. This PR is rebased onto `split/gemma4-04-api-target-loader` instead — the script is independent of the C++ chain.
Depends transitively on #171 → #170 → #169 → #168.

## Scope
- `dflash/scripts/tokenize_prompt.py` only (+74 / -22).

## Default tokenizer change — explicit
The default value of `--model` changes from `Qwen/Qwen3.5-27B` to `google/gemma-4-26b-a4b-it`. Reviewers should explicitly accept this change. Both still work via explicit `--model`.

## Risk: Low-Medium (Python utility, no runtime C++ surface)

## Review checklist
- `--out` and `--csv` mutually exclusive via `argparse` group ✓
- Verbose / informational output goes to stderr when binary `--out` is used ✓
- Local-cache fallback via `local_files_only=True` first, no network when tokenizer is cached ✓
- Default tokenizer change called out above

## Validation
- `python3 -m py_compile dflash/scripts/tokenize_prompt.py` → OK
- Runtime invocation requires the Gemma4 tokenizer to be cached locally; not exercised in CI here.