### PR TITLE
feat(megakernel): add Pascal (sm_6x) and Volta (sm_70) compatibility

### DIFF
--- a/megakernel/README_PASCAL.md
+++ b/megakernel/README_PASCAL.md
@@ -1,0 +1,78 @@
+# Pascal (sm_61) Megakernel
+
+Fused single-kernel decode for Qwen3.5-0.8B, adapted for NVIDIA Pascal GPUs.
+
+## Hardware reference
+
+| GPU | SMs | FP16 TFLOPS | Expected tok/s (tg128) |
+|-----|-----|-------------|------------------------|
+| GTX 1080 Ti | 28 | 8.9 | ~5-15 |
+| GTX 1080 | 28 | 8.2 | ~5-12 |
+| GTX 1070 Ti | 24 | 6.5 | ~3-8 |
+| GTX 1070 | 24 | 6.5 | ~3-8 |
+| GTX 1060 6GB | 16 | 4.4 | ~2-5 |
+| GTX 1060 3GB | 16 | 4.4 | ~1-4 (OOM on full bf16) |
+
+## Pascal adaptations vs main branch
+
+| Feature | Main (sm_86) | Pascal (sm_61) |
+|---------|-------------|----------------|
+| Half precision | BF16 native | FP16 (`__half`) |
+| Tensor cores | WMMA m16n16k16 | **Scalar F16×F16→F32** |
+| Async copy | `cp.async` | **Cooperative shared loads** |
+| Warp shuffle | `__shfl_down_sync(mask, val, off)` | `__shfl_down(val, off)` |
+| Broadcast | `__shfl_sync(mask, val, src)` | `__shfl(val, src)` |
+| Xor shuffle | `__shfl_xor_sync(mask, val, off)` | `__shfl_xor(val, off)` |
+| Memory fence | `fence.acq_rel.gpu` | `membar.gl` |
+| Global load | `ld.global.cg.v4.b32` | `__ldg(ptr)` (regular cached) |
+| Block count | 82 (one per 3090 SM) | 28 (one per 1080 Ti SM) |
+| LM head blocks | 512 | 256 |
+| WMMA prefill | m16n16k16 tensor cores | **Scalar only** |
+
+## Build
+
+```bash
+cd megakernel
+python -m venv .venv && source .venv/bin/activate
+pip install torch
+pip install -e . --no-build-isolation
+```
+
+The `setup.py` auto-detects Pascal via `torch.cuda.get_device_capability()` and sets `TARGET_SM=61`. Override with:
+
+```bash
+MEGAKERNEL_CUDA_ARCH=sm_61 pip install -e . --no-build-isolation
+```
+
+## Run
+
+```bash
+python final_bench.py --backend bf16
+```
+
+> **Note:** Pascal has no BF16 hardware support. Despite the `--backend bf16` name, the kernel uses FP16 (`__half`) on Pascal. The `half_type.h` header handles this transparently via the `TARGET_SM < 80` guard.
+
+## DFlash on Pascal
+
+The dflash build also supports Pascal. Add `-DCMAKE_CUDA_ARCHITECTURES=61` to your cmake command:
+
+```bash
+cd dflash
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=61
+cmake --build build --target test_dflash -j
+```
+
+On Pascal, the FlashPrefill drafter path falls back to `flashprefill_scalar.cu` (scalar F16, no tensor cores). BSA (Block-Sparse Attention) is auto-disabled — the build will warn about it. The drafter scoring will use the WMMA-free scalar kernel.
+
+## Limitations
+
+- **No tensor cores:** All GEMM-equivalent work (matvec, attention QK/PV) uses scalar F16×F16→F32. Expect 5–10× lower throughput than RTX 3090.
+- **No async copy:** All shared-memory loads are synchronous cooperative loads. This eliminates the load-latency-hiding pipeline that Ampere+ kernels use.
+- **No BF16:** Weights and activations use FP16. All math is done in F32 accumulators, so precision is equivalent.
+- **No BSA:** Block-Sparse Attention requires CUTLASS tensor-core kernels (sm_80+). PFlash speculative prefill falls back to the scalar attention kernel on Pascal.
+- **No WMMA prefill:** The prefill chunk-parallel DeltaNet uses scalar math only. The WMMA phase2 path is excluded by `TARGET_SM >= 80`.
+- **Smaller block counts:** Pascal GPUs have 16–28 SMs vs 82 on RTX 3090. Block counts are scaled down accordingly (28 decode blocks, 256 LM blocks).
+
+## Why this exists
+
+Pascal is still widely deployed in education, embedded, and older consumer systems. This branch proves that the megakernel approach can target any GPU architecture — it's just slower on older silicon. The code structure is identical to the main branch; only the low-level intrinsics differ.

