### PR TITLE
docs(dflash): default to Lucebox Qwen3.6 draft GGUF

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@
 </p>
 
 <p align="center">
-  <strong>Open LLM inference, rewritten by hand for one specific chip at a time.</strong><br/>
-  Kernels, speculative decoding, and quantization, tailored per target.<br/>
-  We don't wait for better silicon. We rewrite the software.
+  <strong>Local LLM inference experiments with custom kernels, speculative decoding, and quantized GGUF paths.</strong><br/>
+  Each subproject is scoped to a specific model family and hardware target.
 </p>
 
 ---
 
-## Inside the box
+## Projects
 
-Three projects today, more coming. Each one is a self-contained release with its own benchmarks and paper-style writeup.
+Each directory is a self-contained project with setup instructions and benchmark notes.
 
 <p align="center">
   <a href="megakernel/"><img src="assets/svg/card-megakernel-dark.svg" alt="Megakernel" width="46%"></a>
@@ -54,7 +53,7 @@ All speedups measured vs vendored llama.cpp (`-fa 1`, matching KV quant).
 
 ## 01 · Megakernel Qwen3.5 0.8B on RTX 3090
 
-**The first megakernel for hybrid DeltaNet/Attention LLMs.** All 24 layers of Qwen 3.5-0.8B in a single CUDA dispatch, 1.87 tok/J on a 2020 GPU, matching Apple's latest silicon at 2× the throughput.
+Single-kernel CUDA inference for Qwen 3.5-0.8B on RTX 3090. All 24 layers run in one persistent dispatch.
 
 ```bash
 # 1. clone + enter
@@ -76,7 +75,7 @@ python final_bench.py
 | llama.cpp BF16 `@350W` | 11,247 | 267 | 0.76 |
 | PyTorch HF | 7,578 | 108 | n/a |
 
-**What makes it work:** 82 blocks, 512 threads, one persistent kernel. No CPU round-trips between layers. Weights streamed straight from HuggingFace. Cooperative grid sync instead of ~100 kernel launches per token. Power ceiling hit before compute ceiling, so DVFS converts tight execution straight into saved watts.
+Implementation notes: 82 blocks, 512 threads, cooperative grid sync, no CPU round trips between layers, and weights streamed from Hugging Face on first run.
 
 [Full writeup →](megakernel/README.md) · [Benchmarks →](megakernel/RESULTS.md) · [Blog post →](https://lucebox.com/blog/megakernel)
 
@@ -86,7 +85,7 @@ python final_bench.py
 
 ## 02 · DFlash DDtree Qwen3.5 & Qwen3.6 27B GGUF on RTX 3090
 
-**First GGUF port of DFlash speculative decoding.** Qwen3.5-27B on a single RTX 3090, Q4_K_M target + BF16 draft, DDTree budget=22.
+DFlash speculative decoding for Qwen3.5/Qwen3.6 27B GGUF targets on a single GPU. The default setup uses Qwen3.6-27B Q4_K_M plus the Lucebox Q8_0 GGUF DFlash draft.
 
 - **Up to 207 tok/s** in the demo (207.6 tok/s DFlash vs 38.0 tok/s AR, 5.46×)
 - **129.5 tok/s mean** on the HumanEval 10-prompt bench
@@ -105,9 +104,9 @@ cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
 cmake --build build --target test_dflash -j
 cmake --build build --target test_generate -j
 
-# 3. fetch weights: ~16 GB Q4_K_M target + 3.46 GB bf16 draft
+# 3. fetch weights: ~16 GB Q4_K_M target + 1.84 GB Lucebox Q8_0 GGUF DFlash draft
 hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir models/
-hf download z-lab/Qwen3.6-27B-DFlash model.safetensors --local-dir models/draft/
+hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q8_0.gguf --local-dir models/draft/
 
 # 4a. one-shot streaming generate
 python3 scripts/run.py --prompt "def fibonacci(n):"
@@ -122,13 +121,13 @@ python3 scripts/bench_llm.py
 | Math500 | 37.7 | 110.5 | 2.93× |
 | GSM8K | 37.7 | 96.2 | 2.55× |
 
-**The constraint that shaped the project.** AWQ INT4 of Qwen3.5-27B plus the BF16 draft doesn't leave room for the DDTree verify state on a 24 GB card. Q4_K_M GGUF (~16 GB target) is the largest format that fits target + 3.46 GB draft + budget=22 tree state + KV cache in 24 GB on the RTX 3090. Picking it forced a new port on top of ggml, since no public DFlash runtime supports a GGUF target.
+**Why GGUF/Q4_K_M:** on 24 GB GPUs, the target, draft, DDTree verify state, and KV cache need to fit together. The default Qwen3.6 setup uses a ~16 GB Q4_K_M target and a 1.84 GB GGUF draft.
 
-**What we built vs what we didn't.** The algorithms are not ours:
+Algorithms used:
 - [**DFlash**](https://arxiv.org/abs/2602.06036) (z-lab, 2026): block-diffusion draft conditioned on target hidden states.
 - [**DDTree**](https://arxiv.org/abs/2604.12989) (Ringel et al., 2026): tree-structured verify that beats chain verify at the same compute budget.
 
-What we ported and tuned:
+Implemented here:
 - C++/CUDA decode engine on top of ggml (no libllama, no Python runtime, Q4_K_M target path).
 - Three custom CUDA kernels for tree-aware SSM state rollback: `ggml_ssm_conv_tree`, `ggml_gated_delta_net_tree`, `ggml_gated_delta_net_tree_persist`.
 - DDTree budget swept for RTX 3090 + Q4_K_M target: **budget=22** is the sweet spot.
@@ -171,20 +170,18 @@ cmake -B build -S . -DCMAKE_BUILD_TYPE=Release   # CMake auto-adds the Thor arch
 cmake --build build --target test_dflash -j
 ```
 
