### PR TITLE
Fix inline prefix snapshot confirmation

### DIFF
--- a/dflash/scripts/prefix_cache.py
+++ b/dflash/scripts/prefix_cache.py
@@ -94,6 +94,21 @@ class DaemonStdoutBus:
         """Invoke ``cb()`` whenever the daemon emits a stdout line starting with ``prefix``."""
         self._line_callbacks[prefix] = cb
 
+    def register_waiter(self, prefix: str) -> tuple[tuple[str, asyncio.Future], asyncio.Future]:
+        """Synchronously register a waiter before issuing a daemon command."""
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[str] = loop.create_future()
+        entry = (prefix, fut)
+        self._waiters.append(entry)
+        return entry, fut
+
+    def remove_waiter(self, entry: tuple[str, asyncio.Future]) -> None:
+        """Best-effort waiter cleanup for cancelled / abandoned requests."""
+        try:
+            self._waiters.remove(entry)
+        except ValueError:
+            pass
+
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         self._task = loop.create_task(self._run())
 
@@ -135,17 +150,13 @@ class DaemonStdoutBus:
 
     async def await_reply(self, prefix: str, timeout: float = 10.0) -> str:
         """Block until daemon emits a line starting with *prefix*."""
-        loop = asyncio.get_running_loop()
-        fut: asyncio.Future[str] = loop.create_future()
-        entry = (prefix, fut)
-        self._waiters.append(entry)
+        entry, fut = self.register_waiter(prefix)
         try:
             return await asyncio.wait_for(fut, timeout=timeout)
         finally:
             # On timeout / cancellation the matcher loop never popped us;
             # remove ourselves so _waiters doesn't grow without bound.
-            try: self._waiters.remove(entry)
-            except ValueError: pass
+            self.remove_waiter(entry)
 
 
 @dataclass

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -1085,8 +1085,31 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cmd_line += f" snap={snap_prep[1]}:{snap_prep[0]}"
             return cmd_line + _samp_suffix(req) + "\n", snap_prep
 
