### PR TITLE
Fast CI workflow run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,7 @@ jobs:
             -DDFLASH27B_ENABLE_BSA=OFF \
             -DDFLASH27B_FA_ALL_QUANTS=OFF \
             -DCMAKE_BUILD_TYPE=Release
-          cmake --build build --target test_dflash test_generate -j$(nproc)
-
-      - name: Build sparse FA smoke target
-        run: |
-          cd dflash
-          cmake -B build-bsa \
-            -DCMAKE_CUDA_ARCHITECTURES="86" \
-            -DDFLASH27B_FA_ALL_QUANTS=OFF \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-bsa --target test_flash_attn_sparse -j$(nproc)
+          cmake --build build --target test_dflash test_generate test_flash_attn_sparse -j$(nproc)
 
       - name: Install megakernel Python deps
         run: pip install torch --index-url https://download.pytorch.org/whl/cu126

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build (CUDA 12.8)
+    name: CUDA smoke build (sm_86)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,36 +24,31 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
 
-      - name: Build dflash
+      - name: Build dflash smoke targets
         run: |
           cd dflash
           cmake -B build \
-            -DCMAKE_CUDA_ARCHITECTURES="75;86" \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build -j$(nproc)
-
-      - name: Build sparse FA adapter (sm_86)
-        run: |
-          cd dflash
-          cmake -B build-sm86 \
             -DCMAKE_CUDA_ARCHITECTURES="86" \
             -DDFLASH27B_ENABLE_BSA=OFF \
+            -DDFLASH27B_FA_ALL_QUANTS=OFF \
             -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-sm86 --target test_flash_attn_sparse -j$(nproc)
+          cmake --build build --target test_dflash test_generate -j$(nproc)
+
+      - name: Build sparse FA smoke target
+        run: |
+          cd dflash
+          cmake -B build-bsa \
+            -DCMAKE_CUDA_ARCHITECTURES="86" \
+            -DDFLASH27B_FA_ALL_QUANTS=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-bsa --target test_flash_attn_sparse -j$(nproc)
 
       - name: Install megakernel Python deps
         run: pip install torch --index-url https://download.pytorch.org/whl/cu126
 
-      - name: Build megakernel (sm_75)
-        env:
-          CUDA_HOME: ${{ env.CUDA_PATH }}
-        run: |
-          cd megakernel
-          MEGAKERNEL_CUDA_ARCH=sm_75 python3 setup.py build_ext --inplace
-          rm -rf build
-
-      - name: Build megakernel (sm_86)
+      - name: Build megakernel smoke target
         env:
           CUDA_HOME: ${{ env.CUDA_PATH }}
         run: |


### PR DESCRIPTION
Since we only care if CUDA is broken, we only do one arch build. Also enable pip cache