-**What will NOT auto-port:**
+**Retune per GPU:**
 - **DDTree `budget=22`** tuned for 3090 + Q4_K_M + 24 GB. On the RTX 5090, budget=40 is optimal (swept). On GB10 (128 GB unified), re-sweep — larger tree = more verify throughput until memory bandwidth saturates. `scripts/bench_llm.py --budget N` has the sweep hooks.
 - **TQ3_0 KV cache + sliding `target_feat` ring** was shaped by 24 GB (fits up to 256K context on a 3090). On GB10 (128 GB unified) / 5090 (32 GB) you can push context further or skip quantization entirely and keep F16 KV.
 - **Perf numbers** (207 tok/s demo, 129.5 HumanEval, 2.8× vs SGLang AWQ) are RTX 3090 @ stock. RTX 5090 numbers (205 tok/s HumanEval, 4.84×) are in [RESULTS.md](dflash/RESULTS.md). Ada/GB10/Thor not yet swept, PRs with `RESULTS.md` entries welcome.
 
 [Full writeup →](dflash/README.md) · [Benchmarks →](dflash/RESULTS.md) · [Blog post →](https://lucebox.com/blog/dflash27b)
 
-> **Qwen3.6-27B (supported, experimental draft):** same `qwen35` architecture, so the 3.6 Q4_K_M GGUF loads as a drop-in target. With z-lab's matched [Qwen3.6-27B-DFlash](https://huggingface.co/z-lab/Qwen3.6-27B-DFlash) draft (still under training, 2026-04-26 snapshot), HumanEval lands at ~78 tok/s (AL 5.05); the 3.5 draft gets ~74 tok/s. 3.5↔3.5 reference is 129.5 tok/s. AL should improve as z-lab finishes training the draft. Details in [dflash/README.md](dflash/README.md#qwen36-27b-target-experimental).
-
 ---
 
 ## 03 · PFlash speculative prefill on RTX 3090
 
-**In-process speculative prefill, C++/CUDA only.** A drafter (Qwen3-0.6B BF16) loaded directly into the dflash daemon scores per-token importance over a long prompt; the heavy target (Qwen3.6-27B Q4_K_M) only prefills the spans that matter. Both models share the same ggml allocator on a single RTX 3090. **No Python, no Triton, no PyTorch at runtime** — just the dflash binary and four custom CUDA kernels (`mean_K → score → select → sparse_fwd`) plus BSA ([mit-han-lab/Block-Sparse-Attention](https://github.com/mit-han-lab/Block-Sparse-Attention), FA-2 derived, sm_80+) for the long-context drafter forward.
+Speculative prefill for long prompts. A Qwen3-0.6B BF16 drafter scores token importance, then the 27B target prefills only the retained spans. Runtime is C++/CUDA through the dflash binaries; no PyTorch is required at serving time.
 
 - **~10.4× TTFT** on 128K context: **24.8 s** dflash daemon vs **~257 s** llama.cpp (FA on, Q4_0 KV).
 - **10.0× TTFT** on 64K context: **13.5 s** dflash vs **134.95 s** llama.cpp.
@@ -201,11 +198,11 @@ cmake --build build --target test_dflash test_flashprefill_kernels -j
 # 2. fetch weights: 27B Q4_K_M target + 0.6B BF16 drafter (GGUF) + DFlash spec-decode draft
 hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir models/
 hf download unsloth/Qwen3-0.6B-GGUF Qwen3-0.6B-BF16.gguf --local-dir models/
-hf download z-lab/Qwen3.6-27B-DFlash model.safetensors --local-dir models/draft/
+hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q8_0.gguf --local-dir models/draft/
 
 # 3. run the daemon: compress (drafter scoring) + generate (target spec decode)
 DFLASH_FP_USE_BSA=1 DFLASH_FP_ALPHA=0.85 \
-./build/test_dflash models/Qwen3.6-27B-Q4_K_M.gguf models/draft/model.safetensors --daemon
+./build/test_dflash models/Qwen3.6-27B-Q4_K_M.gguf models/draft/dflash-draft-3.6-q8_0.gguf --daemon
 # stdin protocol: `compress <ids.bin> <keep_x1000> <drafter.gguf>` →
 #                 stream of compressed token ids, then `generate <…>` →
 #                 stream of generated tokens.

--- a/dflash/DEVELOPER.md
+++ b/dflash/DEVELOPER.md
@@ -25,7 +25,7 @@ A setup script is provided that installs everything (run as root):
 sudo bash dflash/scripts/setup_system.sh
 ```
 
-This installs build tools, `huggingface-cli` (via pipx), and the CUDA Toolkit.
+This installs build tools, `hf` (via pipx), and the CUDA Toolkit.
 
 ### Python
 
@@ -90,10 +90,10 @@ Download models before running the server:
 
 ```bash
 # Target model (Q4_K_M quantized Qwen3.6-27B)
-huggingface-cli download <repo-id> --local-dir dflash/models/
+hf download <repo-id> --local-dir dflash/models/
 
-# Draft model (safetensors format)
-# Place model.safetensors under dflash/models/draft/
+# Draft model (1.84 GB default Qwen3.6 GGUF draft)
+hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q8_0.gguf --local-dir dflash/models/draft/
 ```
 
 Expected layout:
@@ -102,7 +102,7 @@ Expected layout:
 dflash/models/
 ├── Qwen3.6-27B-Q4_K_M.gguf          # --target (GGUF)
 └── draft/
-    └── model.safetensors              # --draft  (safetensors)
+    └── dflash-draft-3.6-q8_0.gguf     # --draft  (GGUF)
 ```
 
 The target path can also be set via the `DFLASH_TARGET` environment variable.
@@ -190,12 +190,12 @@ cd dflash/build
 
 # Numerics tests
 ./test_vs_oracle --target ../models/Qwen3.6-27B-Q4_K_M.gguf \
-                 --draft ../models/draft/model.safetensors
+                 --draft ../models/draft/dflash-draft-3.6-q8_0.gguf
 
 # Smoke tests
 ./smoke_load_target --target ../models/Qwen3.6-27B-Q4_K_M.gguf
-./smoke_load_draft --draft ../models/draft/model.safetensors
-./smoke_draft_graph --draft ../models/draft/model.safetensors
+./smoke_load_draft --draft ../models/draft/dflash-draft-3.6-q8_0.gguf
+./smoke_draft_graph --draft ../models/draft/dflash-draft-3.6-q8_0.gguf
 ```
 
 ### Integration tests (require running server)
@@ -224,7 +224,7 @@ dflash/
 │   └── Block-Sparse-Attention/ # BSA kernels (submodule)
 ├── models/                     # Model files (not in git)
 │   ├── Qwen3.6-27B-Q4_K_M.gguf
-│   └── draft/model.safetensors
+│   └── draft/dflash-draft-3.6-q8_0.gguf
 ├── scripts/
 │   ├── server.py               # Main OpenAI/Codex server
 │   ├── prefix_cache.py         # LRU prefix cache

--- a/dflash/README.md
+++ b/dflash/README.md
@@ -9,10 +9,9 @@
 <h1 align="center">Luce DFlash</h1>
 
 <p align="center">
-  <strong>The first GGUF port of DFlash speculative decoding.</strong><br/>
-  Qwen3.5-27B at up to 207 tok/s<sup>*</sup> on a single RTX 3090 (HumanEval 10-prompt bench mean 129.5 tok/s at DDTree budget=22). 128K context on 24 GB.<br/>
-  3.43× faster than autoregressive (+15% over chain spec decoding), 2.8× faster than SGLang AWQ.<br/>
-  <sub><sup>*</sup>Demo run: 207.6 tok/s DFlash vs 38.0 tok/s AR (5.46×).</sub><br/><br/>
+  <strong>GGUF DFlash speculative decoding for Qwen3.5/Qwen3.6 27B.</strong><br/>
+  C++/CUDA runtime on top of ggml. Default path: Qwen3.6-27B Q4_K_M target + Lucebox Q8_0 GGUF DFlash draft.<br/>
+  Qwen3.5 reference: 129.5 tok/s mean on HumanEval (3.43x vs AR); best demo run: 207.6 tok/s vs 38.0 tok/s AR (5.46x).<br/><br/>
   <a href="https://lucebox.com/blog/dflash27b">Blog post</a> · <a href="RESULTS.md">Benchmarks</a> · <a href="https://discord.gg/yHfswqZmJQ">Discord</a> · <a href="https://lucebox.com">lucebox.com</a>
 </p>
 
@@ -29,21 +28,19 @@ Math500               37.71        110.51          2.93x
 GSM8K                 37.65         96.15          2.55x
 ```
 
-> Consumer GPUs can run 27B models at chat-grade speed without multi-GPU, without batching, without quantization compromises. The bottleneck was never hardware. It was the decoding algorithm.
+## Overview
 
-## The gap we filled
+DFlash is a speculative decoder. A small draft proposes multiple tokens, and the target verifies them in one forward pass. DDTree verifies a tree of candidates instead of a single chain, which improves acceptance length at the same target compute budget.
 
-On a 24 GB RTX 3090 with Q4_K_M weights, autoregressive decode of Qwen3.5-27B hits ~37.7 tok/s regardless of framework. Every token reads the full model from VRAM.
+This repo provides the GGUF target path and runtime pieces needed to run that stack on consumer GPUs:
 
-Speculative decoding breaks that ceiling: a tiny draft proposes multiple tokens per step, the target verifies them in one forward. [DFlash (z-lab, 2026)](https://arxiv.org/abs/2602.06036) takes this further with **block-diffusion drafting**: a 5-layer non-causal denoising draft conditioned on captured target hidden states. Accepts ~8 tokens/step vs ~3 for chain EAGLE. The official draft is [`z-lab/Qwen3.5-27B-DFlash`](https://huggingface.co/z-lab/Qwen3.5-27B-DFlash). [DDTree (Ringel & Romano, 2026)](https://arxiv.org/abs/2604.12989) adds tree-structured verify on top, recovering the last 30% of the speedup.
+- C++/CUDA decode loop on top of ggml, without libllama or PyTorch at runtime.
+- Qwen3.5/Qwen3.6 `qwen35` GGUF target support.
+- DFlash draft loading from GGUF or safetensors.
+- DDTree verify with tree-aware SSM rollback kernels.
+- TQ3_0 and asymmetric K/V cache quantization for long context.
 
-**What was missing:** no public implementation ran either on consumer hardware. z-lab targets BF16 on B200 (60+ GB VRAM). No GGUF path. No DDTree port. AWQ INT4 of the target + BF16 draft doesn't leave room for the verify tree on 24 GB.
-
-Q4_K_M GGUF (~16 GB) is the largest quantization that fits target + 3.46 GB draft + budget=22 tree state + KV cache on one RTX 3090. Picking it forced the port onto ggml, the only runtime with first-class Gated DeltaNet CUDA kernels and a GGUF Q4_K_M loader. This repo is that port:
-
-- ~2000 lines of C++/CUDA on top of ggml (no libllama, no Python runtime)
-- a pinned fork of llama.cpp at [`Luce-Org/llama.cpp@luce-dflash`](https://github.com/Luce-Org/llama.cpp/tree/luce-dflash) that adds three tree-mode ggml ops: `ggml_ssm_conv_tree`, `ggml_gated_delta_net_tree`, `ggml_gated_delta_net_tree_persist`
-- hardcoded for the one model pair, decoding at 129.52 tok/s mean on HumanEval
+The default setup fits on a 24 GB RTX 3090: ~16 GB Q4_K_M target, 1.84 GB GGUF draft, DDTree verify state, and KV cache.
 
 ## Results
 
@@ -129,33 +126,33 @@ python3 scripts/run.py --cache-type-k q8_0 --cache-type-v q4_0 --prompt "hello"
 
 Legacy `--kv-tq3` / `--kv-q4` / `--kv-f16` flags continue to work as symmetric shorthand for backward compatibility.
 
-## Qwen3.6-27B target (experimental)
+## Qwen3.6-27B Target
 
-Qwen3.6-27B ships the same `qwen35` architecture string and identical layer/head dims as 3.5, so `test_dflash` loads it with no code change:
+Qwen3.6-27B is the default integration path. It uses the same `qwen35` target architecture as Qwen3.5, and the docs use the Lucebox GGUF DFlash draft by default.
 
 ```bash
 # 1. target
-huggingface-cli download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir models/
+hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir models/
 
-# 2. matched 3.6 draft (gated: accept terms + set HF_TOKEN first)
-huggingface-cli download z-lab/Qwen3.6-27B-DFlash --local-dir models/draft/
+# 2. matched 3.6 draft (GGUF, used by default by scripts/run.py and server.py)
+hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q8_0.gguf --local-dir models/draft/
 
 # 3. bench
 DFLASH_TARGET=models/Qwen3.6-27B-Q4_K_M.gguf python3 scripts/bench_he.py --n-gen 128
 ```
 
-> The draft path is fixed at `models/draft/model.safetensors`; swapping targets requires also swapping the draft file (or pointing `DFLASH_DRAFT` at a different `model.safetensors`).
+The default draft path is discovered under `models/draft/`. Scripts prefer `dflash-draft-*.gguf`, then any `.gguf`, then `model.safetensors`. Explicit `.gguf` and safetensors drafts still work via `DFLASH_DRAFT` / `--draft`; qwen35-compatible targets remain swappable via `DFLASH_TARGET` / `--target`.
 
-**Throughput is lower than on 3.5.** z-lab published a matched [Qwen3.6-27B-DFlash](https://huggingface.co/z-lab/Qwen3.6-27B-DFlash) draft on 2026-04-26 (still under training). AL should climb as the draft matures. Measured on the same RTX 3090:
+Reference measurements from the Qwen3.6 bring-up on RTX 3090:
 
 | Target | Draft | Bench | AL | Accept | Mean tok/s |
 |---|---|---|---:|---:|---:|
 | Qwen3.5-27B Q4_K_M | z-lab/Qwen3.5-27B-DFlash | HumanEval (README config) | 8.33 | ~65% | 134.78 |
 | Qwen3.6-27B Q4_K_M | z-lab/Qwen3.5-27B-DFlash (mismatch) | HumanEval (10 prompts, n_gen=128) | 4.74 | 30.6% | 73.67 |
-| Qwen3.6-27B Q4_K_M | z-lab/Qwen3.6-27B-DFlash (still training) | HumanEval (10 prompts, n_gen=128) | 5.05 | 32.3% | 77.77 |
+| Qwen3.6-27B Q4_K_M | z-lab/Qwen3.6-27B-DFlash safetensors | HumanEval (10 prompts, n_gen=128) | 5.05 | 32.3% | 77.77 |
 | Qwen3.6-27B Q4_K_M | z-lab/Qwen3.5-27B-DFlash (mismatch) | Math (10 prompts, n_gen=128) | 3.63 | 23.7% | 57.00 |
 
-Full `bench_llm.py` suite on **Qwen3.6-27B UD-Q4_K_XL** (unsloth Dynamic 2.0, 10 prompts, n_gen=256, RTX 3090 24 GB, auto-fit `--max-ctx`):
+Full `bench_llm.py` suite on Qwen3.6-27B UD-Q4_K_XL, 10 prompts, n_gen=256, RTX 3090 24 GB, auto-fit `--max-ctx`:
 
 | Bench | AR tok/s | DFlash tok/s | AL | Speedup |
 |---|---:|---:|---:|---:|
@@ -163,10 +160,6 @@ Full `bench_llm.py` suite on **Qwen3.6-27B UD-Q4_K_XL** (unsloth Dynamic 2.0, 10
 | GSM8K | 34.89 | 59.65 | 4.43 | **1.71×** |
 | Math500 | 35.13 | 69.77 | 5.15 | **1.99×** |
 | **Mean** | 34.97 | 69.19 | 5.17 | **1.98×** |
-
-Compare to Qwen3.5-27B on the same harness: 2.87× / 2.21× / 2.56× — cross-generation drop of ~22% uniformly from the draft mismatch, but still a clean ~2× with zero retraining.
-
-Numbers will move once a Qwen3.6-matched DFlash draft lands; swap it in via `DFLASH_DRAFT=...` without rebuilding.
 
 ## Laguna-XS.2 target (experimental, Poolside MoE)
 
@@ -189,9 +182,9 @@ drives both arches end-to-end. The only thing the user changes is `--target`.
 cmake --build build --target test_dflash test_laguna_daemon pflash_daemon -j
 
 # 19 GB Q4_K_M target + 1.2 GB Qwen3-0.6B BF16 drafter + tokenizers
-huggingface-cli download Lucebox/Laguna-XS.2-GGUF laguna-xs2-Q4_K_M.gguf --local-dir models/
-huggingface-cli download unsloth/Qwen3-0.6B-GGUF Qwen3-0.6B-BF16.gguf --local-dir models/
-huggingface-cli download poolside/Laguna-XS.2 --local-dir models/Laguna-XS-2 \
+hf download Lucebox/Laguna-XS.2-GGUF laguna-xs2-Q4_K_M.gguf --local-dir models/
+hf download unsloth/Qwen3-0.6B-GGUF Qwen3-0.6B-BF16.gguf --local-dir models/
+hf download poolside/Laguna-XS.2 --local-dir models/Laguna-XS-2 \
     --include 'tokenizer*' '*.json'
 
 # OpenAI-compatible HTTP server (same scripts/server.py used for qwen35).
@@ -235,7 +228,7 @@ python3 scripts/laguna_pflash_niah.py \
 | 131 072 | Q4_0 | 0.20 |       11.20 |              13.55 |         24.75 s |  ✅  |
 | 131 072 | Q4_0 | 0.30 |       11.41 |              26.43 |         37.84 s |  ✅  |
 
-The **131K @ keep=0.10 PASS** is the surprising result. Earlier scaffolding had this point failing because pflash drops chunk-boundary tokens, truncating multi-token needles like `BLUEHORIZON-7421` to their first kept fragment (`BLUEH`). The fix lives in `scripts/laguna_pflash_niah.py::cross_tok_compressed`: recover kept-token positions by greedy subsequence-match against the original drafter IDs, group consecutive positions into runs, expand each run outward until both endpoints sit on whitespace, then decode the union once. The expanded set is a **superset** of the kept tokens, so semantic compression is preserved while broken words are pulled back together. This rescued every failing (ctx, keep) point at 64K and 131K.
+The 131K `keep=0.10` run depends on token-boundary repair in `scripts/laguna_pflash_niah.py::cross_tok_compressed`. The driver recovers kept-token positions, groups consecutive runs, expands each run to whitespace boundaries, and decodes the union once. That keeps multi-token needles intact after compression.
 
 ### Real-prompt NIAH (code corpus filler)
 
@@ -294,12 +287,12 @@ cd lucebox-hub/dflash
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=86
 cmake --build build --target test_dflash -j
 
-# Fetch models: ~16 GB target + 3.46 GB draft.
+# Fetch models: ~16 GB target + 1.84 GB Lucebox Q8_0 GGUF DFlash draft.
 # Quickstart pins to Qwen3.6-27B (latest release). For Qwen3.5-27B swap in
 # unsloth/Qwen3.5-27B-GGUF + z-lab/Qwen3.5-27B-DFlash; arch is identical so
-# no rebuild is needed (see "Qwen3.6-27B target" section above for AL deltas).
-huggingface-cli download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir models/
-huggingface-cli download z-lab/Qwen3.6-27B-DFlash model.safetensors --local-dir models/draft/
+# no rebuild is needed.
+hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir models/
+hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q8_0.gguf --local-dir models/draft/
 
 # Streaming one-shot generate (run.py defaults to models/Qwen3.6-27B-Q4_K_M.gguf;
 # override with --target or DFLASH_TARGET=... env var).
@@ -322,7 +315,7 @@ python3 scripts/bench_he.py --n-gen 256 --ddtree-budget 22   # minimal HE bench
 ```bash
 DFLASH27B_KV_TQ3=1 DFLASH27B_PREFILL_UBATCH=16 \
   build/test_dflash models/Qwen3.6-27B-Q4_K_M.gguf \
-  models/draft/model.safetensors /tmp/long_prompt.bin 64 /tmp/out.bin \
+  models/draft/dflash-draft-3.6-q8_0.gguf /tmp/long_prompt.bin 64 /tmp/out.bin \
   --fast-rollback --ddtree --ddtree-budget=16 --max-ctx=4096   # align_up(prompt + n_gen + 64, 256); raise up to 262144 for long prompts
 ```
 
@@ -363,13 +356,14 @@ The DeltaNet primitive is already a first-class ggml op (`ggml_gated_delta_net`)
 
 ## Scope and limits
 
-Research proof-of-concept, not production.
+Current scope:
 
 - **Batch size 1**, single-user local inference target (Ollama / LM Studio use case)
-- **One model pair**: Qwen3.5-27B Q4_K_M target + z-lab DFlash BF16 draft. Does not generalize without rewriting the graph builders.
+- **Target family**: Qwen3.5/Qwen3.6 `qwen35` GGUF targets. Other architectures need their own graph builder.
+- **Draft formats**: DFlash GGUF drafts and z-lab-style safetensors drafts.
 - **Optional sampling**: `temperature`, `top_p`, `top_k`, `seed`, and `frequency_penalty` are honored on the OpenAI endpoint. The DDTree verify skeleton stays argmax (preserves accept rate); only the *committed* token at each verify step is drawn from a small CPU sampler chain (rep-pen → top-k → top-p → temp → multinomial). `temperature=0` (default) keeps the path bit-exact greedy. Full Leviathan-style rejection sampling on the tree is still a future addition.
-- **CUDA sm_86+ / sm_110 Thor** only. No Metal, ROCm, multi-GPU.
-- **Q4_K_M target** costs ~30 points of per-position accept vs the paper's BF16. Q5_K_M / Q6_K would recover most of it, if they fit.
+- **Backends**: CUDA is the primary path. HIP support exists for the documented AMD path. No Metal.
+- **Quantized target**: Q4_K_M fits the full stack on 24 GB. Higher target quantizations may improve acceptance if they fit.
 
 Correctness: `test_vs_oracle` validates the draft graph at cos sim 0.999812 vs the PyTorch reference. The target graph matches llama.cpp's `models/qwen35.cpp` semantically and produces bit-identical output to `test_generate` in autoregressive mode.
 

--- a/dflash/scripts/bench_he.py
+++ b/dflash/scripts/bench_he.py
@@ -25,7 +25,7 @@ TARGET = os.environ.get(
     "DFLASH_TARGET",
     str(ROOT / "models" / "Qwen3.6-27B-Q4_K_M.gguf"),
 )
-_LOCAL_DRAFT_FILE = ROOT / "models" / "draft" / "model.safetensors"
+_LOCAL_DRAFT_FILE = ROOT / "models" / "draft" / "dflash-draft-3.6-q8_0.gguf"
 _LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
 DRAFT = None
 TEST_DFLASH = os.environ.get(
@@ -185,10 +185,10 @@ def _find_draft_file(root: Path) -> str | None:
         return str(root) if root.suffix in (".safetensors", ".gguf") else None
     if not root.is_dir():
         return None
-    for st in root.rglob("model.safetensors"):
-        return str(st)
-    for gguf in root.rglob("*.gguf"):
-        return str(gguf)
+    for pattern in ("dflash-draft-*.gguf", "*.gguf", "model.safetensors"):
+        matches = sorted(root.rglob(pattern))
+        if matches:
+            return str(matches[0])
     return None
 
 

--- a/dflash/scripts/bench_llm.py
+++ b/dflash/scripts/bench_llm.py
@@ -5,7 +5,7 @@
 
 Paths resolve from the repo root by default. Override with env vars:
     DFLASH_TARGET    path to target Qwen3.6-27B-Q4_K_M.gguf (or 3.5)
-    DFLASH_DRAFT     path to draft model.safetensors
+    DFLASH_DRAFT     path to DFlash draft GGUF or model.safetensors
     DFLASH_BIN       path to build/test_dflash
     DFLASH_BIN_AR    path to build/test_generate
     DFLASH_TOKENIZER HF tokenizer repo (default Qwen/Qwen3.5-27B; matches run.py)
@@ -25,7 +25,7 @@ TARGET = os.environ.get(
     "DFLASH_TARGET",
     str(ROOT / "models" / "Qwen3.6-27B-Q4_K_M.gguf"),
 )
-_LOCAL_DRAFT_FILE = ROOT / "models" / "draft" / "model.safetensors"
+_LOCAL_DRAFT_FILE = ROOT / "models" / "draft" / "dflash-draft-3.6-q8_0.gguf"
 _LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
 DRAFT = None
 TEST_DFLASH = os.environ.get("DFLASH_BIN", str(ROOT / "build" / f"test_dflash{BIN_SUFFIX}"))
@@ -45,31 +45,33 @@ BENCHES = [
 ]
 
 
-def _find_safetensors(root: Path) -> str | None:
+def _find_draft_model(root: Path) -> str | None:
     if root.is_file():
         return str(root)
     if not root.is_dir():
         return None
-    for st in root.rglob("model.safetensors"):
-        return str(st)
+    for pattern in ("dflash-draft-*.gguf", "*.gguf", "model.safetensors"):
+        matches = sorted(root.rglob(pattern))
+        if matches:
+            return str(matches[0])
     return None
 
 
 def _resolve_draft() -> str:
     env = os.environ.get("DFLASH_DRAFT")
     if env:
-        found = _find_safetensors(Path(env))
+        found = _find_draft_model(Path(env))
         if found:
             return found
-        raise FileNotFoundError(f"DFLASH_DRAFT does not point to model.safetensors: {env}")
+        raise FileNotFoundError(f"DFLASH_DRAFT does not point to a DFlash draft GGUF or model.safetensors: {env}")
 
     for candidate in (_LOCAL_DRAFT_FILE, _LOCAL_DRAFT_ROOT):
-        found = _find_safetensors(candidate)
+        found = _find_draft_model(candidate)
         if found:
             return found
 
     raise FileNotFoundError(
-        "draft model.safetensors not found. Expected one of:\n"
+        "DFlash draft GGUF or model.safetensors not found. Expected one of:\n"
         f"  - {_LOCAL_DRAFT_FILE}\n"
         "Download it as documented in the README, or set DFLASH_DRAFT to an explicit file or directory."
     )

--- a/dflash/scripts/run.py
+++ b/dflash/scripts/run.py
@@ -41,11 +41,12 @@ def resolve_draft(draft_dir: str) -> str:
     if p.is_file():
         return str(p)
     if p.is_dir():
-        for st in p.rglob("model.safetensors"):
-            return str(st)
+        for pattern in ("dflash-draft-*.gguf", "*.gguf", "model.safetensors"):
+            for draft in sorted(p.rglob(pattern)):
+                return str(draft)
 
     raise FileNotFoundError(
-        f"no model.safetensors under {draft_dir}. Download it as documented in the README, or pass --draft explicitly."
+        f"no DFlash draft GGUF or model.safetensors under {draft_dir}. Download it as documented in the README, or pass --draft explicitly."
     )
 
 

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -89,9 +89,10 @@ _ALLOWED_TEMPLATE_KWARGS = frozenset({"enable_thinking", "tools", "add_generatio
 
 
 def resolve_draft(root: Path) -> Path:
-    for st in root.rglob("model.safetensors"):
-        return st
-    raise FileNotFoundError(f"no model.safetensors under {root}")
+    for pattern in ("dflash-draft-*.gguf", "*.gguf", "model.safetensors"):
+        for draft in sorted(root.rglob(pattern)):
+            return draft
+    raise FileNotFoundError(f"no DFlash draft GGUF or model.safetensors under {root}")
 
 
 _QWEN35_FAMILY_TOKENIZERS = {
@@ -664,7 +665,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                f"--stream-fd={stream_fd_val}"]
     else:
         if draft is None:
-            raise SystemExit("qwen35 arch requires --draft model.safetensors")
+            raise SystemExit("qwen35 arch requires --draft <draft.gguf|model.safetensors>")
         cmd = [bin_abs, str(target), str(draft), "--daemon",
                "--fast-rollback", "--ddtree", f"--ddtree-budget={budget}",
                f"--max-ctx={max_ctx}",

--- a/dflash/scripts/setup_system.sh
+++ b/dflash/scripts/setup_system.sh
@@ -42,18 +42,18 @@ apt-get install -y build-essential cmake git git-lfs
 git lfs install --system 2>/dev/null || git lfs install
 ok "Build tools installed."
 
-# ── huggingface-cli (pipx, installed for $SUDO_USER not root) ────────────────
+# ── hf (pipx, installed for $SUDO_USER not root) ────────────────
 
 REAL_USER="${SUDO_USER:-$USER}"
 
 apt-get install -y pipx
 
 if sudo -u "${REAL_USER}" pipx list 2>/dev/null | grep -q huggingface_hub; then
-    ok "huggingface-cli already installed for ${REAL_USER}."
+    ok "hf already installed for ${REAL_USER}."
 else
-    info "Installing huggingface-cli for ${REAL_USER}..."
+    info "Installing hf for ${REAL_USER}..."
     sudo -u "${REAL_USER}" pipx install "huggingface_hub[cli]"
-    ok "huggingface-cli installed."
+    ok "hf installed."
 fi
 
 sudo -u "${REAL_USER}" pipx ensurepath --quiet 2>/dev/null || true


### PR DESCRIPTION
Summary: update setup docs to use the 1.84 GB Lucebox Qwen3.6 DFlash GGUF draft, replace deprecated huggingface-cli examples with hf download, remove experimental wording from the Qwen3.6 path, and make the root/dflash readmes simpler while keeping benchmark tables and 2x/3x/Nx speedup claims. Helper scripts now auto-discover dflash-draft-*.gguf before falling back to safetensors.\n\nValidation: git diff --check and Python AST parse for touched scripts.