### PR TITLE
refactor(scripts): organize placement launch plumbing

### DIFF
--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -16,7 +16,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-from placement.backend_device import apply_backend_visible_devices, TestDflashLaunchArgs
+from placement.backend_device import apply_backend_visible_devices
+from placement.test_dflash_args import TestDflashLaunchArgs
 
 
 ROOT = Path(__file__).resolve().parent.parent

--- a/dflash/scripts/phase_split_dual_gpu.py
+++ b/dflash/scripts/phase_split_dual_gpu.py
@@ -23,7 +23,8 @@ from pathlib import Path
 from statistics import mean
 from typing import Iterable
 
-from placement.backend_device import apply_backend_visible_devices, TestDflashLaunchArgs
+from placement.backend_device import apply_backend_visible_devices
+from placement.test_dflash_args import TestDflashLaunchArgs
 
 
 ROOT = Path(__file__).resolve().parent.parent

--- a/dflash/scripts/placement/__init__.py
+++ b/dflash/scripts/placement/__init__.py
@@ -1,1 +1,1 @@
-"""Script-side backend/device placement helpers."""
+"""Script-side placement helpers."""

--- a/dflash/scripts/placement/backend_device.py
+++ b/dflash/scripts/placement/backend_device.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 """Shared backend/device placement plumbing for script-side test_dflash launchers."""
 
 import os
