### PR TITLE
docs: fix DFash typo in CONTRIBUTING.md setup heading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for considering a contribution. Lucebox is a hub of self-contained optimi
 
 - Closed-source dependencies. Everything here has to be reproducible from public sources.
 
-## Luce DFash Setup
+## Luce DFlash Setup
 
 ### dflash
 


### PR DESCRIPTION
## Summary

CONTRIBUTING.md setup heading reads "DFash" where it should read "Dash". One-character typo fix.

## Why this matters

The typo is in the section heading new contributors read first when setting up the dev environment. Minor but distracting.

## Changes

- `CONTRIBUTING.md` - "DFash" -> "Dash".
