### PR TITLE
fix: reset SSM/conv recurrent state between requests

### DIFF
--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -449,6 +449,12 @@ void free_target_cache(TargetCache & c);
 // requests to avoid the ~5 s overhead of full cache destruction + recreation.
 void reset_target_cache(TargetCache & c);
 
+// Zero only the recurrent state (SSM + conv) without touching the KV cache.
+// Much cheaper than reset_target_cache for new requests where KV will be
+// overwritten during prefill anyway. Essential between HTTP requests to avoid
+// stale delta-net state corrupting subsequent prefills.
+void reset_recurrent_state(TargetCache & c);
+
 // Reallocate a prefill-only cache with full rollback tensors, copying all live
 // state (KV, SSM, conv, target_feat) device-to-device. Frees the old cache.
 bool migrate_prefill_cache(const TargetWeights & w,

--- a/dflash/src/qwen35/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35/qwen35_target_graph.cpp
@@ -305,6 +305,20 @@ void reset_target_cache(TargetCache & c) {
     }
 }
 
+void reset_recurrent_state(TargetCache & c) {
+    auto zero_tensors = [](const std::vector<ggml_tensor *> & tensors) {
+        std::vector<uint8_t> zeros;
+        for (ggml_tensor * t : tensors) {
+            if (!t) continue;
+            const size_t nb = ggml_nbytes(t);
+            if (zeros.size() < nb) zeros.resize(nb, 0);
+            ggml_backend_tensor_set(t, zeros.data(), 0, nb);
+        }
+    };
+    zero_tensors(c.ssm_state);
+    zero_tensors(c.conv_state);
+}
+
 // Attach rollback tensors to an existing prefill cache without touching the
 // base tensors (KV, SSM, conv, target_feat) that prefill already populated.
 // No D2D copies — the base tensors stay right where the graph wrote them.


### PR DESCRIPTION
Add reset_recurrent_state() that zeros only SSM + conv state without touching the KV cache. Essential between requests to prevent stale delta-net state from corrupting subsequent prefills.