-from dataclasses import dataclass
 
 
 def resolve_visible_devices(visible_devices: str | None,
@@ -32,50 +31,3 @@ def apply_backend_visible_devices(backend: str,
         env["ROCR_VISIBLE_DEVICES"] = resolved
         return env
     raise ValueError(f"unknown backend: {backend!r}")
-
-
-@dataclass(frozen=True)
-class TestDflashLaunchArgs:
-    draft_feature_mirror: bool = False
-    peer_access: bool = False
-    target_gpu: int | None = None
-    draft_gpu: int | None = None
-    target_gpus: str | None = None
-    target_layer_split: str | None = None
-    target_split_load_draft: bool = False
-    target_split_dflash: bool = False
-    draft_ipc_bin: str | None = None
-    draft_ipc_gpu: int | None = None
-    draft_ipc_work_dir: str | None = None
-    draft_ipc_ring_cap: int | None = None
-    max_ctx: int | None = None
-
-    def to_cli_args(self) -> list[str]:
-        out: list[str] = []
-        if self.draft_feature_mirror:
-            out.append("--draft-feature-mirror")
-        if self.peer_access:
-            out.append("--peer-access")
-        if self.target_gpu is not None:
-            out.append(f"--target-gpu={self.target_gpu}")
-        if self.draft_gpu is not None:
-            out.append(f"--draft-gpu={self.draft_gpu}")
-        if self.target_gpus:
-            out.append(f"--target-gpus={self.target_gpus}")
-        if self.target_layer_split:
-            out.append(f"--target-layer-split={self.target_layer_split}")
-        if self.target_split_load_draft:
-            out.append("--target-split-load-draft")
-        if self.target_split_dflash:
-            out.append("--target-split-dflash")
-        if self.draft_ipc_bin:
-            out.append(f"--draft-ipc-bin={self.draft_ipc_bin}")
-        if self.draft_ipc_gpu is not None:
-            out.append(f"--draft-ipc-gpu={self.draft_ipc_gpu}")
-        if self.draft_ipc_work_dir:
-            out.append(f"--draft-ipc-work-dir={self.draft_ipc_work_dir}")
-        if self.draft_ipc_ring_cap is not None:
-            out.append(f"--draft-ipc-ring-cap={self.draft_ipc_ring_cap}")
-        if self.max_ctx is not None:
-            out.append(f"--max-ctx={self.max_ctx}")
-        return out

--- a/dflash/scripts/placement/server_resolver.py
+++ b/dflash/scripts/placement/server_resolver.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Server-side placement resolution before daemon launch."""
+
+from dataclasses import dataclass
+from typing import MutableMapping
+
+from .test_dflash_args import TestDflashLaunchArgs
+
+
+@dataclass(frozen=True)
+class ServerPlacement:
+    env_updates: dict[str, str]
+    daemon_args: list[str]
+    prefix_cache_slots: int
+    prefill_cache_slots: int
+    target_gpu: int | None
+    draft_gpu: int | None
+    target_gpus: str | None
+    target_layer_split: str | None
+    draft_feature_mirror: bool
+    peer_access: bool
+    cache_slots_disabled: bool = False
+
+    def apply_env(self, env: MutableMapping[str, str]) -> None:
+        env.update(self.env_updates)
+
+    def log_lines(self) -> list[str]:
+        lines = [
+            f"  placement = {'target-gpus' if self.target_gpus else 'single-target'}",
+        ]
+        if self.target_gpu is not None:
+            lines.append(f"    target_gpu = {self.target_gpu}")
+        if self.draft_gpu is not None:
+            lines.append(f"    draft_gpu  = {self.draft_gpu}")
+        if self.target_gpus:
+            lines.append(f"    target_gpus = {self.target_gpus}")
+            lines.append(f"    layer_split = {self.target_layer_split or '<default>'}")
+        if self.draft_feature_mirror:
+            lines.append("    draft_feature_mirror = on")
+        if self.peer_access:
+            lines.append("    peer_access = on")
+        return lines
+
+
+def resolve_server_placement(args) -> ServerPlacement:
+    env_updates: dict[str, str] = {}
+    if args.target_gpu is not None:
+        env_updates["DFLASH_TARGET_GPU"] = str(args.target_gpu)
+    if args.draft_gpu is not None:
+        env_updates["DFLASH_DRAFT_GPU"] = str(args.draft_gpu)
+
+    daemon_cfg = TestDflashLaunchArgs(
+        draft_feature_mirror=args.draft_feature_mirror,
+        peer_access=args.peer_access,
+    )
+
+    prefix_cache_slots = args.prefix_cache_slots
+    prefill_cache_slots = args.prefill_cache_slots
+    cache_slots_disabled = False
+
+    if args.target_gpus:
+        daemon_cfg = TestDflashLaunchArgs(
+            draft_feature_mirror=args.draft_feature_mirror,
+            peer_access=args.peer_access,
+            target_gpus=args.target_gpus,
+            target_layer_split=args.target_layer_split,
+            target_split_load_draft=True,
+            target_split_dflash=True,
+        )
+        cache_slots_disabled = prefix_cache_slots > 0 or prefill_cache_slots > 0
+        if cache_slots_disabled:
+            prefix_cache_slots = 0
+            prefill_cache_slots = 0
+
+    return ServerPlacement(
+        env_updates=env_updates,
+        daemon_args=daemon_cfg.to_cli_args(),
+        prefix_cache_slots=prefix_cache_slots,
+        prefill_cache_slots=prefill_cache_slots,
+        target_gpu=args.target_gpu,
+        draft_gpu=args.draft_gpu,
+        target_gpus=args.target_gpus,
+        target_layer_split=args.target_layer_split,
+        draft_feature_mirror=args.draft_feature_mirror,
+        peer_access=args.peer_access,
+        cache_slots_disabled=cache_slots_disabled,
+    )

--- a/dflash/scripts/placement/test_dflash_args.py
+++ b/dflash/scripts/placement/test_dflash_args.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Shared test_dflash daemon argument serialization."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TestDflashLaunchArgs:
+    draft_feature_mirror: bool = False
+    peer_access: bool = False
+    target_gpu: int | None = None
+    draft_gpu: int | None = None
+    target_gpus: str | None = None
+    target_layer_split: str | None = None
+    target_split_load_draft: bool = False
+    target_split_dflash: bool = False
+    draft_ipc_bin: str | None = None
+    draft_ipc_gpu: int | None = None
+    draft_ipc_work_dir: str | None = None
+    draft_ipc_ring_cap: int | None = None
+    max_ctx: int | None = None
+
+    def to_cli_args(self) -> list[str]:
+        out: list[str] = []
+        if self.draft_feature_mirror:
+            out.append("--draft-feature-mirror")
+        if self.peer_access:
+            out.append("--peer-access")
+        if self.target_gpu is not None:
+            out.append(f"--target-gpu={self.target_gpu}")
+        if self.draft_gpu is not None:
+            out.append(f"--draft-gpu={self.draft_gpu}")
+        if self.target_gpus:
+            out.append(f"--target-gpus={self.target_gpus}")
+        if self.target_layer_split:
+            out.append(f"--target-layer-split={self.target_layer_split}")
+        if self.target_split_load_draft:
+            out.append("--target-split-load-draft")
+        if self.target_split_dflash:
+            out.append("--target-split-dflash")
+        if self.draft_ipc_bin:
+            out.append(f"--draft-ipc-bin={self.draft_ipc_bin}")
+        if self.draft_ipc_gpu is not None:
+            out.append(f"--draft-ipc-gpu={self.draft_ipc_gpu}")
+        if self.draft_ipc_work_dir:
+            out.append(f"--draft-ipc-work-dir={self.draft_ipc_work_dir}")
+        if self.draft_ipc_ring_cap is not None:
+            out.append(f"--draft-ipc-ring-cap={self.draft_ipc_ring_cap}")
+        if self.max_ctx is not None:
+            out.append(f"--max-ctx={self.max_ctx}")
+        return out

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -40,7 +40,7 @@ from _prefill_hook import (
     PrefillConfig, add_cli_flags, config_from_args,
     compress_text_via_daemon, _drain_until_sentinel,
 )
-from placement.backend_device import TestDflashLaunchArgs
+from placement.server_resolver import resolve_server_placement
 from prefix_cache import DaemonStdoutBus, PrefixCache
 from tool_memory import ToolMemory
 
@@ -2371,10 +2371,8 @@ def main():
     if args.fa_window is not None:
         os.environ["DFLASH27B_FA_WINDOW"] = str(args.fa_window)
 
-    if args.target_gpu is not None:
-        os.environ["DFLASH_TARGET_GPU"] = str(args.target_gpu)
-    if args.draft_gpu is not None:
-        os.environ["DFLASH_DRAFT_GPU"] = str(args.draft_gpu)
+    placement = resolve_server_placement(args)
+    placement.apply_env(os.environ)
 
     if args.prefill_compression != "off":
         os.environ.setdefault("DFLASH27B_LM_HEAD_FIX", "0")
@@ -2421,36 +2419,18 @@ def main():
         drafter_tokenizer = AutoTokenizer.from_pretrained(
             prefill_cfg.drafter_tokenizer_id, trust_remote_code=True)
 
-    extra_daemon_cfg = TestDflashLaunchArgs(
-        draft_feature_mirror=args.draft_feature_mirror,
-        peer_access=args.peer_access,
-    )
-    if args.target_gpus:
-        extra_daemon_cfg = TestDflashLaunchArgs(
-            draft_feature_mirror=args.draft_feature_mirror,
-            peer_access=args.peer_access,
-            target_gpus=args.target_gpus,
-            target_layer_split=args.target_layer_split,
-            # Keep sharded daemon behavior aligned with the single-GPU server path.
-            target_split_load_draft=True,
-            target_split_dflash=True,
-        )
-        # Multi-GPU daemon mode currently does not implement SNAPSHOT/RESTORE.
-        if args.prefix_cache_slots > 0 or args.prefill_cache_slots > 0:
-            print("  [cfg] target-gpus daemon mode disables prefix/full cache slots (snapshot protocol unsupported)")
-            args.prefix_cache_slots = 0
-            args.prefill_cache_slots = 0
-    extra_daemon = extra_daemon_cfg.to_cli_args()
+    if placement.cache_slots_disabled:
+        print("  [cfg] target-gpus daemon mode disables prefix/full cache slots (snapshot protocol unsupported)")
 
     app = build_app(args.target, draft, args.bin, args.budget, args.max_ctx,
                     tokenizer, stop_ids,
                     prefill_cfg=prefill_cfg if prefill_cfg.enabled else None,
                     drafter_tokenizer=drafter_tokenizer,
-                    prefix_cache_slots=args.prefix_cache_slots,
-                    prefill_cache_slots=args.prefill_cache_slots,
+                    prefix_cache_slots=placement.prefix_cache_slots,
+                    prefill_cache_slots=placement.prefill_cache_slots,
                     prefill_cache_bytes=args.prefill_cache_bytes,
                     arch=arch,
-                    extra_daemon_args=extra_daemon or None,
+                    extra_daemon_args=placement.daemon_args or None,
                     lazy_draft=args.lazy_draft,
                     verbose_daemon=args.verbose_daemon)
 
@@ -2468,6 +2448,8 @@ def main():
     print(f"  budget    = {args.budget}")
     print(f"  max_ctx   = {args.max_ctx}")
     print(f"  tokenizer = {tokenizer_id}")
+    for line in placement.log_lines():
+        print(line)
     if args.lazy_draft:
         print("  lazy_draft= ON (decode draft parked when idle)")
     if args.verbose_daemon:


### PR DESCRIPTION
## Summary

This PR organizes script/server placement launch plumbing under `dflash/scripts/placement/`.

It is a behavior-preserving foundation PR before the CUDA/HIP mixed-backend and server integration work. It does not add a new runtime feature; it separates the shared placement primitives from entrypoint-specific policy so bench harnesses and the OpenAI-compatible server can build on the same structure.

## Background

The server already has a thin pass-through for target/draft placement and target-sharding flags from the sharded target daemon work. It forwards arguments such as `--target-gpus`, `--target-layer-split`, `--draft-feature-mirror`, and `--peer-access` to `test_dflash`.

That path works today, but the placement responsibilities were not clearly separated:

- backend visible-device env handling lived next to daemon argument serialization
- bench harnesses and the PFlash phase-split harness reused the shared helpers
- `server.py` still assembled its daemon env, daemon args, target-gpus cache-slot policy, and startup placement logs inline

Before adding CUDA/HIP mixed-backend server support, this PR makes those boundaries explicit.

## Changes

- Keep `placement/backend_device.py` focused on backend visible-device environment mapping:
  - `CUDA_VISIBLE_DEVICES`
  - `HIP_VISIBLE_DEVICES`
  - `ROCR_VISIBLE_DEVICES`
- Add `placement/test_dflash_args.py` for shared `test_dflash` daemon argument serialization.
- Update `bench_he.py` and `phase_split_dual_gpu.py` to import `TestDflashLaunchArgs` from that dedicated module.
- Add `placement/server_resolver.py` for server-specific placement resolution:
  - collects `--target-gpu` / `--draft-gpu` into `DFLASH_TARGET_GPU` / `DFLASH_DRAFT_GPU` env updates
  - builds daemon launch args through shared `TestDflashLaunchArgs`
  - preserves the existing `target-gpus` cache-slot policy
  - exposes resolved placement startup log lines
- Update `server.py` to consume the resolved placement instead of assembling those pieces inline.

## Behavior

This PR should not change daemon launch semantics or cache-slot behavior, aside from clearer startup placement logging.

Preserved behavior:

- `--target-gpu` still sets `DFLASH_TARGET_GPU`.
- `--draft-gpu` still sets `DFLASH_DRAFT_GPU`.
- `--draft-feature-mirror` and `--peer-access` are still forwarded to the daemon.
- `--target-gpus` still forwards target-sharding daemon args.
- Non-empty `--target-layer-split` is still forwarded; an empty value still uses daemon defaults.
- `target-gpus` daemon mode still disables prefix/full cache slots when requested, because daemon snapshot/restore is not supported there yet.
- `phase_split_dual_gpu.py` remains a benchmark/regression harness; this PR does not turn it into the production server path.

## Follow-up Path

This creates a clearer placement foundation for the next functional PRs:

- CUDA/HIP mixed-backend draft/target placement in the server path
- broader DFlash target/draft split integration through the server
- PFlash phase split through the server
- target layer split as a reusable target-model placement capability
- draft residency / memory-budget policy for setups where draft weights and target shards compete for VRAM
- shared placement config objects later, once the server paths are stable enough to define the common config surface

Those follow-ups should extend the `placement/` modules instead of adding more ad-hoc launch logic into each entrypoint.

## Validation

- `python3 -m py_compile dflash/scripts/placement/backend_device.py dflash/scripts/placement/test_dflash_args.py dflash/scripts/placement/server_resolver.py dflash/scripts/bench_he.py dflash/scripts/phase_split_dual_gpu.py dflash/scripts/server.py`
- Resolver smoke check for default placement, explicit target/draft GPU placement, target-gpus layer split, and empty target-layer-split behavior.
- Resolver old-logic equivalence smoke across 8 placement/cache-slot combinations.
- `git diff --check`