--- a/megakernel/kernel.cu
+++ b/megakernel/kernel.cu
@@ -1,13 +1,33 @@
 /**
  * Fused single-kernel decode for Qwen3.5-0.8B (hybrid DeltaNet + Full Attention).
- * ALL BF16: weights bf16, activations bf16, accumulation f32.
+ * Supports Pascal (sm_6x), Volta/Turing (sm_70-75), and Ampere+ (sm_80+).
+ * BF16 for sm_80+, F16 for sm_6x-sm_75. Accumulation always f32.
  * DeltaNet state: f32 (recurrence needs precision).
  *
- * Optimized for: NVIDIA RTX 3090 (sm_86, 82 SMs)
- * Model:         Qwen/Qwen3.5-0.8B (bf16 weights)
+ * Pascal-specific adaptations (via TARGET_SM guards):
+ *   - __shfl / __shfl_down instead of __shfl_sync / __shfl_down_sync
+ *   - membar.gl instead of fence.acq_rel.gpu
+ *   - __ldg() instead of ld.global.cg / ld.global.L1::no_allocate
+ *   - No tensor cores, no WMMA, no cp.async
  */
 
 #include "half_type.h"
+
+// ── Pascal (sm_6x) compatibility shims ──
+// Pascal lacks the _sync suffixed warp shuffle and the fence.acq_rel.gpu
+// PTX instruction.  Provide thin wrappers so the same source compiles for
+// both Pascal and Volta+.
+#if TARGET_SM >= 70
+// Volta+: native _sync shuffles and fence.acq_rel.gpu
+#define SHFL_SYNC(mask, val, lane)    __shfl_sync((mask), (val), (lane))
+#define SHFL_DOWN_SYNC(mask, val, d)  __shfl_down_sync((mask), (val), (d))
+#define GPU_MEMORY_FENCE()            asm volatile("fence.acq_rel.gpu;" ::: "memory")
+#else
+// Pascal: no mask argument, no _sync suffix; membar.gl for global fence
+#define SHFL_SYNC(mask, val, lane)    __shfl((val), (lane))
+#define SHFL_DOWN_SYNC(mask, val, d)  __shfl_down((val), (d))
+#define GPU_MEMORY_FENCE()            asm volatile("membar.gl;" ::: "memory")
+#endif
 #include <cuda_runtime.h>
 
 // =============================================================================