+    def _prime_inline_snap_waiter(snap_prep):
+        if not snap_prep:
+            return None
+        slot, _ = snap_prep
+        return bus.register_waiter(f"[snap] inline slot={slot} ")
+
+    def _consume_inline_snap_waiter(snap_waiter) -> bool:
+        if snap_waiter is None:
+            return False
+        entry, fut = snap_waiter
+        bus.remove_waiter(entry)
+        if not fut.done():
+            fut.cancel()
+            return False
+        if fut.cancelled():
+            return False
+        try:
+            fut.result()
+        except Exception:
+            return False
+        return True
+
     def _confirm_or_abort_snap(n_tokens: int, full_snap_prep, snap_prep,
-                                  prompt_ids, cur_bin, cur_ids):
+                                  prompt_ids, cur_bin, cur_ids,
+                                  inline_snap_ok: bool = False):
         """Confirm prefix-cache snapshots only when the daemon actually
         generated tokens.  When the daemon returns 0 tokens (e.g. empty
         prompt / file read failure), confirming would register a snapshot
@@ -1096,8 +1119,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 fslot, _ = full_snap_prep
                 prefix_cache.confirm_full_snap(
                     fslot, prompt_ids, cur_bin, len(cur_ids))
-            elif snap_prep:
+            elif snap_prep and inline_snap_ok:
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
+            elif snap_prep:
+                prefix_cache.abort_inline_snap(snap_prep[0])
+                log.warning("inline snapshot ack missing — dropped slot reservation")
         else:
             # Abort: release the reservation without registering.
             if full_snap_prep is not None:
@@ -1143,6 +1169,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     timing = {}
                     full_snap_prep_ref = [None]
                     snap_prep = None
+                    snap_waiter = None
 
                     full_hit = prefix_cache.lookup_full(prompt_ids)
                     if full_hit is not None:
@@ -1184,11 +1211,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         cmd_line, snap_prep = _build_cmd_line(
                             req, cur_bin, cur_ids, gen_len, prefix_cache,
                             prompt_ids, full_snap_prep_ref, compression_fired)
+                        snap_waiter = _prime_inline_snap_waiter(snap_prep)
 
                     # FIX 7: guard against dead daemon
                     try:
                         _write_cmd(cmd_line, timing)
                     except RuntimeError as e:
+                        _consume_inline_snap_waiter(snap_waiter)
                         yield f"data: {json.dumps({'error': str(e)})}\n\n"
                         yield "data: [DONE]\n\n"
                         return
@@ -1314,6 +1343,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                                           "completion_tokens": completion_tokens,
                                                           "total_tokens": prompt_len + completion_tokens}}
                                 yield f"data: {json.dumps(usage_chunk)}\n\n"
+                            inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
+                            _confirm_or_abort_snap(
+                                completion_tokens, full_snap_prep_ref[0], snap_prep,
+                                prompt_ids, cur_bin, cur_ids, inline_snap_ok)
                             yield "data: [DONE]\n\n"
                             if timing.get("daemon_done") and full_hit is None:
                                 try: cur_bin.unlink()
@@ -1364,9 +1397,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                 "stream ended before daemon sentinel; "
                                 "retaining prompt .bin for in-flight daemon read")
 
+                    inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
                     _confirm_or_abort_snap(
                         completion_tokens, full_snap_prep_ref[0], snap_prep,
-                        prompt_ids, cur_bin, cur_ids)
+                        prompt_ids, cur_bin, cur_ids, inline_snap_ok)
                     _park_draft_if_lazy(timing)
 
                     yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
@@ -1397,6 +1431,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             timing = {}
             full_snap_prep_ref = [None]
             snap_prep = None
+            snap_waiter = None
 
             full_hit = prefix_cache.lookup_full(prompt_ids)
             if full_hit is not None:
@@ -1430,18 +1465,21 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cmd_line, snap_prep = _build_cmd_line(
                     req, cur_bin, cur_ids, gen_len, prefix_cache,
                     prompt_ids, full_snap_prep_ref, compression_fired)
+                snap_waiter = _prime_inline_snap_waiter(snap_prep)
 
             try:
                 _write_cmd(cmd_line, timing)
             except RuntimeError as e:
+                _consume_inline_snap_waiter(snap_waiter)
                 return JSONResponse({"detail": str(e)}, status_code=503)
 
             # FIX 6: use run_in_executor instead of list() blocking event loop
             tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
+            inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
             _confirm_or_abort_snap(
                 len(tokens), full_snap_prep_ref[0], snap_prep,
-                prompt_ids, cur_bin, cur_ids)
+                prompt_ids, cur_bin, cur_ids, inline_snap_ok)
             _park_draft_if_lazy(timing)
 
         if full_hit is None:
@@ -1586,6 +1624,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     try:
                         _write_cmd(cmd_line, timing)
                     except RuntimeError as e:
+                        _consume_inline_snap_waiter(snap_waiter)
                         yield f"event: error\ndata: {json.dumps({'type':'error','error':{'type':'server_error','message':str(e)}})}\n\n"
                         return
 
@@ -1639,9 +1678,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                 "stream ended before daemon sentinel; "
                                 "retaining prompt .bin for in-flight daemon read")
 
+                    inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
                     _confirm_or_abort_snap(
                         out_tokens, full_snap_prep_ref[0], snap_prep,
-                        prompt_ids, cur_bin, cur_ids)
+                        prompt_ids, cur_bin, cur_ids, inline_snap_ok)
                     _park_draft_if_lazy(timing)
 
                     yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
@@ -1695,19 +1735,22 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cmd_line, snap_prep = _build_cmd_line(
                     req, cur_bin, cur_ids, gen_len, prefix_cache,
                     prompt_ids, full_snap_prep_ref, compression_fired)
+                snap_waiter = _prime_inline_snap_waiter(snap_prep)
 
             try:
                 _write_cmd(cmd_line, timing)
             except RuntimeError as e:
+                _consume_inline_snap_waiter(snap_waiter)
                 return JSONResponse({"type": "error", "error": {"type": "server_error",
                                      "message": str(e)}}, status_code=503)
 
             # FIX 6: use run_in_executor — same fix as OpenAI non-streaming path
             tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
+            inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
             _confirm_or_abort_snap(
                 len(tokens), full_snap_prep_ref[0], snap_prep,
-                prompt_ids, cur_bin, cur_ids)
+                prompt_ids, cur_bin, cur_ids, inline_snap_ok)
             _park_draft_if_lazy(timing)
 
         if full_hit is None:
@@ -1937,10 +1980,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 cmd_line, snap_prep = _build_cmd_line(
                     chat_req, cur_bin, cur_ids, gen_len, prefix_cache,
                     prompt_ids, full_snap_prep_ref, compression_fired)
+                snap_waiter = _prime_inline_snap_waiter(snap_prep)
 
             try:
                 _write_cmd(cmd_line, timing)
             except RuntimeError as e:
+                _consume_inline_snap_waiter(snap_waiter)
                 return JSONResponse({
                     "type": "error",
                     "error": {"type": "server_error", "message": str(e)}
@@ -1948,9 +1993,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
             tokens = await _collect_tokens_sync(r_pipe, gen_len, timing)
 
+            inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
             _confirm_or_abort_snap(
                 len(tokens), full_snap_prep_ref[0], snap_prep,
-                prompt_ids, cur_bin, cur_ids)
+                prompt_ids, cur_bin, cur_ids, inline_snap_ok)
             _park_draft_if_lazy(timing)
 
         if full_hit is None:
@@ -2028,6 +2074,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 timing = {}
                 full_snap_prep_ref = [None]
                 snap_prep = None
+                snap_waiter = None
 
                 full_hit = prefix_cache.lookup_full(prompt_ids)
                 if full_hit is not None:
@@ -2071,10 +2118,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     cmd_line, snap_prep = _build_cmd_line(
                         chat_req, cur_bin, cur_ids, gen_len, prefix_cache,
                         prompt_ids, full_snap_prep_ref, compression_fired)
+                    snap_waiter = _prime_inline_snap_waiter(snap_prep)
 
                 try:
                     _write_cmd(cmd_line, timing)
                 except RuntimeError as e:
+                    _consume_inline_snap_waiter(snap_waiter)
                     yield _resp_sse("error", {
                         "error": {"type": "server_error", "message": str(e)}})
                     return
@@ -2190,9 +2239,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             "stream ended before daemon sentinel; "
                             "retaining prompt .bin for in-flight daemon read")
 
+                inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
                 _confirm_or_abort_snap(
                     completion_tokens, full_snap_prep_ref[0], snap_prep,
-                    prompt_ids, cur_bin, cur_ids)
+                    prompt_ids, cur_bin, cur_ids, inline_snap_ok)
                 _park_draft_if_lazy(timing)
 
                 # Build final output items

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -1572,6 +1572,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     timing = {}
                     full_snap_prep_ref = [None]
                     snap_prep = None
+                    snap_waiter = None
 
                     full_hit = prefix_cache.lookup_full(prompt_ids)
                     if full_hit is not None:
@@ -1609,6 +1610,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         cmd_line, snap_prep = _build_cmd_line(
                             req, cur_bin, cur_ids, gen_len, prefix_cache,
                             prompt_ids, full_snap_prep_ref, compression_fired)
+                        snap_waiter = _prime_inline_snap_waiter(snap_prep)
 
                     message_start = {
                         "type": "message_start",
@@ -1700,6 +1702,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             timing = {}
             full_snap_prep_ref = [None]
             snap_prep = None
+            snap_waiter = None
 
             full_hit = prefix_cache.lookup_full(prompt_ids)
             if full_hit is not None:
@@ -1934,6 +1937,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             timing = {}
             full_snap_prep_ref = [None]
             snap_prep = None
+            snap_waiter = None
 
             full_hit = prefix_cache.lookup_full(prompt_ids)
             if full_hit is not None:

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -385,7 +385,7 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
 int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                                const DaemonIO & io,
                                int snap_pos, int snap_slot) {
-    (void)io; (void)snap_pos; (void)snap_slot;
+    (void)io;
 
     const int hidden = w_.n_embd;
     const int PREFILL_UBATCH = 512;
@@ -401,8 +401,21 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     // Chunked prefill
     std::vector<float> embed_buf((size_t)hidden * PREFILL_UBATCH);
     int committed = 0;
-    for (int start = 0; start < prompt_len; start += PREFILL_UBATCH) {
-        const int n_tokens = std::min(PREFILL_UBATCH, prompt_len - start);
+    for (int start = 0; start < prompt_len;) {
+        if (snap_pos >= 0 && snap_slot >= 0 && snap_pos == start) {
+            cache_.cur_pos = start;
+            if (snapshot_save(snap_slot)) {
+                std::printf("[snap] inline slot=%d cur_pos=%d\n", snap_slot, start);
+                std::fflush(stdout);
+            }
+            snap_pos = -1;
+            snap_slot = -1;
+        }
+
+        int n_tokens = std::min(PREFILL_UBATCH, prompt_len - start);
+        if (snap_pos > start && snap_pos < start + n_tokens) {
+            n_tokens = snap_pos - start;
+        }
         const bool with_mask = (cfg_.kq_stride_pad > KQ_MASK_PAD) || (n_tokens > 1);
 
         if (!build_target_step(sg_, w_, cache_, target_backend_,
@@ -453,24 +466,31 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
             return -1;
         }
 
-        // Snapshot at boundary if requested
-        if (snap_pos >= 0 && snap_slot >= 0 &&
-            start + n_tokens >= snap_pos && start < snap_pos) {
-            // Not at boundary yet — next chunk will cross it
-        } else if (snap_pos >= 0 && snap_slot >= 0 &&
-                   start + n_tokens == snap_pos) {
-            cache_.cur_pos = snap_pos;
-            snapshot_save(snap_slot);
-        }
+        int32_t last_tok = -1;
+        const size_t argmax_off =
+            (start + n_tokens < prompt_len) ? 0 : sizeof(int32_t) * (size_t)(n_tokens - 1);
+        ggml_backend_tensor_get(sg_.argmax_tokens, &last_tok, argmax_off, sizeof(int32_t));
+        cache_.last_tok = last_tok;
 
         committed = start + n_tokens;
         cache_.cur_pos = committed;
+
+        if (snap_pos >= 0 && snap_slot >= 0 && committed == snap_pos) {
+            if (snapshot_save(snap_slot)) {
+                std::printf("[snap] inline slot=%d cur_pos=%d\n", snap_slot, committed);
+                std::fflush(stdout);
+            }
+            snap_pos = -1;
+            snap_slot = -1;
+        }
 
         // Sync feature mirror if active
         if (feature_mirror_.target_feat && !draft_parked_) {
             draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
                                             feature_mirror_, start, n_tokens);
         }
+
+        start = committed;
     }
 
     return committed;


### PR DESCRIPTION
Only commit inline prefix-cache slots after the daemon confirms that the snapshot was actually written.

Register stdout waiters synchronously before issuing generation requests, thread the waiter through the server request paths, and drop slot reservations when the inline snapshot ack never arrives.

On qwen35, split prefill chunks at snapshot boundaries, preserve last-token state across prefill, and emit an inline snapshot ack when snapshot_save() succeeds so restores cannot target an empty slot.