### PR TITLE
refactor: separate drafter weight cleanup from backend destroy

### DIFF
--- a/dflash/src/qwen3/qwen3_drafter.cpp
+++ b/dflash/src/qwen3/qwen3_drafter.cpp
@@ -197,6 +197,14 @@ bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
 }
 
 void free_drafter(DrafterContext & ctx) {
+    free_drafter_weights(ctx);
+    if (ctx.backend) {
+        ggml_backend_free(ctx.backend);
+        ctx.backend = nullptr;
+    }
+}
+
+void free_drafter_weights(DrafterContext & ctx) {
     if (ctx.arch == DrafterArch::Qwen35_0p8b && ctx.arch_state) {
         auto * st = static_cast<Qwen35DrafterState *>(ctx.arch_state);
         free_target_weights(st->weights);
@@ -207,10 +215,6 @@ void free_drafter(DrafterContext & ctx) {
         if (ctx.arch == DrafterArch::Qwen3_0p6b) {
             free_qwen3_drafter_model(ctx.weights);
         }
-    }
-    if (ctx.backend) {
-        ggml_backend_free(ctx.backend);
-        ctx.backend = nullptr;
     }
     ctx.loaded = false;
 }

--- a/dflash/src/qwen3/qwen3_drafter.h
+++ b/dflash/src/qwen3/qwen3_drafter.h
@@ -54,6 +54,10 @@ bool load_drafter(const std::string & gguf_path, int gpu_layers,
 
 void free_drafter(DrafterContext & ctx);
 
+// Free only model weights, keeping the CUDA backend alive for reuse.
+// Avoids repeated ggml backend create/destroy which corrupts CUDA state.
+void free_drafter_weights(DrafterContext & ctx);
+
 // Score importance per token via Liu Q-hook tail attention, then chunk-top-K
 // span merge. Returns surviving token IDs (drafter vocab).
 //


### PR DESCRIPTION
Add free_drafter_weights() that frees model weights while keeping the CUDA backend alive for reuse. Avoids repeated ggml backend create/destroy which corrupts CUDA state on multi-cycle compress.