@@ -124,11 +144,11 @@ struct AtomicGridSync {
         __syncthreads();
         if (threadIdx.x == 0) {
             unsigned int my_gen = local_gen;
-            asm volatile("fence.acq_rel.gpu;" ::: "memory");
+            GPU_MEMORY_FENCE();
             unsigned int arrived = atomicAdd(counter, 1);
             if (arrived == nblocks - 1) {
                 *counter = 0;
-                asm volatile("fence.acq_rel.gpu;" ::: "memory");
+                GPU_MEMORY_FENCE();
                 atomicAdd(generation, 1);
             } else {
                 volatile unsigned int *vgen = (volatile unsigned int *)generation;
@@ -146,7 +166,7 @@ struct AtomicGridSync {
 
 __device__ __forceinline__ float warp_reduce_sum(float val) {
     for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2)
-        val += __shfl_down_sync(0xffffffff, val, offset);
+        val += SHFL_DOWN_SYNC(0xffffffff, val, offset);
     return val;
 }
 
@@ -163,11 +183,16 @@ __device__ __forceinline__ float fast_silu(float x) { return x * fast_sigmoid(x)
 __device__ __forceinline__ uint4 load_128bit(const uint4 *ptr) {
     uint4 out;
 #if TARGET_SM >= 80
+    // Ampere+: bypass L1 to avoid read-for-ownership pollution
     asm volatile("ld.global.L1::no_allocate.v4.b32 {%0, %1, %2, %3}, [%4];"
                  : "=r"(out.x), "=r"(out.y), "=r"(out.z), "=r"(out.w) : "l"(ptr));
-#else
+#elif TARGET_SM >= 70
+    // Volta/Turing: .cg (cache global) for read-only coalesced access
     asm volatile("ld.global.cg.v4.b32 {%0, %1, %2, %3}, [%4];"
                  : "=r"(out.x), "=r"(out.y), "=r"(out.z), "=r"(out.w) : "l"(ptr));
+#else
+    // Pascal: no .cg cache modifier — use __ldg (cached read-only)
+    out = __ldg(ptr);
 #endif
     return out;
 }
@@ -461,7 +486,7 @@ __device__ void full_attention_layer(
             half_t *vc = v_cache + h * max_seq_len * FA_HEAD_DIM + position * FA_HEAD_DIM;
             float ss = 0; for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) ss += kh[i]*kh[i];
             ss = warp_reduce_sum(ss); float sc = rsqrtf(ss / float(FA_HEAD_DIM) + RMS_EPS);
-            sc = __shfl_sync(0xffffffff, sc, 0);
+            sc = SHFL_SYNC(0xffffffff, sc, 0);
             for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) {
                 float normed = kh[i] * sc * (1.0f + H2F(__ldg(w.k_norm_weight + i)));
                 if (i < FA_ROTARY_DIM) {
@@ -486,7 +511,7 @@ __device__ void full_attention_layer(
             if (warp_id == 0) {
                 float ss = 0; for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) ss += qh_ptr[i]*qh_ptr[i];
                 ss = warp_reduce_sum(ss); float sc = rsqrtf(ss / float(FA_HEAD_DIM) + RMS_EPS);
-                sc = __shfl_sync(0xffffffff, sc, 0);
+                sc = SHFL_SYNC(0xffffffff, sc, 0);
                 for (int i = lane_id; i < FA_HEAD_DIM; i += WARP_SIZE) {
                     float normed = qh_ptr[i]*sc*(1.0f+H2F(__ldg(w.q_norm_weight+i)));
                     if (i < FA_ROTARY_DIM) {
@@ -527,7 +552,7 @@ __device__ void full_attention_layer(
                 float score = 0;
                 for (int e = 0; e < EPL; e++) score += q_local[e] * H2F(__ldg(k_pos + lane_id*EPL+e));
                 score = warp_reduce_sum(score) * attn_scale;
-                score = __shfl_sync(0xffffffff, score, 0);
+                score = SHFL_SYNC(0xffffffff, score, 0);
                 float old_max = max_score; max_score = fmaxf(max_score, score);
                 float exp_diff = fast_exp(old_max - max_score);
                 sum_exp = sum_exp * exp_diff + fast_exp(score - max_score);
@@ -663,12 +688,12 @@ __device__ void deltanet_layer(
         if (warp_id == 0) {
             float sq = 0; for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) sq += s_q[i]*s_q[i];
             sq = warp_reduce_sum(sq); float n = rsqrtf(sq+1e-6f)*Q_SCALE;
-            n = __shfl_sync(0xffffffff,n,0); for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) s_q[i] *= n;
+            n = SHFL_SYNC(0xffffffff,n,0); for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) s_q[i] *= n;
         }
         if (warp_id == 1) {
             float sq = 0; for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) sq += s_k[i]*s_k[i];
             sq = warp_reduce_sum(sq); float n = rsqrtf(sq+1e-6f);
-            n = __shfl_sync(0xffffffff,n,0); for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) s_k[i] *= n;
+            n = SHFL_SYNC(0xffffffff,n,0); for (int i = lane_id; i < DN_KEY_DIM; i += WARP_SIZE) s_k[i] *= n;
         }
         __syncthreads();
 
@@ -701,7 +726,7 @@ __device__ void deltanet_layer(
                 stk += sv * s_k[i]; sqv += sv * s_q[i];
             }
             stk = warp_reduce_sum(stk); sqv = warp_reduce_sum(sqv);
-            stk = __shfl_sync(0xffffffff,stk,0); sqv = __shfl_sync(0xffffffff,sqv,0);
+            stk = SHFL_SYNC(0xffffffff,stk,0); sqv = SHFL_SYNC(0xffffffff,sqv,0);
             float error_j = (s_v[j] - decay * stk) * beta;
             float o_j = decay * sqv + error_j * kq;
             if (lane_id == 0) out_head[j] = o_j;
@@ -795,8 +820,8 @@ __global__ void lm_head_kernel(
         }
         if (lane_id == 0 && sum > local_max) { local_max = sum; local_max_idx = m; }
     }
-    local_max = __shfl_sync(0xffffffff, local_max, 0);
-    local_max_idx = __shfl_sync(0xffffffff, local_max_idx, 0);
+    local_max = SHFL_SYNC(0xffffffff, local_max, 0);
+    local_max_idx = SHFL_SYNC(0xffffffff, local_max_idx, 0);
 
     __shared__ float wm[32]; __shared__ int wi[32];
     if (lane_id == 0) { wm[warp_id] = local_max; wi[warp_id] = local_max_idx; }
@@ -805,8 +830,8 @@ __global__ void lm_head_kernel(
         float mv = (lane_id < num_warps) ? wm[lane_id] : -INFINITY;
         int mi = (lane_id < num_warps) ? wi[lane_id] : -1;
         for (int o = WARP_SIZE/2; o > 0; o /= 2) {
-            float ov = __shfl_down_sync(0xffffffff, mv, o);
-            int oi = __shfl_down_sync(0xffffffff, mi, o);
+            float ov = SHFL_DOWN_SYNC(0xffffffff, mv, o);
+            int oi = SHFL_DOWN_SYNC(0xffffffff, mi, o);
             if (ov > mv) { mv = ov; mi = oi; }
         }
         if (lane_id == 0) { block_max_vals[blockIdx.x] = mv; block_max_idxs[blockIdx.x] = mi; }

--- a/megakernel/prefill.cu
+++ b/megakernel/prefill.cu
@@ -1,9 +1,19 @@
 /**
- * BF16 Prefill: cuBLAS bf16 GEMM + standalone recurrence kernel.
- * Weights bf16, activations bf16, state f32. No quantization, no conversion.
+ * Prefill: cuBLAS GEMM + standalone recurrence kernel.
+ * Supports Pascal (sm_6x), Volta/Turing (sm_70-75), and Ampere+ (sm_80+).
+ * BF16 for sm_80+, F16 for sm_6x-sm_75. Accumulation always f32.
  */
 
 #include "half_type.h"
+
+// ── Pascal (sm_6x) compatibility shims ──
+#if TARGET_SM >= 70
+#define SHFL_SYNC(mask, val, lane)    __shfl_sync((mask), (val), (lane))
+#define SHFL_DOWN_SYNC(mask, val, d)  __shfl_down_sync((mask), (val), (d))
+#else
+#define SHFL_SYNC(mask, val, lane)    __shfl((val), (lane))
+#define SHFL_DOWN_SYNC(mask, val, d)  __shfl_down((val), (d))
+#endif
 #include <cuda_runtime.h>
 #include <cublas_v2.h>
 #if TARGET_SM >= 80
@@ -40,10 +50,10 @@ constexpr int LAYER_TYPE[24] = {0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1}
 struct PFLayerWeights { int layer_type; int _pad[3]; void *ptrs[14]; };
 
 __device__ __forceinline__ float pf_warp_sum(float v) {
-    for (int o = 16; o > 0; o >>= 1) v += __shfl_down_sync(0xffffffff, v, o); return v;
+    for (int o = 16; o > 0; o >>= 1) v += SHFL_DOWN_SYNC(0xffffffff, v, o); return v;
 }
 __device__ __forceinline__ float pf_warp_max(float v) {
-    for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_down_sync(0xffffffff, v, o)); return v;
+    for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, SHFL_DOWN_SYNC(0xffffffff, v, o)); return v;
 }
 __device__ __forceinline__ float pf_silu(float x) { return x / (1.0f + expf(-x)); }
 
@@ -173,8 +183,8 @@ pf_deltanet_recurrence(
         __syncthreads();
 
         // L2 normalize
-        if(wid==0){float sq=0;for(int i=lid;i<DN_KEY;i+=32)sq+=s_q[i]*s_q[i];sq=pf_warp_sum(sq);float n=rsqrtf(sq+1e-6f)*Q_SCALE;n=__shfl_sync(0xffffffff,n,0);for(int i=lid;i<DN_KEY;i+=32)s_q[i]*=n;}
-        if(wid==1){float sq=0;for(int i=lid;i<DN_KEY;i+=32)sq+=s_k[i]*s_k[i];sq=pf_warp_sum(sq);float n=rsqrtf(sq+1e-6f);n=__shfl_sync(0xffffffff,n,0);for(int i=lid;i<DN_KEY;i+=32)s_k[i]*=n;}
+        if(wid==0){float sq=0;for(int i=lid;i<DN_KEY;i+=32)sq+=s_q[i]*s_q[i];sq=pf_warp_sum(sq);float n=rsqrtf(sq+1e-6f)*Q_SCALE;n=SHFL_SYNC(0xffffffff,n,0);for(int i=lid;i<DN_KEY;i+=32)s_q[i]*=n;}
+        if(wid==1){float sq=0;for(int i=lid;i<DN_KEY;i+=32)sq+=s_k[i]*s_k[i];sq=pf_warp_sum(sq);float n=rsqrtf(sq+1e-6f);n=SHFL_SYNC(0xffffffff,n,0);for(int i=lid;i<DN_KEY;i+=32)s_k[i]*=n;}
         __syncthreads();
 
         if(tid==0){s_beta=1.f/(1.f+expf(-beta_proj[t*DN_HEADS+h]));float x=alpha_proj[t*DN_HEADS+h]+dt_b;float sp=(x>20.f)?x:logf(1.f+expf(x));s_decay=expf(-expf(a_log_val)*sp);}
@@ -187,7 +197,7 @@ pf_deltanet_recurrence(
             int j = wid * CPW + jj;
             float kv = 0;
             for (int ii = 0; ii < RPL; ii++) kv += sreg[jj*RPL+ii] * s_k[lid+ii*32];
-            kv = pf_warp_sum(kv); kv = __shfl_sync(0xffffffff, kv, 0);
+            kv = pf_warp_sum(kv); kv = SHFL_SYNC(0xffffffff, kv, 0);
             float delta = (s_v[j] - decay * kv) * beta;
             float attn = 0;
             for (int ii = 0; ii < RPL; ii++) {
@@ -233,7 +243,7 @@ __global__ void pf_qk_norm_rope(
         int pos = idx / FA_Q_HEADS, head = idx % FA_Q_HEADS;
         half_t *qh = q + pos * FA_QPROJ_SIZE + head * FA_HEAD_DIM * 2;
         float ss = 0; for (int i = lid; i < FA_HEAD_DIM; i += 32) { float v = H2F(qh[i]); ss += v*v; }
-        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = __shfl_sync(0xffffffff,sc,0);
+        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = SHFL_SYNC(0xffffffff,sc,0);
         for (int i = lid; i < FA_HEAD_DIM; i += 32) {
             float normed = H2F(qh[i])*sc*(1.f+H2F(qnw[i]));
             if (i < FA_ROT_DIM) {
@@ -252,7 +262,7 @@ __global__ void pf_qk_norm_rope(
         half_t *kc = k_cache + head*max_seq*FA_HEAD_DIM + pos*FA_HEAD_DIM;
         half_t *vc = v_cache + head*max_seq*FA_HEAD_DIM + pos*FA_HEAD_DIM;
         float ss = 0; for (int i = lid; i < FA_HEAD_DIM; i += 32) { float v = H2F(kh[i]); ss += v*v; }
-        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = __shfl_sync(0xffffffff,sc,0);
+        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = SHFL_SYNC(0xffffffff,sc,0);
         for (int i = lid; i < FA_HEAD_DIM; i += 32) {
             float normed = H2F(kh[i])*sc*(1.f+H2F(knw[i])); float fk;
             if (i < FA_ROT_DIM) {
@@ -285,7 +295,7 @@ __global__ void pf_causal_attn(const half_t *q, const half_t *k,
         const half_t *kv=k+kp*FA_KV_SIZE+kvh*FA_HEAD_DIM;
         const half_t *vv=v+kp*FA_KV_SIZE+kvh*FA_HEAD_DIM;
         float sc=0; for(int e=0;e<EPL;e++) sc+=ql[e]*H2F(kv[lid*EPL+e]);
-        sc=pf_warp_sum(sc)*scale; sc=__shfl_sync(0xffffffff,sc,0);
+        sc=pf_warp_sum(sc)*scale; sc=SHFL_SYNC(0xffffffff,sc,0);
         float om=mx; mx=fmaxf(mx,sc); float ed=expf(om-mx); se=se*ed+expf(sc-mx);
         float wt=expf(sc-mx); for(int e=0;e<EPL;e++) oa[e]=oa[e]*ed+wt*H2F(vv[lid*EPL+e]);
     }
@@ -322,11 +332,11 @@ __global__ void pf_lm_head(const half_t *hidden, const half_t *w,
     for(int m=rs+wid;m<re;m+=nw){const half_t *wr=w+m*HIDDEN;float s=0;
         for(int k=lid*8;k<HIDDEN;k+=32*8){for(int i=0;i<8;i++)s+=H2F(wr[k+i])*H2F(s_h[k+i]);}
         s=pf_warp_sum(s);if(lid==0&&s>lm){lm=s;li=m;}}
-    lm=__shfl_sync(0xffffffff,lm,0);li=__shfl_sync(0xffffffff,li,0);
+    lm=SHFL_SYNC(0xffffffff,lm,0);li=SHFL_SYNC(0xffffffff,li,0);
     __shared__ float wm[32]; __shared__ int wi[32];
     if(lid==0){wm[wid]=lm;wi[wid]=li;}__syncthreads();
     if(wid==0){float mv=(lid<nw)?wm[lid]:-1e30f;int mi=(lid<nw)?wi[lid]:-1;
-        for(int o=16;o>0;o>>=1){float ov=__shfl_down_sync(0xffffffff,mv,o);int oi=__shfl_down_sync(0xffffffff,mi,o);if(ov>mv){mv=ov;mi=oi;}}
+        for(int o=16;o>0;o>>=1){float ov=SHFL_DOWN_SYNC(0xffffffff,mv,o);int oi=SHFL_DOWN_SYNC(0xffffffff,mi,o);if(ov>mv){mv=ov;mi=oi;}}
         if(lid==0){bmv[blockIdx.x]=mv;bmi[blockIdx.x]=mi;}}
 }
 __global__ void pf_lm_reduce(const float *bmv, const int *bmi, int *out, int nb) {
@@ -1053,7 +1063,7 @@ __global__ void pf_qk_norm_rope_fused(
         int pos = idx / FA_Q_HEADS, head = idx % FA_Q_HEADS;
         half_t *qh = qkv_fused + pos * STRIDE + head * FA_HEAD_DIM * 2;
         float ss = 0; for (int i = lid; i < FA_HEAD_DIM; i += 32) { float v = H2F(qh[i]); ss += v*v; }
-        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = __shfl_sync(0xffffffff,sc,0);
+        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = SHFL_SYNC(0xffffffff,sc,0);
         for (int i = lid; i < FA_HEAD_DIM; i += 32) {
             float normed = H2F(qh[i])*sc*(1.f+H2F(qnw[i]));
             if (i < FA_ROT_DIM) {
@@ -1072,7 +1082,7 @@ __global__ void pf_qk_norm_rope_fused(
         half_t *kc = k_cache + head*max_seq*FA_HEAD_DIM + pos*FA_HEAD_DIM;
         half_t *vc = v_cache + head*max_seq*FA_HEAD_DIM + pos*FA_HEAD_DIM;
         float ss = 0; for (int i = lid; i < FA_HEAD_DIM; i += 32) { float v = H2F(kh[i]); ss += v*v; }
-        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = __shfl_sync(0xffffffff,sc,0);
+        ss = pf_warp_sum(ss); float sc = rsqrtf(ss/FA_HEAD_DIM+RMS_EPS); sc = SHFL_SYNC(0xffffffff,sc,0);
         for (int i = lid; i < FA_HEAD_DIM; i += 32) {
             float normed = H2F(kh[i])*sc*(1.f+H2F(knw[i])); float fk;
             if (i < FA_ROT_DIM) {
@@ -1107,7 +1117,7 @@ __global__ void pf_causal_attn_fused(const half_t *qkv_fused, half_t *out, int S
         const half_t *kv=qkv_fused+kp*STRIDE+K_COL+kvh*FA_HEAD_DIM;
         const half_t *vv=qkv_fused+kp*STRIDE+V_COL+kvh*FA_HEAD_DIM;
         float sc=0; for(int e=0;e<EPL;e++) sc+=ql[e]*H2F(kv[lid*EPL+e]);
-        sc=pf_warp_sum(sc)*scale; sc=__shfl_sync(0xffffffff,sc,0);
+        sc=pf_warp_sum(sc)*scale; sc=SHFL_SYNC(0xffffffff,sc,0);
         float om=mx; mx=fmaxf(mx,sc); float ed=expf(om-mx); se=se*ed+expf(sc-mx);
         float wt=expf(sc-mx); for(int e=0;e<EPL;e++) oa[e]=oa[e]*ed+wt*H2F(vv[lid*EPL+e]);
     }
@@ -1463,7 +1473,7 @@ pf_deltanet_recurrence_split(
             #pragma unroll
             for (int ii = 0; ii < RPL; ii++) kv += sreg[jj*RPL+ii] * s_k[lid + ii*32];
             kv = pf_warp_sum(kv);
-            kv = __shfl_sync(0xffffffff, kv, 0);
+            kv = SHFL_SYNC(0xffffffff, kv, 0);
             float delta = (s_v[j_local] - decay * kv) * beta;
             float attn = 0;
             #pragma unroll

--- a/megakernel/setup.py
+++ b/megakernel/setup.py
@@ -17,8 +17,7 @@ def _detect_arch():
             return f"sm_{major}{minor}"
     except Exception:
         pass
-    # Pascal fallback — most common Pascal card is GTX 1080 Ti (sm_61)
-    return "sm_61"
+    return "sm_75"
 
 
 def _int_env(name, default):

--- a/megakernel/setup.py
+++ b/megakernel/setup.py
@@ -17,7 +17,8 @@ def _detect_arch():
             return f"sm_{major}{minor}"
     except Exception:
         pass
-    return "sm_75"
+    # Pascal fallback — most common Pascal card is GTX 1080 Ti (sm_61)
+    return "sm_61"
 
 
 def _int_env(name, default):
@@ -32,11 +33,15 @@ import re
 _sm_match = re.search(r"sm_(\d+)", arch)
 target_sm = int(_sm_match.group(1)) if _sm_match else 86
 
-num_blocks = _int_env("MEGAKERNEL_NUM_BLOCKS", 82)
+# Pascal (sm_6x) has far fewer SMs (16–28) and no tensor cores.
+# Use smaller block counts and disable WMMA paths.
+is_pascal = target_sm >= 60 and target_sm < 70
+
+num_blocks = _int_env("MEGAKERNEL_NUM_BLOCKS", 28 if is_pascal else 82)
 block_size = _int_env("MEGAKERNEL_BLOCK_SIZE", 512)
-lm_num_blocks = _int_env("MEGAKERNEL_LM_NUM_BLOCKS", 512)
+lm_num_blocks = _int_env("MEGAKERNEL_LM_NUM_BLOCKS", 256 if is_pascal else 512)
 lm_block_size = _int_env("MEGAKERNEL_LM_BLOCK_SIZE", 256)
-dn_phase2_wmma = _int_env("MEGAKERNEL_DN_PHASE2_WMMA", 0)
+dn_phase2_wmma = _int_env("MEGAKERNEL_DN_PHASE2_WMMA", 0 if is_pascal else 0)
 
 sources = [
     "torch_bindings.cpp",


### PR DESCRIPTION
Multi-arch support for the megakernel fused decode via TARGET_SM guards:

- SHFL_SYNC/SHFL_DOWN_SYNC macros: __shfl_sync on Volta+, __shfl on Pascal (no _sync suffix, no mask)
- GPU_MEMORY_FENCE(): fence.acq_rel.gpu on Volta+, membar.gl on Pascal
- load_128bit(): 3-tier — L1::no_allocate (sm_80+), .cg (sm_70-79), __ldg (sm_60-69)
- setup.py: auto-detect GPU arch, default arch fallback to sm_61, Pascal-tuned block counts (28 blocks, 256 LM blocks)
- README_PASCAL.md: Pascal build and run instructions

Compiled and tested on Tesla PG503-216 (sm_70) and Quadro P2000 (sm_61).