### PR TITLE
fix(dflash): Honor prefill ubatch env `DFLASH27B_PREFILL_UBATCH` in qwen35 backend

### DIFF
--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 namespace dflash27b {
@@ -388,7 +389,10 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     (void)io;
 
     const int hidden = w_.n_embd;
-    const int PREFILL_UBATCH = 512;
+    int prefill_ubatch = 512;
+    if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
+        prefill_ubatch = std::max(1, std::atoi(s));
+    }
     const int prompt_len = (int)tokens.size();
 
     // Migrate to full-mode KV cache if needed
@@ -399,7 +403,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                           target_backend_, cache_);
 
     // Chunked prefill
-    std::vector<float> embed_buf((size_t)hidden * PREFILL_UBATCH);
+    std::vector<float> embed_buf((size_t)hidden * prefill_ubatch);
     int committed = 0;
     for (int start = 0; start < prompt_len;) {
         if (snap_pos >= 0 && snap_slot >= 0 && snap_pos == start) {
@@ -412,7 +416,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
             snap_slot = -1;
         }
 
-        int n_tokens = std::min(PREFILL_UBATCH, prompt_len - start);
+        int n_tokens = std::min(prefill_ubatch, prompt_len - start);
         if (snap_pos > start && snap_pos < start + n_tokens) {
             n_tokens = snap_pos - start;
         }


### PR DESCRIPTION
While using Hermes I saw a lot of OOM when I updated.  It seems there is some regression.  This is more clearly stated by codex below:

The qwen35 backend refactor hardcoded single-GPU prefill chunk size to `512`,
which made `DFLASH27B_PREFILL_UBATCH` ineffective for the main dflash daemon
path. This restores the environment override while keeping `512` as the default.

This matters on 24 GB GPUs because qwen35 at 64k context has little VRAM
headroom once target weights, KV cache, rollback buffers, and one prefix-cache
snapshot are resident. Operators need a working prefill ubatch knob to trade
prefill speed for lower peak graph/activation memory.

## User-Visible Failure

On an RTX 3090, current upstream can OOM during heavy Hermes/OpenClaw requests
even when the deployment sets a lower ubatch:

```text
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 1245.63 MiB on device 0: cudaMalloc failed: out of memory
alloc_tensor_range: failed to allocate CUDA0 buffer of size 1306136576
```

The deployment had:

```yaml
DFLASH27B_PREFILL_UBATCH: "128"
```

but the single-GPU qwen35 backend ignored it because `do_prefill()` used:

```cpp
const int PREFILL_UBATCH = 512;
```

## Root Cause

PR #175 extracted `Qwen35Backend` and introduced a hardcoded prefill ubatch in
`dflash/src/qwen35/qwen35_backend.cpp`. The older daemon/test path did read
`DFLASH27B_PREFILL_UBATCH`, and the layer-split path still does, but the
single-GPU qwen35 backend no longer did.

## What Changed

`Qwen35Backend::do_prefill()` now reads:

```cpp
int prefill_ubatch = 512;
if (const char * s = std::getenv("DFLASH27B_PREFILL_UBATCH")) {
    prefill_ubatch = std::max(1, std::atoi(s));
}
```

and uses that value for the prefill embedding buffer and chunk size.