### PR TITLE
Add client harness tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ All speedups measured vs vendored llama.cpp (`-fa 1`, matching KV quant).
 | RTX 5090 | Qwen 3.6-27B Q4_K_M (DFlash + DDTree) | — | **4.84×** vs AR (205 tok/s) |
 | Ryzen AI MAX+ 395 (gfx1151) | Qwen 3.5-27B Q4_K_M (DFlash + PFlash, HIP) | **2.24×** @ 16K | **3.08×** vs llama.cpp HIP AR (37 tok/s) |
 
+## Client harnesses
+
+[`harness/`](harness/) contains RTX 3090 client launchers and regression tests
+for Lucebox server compatibility. Use it to run Lucebox inside Claude Code,
+Codex, OpenCode, Hermes, Pi, OpenClaw, or Open WebUI, or to check that a server
+change still works with those clients.
+
+```bash
+harness/clients/run_codex.sh
+harness/clients/run_claude_code.sh
+python3 harness/client_test_runner.py probe --url http://127.0.0.1:8000
+```
+
 ## 01 · Megakernel Qwen3.5 0.8B on RTX 3090
 
 Single-kernel CUDA inference for Qwen 3.5-0.8B on RTX 3090. All 24 layers run in one persistent dispatch.

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -231,6 +231,16 @@ def parse_reasoning(
     return _strip_leading_think_closers(content), (reasoning.strip() or None)
 
 
+def _thinking_enabled(template_kwargs: dict | None) -> bool:
+    """Return whether Qwen think blocks are enabled for this rendered prompt."""
+    return bool((template_kwargs or {}).get("enable_thinking", False))
+
+
+def prompt_starts_in_thinking(prompt: str) -> bool:
+    """True when the chat template ended by opening a think block."""
+    return bool(re.search(r"<think>\s*$", prompt))
+
+
 def _find_tool_properties(tools, function_name):
     """Returns the parameters dict for a given function name, or {}."""
     for t in tools or []:
@@ -448,9 +458,65 @@ def _content_to_str(content: "str | list[dict] | None") -> str:
         return content
     parts = []
     for block in content:
-        if isinstance(block, dict) and block.get("type") == "text":
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") in ("text", "input_text", "output_text"):
             parts.append(block.get("text", ""))
+        elif block.get("type") == "tool_result":
+            value = block.get("content", "")
+            parts.append(_content_to_str(value) if isinstance(value, list) else str(value))
     return "".join(parts)
+
+
+def _normalize_anthropic_system(system_text: str | None) -> str | None:
+    if not system_text:
+        return None
+    if os.environ.get("DFLASH_ANTHROPIC_RAW_SYSTEM", "0") == "1":
+        return system_text
+    # Claude Code's default system prompt is written for Claude and can be tens
+    # of thousands of tokens once skills/reminders are expanded. Qwen handles
+    # the Anthropic Messages route much more reliably with a compact adapter
+    # prompt while still receiving the user's message and advertised tools.
+    if (
+        "x-anthropic-billing-header:" in system_text
+        or "Claude Agent SDK" in system_text
+        or "Claude Code" in system_text
+    ):
+        return (
+            "You are a concise coding assistant running behind an Anthropic "
+            "Messages compatible client. Answer the user's request directly. "
+            "Use the provided tools only when they are needed."
+        )
+    return system_text
+
+
+def _normalize_anthropic_user_text(text: str) -> str:
+    if os.environ.get("DFLASH_ANTHROPIC_RAW_USER", "0") == "1":
+        return text
+
+    def replace_reminder(match: re.Match[str]) -> str:
+        block = match.group(0)
+        # Claude Code may inject long skill-selection reminders for Claude's
+        # own skill runtime. They are not useful to Qwen and can dominate the
+        # prompt. Keep ordinary user/system-reminder context such as dates.
+        if "SKIP:" in block and ("- init:" in block or "- review:" in block):
+            return ""
+        return block
+
+    return re.sub(
+        r"<system-reminder>.*?</system-reminder>",
+        replace_reminder,
+        text,
+        flags=re.DOTALL,
+    )
+
+
+def _json_args_obj(args: str) -> dict:
+    try:
+        value = json.loads(args or "{}")
+        return value if isinstance(value, dict) else {"value": value}
+    except Exception:
+        return {"_raw": args}
 
 
 # ─── pydantic schemas ──────────────────────────────────────────────
@@ -478,6 +544,27 @@ class ChatMessage(BaseModel):
 class ToolDef(BaseModel):
     type: str = "function"
     function: dict  # {name, description, parameters: {...JSON schema...}}
+
+
+def _anthropic_tools_to_openai(tools: list[dict] | None) -> list[ToolDef] | None:
+    if not tools:
+        return None
+    out: list[ToolDef] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name")
+        if not name:
+            continue
+        out.append(ToolDef(type="function", function={
+            "name": name,
+            "description": tool.get("description", ""),
+            "parameters": tool.get("input_schema") or tool.get("parameters") or {
+                "type": "object",
+                "properties": {},
+            },
+        }))
+    return out or None
 
 
 # Default cap when the client omits ``max_tokens``. Override at start via
@@ -515,6 +602,8 @@ class AnthropicMessagesRequest(BaseModel):
     max_tokens: int
     messages: list[AnthropicMessage]
     system: str | list[dict] | None = None
+    tools: list[dict] | None = None
+    tool_choice: Any | None = None
     stream: bool = False
     temperature: float | None = None
     top_p: float | None = None
@@ -604,6 +693,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
               prefill_cache_slots: int = 4,
               prefill_cache_bytes: int = 0,
               arch: str = "qwen35",
+              verify_mode: str = "ddtree",
               extra_daemon_args: list[str] | None = None,
               lazy_draft: bool = False,
               verbose_daemon: bool = False) -> FastAPI:
@@ -667,9 +757,17 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         if draft is None:
             raise SystemExit("qwen35 arch requires --draft <draft.gguf|model.safetensors>")
         cmd = [bin_abs, str(target), str(draft), "--daemon",
-               "--fast-rollback", "--ddtree", f"--ddtree-budget={budget}",
                f"--max-ctx={max_ctx}",
                f"--stream-fd={stream_fd_val}"]
+        if verify_mode == "ddtree":
+            cmd.append("--fast-rollback")
+            cmd.extend(["--ddtree", f"--ddtree-budget={budget}"])
+        elif verify_mode == "fast":
+            cmd.append("--fast-rollback")
+        elif verify_mode == "seq":
+            cmd.append("--seq-verify")
+        elif verify_mode != "replay":
+            raise SystemExit(f"unknown verify_mode={verify_mode}")
         if extra_daemon_args:
             cmd.extend(extra_daemon_args)
     if sys.platform == "win32":
@@ -1123,7 +1221,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 prefix_cache.confirm_inline_snap(*snap_prep, cur_ids)
             elif snap_prep:
                 prefix_cache.abort_inline_snap(snap_prep[0])
-                log.warning("inline snapshot ack missing — dropped slot reservation")
+                log.warning("inline snapshot ack missing - dropped slot reservation")
         else:
             # Abort: release the reservation without registering.
             if full_snap_prep is not None:
@@ -1550,20 +1648,95 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
     def _tokenize_anthropic(req: AnthropicMessagesRequest
                             ) -> tuple[Path, list[int], list[dict], bool]:
-        msgs = []
+        chat_messages: list[ChatMessage] = []
         system_text = _content_to_str(req.system) if req.system else None
+        system_text = _normalize_anthropic_system(system_text)
         if system_text:
-            msgs.append({"role": "system", "content": system_text})
+            chat_messages.append(ChatMessage(role="system", content=system_text))
         for m in req.messages:
-            msgs.append({"role": m.role, "content": _content_to_str(m.content)})
-        path, ids, prompt = _render_messages(msgs, req.chat_template_kwargs)
+            if isinstance(m.content, list):
+                text_parts: list[str] = []
+                tool_calls: list[ToolCall] = []
+                for block in m.content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type")
+                    if btype == "text":
+                        text_parts.append(_normalize_anthropic_user_text(block.get("text", "")))
+                    elif btype == "tool_use":
+                        tool_calls.append(ToolCall(
+                            id=block.get("id"),
+                            type="function",
+                            function=ToolCallFunction(
+                                name=block.get("name", ""),
+                                arguments=json.dumps(block.get("input") or {}),
+                            ),
+                        ))
+                    elif btype == "tool_result":
+                        if text_parts:
+                            chat_messages.append(ChatMessage(
+                                role=m.role, content="".join(text_parts)))
+                            text_parts = []
+                        value = block.get("content", "")
+                        chat_messages.append(ChatMessage(
+                            role="tool",
+                            tool_call_id=block.get("tool_use_id", ""),
+                            content=_content_to_str(value) if isinstance(value, list) else str(value),
+                        ))
+                if tool_calls:
+                    chat_messages.append(ChatMessage(
+                        role="assistant",
+                        content=("".join(text_parts) or None),
+                        tool_calls=tool_calls,
+                    ))
+                elif text_parts:
+                    chat_messages.append(ChatMessage(role=m.role, content="".join(text_parts)))
+            else:
+                chat_messages.append(ChatMessage(
+                    role=m.role,
+                    content=_normalize_anthropic_user_text(_content_to_str(m.content)),
+                ))
+
+        tools = _anthropic_tools_to_openai(req.tools)
+        chat_req = ChatRequest(
+            model=req.model or MODEL_NAME,
+            messages=chat_messages,
+            max_tokens=req.max_tokens,
+            temperature=req.temperature,
+            top_p=req.top_p,
+            seed=req.seed,
+            frequency_penalty=req.frequency_penalty,
+            stop=req.stop_sequences,
+            tools=tools,
+            tool_choice=req.tool_choice,
+            chat_template_kwargs=req.chat_template_kwargs or {"enable_thinking": True},
+        )
+        path, ids, msgs, _ = _tokenize_prompt(chat_req)
+        prompt = tokenizer.decode(ids, skip_special_tokens=False)
         think = _thinking_enabled(req.chat_template_kwargs) and prompt_starts_in_thinking(prompt)
         return path, ids, msgs, think
 
     @app.post("/v1/messages")
     async def anthropic_messages(req: AnthropicMessagesRequest):
+        # Keep local Anthropic-compatible decoding deterministic by default.
+        # The route can still honor client sampling with
+        # DFLASH_ANTHROPIC_ALLOW_SAMPLING=1.
+        if os.environ.get("DFLASH_ANTHROPIC_ALLOW_SAMPLING", "0") != "1":
+            req.temperature = 0.0
         prompt_bin, prompt_ids, raw_msgs, started_in_thinking = _tokenize_anthropic(req)
         msg_id = "msg_" + uuid.uuid4().hex[:24]
+        t0 = time.monotonic()
+        prompt_len = len(prompt_ids)
+        n_tools = len(req.tools) if req.tools else 0
+        log.info(
+            "messages %s  stream=%s  msgs=%d  tools=%d  "
+            "prompt_tokens=%d  max_tokens=%d  effective_max_tokens=%d  "
+            "temperature=%s  max_ctx=%d  model=%s",
+            msg_id, req.stream, len(req.messages), n_tools,
+            prompt_len, req.max_tokens, _max_tokens_for(req), req.temperature,
+            max_ctx,
+            req.model or MODEL_NAME,
+        )
 
         if req.stream:
             async def sse() -> AsyncIterator[str]:
@@ -1631,42 +1804,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         return
 
                     out_tokens = 0
-                    window, mode = "", ("reasoning" if started_in_thinking else "content")
-                    block_index = 0
-                    active_kind = "thinking" if mode == "reasoning" else "text"
-                    block = {"type": active_kind}
-                    if active_kind == "thinking":
-                        block["thinking"] = ""
-                    else:
-                        block["text"] = ""
-                    yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': block})}\n\n"
+                    tokens: list[int] = []
                     try:
                         async for tok_id in _astream_tokens(r_pipe, gen_len, timing):
                             out_tokens += 1
-                            outputs, window, mode = consume_stream_piece(
-                                window, mode, tokenizer.decode([tok_id]))
-                            for kind, text in outputs:
-                                target_kind = "thinking" if kind == "reasoning_content" else "text"
-                                if target_kind != active_kind:
-                                    yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
-                                    block_index += 1
-                                    active_kind = target_kind
-                                    new_block = {"type": active_kind, active_kind: ""}
-                                    yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': new_block})}\n\n"
-                                delta_type = "thinking_delta" if target_kind == "thinking" else "text_delta"
-                                delta_key = "thinking" if target_kind == "thinking" else "text"
-                                yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': block_index, 'delta': {'type': delta_type, delta_key: text}})}\n\n"
-                        for kind, text in flush_stream_deltas(window, mode):
-                            target_kind = "thinking" if kind == "reasoning_content" else "text"
-                            if target_kind != active_kind:
-                                yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
-                                block_index += 1
-                                active_kind = target_kind
-                                new_block = {"type": active_kind, active_kind: ""}
-                                yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': new_block})}\n\n"
-                            delta_type = "thinking_delta" if target_kind == "thinking" else "text_delta"
-                            delta_key = "thinking" if target_kind == "thinking" else "text"
-                            yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': block_index, 'delta': {'type': delta_type, delta_key: text}})}\n\n"
+                            tokens.append(tok_id)
                     finally:
                         if timing.get("daemon_done"):
                             if full_hit is None:
@@ -1686,13 +1828,68 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         prompt_ids, cur_bin, cur_ids, inline_snap_ok)
                     _park_draft_if_lazy(timing)
 
-                    yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+                    text = tokenizer.decode(tokens, skip_special_tokens=True)
+                    cleaned, tool_calls = parse_tool_calls(
+                        text, tools=_anthropic_tools_to_openai(req.tools))
+                    _remember_tool_call_text(text, tool_calls)
+                    cleaned, reasoning = parse_reasoning(
+                        cleaned,
+                        thinking_enabled=_thinking_enabled(req.chat_template_kwargs),
+                        started_in_thinking=started_in_thinking,
+                    )
+
+                    block_index = 0
+                    emitted_block = False
+
+                    async def emit_text_block(kind: str, value: str):
+                        nonlocal block_index, emitted_block
+                        block = {"type": kind, kind: ""}
+                        yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': block})}\n\n"
+                        delta_type = "thinking_delta" if kind == "thinking" else "text_delta"
+                        delta_key = "thinking" if kind == "thinking" else "text"
+                        yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': block_index, 'delta': {'type': delta_type, delta_key: value}})}\n\n"
+                        yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+                        block_index += 1
+                        emitted_block = True
+
+                    if reasoning:
+                        async for event in emit_text_block("thinking", reasoning):
+                            yield event
+                    if cleaned:
+                        async for event in emit_text_block("text", cleaned):
+                            yield event
+                    for tc in tool_calls:
+                        args = tc["function"]["arguments"]
+                        block = {
+                            "type": "tool_use",
+                            "id": tc["id"],
+                            "name": tc["function"]["name"],
+                            "input": {},
+                        }
+                        yield f"event: content_block_start\ndata: {json.dumps({'type': 'content_block_start', 'index': block_index, 'content_block': block})}\n\n"
+                        yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': block_index, 'delta': {'type': 'input_json_delta', 'partial_json': args}})}\n\n"
+                        yield f"event: content_block_stop\ndata: {json.dumps({'type': 'content_block_stop', 'index': block_index})}\n\n"
+                        block_index += 1
+                        emitted_block = True
+                    if not emitted_block:
+                        async for event in emit_text_block("text", ""):
+                            yield event
+
                     msg_delta = {
                         "type": "message_delta",
-                        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                        "delta": {"stop_reason": "tool_use" if tool_calls else "end_turn",
+                                  "stop_sequence": None},
                         "usage": {"output_tokens": out_tokens},
                     }
                     yield f"event: message_delta\ndata: {json.dumps(msg_delta)}\n\n"
+                    finish_reason = "tool_use" if tool_calls else "end_turn"
+                    elapsed = time.monotonic() - t0
+                    tok_s = out_tokens / elapsed if elapsed > 0 else 0.0
+                    log.info(
+                        "messages DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s  %s",
+                        msg_id, prompt_len, out_tokens, elapsed, tok_s,
+                        finish_reason, _timing_summary(timing, out_tokens),
+                    )
                     yield f"event: message_stop\ndata: {json.dumps({'type': 'message_stop'})}\n\n"
 
             return StreamingResponse(sse(), media_type="text/event-stream")
@@ -1764,21 +1961,43 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             except Exception: pass
 
         text = tokenizer.decode(tokens, skip_special_tokens=True)
+        cleaned, tool_calls = parse_tool_calls(
+            text, tools=_anthropic_tools_to_openai(req.tools))
+        _remember_tool_call_text(text, tool_calls)
         cleaned, reasoning = parse_reasoning(
-            text,
+            cleaned,
             thinking_enabled=_thinking_enabled(req.chat_template_kwargs),
             started_in_thinking=started_in_thinking,
         )
-        content = [{"type": "text", "text": cleaned}]
+        content = []
         if reasoning:
             content.insert(0, {"type": "thinking", "thinking": reasoning})
+        if cleaned:
+            content.append({"type": "text", "text": cleaned})
+        for tc in tool_calls:
+            content.append({
+                "type": "tool_use",
+                "id": tc["id"],
+                "name": tc["function"]["name"],
+                "input": _json_args_obj(tc["function"]["arguments"]),
+            })
+        if not content:
+            content.append({"type": "text", "text": ""})
+        finish_reason = "tool_use" if tool_calls else "end_turn"
+        elapsed = time.monotonic() - t0
+        tok_s = len(tokens) / elapsed if elapsed > 0 else 0.0
+        log.info(
+            "messages DONE %s  in=%d out=%d  %.1fs  %.1f tok/s  finish=%s  %s",
+            msg_id, prompt_len, len(tokens), elapsed, tok_s, finish_reason,
+            _timing_summary(timing, len(tokens)),
+        )
         return JSONResponse({
             "id": msg_id,
             "type": "message",
             "role": "assistant",
             "model": req.model or MODEL_NAME,
             "content": content,
-            "stop_reason": "end_turn",
+            "stop_reason": finish_reason,
             "stop_sequence": None,
             "usage": {"input_tokens": prompt_len,
                       "output_tokens": len(tokens)},
@@ -2260,22 +2479,39 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         for tc in tool_calls:
                             tool_call_active = True
                             tc_item_id = tc["id"]
-                            # Emit function_call_arguments.delta for each tool call
+                            output_index = len(final_output) + 1
+                            in_progress_item = {
+                                "type": "function_call",
+                                "id": tc_item_id,
+                                "status": "in_progress",
+                                "call_id": tc_item_id,
+                                "name": tc["function"]["name"],
+                                "arguments": "",
+                            }
+                            yield _resp_sse("response.output_item.added", {
+                                "output_index": output_index,
+                                "item": in_progress_item,
+                            })
                             yield _resp_sse("response.function_call_arguments.delta", {
-                                "item_id": tc_item_id, "output_index": 0,
+                                "item_id": tc_item_id, "output_index": output_index,
                                 "delta": tc["function"]["arguments"]})
                             yield _resp_sse("response.function_call_arguments.done", {
-                                "item_id": tc_item_id, "output_index": 0,
+                                "item_id": tc_item_id, "output_index": output_index,
                                 "arguments": tc["function"]["arguments"],
                                 "name": tc["function"]["name"]})
-                            final_output.append({
+                            done_item = {
                                 "type": "function_call",
                                 "id": tc_item_id,
                                 "status": "completed",
                                 "call_id": tc_item_id,
                                 "name": tc["function"]["name"],
                                 "arguments": tc["function"]["arguments"],
+                            }
+                            yield _resp_sse("response.output_item.done", {
+                                "output_index": output_index,
+                                "item": done_item,
                             })
+                            final_output.append(done_item)
                     else:
                         accumulated_text += tool_buffer
                         yield _resp_sse("response.output_text.delta", {
@@ -2292,22 +2528,20 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     "part": {"type": "output_text", "text": accumulated_text,
                              "annotations": []}})
 
+                message_item = {
+                    "type": "message",
+                    "id": msg_item_id,
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": ([{"type": "output_text", "text": accumulated_text,
+                                  "annotations": []}] if accumulated_text else []),
+                }
                 if not tool_call_active:
-                    final_output.append({
-                        "type": "message",
-                        "id": msg_item_id,
-                        "status": "completed",
-                        "role": "assistant",
-                        "content": [{"type": "output_text", "text": accumulated_text,
-                                     "annotations": []}],
-                    })
+                    final_output.append(message_item)
 
                 yield _resp_sse("response.output_item.done", {
                     "output_index": 0,
-                    "item": final_output[0] if final_output else {
-                        "type": "message", "id": msg_item_id,
-                        "status": "completed", "role": "assistant",
-                        "content": []}})
+                    "item": message_item})
 
                 # response.completed
                 shell = _resp_shell(response_id, chat_req.model, created_at,
@@ -2359,6 +2593,10 @@ def main():
     ap.add_argument("--draft",  type=Path, default=DEFAULT_DRAFT_ROOT)
     ap.add_argument("--bin",    type=Path, default=DEFAULT_BIN)
     ap.add_argument("--budget", type=int,  default=DEFAULT_BUDGET)
+    ap.add_argument("--verify-mode", choices=["ddtree", "fast", "seq", "replay"],
+                    default="ddtree",
+                    help="Qwen daemon verify mode: ddtree (default), fast "
+                         "rollback, sequential verify, or replay rollback.")
     default_ctx = 16384
     ap.add_argument("--max-ctx", type=int, default=default_ctx,
                     help=f"Maximum context length (default: {default_ctx}; "
@@ -2485,6 +2723,7 @@ def main():
                     prefill_cache_slots=placement.prefill_cache_slots,
                     prefill_cache_bytes=args.prefill_cache_bytes,
                     arch=arch,
+                    verify_mode=args.verify_mode,
                     extra_daemon_args=placement.daemon_args or None,
                     lazy_draft=args.lazy_draft,
                     verbose_daemon=args.verbose_daemon)

--- a/harness/.gitignore
+++ b/harness/.gitignore
@@ -1,0 +1,4 @@
+.harness-work/
+results/
+*.json
+__pycache__/

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,87 @@
+# Lucebox Harness
+
+<p align="center">
+  <img src="assets/hero.png" alt="Lucebox client harness experiments on RTX 3090" width="100%">
+</p>
+
+Use this folder for two things:
+
+- launch Lucebox through a real client: Claude Code, Codex, OpenCode, Hermes,
+  Pi, OpenClaw, or Open WebUI
+- test a Lucebox change against the HTTP protocols those clients use
+
+The defaults are tuned for an RTX 3090 / 24 GB setup. Paths and server settings
+can be overridden with environment variables.
+
+## Run a client
+
+Each script starts Lucebox, runs one real client, saves logs, then stops the
+server.
+
+```bash
+cd /workspace/lucebox-hub-harness
+
+harness/clients/run_codex.sh
+harness/clients/run_claude_code.sh
+harness/clients/run_opencode.sh
+```
+
+Common overrides:
+
+```bash
+MAX_CTX=32768 BUDGET=22 VERIFY_MODE=ddtree harness/clients/run_codex.sh
+PROMPT_FILE=harness/clients/prompts/repo_inspection.txt harness/clients/run_hermes.sh
+CLIENT=opencode harness/clients/run_backend_pair.sh
+```
+
+The per-client defaults live in [`clients/README.md`](clients/README.md).
+They are not all the same: a tool-heavy agent prompt and a chat/proxy prompt
+need different context limits on a 24 GB card.
+
+## Test a server change
+
+If you already have `dflash/scripts/server.py` running, use `probe`:
+
+```bash
+python3 harness/client_test_runner.py probe \
+  --url http://127.0.0.1:8000 \
+  --clients claude_code,codex,opencode,openwebui,pi \
+  --json-out /tmp/lucebox_harness_probe.json
+```
+
+Add `--install-packages` when you also want the runner to install/smoke the
+client packages. Without it, the HTTP protocol probes still run.
+
+For a GPU sweep, let the runner start Lucebox for each profile:
+
+```bash
+python3 harness/client_test_runner.py sweep \
+  --target dflash/models/Qwen3.6-27B-Q4_K_M.gguf \
+  --draft dflash/models/draft \
+  --bin dflash/build/test_dflash \
+  --profiles rtx3090_dflash_safe,rtx3090_dflash_long \
+  --clients all \
+  --json-out /tmp/lucebox_harness_sweep.json
+```
+
+Use `--isolate-clients` when you want each client tested against a fresh server.
+
+## Compare with llama.cpp
+
+For client-level speed checks, run the same harness once against llama.cpp and
+once against Lucebox:
+
+```bash
+CLIENT=opencode PROMPT_FILE=harness/clients/prompts/repo_inspection.txt \
+  harness/clients/run_backend_pair.sh
+```
+
+This keeps the client prompt, tools, and request shape the same for both
+backends.
+
+## Files
+
+- `client_test_runner.py`: package smoke tests, protocol probes, and server sweeps
+- `clients/`: real client launchers
+- `clients/prompts/`: short prompts used by the launchers
+- `benchmarks/`: direct generation benchmark against OpenAI-compatible servers

--- a/harness/assets/hero.png
+++ b/harness/assets/hero.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f5460ed96d7b2f5f7c1d55f227eb37fe657b8e96283f5147a951fa8ec6a7706
+size 2433036

--- a/harness/benchmarks/README.md
+++ b/harness/benchmarks/README.md
@@ -1,0 +1,40 @@
+# Generation Benchmarks
+
+These checks are separate from the client harness launchers. They compare Lucebox
+generation against a llama.cpp baseline on the same target GGUF, using small
+deterministic prompts.
+
+Use this when you want to know whether a server change affects output quality or
+decode speed. Use `harness/clients/` when you want to know whether Codex,
+OpenCode, Open WebUI, Pi, and the other clients still work.
+
+## Lucebox vs llama.cpp
+
+Run from the repo root on the GPU host:
+
+```bash
+harness/benchmarks/run_lucebox_vs_llamacpp.sh
+```
+
+The runner starts llama.cpp first, runs the prompt set, stops it, then starts
+Lucebox and runs the same prompt set. It is sequential on purpose so a 24 GB
+card does not need to hold two copies of the target model.
+
+Common overrides:
+
+```bash
+MAX_CTX=65536 MAX_TOKENS=512 harness/benchmarks/run_lucebox_vs_llamacpp.sh
+LLAMA_SERVER_BIN=/path/to/llama-server harness/benchmarks/run_lucebox_vs_llamacpp.sh
+PROMPTS=/tmp/my_prompts.jsonl harness/benchmarks/run_lucebox_vs_llamacpp.sh
+```
+
+Each run writes:
+
+- `llamacpp.json`: raw llama.cpp endpoint results
+- `lucebox.json`: raw Lucebox endpoint results
+- `compare.json`: machine-readable comparison
+- `report.md`: speed and expected-output summary
+
+Prompt files are JSONL. Each line needs `id` and either `prompt` or `messages`.
+Optional `expect_contains` and `expect_regex` fields define lightweight accuracy
+checks.

--- a/harness/benchmarks/generation_benchmark.py
+++ b/harness/benchmarks/generation_benchmark.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Run deterministic generation checks and compare Lucebox against llama.cpp.
+
+The client launchers answer "can this real client talk to Lucebox?". This file
+answers a different question: "does Lucebox generate the same kind of output as
+a llama.cpp baseline, and how fast is it on the same prompts?".
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def load_cases(path: Path) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            case = json.loads(line)
+            if "id" not in case:
+                raise ValueError(f"{path}:{line_no}: missing id")
+            if "messages" not in case and "prompt" not in case:
+                raise ValueError(f"{path}:{line_no}: missing messages or prompt")
+            cases.append(case)
+    return cases
+
+
+def messages_for_case(case: dict[str, Any]) -> list[dict[str, str]]:
+    if "messages" in case:
+        return case["messages"]
+    return [{"role": "user", "content": case["prompt"]}]
+
+
+def normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def approx_token_count(text: str) -> int:
+    # Fallback only. Prefer server usage.completion_tokens when available.
+    return max(1, len(re.findall(r"\S+", text)))
+
+
+def expected_pass(case: dict[str, Any], text: str) -> tuple[bool, list[str]]:
+    failures: list[str] = []
+    for needle in case.get("expect_contains", []):
+        if needle not in text:
+            failures.append(f"missing {needle!r}")
+    for pattern in case.get("expect_regex", []):
+        if not re.search(pattern, text, flags=re.MULTILINE):
+            failures.append(f"regex did not match {pattern!r}")
+    return not failures, failures
+
+
+def post_chat(
+    base_url: str,
+    api_key: str,
+    model: str,
+    messages: list[dict[str, str]],
+    max_tokens: int,
+    temperature: float,
+    timeout: float,
+) -> dict[str, Any]:
+    url = base_url.rstrip("/") + "/chat/completions"
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": False,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {e.code} from {url}: {detail}") from e
+
+
+def extract_text(response: dict[str, Any]) -> str:
+    choices = response.get("choices") or []
+    if not choices:
+        return ""
+    message = choices[0].get("message") or {}
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "".join(parts)
+    return ""
+
+
+def run_case(
+    case: dict[str, Any],
+    base_url: str,
+    api_key: str,
+    model: str,
+    max_tokens: int,
+    temperature: float,
+    timeout: float,
+    repeats: int,
+) -> dict[str, Any]:
+    runs: list[dict[str, Any]] = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        response = post_chat(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            messages=messages_for_case(case),
+            max_tokens=max_tokens,
+            temperature=temperature,
+            timeout=timeout,
+        )
+        elapsed = time.perf_counter() - start
+        text = extract_text(response)
+        usage = response.get("usage") or {}
+        completion_tokens = usage.get("completion_tokens")
+        token_source = "usage"
+        if not isinstance(completion_tokens, int) or completion_tokens <= 0:
+            completion_tokens = approx_token_count(text)
+            token_source = "approx_words"
+        prompt_tokens = usage.get("prompt_tokens")
+        pass_expected, failures = expected_pass(case, text)
+        runs.append(
+            {
+                "elapsed_s": elapsed,
+                "completion_tokens": completion_tokens,
+                "prompt_tokens": prompt_tokens,
+                "tok_s": completion_tokens / elapsed if elapsed > 0 else 0.0,
+                "token_count_source": token_source,
+                "expected_pass": pass_expected,
+                "expected_failures": failures,
+                "text": text,
+                "usage": usage,
+            }
+        )
+
+    tok_s_values = [r["tok_s"] for r in runs]
+    elapsed_values = [r["elapsed_s"] for r in runs]
+    return {
+        "id": case["id"],
+        "description": case.get("description", ""),
+        "expect_contains": case.get("expect_contains", []),
+        "expect_regex": case.get("expect_regex", []),
+        "runs": runs,
+        "mean_tok_s": statistics.mean(tok_s_values),
+        "median_tok_s": statistics.median(tok_s_values),
+        "mean_elapsed_s": statistics.mean(elapsed_values),
+        "expected_pass": all(r["expected_pass"] for r in runs),
+        "text": runs[-1]["text"],
+        "completion_tokens": runs[-1]["completion_tokens"],
+        "prompt_tokens": runs[-1]["prompt_tokens"],
+        "token_count_source": runs[-1]["token_count_source"],
+    }
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    cases = load_cases(Path(args.prompts))
+    results = []
+    for case in cases:
+        print(f"[bench] {args.name}: {case['id']}", flush=True)
+        results.append(
+            run_case(
+                case=case,
+                base_url=args.url,
+                api_key=args.api_key,
+                model=args.model,
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+                timeout=args.timeout,
+                repeats=args.repeats,
+            )
+        )
+
+    report = {
+        "name": args.name,
+        "url": args.url,
+        "model": args.model,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "prompts": str(Path(args.prompts)),
+        "max_tokens": args.max_tokens,
+        "temperature": args.temperature,
+        "repeats": args.repeats,
+        "cases": results,
+        "summary": {
+            "cases": len(results),
+            "expected_pass": sum(1 for r in results if r["expected_pass"]),
+            "mean_tok_s": statistics.mean([r["mean_tok_s"] for r in results]) if results else 0.0,
+        },
+    }
+    out = Path(args.json_out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"[bench] wrote {out}")
+    return 0 if report["summary"]["expected_pass"] == len(results) else 1
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def case_map(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {case["id"]: case for case in report.get("cases", [])}
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    baseline = load_report(Path(args.baseline))
+    candidate = load_report(Path(args.candidate))
+    base_cases = case_map(baseline)
+    cand_cases = case_map(candidate)
+    rows = []
+    for case_id in sorted(base_cases.keys() & cand_cases.keys()):
+        base = base_cases[case_id]
+        cand = cand_cases[case_id]
+        base_tps = float(base.get("mean_tok_s", 0.0))
+        cand_tps = float(cand.get("mean_tok_s", 0.0))
+        rows.append(
+            {
+                "id": case_id,
+                "baseline_tok_s": base_tps,
+                "candidate_tok_s": cand_tps,
+                "speedup": cand_tps / base_tps if base_tps > 0 else None,
+                "baseline_expected_pass": bool(base.get("expected_pass")),
+                "candidate_expected_pass": bool(cand.get("expected_pass")),
+                "normalized_match": normalize_text(base.get("text", ""))
+                == normalize_text(cand.get("text", "")),
+                "baseline_text": base.get("text", ""),
+                "candidate_text": cand.get("text", ""),
+            }
+        )
+
+    summary = {
+        "cases": len(rows),
+        "baseline": baseline.get("name"),
+        "candidate": candidate.get("name"),
+        "baseline_expected_pass": sum(1 for r in rows if r["baseline_expected_pass"]),
+        "candidate_expected_pass": sum(1 for r in rows if r["candidate_expected_pass"]),
+        "normalized_matches": sum(1 for r in rows if r["normalized_match"]),
+        "baseline_mean_tok_s": statistics.mean([r["baseline_tok_s"] for r in rows]) if rows else 0.0,
+        "candidate_mean_tok_s": statistics.mean([r["candidate_tok_s"] for r in rows]) if rows else 0.0,
+    }
+    if summary["baseline_mean_tok_s"] > 0:
+        summary["mean_speedup"] = summary["candidate_mean_tok_s"] / summary["baseline_mean_tok_s"]
+    else:
+        summary["mean_speedup"] = None
+
+    report = {
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "baseline_report": str(Path(args.baseline)),
+        "candidate_report": str(Path(args.candidate)),
+        "summary": summary,
+        "cases": rows,
+    }
+    json_out = Path(args.json_out)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    if args.md_out:
+        write_markdown(report, Path(args.md_out))
+    print(f"[bench] wrote {json_out}")
+    return 0 if summary["candidate_expected_pass"] == summary["cases"] else 1
+
+
+def fmt_speedup(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return "n/a"
+    return f"{value:.2f}x"
+
+
+def write_markdown(report: dict[str, Any], path: Path) -> None:
+    summary = report["summary"]
+    lines = [
+        "# Lucebox vs llama.cpp Generation Benchmark",
+        "",
+        f"Baseline: `{summary['baseline']}`",
+        f"Candidate: `{summary['candidate']}`",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Baseline mean tok/s | {summary['baseline_mean_tok_s']:.2f} |",
+        f"| Candidate mean tok/s | {summary['candidate_mean_tok_s']:.2f} |",
+        f"| Mean speedup | {fmt_speedup(summary['mean_speedup'])} |",
+        f"| Candidate expected checks | {summary['candidate_expected_pass']}/{summary['cases']} |",
+        f"| Normalized output matches | {summary['normalized_matches']}/{summary['cases']} |",
+        "",
+        "| Case | llama.cpp tok/s | Lucebox tok/s | Speedup | Expected | Same normalized text |",
+        "| --- | ---: | ---: | ---: | --- | --- |",
+    ]
+    for row in report["cases"]:
+        expected = "pass" if row["candidate_expected_pass"] else "fail"
+        match = "yes" if row["normalized_match"] else "no"
+        lines.append(
+            f"| `{row['id']}` | {row['baseline_tok_s']:.2f} | "
+            f"{row['candidate_tok_s']:.2f} | {fmt_speedup(row['speedup'])} | "
+            f"{expected} | {match} |"
+        )
+    lines.append("")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="Run one OpenAI-compatible endpoint")
+    run.add_argument("--name", required=True)
+    run.add_argument("--url", required=True, help="Base URL ending in /v1")
+    run.add_argument("--api-key", default="")
+    run.add_argument("--model", required=True)
+    run.add_argument("--prompts", default=str(Path(__file__).with_name("prompts") / "generation_smoke.jsonl"))
+    run.add_argument("--json-out", required=True)
+    run.add_argument("--max-tokens", type=int, default=256)
+    run.add_argument("--temperature", type=float, default=0.0)
+    run.add_argument("--timeout", type=float, default=600.0)
+    run.add_argument("--repeats", type=int, default=1)
+    run.set_defaults(func=cmd_run)
+
+    compare = sub.add_parser("compare", help="Compare two endpoint reports")
+    compare.add_argument("--baseline", required=True)
+    compare.add_argument("--candidate", required=True)
+    compare.add_argument("--json-out", required=True)
+    compare.add_argument("--md-out", default="")
+    compare.set_defaults(func=cmd_compare)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except Exception as exc:
+        print(f"[bench] error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/benchmarks/prompts/generation_smoke.jsonl
+++ b/harness/benchmarks/prompts/generation_smoke.jsonl
@@ -1,0 +1,5 @@
+{"id":"exact-marker","description":"Basic deterministic marker generation.","prompt":"Reply with exactly: LUCEBOX_BENCH_OK","expect_contains":["LUCEBOX_BENCH_OK"]}
+{"id":"arithmetic","description":"Small arithmetic with terse answer.","prompt":"Compute 17 * 23. Reply with only the integer.","expect_contains":["391"]}
+{"id":"json-marker","description":"Structured output check.","messages":[{"role":"system","content":"Return only compact JSON. Do not use markdown."},{"role":"user","content":"Return JSON with status ok and marker LUCEBOX_JSON_OK."}],"expect_contains":["LUCEBOX_JSON_OK","status"]}
+{"id":"short-code","description":"Short code generation check.","prompt":"Write a Python function named add_pair(a, b) that returns the sum. End your answer with BENCH_DONE.","expect_contains":["def add_pair","BENCH_DONE"]}
+{"id":"needle-short","description":"Short context retrieval check.","prompt":"Context: build id alpha-839 is the only release candidate. Ignore build id beta-102 because it was cancelled. What is the release candidate build id? Reply with the id only.","expect_contains":["alpha-839"]}

--- a/harness/benchmarks/run_lucebox_vs_llamacpp.sh
+++ b/harness/benchmarks/run_lucebox_vs_llamacpp.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+RUN_DIR="${RUN_DIR:-$REPO_DIR/.harness-runs}"
+STAMP="${STAMP:-generation-baseline-$(date +%Y%m%d-%H%M%S)}"
+LOG_DIR="$RUN_DIR/$STAMP"
+
+TARGET="${TARGET:-$REPO_DIR/dflash/models/Qwen3.6-27B-Q4_K_M.gguf}"
+DRAFT="${DRAFT:-$REPO_DIR/dflash/models/draft/dflash-draft-3.6-q8_0.gguf}"
+DFLASH_BIN="${DFLASH_BIN:-$REPO_DIR/dflash/build/test_dflash}"
+LLAMA_SERVER_BIN="${LLAMA_SERVER_BIN:-$REPO_DIR/dflash/deps/llama.cpp/build/bin/llama-server}"
+
+HOST="${HOST:-127.0.0.1}"
+LUCEBOX_PORT="${LUCEBOX_PORT:-18080}"
+LLAMA_PORT="${LLAMA_PORT:-18082}"
+MAX_CTX="${MAX_CTX:-32768}"
+MAX_TOKENS="${MAX_TOKENS:-256}"
+BUDGET="${BUDGET:-22}"
+VERIFY_MODE="${VERIFY_MODE:-ddtree}"
+FA_WINDOW="${FA_WINDOW:-2048}"
+CACHE_TYPE_K="${CACHE_TYPE_K:-tq3_0}"
+CACHE_TYPE_V="${CACHE_TYPE_V:-tq3_0}"
+EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS:---lazy-draft}"
+LLAMA_N_GPU_LAYERS="${LLAMA_N_GPU_LAYERS:-999}"
+MODEL_ID="${MODEL_ID:-luce-dflash}"
+LLAMA_MODEL_ID="${LLAMA_MODEL_ID:-llama-cpp}"
+API_KEY="${API_KEY:-sk-lucebox}"
+PROMPTS="${PROMPTS:-$SCRIPT_DIR/prompts/generation_smoke.jsonl}"
+
+mkdir -p "$LOG_DIR"
+
+wait_health() {
+  local url="$1"
+  local pid="$2"
+  local log="$3"
+  for _ in $(seq 1 300); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "process exited early; log: $log" >&2
+      tail -n 160 "$log" >&2 || true
+      return 1
+    fi
+  done
+  echo "process did not become healthy; log: $log" >&2
+  tail -n 160 "$log" >&2 || true
+  return 1
+}
+
+stop_pid() {
+  local pid="${1:-}"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+resolve_llama_server() {
+  if [[ -x "$LLAMA_SERVER_BIN" ]]; then
+    echo "$LLAMA_SERVER_BIN"
+    return 0
+  fi
+  if command -v llama-server >/dev/null 2>&1; then
+    command -v llama-server
+    return 0
+  fi
+  echo "llama-server not found. Set LLAMA_SERVER_BIN=/path/to/llama-server." >&2
+  return 1
+}
+
+LLAMA_JSON="$LOG_DIR/llamacpp.json"
+LUCEBOX_JSON="$LOG_DIR/lucebox.json"
+COMPARE_JSON="$LOG_DIR/compare.json"
+REPORT_MD="$LOG_DIR/report.md"
+
+LLAMA_LOG="$LOG_DIR/llamacpp-server.log"
+LLAMA_SERVER_BIN="$(resolve_llama_server)"
+"$LLAMA_SERVER_BIN" \
+  --model "$TARGET" \
+  --alias "$LLAMA_MODEL_ID" \
+  --ctx-size "$MAX_CTX" \
+  --n-gpu-layers "$LLAMA_N_GPU_LAYERS" \
+  --host "$HOST" \
+  --port "$LLAMA_PORT" \
+  > "$LLAMA_LOG" 2>&1 &
+LLAMA_PID=$!
+trap 'stop_pid "${LLAMA_PID:-}"; stop_pid "${LUCEBOX_PID:-}"' EXIT
+wait_health "http://$HOST:$LLAMA_PORT/health" "$LLAMA_PID" "$LLAMA_LOG"
+
+python3 "$SCRIPT_DIR/generation_benchmark.py" run \
+  --name llama.cpp \
+  --url "http://$HOST:$LLAMA_PORT/v1" \
+  --model "$LLAMA_MODEL_ID" \
+  --prompts "$PROMPTS" \
+  --max-tokens "$MAX_TOKENS" \
+  --json-out "$LLAMA_JSON"
+
+stop_pid "$LLAMA_PID"
+LLAMA_PID=""
+
+LUCEBOX_LOG="$LOG_DIR/lucebox-server.log"
+cd "$REPO_DIR"
+extra_args=()
+if [[ -n "$EXTRA_SERVER_ARGS" ]]; then
+  read -r -a extra_args <<< "$EXTRA_SERVER_ARGS"
+fi
+python3 -u dflash/scripts/server.py \
+  --host "$HOST" \
+  --port "$LUCEBOX_PORT" \
+  --target "$TARGET" \
+  --draft "$DRAFT" \
+  --bin "$DFLASH_BIN" \
+  --budget "$BUDGET" \
+  --verify-mode "$VERIFY_MODE" \
+  --max-ctx "$MAX_CTX" \
+  --fa-window "$FA_WINDOW" \
+  --cache-type-k "$CACHE_TYPE_K" \
+  --cache-type-v "$CACHE_TYPE_V" \
+  --prefix-cache-slots 0 \
+  --prefill-cache-slots 0 \
+  "${extra_args[@]}" \
+  > "$LUCEBOX_LOG" 2>&1 &
+LUCEBOX_PID=$!
+wait_health "http://$HOST:$LUCEBOX_PORT/health" "$LUCEBOX_PID" "$LUCEBOX_LOG"
+
+python3 "$SCRIPT_DIR/generation_benchmark.py" run \
+  --name lucebox \
+  --url "http://$HOST:$LUCEBOX_PORT/v1" \
+  --api-key "$API_KEY" \
+  --model "$MODEL_ID" \
+  --prompts "$PROMPTS" \
+  --max-tokens "$MAX_TOKENS" \
+  --json-out "$LUCEBOX_JSON"
+
+python3 "$SCRIPT_DIR/generation_benchmark.py" compare \
+  --baseline "$LLAMA_JSON" \
+  --candidate "$LUCEBOX_JSON" \
+  --json-out "$COMPARE_JSON" \
+  --md-out "$REPORT_MD"
+
+echo "run_dir=$LOG_DIR"
+echo "report=$REPORT_MD"

--- a/harness/client_test_runner.py
+++ b/harness/client_test_runner.py
@@ -1,0 +1,1416 @@
+#!/usr/bin/env python3
+"""Client-harness compatibility and server-profile sweeps for Luce DFlash.
+
+The goal is deliberately narrower than a full SWE-bench agent run:
+
+1. Download the real client packages contributors care about.
+2. Smoke-test their installed binaries where possible.
+3. Probe the DFlash HTTP protocol shape each client depends on.
+4. Sweep server settings and record latency / token / OOM signals.
+
+The script uses only the Python standard library so it can run on fresh GPU
+test machines before project Python dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import venv
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_WORK_DIR = ROOT / ".harness-work"
+MODEL = "luce-dflash"
+PROBE_COUNTER = itertools.count(1)
+EXPECTED_MARKER = "lucebox"
+
+
+@dataclass(frozen=True)
+class ClientSpec:
+    name: str
+    install: str
+    package: str
+    binary: str
+    protocol: str
+    version_args: tuple[str, ...] = ("--version",)
+    help_args: tuple[str, ...] = ("--help",)
+    notes: str = ""
+
+
+CLIENTS: dict[str, ClientSpec] = {
+    "claude_code": ClientSpec(
+        name="claude_code",
+        install="npm",
+        package="@anthropic-ai/claude-code",
+        binary="claude",
+        protocol="anthropic_messages",
+        notes="Claude Code speaks Anthropic Messages; ANTHROPIC_BASE_URL points to the server root.",
+    ),
+    "codex": ClientSpec(
+        name="codex",
+        install="npm",
+        package="@openai/codex",
+        binary="codex",
+        protocol="responses",
+        notes="Codex CLI uses OpenAI Responses and queries /v1/models?client_version=.",
+    ),
+    "hermes": ClientSpec(
+        name="hermes",
+        install="hermes",
+        package="https://github.com/NousResearch/hermes-agent",
+        binary="hermes",
+        protocol="openai_chat",
+        notes="Hermes Agent can use a named custom OpenAI-compatible provider.",
+    ),
+    "openclaw": ClientSpec(
+        name="openclaw",
+        install="npm",
+        package="openclaw",
+        binary="openclaw",
+        protocol="openai_chat",
+    ),
+    "openwebui": ClientSpec(
+        name="openwebui",
+        install="pip",
+        package="open-webui",
+        binary="open-webui",
+        protocol="openwebui",
+    ),
+    "opencode": ClientSpec(
+        name="opencode",
+        install="npm",
+        package="opencode-ai",
+        binary="opencode",
+        protocol="openai_chat",
+    ),
+    "pi": ClientSpec(
+        name="pi",
+        install="npm",
+        package="@mariozechner/pi-coding-agent",
+        binary="pi",
+        protocol="openai_chat",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ServerProfile:
+    name: str
+    args: tuple[str, ...]
+    env: dict[str, str] = field(default_factory=dict)
+    needs_prefill_drafter: bool = False
+    long_prompt: bool = False
+
+
+SERVER_PROFILES: dict[str, ServerProfile] = {
+    "rtx3090_dflash_fast": ServerProfile(
+        name="rtx3090_dflash_fast",
+        args=(
+            "--budget", "22",
+            "--verify-mode", "ddtree",
+            "--max-ctx", "4096",
+            "--fa-window", "1024",
+            "--cache-type-k", "q8_0",
+            "--cache-type-v", "q8_0",
+            "--prefix-cache-slots", "0",
+            "--prefill-cache-slots", "0",
+        ),
+    ),
+    "rtx3090_dflash_safe": ServerProfile(
+        name="rtx3090_dflash_safe",
+        args=(
+            "--budget", "22",
+            "--verify-mode", "ddtree",
+            "--max-ctx", "8192",
+            "--fa-window", "2048",
+            "--cache-type-k", "tq3_0",
+            "--cache-type-v", "tq3_0",
+            "--prefix-cache-slots", "0",
+            "--prefill-cache-slots", "0",
+        ),
+    ),
+    "rtx3090_dflash_16k": ServerProfile(
+        name="rtx3090_dflash_16k",
+        args=(
+            "--budget", "22",
+            "--verify-mode", "ddtree",
+            "--max-ctx", "16384",
+            "--fa-window", "2048",
+            "--cache-type-k", "tq3_0",
+            "--cache-type-v", "tq3_0",
+            "--prefix-cache-slots", "0",
+            "--prefill-cache-slots", "0",
+        ),
+    ),
+    "rtx3090_dflash_long": ServerProfile(
+        name="rtx3090_dflash_long",
+        args=(
+            "--budget", "16",
+            "--verify-mode", "ddtree",
+            "--max-ctx", "32768",
+            "--fa-window", "2048",
+            "--cache-type-k", "tq3_0",
+            "--cache-type-v", "tq3_0",
+            "--prefix-cache-slots", "0",
+            "--prefill-cache-slots", "0",
+            "--lazy-draft",
+        ),
+        long_prompt=True,
+    ),
+    "rtx3090_pflash_32k": ServerProfile(
+        name="rtx3090_pflash_32k",
+        args=(
+            "--budget", "16",
+            "--verify-mode", "ddtree",
+            "--max-ctx", "32768",
+            "--fa-window", "2048",
+            "--cache-type-k", "tq3_0",
+            "--cache-type-v", "tq3_0",
+            "--prefix-cache-slots", "0",
+            "--prefill-cache-slots", "0",
+            "--prefill-compression", "auto",
+            "--prefill-threshold", "4096",
+            "--prefill-keep-ratio", "0.10",
+            "--lazy-draft",
+        ),
+        needs_prefill_drafter=True,
+        long_prompt=True,
+    ),
+}
+
+
+class HarnessError(RuntimeError):
+    pass
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def split_csv(value: str, choices: dict[str, Any]) -> list[str]:
+    if value == "all":
+        return list(choices)
+    out = [x.strip() for x in value.split(",") if x.strip()]
+    unknown = [x for x in out if x not in choices]
+    if unknown:
+        raise SystemExit(f"unknown selection(s): {', '.join(unknown)}")
+    return out
+
+
+def run_cmd(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 300,
+) -> dict[str, Any]:
+    t0 = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            check=False,
+        )
+        return {
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "seconds": round(time.perf_counter() - t0, 3),
+            "cmd": cmd,
+            "output_tail": proc.stdout[-4000:],
+        }
+    except FileNotFoundError as exc:
+        return {
+            "ok": False,
+            "returncode": 127,
+            "seconds": round(time.perf_counter() - t0, 3),
+            "cmd": cmd,
+            "output_tail": str(exc),
+        }
+    except subprocess.TimeoutExpired as exc:
+        out = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
+        return {
+            "ok": False,
+            "returncode": 124,
+            "seconds": round(time.perf_counter() - t0, 3),
+            "cmd": cmd,
+            "output_tail": out[-4000:] + "\nTIMEOUT",
+        }
+
+
+def npm_prefix(work_dir: Path, client: str) -> Path:
+    return work_dir / "clients" / client / "npm"
+
+
+def pip_venv(work_dir: Path, client: str) -> Path:
+    return work_dir / "clients" / client / "venv"
+
+
+def hermes_home(work_dir: Path) -> Path:
+    return work_dir / "clients" / "hermes" / "home"
+
+
+def client_bin(work_dir: Path, spec: ClientSpec) -> Path:
+    if spec.install == "npm":
+        return npm_prefix(work_dir, spec.name) / "bin" / spec.binary
+    if spec.install == "pip":
+        return pip_venv(work_dir, spec.name) / "bin" / spec.binary
+    if spec.install == "hermes":
+        return hermes_home(work_dir) / ".local" / "bin" / spec.binary
+    raise HarnessError(f"unknown installer {spec.install}")
+
+
+def client_smoke_env(work_dir: Path, spec: ClientSpec) -> dict[str, str] | None:
+    if spec.install != "hermes":
+        return None
+    home = hermes_home(work_dir)
+    env = os.environ.copy()
+    env.update({
+        "HOME": str(home),
+        "HERMES_HOME": str(home),
+    })
+    return env
+
+
+def install_client(work_dir: Path, spec: ClientSpec) -> dict[str, Any]:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    if spec.install == "npm":
+        prefix = npm_prefix(work_dir, spec.name)
+        prefix.mkdir(parents=True, exist_ok=True)
+        result = run_cmd(
+            ["npm", "install", "--global", "--prefix", str(prefix), spec.package],
+            timeout=900,
+        )
+    elif spec.install == "pip":
+        env_dir = pip_venv(work_dir, spec.name)
+        if not (env_dir / "bin" / "python").exists():
+            venv.EnvBuilder(with_pip=True).create(env_dir)
+        result = run_cmd(
+            [str(env_dir / "bin" / "python"), "-m", "pip", "install", "-U", spec.package],
+            timeout=1200,
+        )
+    elif spec.install == "hermes":
+        root = work_dir / "clients" / spec.name
+        home = hermes_home(work_dir)
+        install_dir = root / "hermes-agent"
+        root.mkdir(parents=True, exist_ok=True)
+        home.mkdir(parents=True, exist_ok=True)
+        script_path = root / "install.sh"
+        urllib.request.urlretrieve(
+            "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh",
+            script_path,
+        )
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(home),
+            "HERMES_HOME": str(home),
+            "HERMES_INSTALL_DIR": str(install_dir),
+        })
+        result = run_cmd(
+            ["bash", str(script_path), "--skip-setup", "--skip-browser"],
+            env=env,
+            timeout=1800,
+        )
+    else:
+        raise HarnessError(f"unknown installer {spec.install}")
+
+    bin_path = client_bin(work_dir, spec)
+    version = binary_smoke(
+        bin_path,
+        spec.version_args,
+        timeout=30,
+        env=client_smoke_env(work_dir, spec),
+    )
+    result.update({
+        "client": spec.name,
+        "installer": spec.install,
+        "package": spec.package,
+        "binary": str(bin_path),
+        "binary_exists": bin_path.exists(),
+        "version": version,
+    })
+    return result
+
+
+def binary_smoke(
+    path: Path,
+    args: tuple[str, ...],
+    timeout: int = 20,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if not path.exists():
+        return {"ok": False, "output_tail": f"missing binary: {path}"}
+    return run_cmd([str(path), *args], timeout=timeout, env=env)
+
+
+def package_smoke(work_dir: Path, spec: ClientSpec) -> dict[str, Any]:
+    path = client_bin(work_dir, spec)
+    env = client_smoke_env(work_dir, spec)
+    version = binary_smoke(path, spec.version_args, timeout=20, env=env)
+    if version["ok"]:
+        return {"client": spec.name, "ok": True, "binary": str(path), "version": version}
+    help_result = binary_smoke(path, spec.help_args, timeout=20, env=env)
+    return {
+        "client": spec.name,
+        "ok": bool(help_result.get("ok")),
+        "binary": str(path),
+        "version": version,
+        "help": help_result,
+    }
+
+
+def http_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: int = 600,
+) -> tuple[int, dict[str, Any] | str, float]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    all_headers = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(url, data=body, headers=all_headers, method=method)
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            elapsed = time.perf_counter() - t0
+            try:
+                return resp.status, json.loads(raw), elapsed
+            except json.JSONDecodeError:
+                return resp.status, raw, elapsed
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        elapsed = time.perf_counter() - t0
+        try:
+            parsed: dict[str, Any] | str = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = raw
+        return exc.code, parsed, elapsed
+
+
+def http_sse(
+    url: str,
+    payload: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+    expect_substring: str | None = None,
+    timeout: int = 600,
+) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            **(headers or {}),
+        },
+    )
+    t0 = time.perf_counter()
+    first = None
+    events: list[dict[str, Any] | str] = []
+    token_deltas = 0
+    text = ""
+    status = 0
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.status
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                if first is None:
+                    first = time.perf_counter()
+                try:
+                    obj = json.loads(data)
+                except json.JSONDecodeError:
+                    events.append(data)
+                    continue
+                events.append(obj)
+                choices = obj.get("choices") or []
+                if choices:
+                    delta = choices[0].get("delta") or {}
+                    piece = (
+                        delta.get("content")
+                        or delta.get("reasoning_content")
+                        or ""
+                    )
+                    if piece:
+                        token_deltas += 1
+                        text += str(piece)
+    except urllib.error.HTTPError as exc:
+        return {
+            "ok": False,
+            "status": exc.code,
+            "seconds": round(time.perf_counter() - t0, 3),
+            "error": exc.read().decode("utf-8", errors="replace")[-4000:],
+        }
+    elapsed = time.perf_counter() - t0
+    check = text_check(text, expect_substring)
+    return {
+        "ok": status == 200 and token_deltas > 0 and check["generated_ok"],
+        "status": status,
+        "seconds": round(elapsed, 3),
+        "first_token_seconds": round(first - t0, 3) if first else None,
+        "events": len(events),
+        "token_deltas": token_deltas,
+        **check,
+        "tail": events[-3:],
+    }
+
+
+def short_prompt() -> str:
+    return (
+        "You are checking a local model server. Reply with one short sentence "
+        "that contains the word lucebox."
+    )
+
+
+def coding_prompt() -> str:
+    return (
+        "In a Python project, explain what this function does and mention one "
+        "edge case. Include the word lucebox in your answer.\n\n"
+        "def clamp(x, lo, hi):\n"
+        "    if lo > hi:\n"
+        "        raise ValueError('bad bounds')\n"
+        "    return min(max(x, lo), hi)\n"
+    )
+
+
+def long_prompt() -> str:
+    unit = (
+        "The server is being tested for long-context harness behavior. "
+        "Keep the invariant NEEDLE=lucebox-harness visible in your answer. "
+        "Most of this text is filler that should survive tokenization and "
+        "optional PFlash compression without crashing the server.\n"
+    )
+    return unit * 180
+
+
+def unique_prompt(text: str, label: str) -> str:
+    return f"{text}\n\nlucebox-harness request {label}-{next(PROBE_COUNTER)}"
+
+
+def text_check(text: str | None, expect_substring: str | None = None) -> dict[str, Any]:
+    value = text or ""
+    ok = bool(value.strip())
+    marker_seen = (
+        expect_substring.lower() in value.lower()
+        if expect_substring else None
+    )
+    return {
+        "generated_ok": ok,
+        "generated_chars": len(value),
+        "generated_text_tail": value[-500:],
+        "expected_substring": expect_substring,
+        "expected_substring_seen": marker_seen,
+    }
+
+
+def openai_chat_text(body: dict[str, Any] | str) -> str:
+    if not isinstance(body, dict):
+        return ""
+    choices = body.get("choices") or []
+    if not choices:
+        return ""
+    message = choices[0].get("message") or {}
+    return str(message.get("content") or "")
+
+
+def anthropic_text(body: dict[str, Any] | str) -> str:
+    if not isinstance(body, dict):
+        return ""
+    pieces = []
+    for item in body.get("content") or []:
+        if isinstance(item, dict):
+            pieces.append(str(item.get("text") or item.get("thinking") or ""))
+    return "".join(pieces)
+
+
+def responses_text(body: dict[str, Any] | str) -> str:
+    if not isinstance(body, dict):
+        return ""
+    if body.get("output_text"):
+        return str(body["output_text"])
+    pieces = []
+    for item in body.get("output") or []:
+        for content in item.get("content") or []:
+            if isinstance(content, dict):
+                pieces.append(str(content.get("text") or ""))
+    return "".join(pieces)
+
+
+def record_probe(
+    name: str,
+    status: int,
+    body: dict[str, Any] | str,
+    elapsed: float,
+    expect_status: int = 200,
+    generated_text: str | None = None,
+    expect_substring: str | None = None,
+    required: bool = True,
+) -> dict[str, Any]:
+    usage = body.get("usage") if isinstance(body, dict) else None
+    out = {
+        "name": name,
+        "ok": status == expect_status,
+        "status": status,
+        "required": required,
+        "seconds": round(elapsed, 3),
+        "usage": usage,
+        "body_tail": body if isinstance(body, str) else json.dumps(body)[-2000:],
+    }
+    if generated_text is not None:
+        check = text_check(generated_text, expect_substring)
+        out.update(check)
+        out["ok"] = out["ok"] and check["generated_ok"]
+    return out
+
+
+def probe_health(base_url: str) -> list[dict[str, Any]]:
+    out = []
+    for path in ("/health", "/v1/models"):
+        status, body, elapsed = http_json("GET", base_url + path)
+        out.append(record_probe(path, status, body, elapsed))
+    return out
+
+
+def probe_openai_chat(base_url: str, *, include_long: bool = False) -> list[dict[str, Any]]:
+    prompt = unique_prompt(
+        long_prompt() if include_long else coding_prompt(),
+        "chat-non-stream",
+    )
+    probes = probe_health(base_url)
+    payload = {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": "Answer concisely."},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": 32,
+        "temperature": 0,
+        "stop": ["\n\n\n"],
+    }
+    stream_prompt = unique_prompt(
+        long_prompt() if include_long else coding_prompt(),
+        "chat-stream",
+    )
+    stream_payload = dict(payload)
+    stream_payload["messages"] = [
+        {"role": "system", "content": "Answer concisely."},
+        {"role": "user", "content": stream_prompt},
+    ]
+    stream_payload.update({"stream": True, "stream_options": {"include_usage": True}})
+    probes.append({
+        "name": "chat.stream",
+        **http_sse(
+            base_url + "/v1/chat/completions",
+            stream_payload,
+            expect_substring=EXPECTED_MARKER,
+        ),
+    })
+
+    status, body, elapsed = http_json("POST", base_url + "/v1/chat/completions", payload)
+    probes.append(record_probe(
+        "chat.non_stream", status, body, elapsed,
+        generated_text=openai_chat_text(body),
+        expect_substring=EXPECTED_MARKER,
+        required=False,
+    ))
+
+    tool_payload = {
+        "model": MODEL,
+        "messages": [{
+            "role": "user",
+            "content": unique_prompt(
+                "Return a short answer and include the word lucebox.",
+                "chat-tools",
+            ),
+        }],
+        "max_tokens": 16,
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+        }],
+        "tool_choice": "auto",
+    }
+    status, body, elapsed = http_json("POST", base_url + "/v1/chat/completions", tool_payload)
+    probes.append(record_probe("chat.tools_accepted", status, body, elapsed))
+    return probes
+
+
+def probe_openwebui(base_url: str, *, include_long: bool = False) -> list[dict[str, Any]]:
+    probes = probe_openai_chat(base_url, include_long=include_long)
+    status, body, elapsed = http_json("GET", base_url + "/v1/models")
+    model_meta_ok = False
+    if isinstance(body, dict):
+        data = body.get("data") or []
+        model_meta_ok = bool(data and data[0].get("context_length"))
+    probes.append({
+        "name": "openwebui.model_metadata",
+        "ok": status == 200 and model_meta_ok,
+        "status": status,
+        "seconds": round(elapsed, 3),
+        "body_tail": body if isinstance(body, str) else json.dumps(body)[-2000:],
+    })
+    return probes
+
+
+def probe_anthropic_messages(base_url: str, *, include_long: bool = False) -> list[dict[str, Any]]:
+    prompt = unique_prompt(
+        long_prompt() if include_long else short_prompt(),
+        "anthropic-non-stream",
+    )
+    probes = probe_health(base_url)
+    payload = {
+        "model": MODEL,
+        "system": "You are Claude Code compatibility smoke-test traffic.",
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 32,
+        "temperature": 0,
+        "stop_sequences": ["\n\n\n"],
+        # Claude Code sends tool metadata. server.py currently ignores extra
+        # Anthropic fields, but the request must not fail validation.
+        "tools": [{
+            "name": "Read",
+            "description": "Read a file",
+            "input_schema": {
+                "type": "object",
+                "properties": {"file_path": {"type": "string"}},
+                "required": ["file_path"],
+            },
+        }],
+    }
+    stream_payload = dict(payload)
+    stream_payload["messages"] = [{
+        "role": "user",
+        "content": "Reply with exactly: lucebox-stream-ok two",
+    }]
+    stream_payload["stream"] = True
+    probes.append({
+        "name": "anthropic.messages_stream",
+        **probe_anthropic_sse(base_url + "/v1/messages", stream_payload),
+    })
+
+    status, body, elapsed = http_json("POST", base_url + "/v1/messages", payload)
+    probes.append(record_probe(
+        "anthropic.messages", status, body, elapsed,
+        generated_text=anthropic_text(body),
+        expect_substring=EXPECTED_MARKER,
+        required=False,
+    ))
+    return probes
+
+
+def probe_anthropic_sse(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "x-api-key": "lucebox-local",
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    t0 = time.perf_counter()
+    first = None
+    events = 0
+    text_deltas = 0
+    text = ""
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            status = resp.status
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if line.startswith("event:"):
+                    events += 1
+                elif line.startswith("data:") and first is None:
+                    first = time.perf_counter()
+                if line.startswith("data:"):
+                    try:
+                        obj = json.loads(line[5:].strip())
+                    except json.JSONDecodeError:
+                        obj = None
+                    if isinstance(obj, dict):
+                        delta = obj.get("delta") or {}
+                        piece = delta.get("text") or delta.get("thinking") or ""
+                        if piece:
+                            text += str(piece)
+                            text_deltas += 1
+    except urllib.error.HTTPError as exc:
+        return {
+            "ok": False,
+            "status": exc.code,
+            "seconds": round(time.perf_counter() - t0, 3),
+            "error": exc.read().decode("utf-8", errors="replace")[-4000:],
+        }
+    elapsed = time.perf_counter() - t0
+    check = text_check(text, EXPECTED_MARKER)
+    return {
+        "ok": status == 200 and text_deltas > 0 and check["generated_ok"],
+        "status": status,
+        "seconds": round(elapsed, 3),
+        "first_token_seconds": round(first - t0, 3) if first else None,
+        "events": events,
+        "text_deltas": text_deltas,
+        **check,
+    }
+
+
+def probe_responses(base_url: str, *, include_long: bool = False) -> list[dict[str, Any]]:
+    prompt = unique_prompt(
+        long_prompt() if include_long else coding_prompt(),
+        "responses-non-stream",
+    )
+    probes = []
+    status, body, elapsed = http_json("GET", base_url + "/v1/models?client_version=harness-smoke")
+    models_ok = isinstance(body, dict) and bool(body.get("models"))
+    probes.append({
+        "name": "codex.models",
+        "ok": status == 200 and models_ok,
+        "status": status,
+        "seconds": round(elapsed, 3),
+        "body_tail": body if isinstance(body, str) else json.dumps(body)[-2000:],
+    })
+    payload = {
+        "model": MODEL,
+        "instructions": "You are a concise coding agent.",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": prompt}],
+        }],
+        "tools": [{
+            "type": "function",
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        }],
+        "tool_choice": "auto",
+        "reasoning": {"effort": "low"},
+        "max_output_tokens": 32,
+    }
+    status, body, elapsed = http_json("POST", base_url + "/v1/responses", payload)
+    probes.append(record_probe(
+        "responses.non_stream", status, body, elapsed,
+        generated_text=responses_text(body),
+        expect_substring=EXPECTED_MARKER,
+    ))
+
+    stream_prompt = unique_prompt(
+        long_prompt() if include_long else coding_prompt(),
+        "responses-stream",
+    )
+    stream_payload = dict(payload)
+    stream_payload["input"] = [{
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": stream_prompt}],
+    }]
+    stream_payload["stream"] = True
+    probes.append({
+        "name": "responses.stream",
+        **probe_responses_sse(base_url + "/v1/responses", stream_payload),
+    })
+    return probes
+
+
+def probe_responses_sse(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Accept": "text/event-stream"},
+    )
+    t0 = time.perf_counter()
+    first = None
+    events = 0
+    event_types: set[str] = set()
+    text = ""
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            status = resp.status
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if line.startswith("event:"):
+                    events += 1
+                    event_types.add(line[6:].strip())
+                    if first is None:
+                        first = time.perf_counter()
+                elif line.startswith("data:"):
+                    try:
+                        obj = json.loads(line[5:].strip())
+                    except json.JSONDecodeError:
+                        obj = None
+                    if isinstance(obj, dict):
+                        piece = obj.get("delta") or ""
+                        if piece:
+                            text += str(piece)
+    except urllib.error.HTTPError as exc:
+        return {
+            "ok": False,
+            "status": exc.code,
+            "seconds": round(time.perf_counter() - t0, 3),
+            "error": exc.read().decode("utf-8", errors="replace")[-4000:],
+        }
+    elapsed = time.perf_counter() - t0
+    check = text_check(text, EXPECTED_MARKER)
+    return {
+        "ok": status == 200 and events > 0 and check["generated_ok"],
+        "status": status,
+        "seconds": round(elapsed, 3),
+        "first_event_seconds": round(first - t0, 3) if first else None,
+        "events": events,
+        "event_types": sorted(event_types),
+        **check,
+    }
+
+
+def probe_wrapper(base_url: str, *, include_long: bool = False) -> list[dict[str, Any]]:
+    # harness.lol itself wraps child CLIs; the server-side compatibility risk is
+    # already covered by the child protocols. Keep this cheap and explicit.
+    probes = probe_health(base_url)
+    probes.append({
+        "name": "wrapper.protocols_delegated",
+        "ok": True,
+        "status": 200,
+        "seconds": 0.0,
+        "body_tail": "harness wraps claude/codex/opencode; run those probes too.",
+    })
+    return probes
+
+
+PROBE_BY_PROTOCOL = {
+    "openai_chat": probe_openai_chat,
+    "openwebui": probe_openwebui,
+    "anthropic_messages": probe_anthropic_messages,
+    "responses": probe_responses,
+    "wrapper": probe_wrapper,
+}
+
+
+def probe_required(probe: dict[str, Any]) -> bool:
+    if "required" in probe:
+        return bool(probe["required"])
+    return probe.get("name") not in {"chat.non_stream", "anthropic.messages"}
+
+
+def run_client_probe(
+    base_url: str,
+    spec: ClientSpec,
+    *,
+    work_dir: Path,
+    include_long: bool,
+    package_check: bool,
+) -> dict[str, Any]:
+    started = now_ms()
+    package_result = package_smoke(work_dir, spec) if package_check else None
+    probe_fn = PROBE_BY_PROTOCOL[spec.protocol]
+    try:
+        probes = probe_fn(base_url, include_long=include_long)
+    except Exception as exc:
+        probes = [{
+            "name": "probe_exception",
+            "ok": False,
+            "status": 0,
+            "seconds": 0.0,
+            "body_tail": repr(exc),
+        }]
+    return {
+        "client": spec.name,
+        "protocol": spec.protocol,
+        "package": spec.package,
+        "package_smoke": package_result,
+        "ok": all((not probe_required(p)) or p.get("ok") for p in probes) and (
+            package_result is None or bool(package_result.get("ok"))
+        ),
+        "probes": probes,
+        "started_ms": started,
+        "ended_ms": now_ms(),
+    }
+
+
+def wait_http(base_url: str, proc: subprocess.Popen | None = None, timeout: int = 240) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            return False
+        try:
+            status, _body, _elapsed = http_json("GET", base_url + "/health", timeout=2)
+            if status == 200:
+                return True
+        except (urllib.error.URLError, TimeoutError, ConnectionResetError, socket.timeout):
+            pass
+        time.sleep(1)
+    return False
+
+
+def gpu_mem() -> dict[str, Any] | None:
+    if shutil.which("nvidia-smi") is None:
+        return None
+    result = run_cmd([
+        "nvidia-smi",
+        "--query-gpu=name,memory.used,memory.total,utilization.gpu",
+        "--format=csv,noheader,nounits",
+    ], timeout=10)
+    if not result["ok"]:
+        return {"error": result["output_tail"]}
+    rows = []
+    for line in result["output_tail"].strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 4:
+            rows.append({
+                "name": parts[0],
+                "memory_used_mib": int(parts[1]),
+                "memory_total_mib": int(parts[2]),
+                "gpu_util_percent": int(parts[3]),
+            })
+    return {"gpus": rows}
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def stop_proc(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=20)
+
+
+def start_server(
+    profile: ServerProfile,
+    *,
+    target: Path,
+    draft: Path,
+    bin_path: Path,
+    prefill_drafter: Path | None,
+    port: int,
+    work_dir: Path,
+) -> tuple[subprocess.Popen, Path, list[str], dict[str, str]]:
+    log_dir = work_dir / "server-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{profile.name}-{int(time.time())}-{port}.log"
+    args = [
+        sys.executable,
+        "-u",
+        str(ROOT / "dflash" / "scripts" / "server.py"),
+        "--host", "127.0.0.1",
+        "--port", str(port),
+        "--target", str(target),
+        "--draft", str(draft),
+        "--bin", str(bin_path),
+        *profile.args,
+    ]
+    if profile.needs_prefill_drafter:
+        if prefill_drafter is None:
+            raise HarnessError(f"profile {profile.name} requires --prefill-drafter")
+        args.extend(["--prefill-drafter", str(prefill_drafter)])
+    env = os.environ.copy()
+    env.update(profile.env)
+    log_f = open(log_path, "w")
+    proc = subprocess.Popen(
+        args,
+        cwd=str(ROOT / "dflash"),
+        env=env,
+        stdout=log_f,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    # Keep fd alive on proc object so it does not close immediately.
+    proc._lucebox_log_f = log_f  # type: ignore[attr-defined]
+    return proc, log_path, args, env
+
+
+def close_server_log(proc: subprocess.Popen) -> None:
+    log_f = getattr(proc, "_lucebox_log_f", None)
+    if log_f:
+        try:
+            log_f.close()
+        except Exception:
+            pass
+
+
+def tail(path: Path, n: int = 5000) -> str:
+    try:
+        return path.read_text(errors="replace")[-n:]
+    except FileNotFoundError:
+        return ""
+
+
+def write_json(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        print(json.dumps(payload, indent=2))
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {path}")
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    work_dir = args.work_dir.resolve()
+    selected = split_csv(args.clients, CLIENTS)
+    results = [install_client(work_dir, CLIENTS[name]) for name in selected]
+    payload = {"command": "install", "clients": results, "ok": all(r["ok"] for r in results)}
+    write_json(args.json_out, payload)
+    return 0 if payload["ok"] else 1
+
+
+def cmd_probe(args: argparse.Namespace) -> int:
+    work_dir = args.work_dir.resolve()
+    selected = split_csv(args.clients, CLIENTS)
+    install_results = []
+    if args.install_packages:
+        for name in selected:
+            install_results.append(install_client(work_dir, CLIENTS[name]))
+    results = [
+        run_client_probe(
+            args.url.rstrip("/"),
+            CLIENTS[name],
+            work_dir=work_dir,
+            include_long=args.long_prompt,
+            package_check=args.install_packages or args.package_smoke,
+        )
+        for name in selected
+    ]
+    payload = {
+        "command": "probe",
+        "url": args.url.rstrip("/"),
+        "install_results": install_results,
+        "clients": results,
+        "ok": all(r["ok"] for r in results),
+        "gpu": gpu_mem(),
+    }
+    write_json(args.json_out, payload)
+    return 0 if payload["ok"] else 1
+
+
+def cmd_sweep(args: argparse.Namespace) -> int:
+    work_dir = args.work_dir.resolve()
+    selected_clients = split_csv(args.clients, CLIENTS)
+    selected_profiles = split_csv(args.profiles, SERVER_PROFILES)
+    install_results = []
+    if args.install_packages:
+        for name in selected_clients:
+            install_results.append(install_client(work_dir, CLIENTS[name]))
+
+    all_profiles = []
+    for profile_name in selected_profiles:
+        profile = SERVER_PROFILES[profile_name]
+        port = args.port or free_port()
+        base_url = f"http://127.0.0.1:{port}"
+        before_gpu = gpu_mem()
+        proc = None
+        log_path = None
+        profile_result: dict[str, Any] = {
+            "profile": profile.name,
+            "base_url": base_url,
+            "server_args": [],
+            "before_gpu": before_gpu,
+            "clients": [],
+            "ok": False,
+        }
+        if args.isolate_clients:
+            profile_result["isolated_clients"] = True
+            for client_name in selected_clients:
+                client_port = args.port or free_port()
+                client_base_url = f"http://127.0.0.1:{client_port}"
+                client_proc = None
+                client_log_path = None
+                try:
+                    client_proc, client_log_path, server_args, _env = start_server(
+                        profile,
+                        target=args.target.resolve(),
+                        draft=args.draft.resolve(),
+                        bin_path=args.bin.resolve(),
+                        prefill_drafter=args.prefill_drafter.resolve() if args.prefill_drafter else None,
+                        port=client_port,
+                        work_dir=work_dir,
+                    )
+                    up = wait_http(client_base_url, proc=client_proc, timeout=args.start_timeout)
+                    if up:
+                        client_result = run_client_probe(
+                            client_base_url,
+                            CLIENTS[client_name],
+                            work_dir=work_dir,
+                            include_long=profile.long_prompt or args.long_prompt,
+                            package_check=args.install_packages or args.package_smoke,
+                        )
+                    else:
+                        client_result = {
+                            "client": client_name,
+                            "ok": False,
+                            "probes": [],
+                            "server_started": False,
+                        }
+                    client_result["base_url"] = client_base_url
+                    client_result["server_args"] = server_args
+                    client_result["server_started"] = up
+                    client_result["log_path"] = str(client_log_path)
+                except Exception as exc:
+                    client_result = {
+                        "client": client_name,
+                        "ok": False,
+                        "probes": [],
+                        "exception": repr(exc),
+                    }
+                    if client_log_path:
+                        client_result["server_log_tail"] = tail(client_log_path)
+                finally:
+                    if client_proc is not None:
+                        stop_proc(client_proc)
+                        close_server_log(client_proc)
+                        client_result["server_returncode"] = client_proc.poll()
+                    client_result["after_gpu"] = gpu_mem()
+                    if client_log_path and not client_result.get("server_log_tail"):
+                        client_result["server_log_tail"] = tail(client_log_path)[-2000:]
+                profile_result["clients"].append(client_result)
+            profile_result["ok"] = all(c["ok"] for c in profile_result["clients"])
+            profile_result["after_gpu"] = gpu_mem()
+            all_profiles.append(profile_result)
+            continue
+        try:
+            proc, log_path, server_args, _env = start_server(
+                profile,
+                target=args.target.resolve(),
+                draft=args.draft.resolve(),
+                bin_path=args.bin.resolve(),
+                prefill_drafter=args.prefill_drafter.resolve() if args.prefill_drafter else None,
+                port=port,
+                work_dir=work_dir,
+            )
+            profile_result["server_args"] = server_args
+            up = wait_http(base_url, proc=proc, timeout=args.start_timeout)
+            profile_result["server_started"] = up
+            profile_result["log_path"] = str(log_path)
+            if not up:
+                profile_result["server_returncode"] = proc.poll()
+                profile_result["server_log_tail"] = tail(log_path)
+            else:
+                for client_name in selected_clients:
+                    profile_result["clients"].append(
+                        run_client_probe(
+                            base_url,
+                            CLIENTS[client_name],
+                            work_dir=work_dir,
+                            include_long=profile.long_prompt or args.long_prompt,
+                            package_check=args.install_packages or args.package_smoke,
+                        )
+                    )
+                profile_result["ok"] = all(c["ok"] for c in profile_result["clients"])
+        except Exception as exc:
+            profile_result["exception"] = repr(exc)
+            if log_path:
+                profile_result["server_log_tail"] = tail(log_path)
+        finally:
+            if proc is not None:
+                stop_proc(proc)
+                close_server_log(proc)
+                profile_result["server_returncode"] = proc.poll()
+            profile_result["after_gpu"] = gpu_mem()
+            if log_path:
+                log_tail = tail(log_path)
+                if not profile_result.get("server_log_tail"):
+                    profile_result["server_log_tail"] = log_tail[-2000:]
+        all_profiles.append(profile_result)
+
+    payload = {
+        "command": "sweep",
+        "install_results": install_results,
+        "profiles": all_profiles,
+        "ok": all(p.get("ok") for p in all_profiles),
+    }
+    write_json(args.json_out, payload)
+    return 0 if payload["ok"] else 1
+
+
+def cmd_list(_args: argparse.Namespace) -> int:
+    print("clients:")
+    for name, spec in CLIENTS.items():
+        print(f"  {name:12s} {spec.install:5s} {spec.package:36s} {spec.protocol}")
+    print("\nprofiles:")
+    for name, profile in SERVER_PROFILES.items():
+        marker = " pflash" if profile.needs_prefill_drafter else ""
+        print(f"  {name:24s}{marker}  {' '.join(profile.args)}")
+    return 0
+
+
+def score_client(client: dict[str, Any]) -> dict[str, Any]:
+    probes = client.get("probes") or []
+    failed = [p.get("name") for p in probes if not p.get("ok")]
+    failed_required = [
+        p.get("name") for p in probes
+        if probe_required(p) and not p.get("ok")
+    ]
+    decode_failed = [
+        p.get("name") for p in probes
+        if "generated_ok" in p and not p.get("generated_ok")
+    ]
+    required_decode_failed = [
+        p.get("name") for p in probes
+        if probe_required(p) and "generated_ok" in p and not p.get("generated_ok")
+    ]
+    seconds = sum(float(p.get("seconds") or 0.0) for p in probes)
+    generated_chars = sum(int(p.get("generated_chars") or 0) for p in probes)
+    return {
+        "ok": not failed_required,
+        "failed_probes": failed,
+        "failed_required_probes": failed_required,
+        "decode_failed_probes": decode_failed,
+        "required_decode_failed_probes": required_decode_failed,
+        "seconds": round(seconds, 3),
+        "generated_chars": generated_chars,
+    }
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    rows: list[dict[str, Any]] = []
+    for path in args.json_in:
+        data = json.loads(path.read_text())
+        for profile in data.get("profiles") or []:
+            for client in profile.get("clients") or []:
+                score = score_client(client)
+                rows.append({
+                    "source": str(path),
+                    "profile": profile.get("profile"),
+                    "client": client.get("client"),
+                    "server_args": client.get("server_args") or profile.get("server_args"),
+                    **score,
+                })
+
+    by_client: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_client.setdefault(str(row["client"]), []).append(row)
+
+    best: dict[str, Any] = {}
+    for client, client_rows in sorted(by_client.items()):
+        ranked = sorted(
+            client_rows,
+            key=lambda r: (
+                not r["ok"],
+                len(r["failed_required_probes"]),
+                len(r["required_decode_failed_probes"]),
+                len(r["failed_probes"]),
+                r["seconds"],
+            ),
+        )
+        best[client] = ranked[0] if ranked else None
+
+    payload = {
+        "command": "report",
+        "inputs": [str(p) for p in args.json_in],
+        "best_by_client": best,
+        "rows": rows,
+        "ok": all(bool(row["ok"]) for row in best.values()),
+    }
+    write_json(args.json_out, payload)
+    if args.json_out is not None:
+        for client, row in best.items():
+            status = "PASS" if row and row["ok"] else "FAIL"
+            profile = row.get("profile") if row else None
+            seconds = row.get("seconds") if row else None
+            print(f"{client:12s} {status:4s} {profile} {seconds}s")
+    return 0 if payload["ok"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--work-dir", type=Path, default=DEFAULT_WORK_DIR)
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="List known clients and profiles")
+    p_list.set_defaults(func=cmd_list)
+
+    p_install = sub.add_parser("install", help="Download client packages")
+    p_install.add_argument("--clients", default="all")
+    p_install.add_argument("--json-out", type=Path, default=None)
+    p_install.set_defaults(func=cmd_install)
+
+    p_probe = sub.add_parser("probe", help="Probe an already-running server")
+    p_probe.add_argument("--url", default="http://127.0.0.1:8000")
+    p_probe.add_argument("--clients", default="all")
+    p_probe.add_argument("--install-packages", action="store_true")
+    p_probe.add_argument("--package-smoke", action="store_true")
+    p_probe.add_argument("--long-prompt", action="store_true")
+    p_probe.add_argument("--json-out", type=Path, default=None)
+    p_probe.set_defaults(func=cmd_probe)
+
+    p_sweep = sub.add_parser("sweep", help="Start server profiles and probe them")
+    p_sweep.add_argument("--target", type=Path, required=True)
+    p_sweep.add_argument("--draft", type=Path, required=True)
+    p_sweep.add_argument("--bin", type=Path, required=True)
+    p_sweep.add_argument("--prefill-drafter", type=Path, default=None)
+    p_sweep.add_argument("--profiles", default="rtx3090_dflash_fast,rtx3090_dflash_safe")
+    p_sweep.add_argument("--clients", default="all")
+    p_sweep.add_argument("--install-packages", action="store_true")
+    p_sweep.add_argument("--package-smoke", action="store_true")
+    p_sweep.add_argument("--long-prompt", action="store_true")
+    p_sweep.add_argument("--isolate-clients", action="store_true",
+                         help="Restart the server for each client probe")
+    p_sweep.add_argument("--port", type=int, default=None)
+    p_sweep.add_argument("--start-timeout", type=int, default=240)
+    p_sweep.add_argument("--json-out", type=Path, default=None)
+    p_sweep.set_defaults(func=cmd_sweep)
+
+    p_report = sub.add_parser("report", help="Summarize sweep JSON and pick per-client profiles")
+    p_report.add_argument("json_in", nargs="+", type=Path)
+    p_report.add_argument("--json-out", type=Path, default=None)
+    p_report.set_defaults(func=cmd_report)
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/clients/README.md
+++ b/harness/clients/README.md
@@ -1,0 +1,70 @@
+# Client Launchers
+
+These scripts run real clients against Lucebox. They are useful when you want to
+use Lucebox from a specific tool, and when you want to check that a server
+change did not break that tool.
+
+Run from the repo on the GPU machine:
+
+```bash
+cd /workspace/lucebox-hub-harness
+harness/clients/run_codex.sh
+```
+
+Each launcher starts `dflash/scripts/server.py`, runs the client, writes logs
+under `/workspace/lucebox-client-harness-runs`, then stops the server.
+
+## Defaults
+
+The defaults below are the current RTX 3090 starting points for
+`Qwen3.6-27B-Q4_K_M` plus the Lucebox DFlash draft.
+
+| Client | Launcher | Default profile |
+| --- | --- | --- |
+| Claude Code | `run_claude_code.sh` | `MAX_CTX=49152 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| Codex | `run_codex.sh` | `MAX_CTX=32768 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| OpenCode | `run_opencode.sh` | `MAX_CTX=86016 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| Hermes Agent | `run_hermes.sh` | `MAX_CTX=98304 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| Pi | `run_pi.sh` | `MAX_CTX=65536 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| OpenClaw | `run_openclaw.sh` | `MAX_CTX=204800 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| Open WebUI chat | `run_openwebui.sh` | `MAX_CTX=262144 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+| Open WebUI tools | `run_openwebui_tools.sh` | `MAX_CTX=65536 BUDGET=22 VERIFY_MODE=ddtree EXTRA_SERVER_ARGS=--lazy-draft` |
+
+Override any setting inline:
+
+```bash
+MAX_CTX=32768 harness/clients/run_claude_code.sh
+PROMPT='Explain the repo and end with lucebox-client-ok' harness/clients/run_opencode.sh
+PROMPT_FILE=harness/clients/prompts/repo_inspection.txt harness/clients/run_hermes.sh
+```
+
+Claude Code uses the real Anthropic Messages client path. Lucebox trims
+Claude-specific prompt boilerplate by default for local-model reliability. To
+test the raw prompt, set:
+
+```bash
+DFLASH_ANTHROPIC_RAW_SYSTEM=1 DFLASH_ANTHROPIC_RAW_USER=1 \
+  harness/clients/run_claude_code.sh
+```
+
+## Compare Backends
+
+Use `run_backend_pair.sh` to run the same client once with llama.cpp and once
+with Lucebox:
+
+```bash
+CLIENT=opencode PROMPT_FILE=harness/clients/prompts/repo_inspection.txt \
+  harness/clients/run_backend_pair.sh
+```
+
+OpenAI Chat Completions clients can call llama.cpp directly. Claude Code and
+Codex use `llamacpp_compat_proxy.py` so their real Anthropic Messages and
+Responses requests can be compared too.
+
+## Notes
+
+- `common.sh` contains the shared server startup logic.
+- `run_openwebui_tools.sh` supports `OPENWEBUI_FUNCTION_CALLING=default` and
+  `OPENWEBUI_FUNCTION_CALLING=native`.
+- Every launcher redirects stdin from `/dev/null`; this prevents SSH input from
+  being accidentally treated as a user prompt by interactive clients.

--- a/harness/clients/common.sh
+++ b/harness/clients/common.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Source this file from a client harness launcher on the RTX 3090 host.
+# Assumes the repo and client package cache already exist on that machine.
+
+REPO_DIR="${REPO_DIR:-/workspace/lucebox-hub-harness}"
+CLIENT_WORK_DIR="${CLIENT_WORK_DIR:-/workspace/lucebox-harness-work}"
+RUN_DIR="${RUN_DIR:-/workspace/lucebox-client-harness-runs}"
+
+TARGET="${TARGET:-$REPO_DIR/dflash/models/Qwen3.6-27B-Q4_K_M.gguf}"
+DRAFT="${DRAFT:-$REPO_DIR/dflash/models/draft/dflash-draft-3.6-q8_0.gguf}"
+DFLASH_BIN="${DFLASH_BIN:-$REPO_DIR/dflash/build/test_dflash}"
+MODEL_SERVER="${MODEL_SERVER:-lucebox}"
+LLAMA_SERVER_BIN="${LLAMA_SERVER_BIN:-/workspace/llama-cpp-server-build/bin/llama-server}"
+LLAMA_N_GPU_LAYERS="${LLAMA_N_GPU_LAYERS:-999}"
+LLAMA_FLASH_ATTN="${LLAMA_FLASH_ATTN:-1}"
+LLAMA_PARALLEL="${LLAMA_PARALLEL:-1}"
+LLAMA_CACHE_RAM="${LLAMA_CACHE_RAM:-0}"
+LLAMA_EXTRA_ARGS="${LLAMA_EXTRA_ARGS:-}"
+LLAMA_COMPAT_PROXY="${LLAMA_COMPAT_PROXY:-}"
+LLAMA_COMPAT_MAX_TOKENS="${LLAMA_COMPAT_MAX_TOKENS:-0}"
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-18080}"
+LLAMA_UPSTREAM_PORT="${LLAMA_UPSTREAM_PORT:-$((PORT + 1))}"
+MAX_CTX="${MAX_CTX:-16384}"
+VERIFY_MODE="${VERIFY_MODE:-seq}"
+BUDGET="${BUDGET:-22}"
+FA_WINDOW="${FA_WINDOW:-2048}"
+CACHE_TYPE_K="${CACHE_TYPE_K:-tq3_0}"
+CACHE_TYPE_V="${CACHE_TYPE_V:-tq3_0}"
+LLAMA_CACHE_TYPE_K="${LLAMA_CACHE_TYPE_K:-$CACHE_TYPE_K}"
+LLAMA_CACHE_TYPE_V="${LLAMA_CACHE_TYPE_V:-$CACHE_TYPE_V}"
+MAX_TOKENS="${MAX_TOKENS:-2048}"
+EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS:-}"
+
+MODEL_ID="${MODEL_ID:-luce-dflash}"
+API_KEY="${API_KEY:-sk-lucebox}"
+MARKER="${MARKER:-lucebox-client-ok}"
+PROMPT="${PROMPT:-Reply with exactly: $MARKER}"
+PROMPT_FILE="${PROMPT_FILE:-}"
+
+if [[ -n "$PROMPT_FILE" ]]; then
+  PROMPT="$(<"$PROMPT_FILE")"
+fi
+
+STAMP="${STAMP:-$(date +%Y%m%d-%H%M%S)}"
+BASE_URL="http://$HOST:$PORT"
+LOG_DIR="$RUN_DIR/$STAMP"
+SERVER_LOG="$LOG_DIR/server.log"
+
+mkdir -p "$LOG_DIR"
+
+start_lucebox_server() {
+  if [[ "$MODEL_SERVER" == "llamacpp" ]]; then
+    start_llamacpp_server
+    return
+  fi
+  if [[ "$MODEL_SERVER" != "lucebox" ]]; then
+    echo "unknown MODEL_SERVER=$MODEL_SERVER; expected lucebox or llamacpp" >&2
+    return 1
+  fi
+  cd "$REPO_DIR"
+  local extra_args=()
+  if [[ -n "$EXTRA_SERVER_ARGS" ]]; then
+    # Shell-word splitting is intentional here for simple flag lists such as:
+    # EXTRA_SERVER_ARGS="--lazy-draft --prefill-compression auto"
+    read -r -a extra_args <<< "$EXTRA_SERVER_ARGS"
+  fi
+  python3 -u dflash/scripts/server.py \
+    --host "$HOST" \
+    --port "$PORT" \
+    --target "$TARGET" \
+    --draft "$DRAFT" \
+    --bin "$DFLASH_BIN" \
+    --budget "$BUDGET" \
+    --verify-mode "$VERIFY_MODE" \
+    --max-ctx "$MAX_CTX" \
+    --fa-window "$FA_WINDOW" \
+    --cache-type-k "$CACHE_TYPE_K" \
+    --cache-type-v "$CACHE_TYPE_V" \
+    --prefix-cache-slots 0 \
+    --prefill-cache-slots 0 \
+    "${extra_args[@]}" \
+    > "$SERVER_LOG" 2>&1 &
+  SERVER_PID=$!
+}
+
+start_llamacpp_server() {
+  if [[ ! -x "$LLAMA_SERVER_BIN" ]]; then
+    echo "llama-server not found or not executable: $LLAMA_SERVER_BIN" >&2
+    echo "Build it first, for example:" >&2
+    echo "  cmake -S $REPO_DIR/dflash/deps/llama.cpp -B /workspace/llama-cpp-server-build -DGGML_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_CURL=OFF" >&2
+    echo "  cmake --build /workspace/llama-cpp-server-build --target llama-server -j2" >&2
+    return 1
+  fi
+  local extra_args=()
+  if [[ -n "$LLAMA_EXTRA_ARGS" ]]; then
+    read -r -a extra_args <<< "$LLAMA_EXTRA_ARGS"
+  fi
+  local flash_args=()
+  if [[ "$LLAMA_FLASH_ATTN" == "1" ]]; then
+    flash_args=(--flash-attn on)
+  fi
+  local llama_port="$PORT"
+  if [[ -n "$LLAMA_COMPAT_PROXY" ]]; then
+    llama_port="$LLAMA_UPSTREAM_PORT"
+  fi
+  "$LLAMA_SERVER_BIN" \
+    --model "$TARGET" \
+    --alias "$MODEL_ID" \
+    --ctx-size "$MAX_CTX" \
+    --n-gpu-layers "$LLAMA_N_GPU_LAYERS" \
+    --cache-type-k "$LLAMA_CACHE_TYPE_K" \
+    --cache-type-v "$LLAMA_CACHE_TYPE_V" \
+    --parallel "$LLAMA_PARALLEL" \
+    --cache-ram "$LLAMA_CACHE_RAM" \
+    --host "$HOST" \
+    --port "$llama_port" \
+    "${flash_args[@]}" \
+    "${extra_args[@]}" \
+    > "$SERVER_LOG" 2>&1 &
+  LLAMA_SERVER_PID=$!
+
+  if [[ -n "$LLAMA_COMPAT_PROXY" ]]; then
+    for _ in $(seq 1 300); do
+      if curl -fsS "http://$HOST:$LLAMA_UPSTREAM_PORT/health" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 1
+      if ! kill -0 "$LLAMA_SERVER_PID" 2>/dev/null; then
+        echo "llama-server exited early; log: $SERVER_LOG" >&2
+        tail -n 160 "$SERVER_LOG" >&2 || true
+        return 1
+      fi
+    done
+    python3 -u "$SCRIPT_DIR/llamacpp_compat_proxy.py" \
+      --host "$HOST" \
+      --port "$PORT" \
+      --upstream "http://$HOST:$LLAMA_UPSTREAM_PORT" \
+      --model "$MODEL_ID" \
+      --max-tokens-cap "$LLAMA_COMPAT_MAX_TOKENS" \
+      >> "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+  else
+    SERVER_PID=$LLAMA_SERVER_PID
+  fi
+}
+
+wait_lucebox_server() {
+  for _ in $(seq 1 300); do
+    if curl -fsS "$BASE_URL/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "server exited early; log: $SERVER_LOG" >&2
+      tail -n 160 "$SERVER_LOG" >&2 || true
+      return 1
+    fi
+  done
+  echo "server did not become healthy; log: $SERVER_LOG" >&2
+  tail -n 160 "$SERVER_LOG" >&2 || true
+  return 1
+}
+
+stop_lucebox_server() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${LLAMA_SERVER_PID:-}" ]] && [[ "${LLAMA_SERVER_PID:-}" != "${SERVER_PID:-}" ]] && kill -0 "$LLAMA_SERVER_PID" 2>/dev/null; then
+    kill "$LLAMA_SERVER_PID" 2>/dev/null || true
+    wait "$LLAMA_SERVER_PID" 2>/dev/null || true
+  fi
+}
+
+finish_report() {
+  local client_out="$1"
+  local rc="$2"
+  echo "rc=$rc"
+  echo "model_server=$MODEL_SERVER"
+  echo "run_dir=$LOG_DIR"
+  echo "client_out=$client_out"
+  echo "server_log=$SERVER_LOG"
+  echo "--- marker check ---"
+  grep -n "$MARKER" "$client_out" || true
+  echo "--- server tail ---"
+  tail -n 120 "$SERVER_LOG" || true
+  echo "--- gpu ---"
+  nvidia-smi --query-gpu=name,memory.used,memory.total,utilization.gpu --format=csv,noheader || true
+}

--- a/harness/clients/llamacpp_compat_proxy.py
+++ b/harness/clients/llamacpp_compat_proxy.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Small protocol shim for client harness llama.cpp comparisons.
+
+The proxy accepts the client-facing routes Lucebox supports and forwards the
+model call to llama-server's OpenAI Chat Completions endpoint. It is intentionally
+minimal: enough for harness benchmarks, not a full public API implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import re
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+
+def text_from_content(content) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                out.append(part)
+            elif isinstance(part, dict):
+                typ = part.get("type")
+                if typ in ("text", "input_text", "output_text"):
+                    out.append(part.get("text", ""))
+                elif typ == "tool_result":
+                    out.append(str(part.get("content", "")))
+        return "".join(out)
+    return str(content)
+
+
+def normalize_anthropic_system(system_text: str | None) -> str | None:
+    if not system_text:
+        return None
+    if os.environ.get("LLAMA_COMPAT_RAW_ANTHROPIC_SYSTEM", "0") == "1":
+        return system_text
+    if (
+        "x-anthropic-billing-header:" in system_text
+        or "Claude Agent SDK" in system_text
+        or "Claude Code" in system_text
+    ):
+        return (
+            "You are a concise coding assistant running behind an Anthropic "
+            "Messages compatible client. Answer the user's request directly. "
+            "Use the provided tools only when they are needed."
+        )
+    return system_text
+
+
+def normalize_anthropic_user_text(text: str) -> str:
+    if os.environ.get("LLAMA_COMPAT_RAW_ANTHROPIC_USER", "0") == "1":
+        return text
+
+    def replace_reminder(match: re.Match[str]) -> str:
+        block = match.group(0)
+        if "SKIP:" in block and ("- init:" in block or "- review:" in block):
+            return ""
+        return block
+
+    return re.sub(
+        r"<system-reminder>.*?</system-reminder>",
+        replace_reminder,
+        text,
+        flags=re.DOTALL,
+    )
+
+
+def map_responses_input(req: dict) -> tuple[list[dict], list[dict] | None]:
+    messages: list[dict] = []
+    system_parts: list[str] = []
+    if req.get("instructions"):
+        system_parts.append(str(req["instructions"]))
+
+    inp = req.get("input", "")
+    if isinstance(inp, str):
+        messages.append({"role": "user", "content": inp})
+    elif isinstance(inp, list):
+        for item in inp:
+            if not isinstance(item, dict):
+                continue
+            typ = item.get("type", "message")
+            if typ == "message":
+                role = item.get("role", "user")
+                content = text_from_content(item.get("content", ""))
+                if role in ("developer", "system"):
+                    system_parts.append(content)
+                else:
+                    messages.append({"role": role, "content": content})
+            elif typ == "function_call":
+                messages.append({
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": item.get("call_id") or item.get("id") or "call_" + uuid.uuid4().hex[:12],
+                        "type": "function",
+                        "function": {
+                            "name": item.get("name", ""),
+                            "arguments": item.get("arguments", "{}"),
+                        },
+                    }],
+                })
+            elif typ == "function_call_output":
+                output = item.get("output", "")
+                if not isinstance(output, str):
+                    output = json.dumps(output)
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id", ""),
+                    "content": output,
+                })
+
+    if system_parts:
+        messages.insert(0, {"role": "system", "content": "\n\n".join(system_parts)})
+
+    tools = []
+    for tool in req.get("tools") or []:
+        if not isinstance(tool, dict):
+            continue
+        if tool.get("type") == "function":
+            fn = {
+                "name": tool.get("name", ""),
+                "description": tool.get("description", ""),
+                "parameters": tool.get("parameters", {"type": "object", "properties": {}}),
+            }
+            tools.append({"type": "function", "function": fn})
+    return messages, tools or None
+
+
+def map_anthropic_messages(req: dict) -> tuple[list[dict], list[dict] | None]:
+    messages: list[dict] = []
+    system = req.get("system")
+    if system:
+        normalized = normalize_anthropic_system(text_from_content(system))
+        if normalized:
+            messages.append({"role": "system", "content": normalized})
+
+    for msg in req.get("messages") or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            text_parts: list[str] = []
+            tool_calls = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                typ = part.get("type")
+                if typ == "text":
+                    text_parts.append(normalize_anthropic_user_text(part.get("text", "")))
+                elif typ == "tool_use":
+                    tool_calls.append({
+                        "id": part.get("id", "call_" + uuid.uuid4().hex[:12]),
+                        "type": "function",
+                        "function": {
+                            "name": part.get("name", ""),
+                            "arguments": json.dumps(part.get("input", {})),
+                        },
+                    })
+                elif typ == "tool_result":
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": part.get("tool_use_id", ""),
+                        "content": text_from_content(part.get("content", "")),
+                    })
+            if tool_calls:
+                messages.append({"role": "assistant", "content": "".join(text_parts), "tool_calls": tool_calls})
+            elif text_parts:
+                messages.append({"role": role, "content": "".join(text_parts)})
+        else:
+            messages.append({
+                "role": role,
+                "content": normalize_anthropic_user_text(text_from_content(content)),
+            })
+
+    tools = []
+    for tool in req.get("tools") or []:
+        if not isinstance(tool, dict):
+            continue
+        fn = {
+            "name": tool.get("name", ""),
+            "description": tool.get("description", ""),
+            "parameters": tool.get("input_schema", {"type": "object", "properties": {}}),
+        }
+        tools.append({"type": "function", "function": fn})
+    return messages, tools or None
+
+
+def upstream_chat(upstream: str, payload: dict) -> tuple[int, dict]:
+    url = urlparse(upstream)
+    conn_cls = http.client.HTTPSConnection if url.scheme == "https" else http.client.HTTPConnection
+    port = url.port or (443 if url.scheme == "https" else 80)
+    conn = conn_cls(url.hostname, port, timeout=900)
+    body = json.dumps(payload).encode("utf-8")
+    path = (url.path.rstrip("/") or "") + "/v1/chat/completions"
+    conn.request("POST", path, body, {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    })
+    resp = conn.getresponse()
+    data = resp.read()
+    try:
+        obj = json.loads(data.decode("utf-8"))
+    except Exception:
+        obj = {"error": data.decode("utf-8", errors="replace")}
+    return resp.status, obj
+
+
+def chat_text_and_tools(chat: dict) -> tuple[str, list[dict]]:
+    choices = chat.get("choices") or []
+    if not choices:
+        return "", []
+    msg = choices[0].get("message") or {}
+    text = msg.get("content") or ""
+    return text, msg.get("tool_calls") or []
+
+
+def responses_json(req: dict, chat: dict, model: str) -> dict:
+    text, tool_calls = chat_text_and_tools(chat)
+    resp_id = "resp_" + uuid.uuid4().hex[:24]
+    output = []
+    for tc in tool_calls:
+        fn = tc.get("function") or {}
+        output.append({
+            "type": "function_call",
+            "id": tc.get("id", "call_" + uuid.uuid4().hex[:12]),
+            "status": "completed",
+            "call_id": tc.get("id", "call_" + uuid.uuid4().hex[:12]),
+            "name": fn.get("name", ""),
+            "arguments": fn.get("arguments", "{}"),
+        })
+    if not output:
+        output.append({
+            "type": "message",
+            "id": "msg_" + uuid.uuid4().hex[:24],
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": text, "annotations": []}],
+        })
+    usage = chat.get("usage") or {}
+    return {
+        "id": resp_id,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "completed",
+        "model": model,
+        "output": output,
+        "output_text": text,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+        },
+    }
+
+
+def anthropic_json(req: dict, chat: dict, model: str) -> dict:
+    text, tool_calls = chat_text_and_tools(chat)
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for tc in tool_calls:
+        fn = tc.get("function") or {}
+        try:
+            args = json.loads(fn.get("arguments") or "{}")
+        except Exception:
+            args = {}
+        content.append({
+            "type": "tool_use",
+            "id": tc.get("id", "call_" + uuid.uuid4().hex[:12]),
+            "name": fn.get("name", ""),
+            "input": args,
+        })
+    if not content:
+        content.append({"type": "text", "text": ""})
+    usage = chat.get("usage") or {}
+    return {
+        "id": "msg_" + uuid.uuid4().hex[:24],
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content,
+        "stop_reason": "tool_use" if tool_calls else "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+        },
+    }
+
+
+def responses_sse(obj: dict) -> bytes:
+    events = []
+    shell = {k: v for k, v in obj.items() if k != "output"}
+    shell["output"] = []
+    events.append(("response.created", {"response": {**shell, "status": "in_progress"}}))
+    for i, item in enumerate(obj.get("output") or []):
+        events.append(("response.output_item.added", {"output_index": i, "item": item}))
+        if item.get("type") == "message":
+            content = (item.get("content") or [{"text": ""}])[0]
+            text = content.get("text", "")
+            events.append(("response.content_part.added", {
+                "item_id": item["id"], "output_index": i, "content_index": 0,
+                "part": {"type": "output_text", "text": "", "annotations": []},
+            }))
+            if text:
+                events.append(("response.output_text.delta", {
+                    "item_id": item["id"], "output_index": i, "content_index": 0,
+                    "delta": text,
+                }))
+            events.append(("response.output_text.done", {
+                "item_id": item["id"], "output_index": i, "content_index": 0,
+                "text": text,
+            }))
+            events.append(("response.content_part.done", {
+                "item_id": item["id"], "output_index": i, "content_index": 0,
+                "part": {"type": "output_text", "text": text, "annotations": []},
+            }))
+        elif item.get("type") == "function_call":
+            events.append(("response.function_call_arguments.delta", {
+                "item_id": item["id"], "output_index": i, "delta": item.get("arguments", "{}"),
+            }))
+            events.append(("response.function_call_arguments.done", {
+                "item_id": item["id"], "output_index": i, "arguments": item.get("arguments", "{}"),
+                "name": item.get("name", ""),
+            }))
+        events.append(("response.output_item.done", {"output_index": i, "item": item}))
+    events.append(("response.completed", {"response": obj}))
+    out = []
+    for event, data in events:
+        data["type"] = event
+        out.append(f"event: {event}\ndata: {json.dumps(data)}\n\n")
+    return "".join(out).encode("utf-8")
+
+
+def anthropic_sse(obj: dict) -> bytes:
+    events = []
+    start = {**obj, "content": [], "stop_reason": None, "usage": {**obj.get("usage", {}), "output_tokens": 0}}
+    events.append(("message_start", {"type": "message_start", "message": start}))
+    for i, block in enumerate(obj.get("content") or []):
+        events.append(("content_block_start", {"type": "content_block_start", "index": i, "content_block": block}))
+        if block.get("type") == "text":
+            events.append(("content_block_delta", {
+                "type": "content_block_delta", "index": i,
+                "delta": {"type": "text_delta", "text": block.get("text", "")},
+            }))
+        elif block.get("type") == "tool_use":
+            events.append(("content_block_delta", {
+                "type": "content_block_delta", "index": i,
+                "delta": {"type": "input_json_delta", "partial_json": json.dumps(block.get("input", {}))},
+            }))
+        events.append(("content_block_stop", {"type": "content_block_stop", "index": i}))
+    events.append(("message_delta", {
+        "type": "message_delta",
+        "delta": {"stop_reason": obj.get("stop_reason", "end_turn"), "stop_sequence": None},
+        "usage": {"output_tokens": obj.get("usage", {}).get("output_tokens", 0)},
+    }))
+    events.append(("message_stop", {"type": "message_stop"}))
+    out = []
+    for event, data in events:
+        out.append(f"event: {event}\ndata: {json.dumps(data)}\n\n")
+    return "".join(out).encode("utf-8")
+
+
+class Handler(BaseHTTPRequestHandler):
+    upstream = ""
+    model = "luce-dflash"
+    max_tokens_cap = 0
+
+    def log_message(self, fmt, *args):
+        print("[%s] %s" % (self.log_date_time_string(), fmt % args), flush=True)
+
+    def send_json(self, status: int, obj: dict):
+        data = json.dumps(obj).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def send_sse(self, data: bytes):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def read_json(self) -> dict:
+        n = int(self.headers.get("Content-Length", "0"))
+        if n <= 0:
+            return {}
+        return json.loads(self.rfile.read(n).decode("utf-8"))
+
+    def do_GET(self):
+        if self.path.startswith("/health"):
+            self.send_json(200, {"status": "ok", "upstream": self.upstream})
+        elif self.path.startswith("/v1/models"):
+            self.send_json(200, {
+                "object": "list",
+                "data": [{"id": self.model, "object": "model", "created": 0, "owned_by": "llamacpp"}],
+            })
+        else:
+            self.send_json(404, {"error": "not found"})
+
+    def do_POST(self):
+        try:
+            req = self.read_json()
+            if self.path.startswith("/v1/responses"):
+                self.handle_responses(req)
+            elif self.path.startswith("/v1/messages"):
+                self.handle_anthropic(req)
+            elif self.path.startswith("/v1/chat/completions"):
+                status, obj = upstream_chat(self.upstream, {**req, "stream": False})
+                self.send_json(status, obj)
+            else:
+                self.send_json(404, {"error": "not found"})
+        except Exception as exc:
+            self.send_json(500, {"error": str(exc)})
+
+    def handle_responses(self, req: dict):
+        messages, tools = map_responses_input(req)
+        requested_max = req.get("max_output_tokens") or req.get("max_tokens") or 1024
+        if self.max_tokens_cap > 0:
+            requested_max = min(int(requested_max), self.max_tokens_cap)
+        payload = {
+            "model": req.get("model") or self.model,
+            "messages": messages,
+            "stream": False,
+            "max_tokens": requested_max,
+            "temperature": req.get("temperature", 0),
+            "top_p": req.get("top_p", 1),
+        }
+        if tools:
+            payload["tools"] = tools
+        status, chat = upstream_chat(self.upstream, payload)
+        if status >= 400:
+            self.send_json(status, chat)
+            return
+        obj = responses_json(req, chat, payload["model"])
+        if req.get("stream"):
+            self.send_sse(responses_sse(obj))
+        else:
+            self.send_json(200, obj)
+
+    def handle_anthropic(self, req: dict):
+        messages, tools = map_anthropic_messages(req)
+        requested_max = req.get("max_tokens") or 1024
+        if self.max_tokens_cap > 0:
+            requested_max = min(int(requested_max), self.max_tokens_cap)
+        payload = {
+            "model": req.get("model") or self.model,
+            "messages": messages,
+            "stream": False,
+            "max_tokens": requested_max,
+            "temperature": req.get("temperature", 0),
+            "top_p": req.get("top_p", 1),
+        }
+        if tools:
+            payload["tools"] = tools
+        status, chat = upstream_chat(self.upstream, payload)
+        if status >= 400:
+            self.send_json(status, chat)
+            return
+        obj = anthropic_json(req, chat, payload["model"])
+        if req.get("stream"):
+            self.send_sse(anthropic_sse(obj))
+        else:
+            self.send_json(200, obj)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=18080)
+    ap.add_argument("--upstream", default="http://127.0.0.1:18081")
+    ap.add_argument("--model", default="luce-dflash")
+    ap.add_argument("--max-tokens-cap", type=int, default=int(os.environ.get("LLAMA_COMPAT_MAX_TOKENS", "0")))
+    args = ap.parse_args()
+    Handler.upstream = args.upstream.rstrip("/")
+    Handler.model = args.model
+    Handler.max_tokens_cap = args.max_tokens_cap
+    srv = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"llama.cpp compat proxy on http://{args.host}:{args.port} -> {Handler.upstream}", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/clients/prompts/decode_check.txt
+++ b/harness/clients/prompts/decode_check.txt
@@ -1,0 +1,6 @@
+Explain what this Python function does. End your answer with OK_DONE.
+
+def clamp(x, lo, hi):
+    if lo > hi:
+        raise ValueError("bad bounds")
+    return min(max(x, lo), hi)

--- a/harness/clients/prompts/repo_inspection.txt
+++ b/harness/clients/prompts/repo_inspection.txt
@@ -1,0 +1,8 @@
+Use your normal file-reading tools if they are available. Do not modify files.
+
+Inspect the current repository and answer these questions:
+1. What is the first Markdown heading in README.md?
+2. What is the first Markdown heading in dflash/README.md?
+3. Does dflash/README.md mention Qwen3.6?
+
+Keep the answer short and end with OK_DONE.

--- a/harness/clients/run_backend_pair.sh
+++ b/harness/clients/run_backend_pair.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_DIR="${RUN_DIR:-/workspace/lucebox-client-harness-runs}"
+CLIENT="${CLIENT:-opencode}"
+PAIR_STAMP="${PAIR_STAMP:-backend-pair-$CLIENT-$(date +%Y%m%d-%H%M%S)}"
+PAIR_DIR="$RUN_DIR/$PAIR_STAMP"
+
+case "$CLIENT" in
+  claude|claude_code) CLIENT_SCRIPT="$SCRIPT_DIR/run_claude_code.sh" ;;
+  codex) CLIENT_SCRIPT="$SCRIPT_DIR/run_codex.sh" ;;
+  hermes) CLIENT_SCRIPT="$SCRIPT_DIR/run_hermes.sh" ;;
+  opencode) CLIENT_SCRIPT="$SCRIPT_DIR/run_opencode.sh" ;;
+  openclaw) CLIENT_SCRIPT="$SCRIPT_DIR/run_openclaw.sh" ;;
+  openwebui) CLIENT_SCRIPT="$SCRIPT_DIR/run_openwebui.sh" ;;
+  openwebui_tools) CLIENT_SCRIPT="$SCRIPT_DIR/run_openwebui_tools.sh" ;;
+  pi) CLIENT_SCRIPT="$SCRIPT_DIR/run_pi.sh" ;;
+  *)
+    echo "unknown CLIENT=$CLIENT" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$PAIR_DIR"
+PAIR_LOG="$PAIR_DIR/pair.log"
+
+run_backend() {
+  local backend="$1"
+  local stamp="$PAIR_STAMP-$backend"
+  echo "[$(date -Is)] backend=$backend client=$CLIENT script=$CLIENT_SCRIPT" | tee -a "$PAIR_LOG"
+  set +e
+  MODEL_SERVER="$backend" \
+  RUN_DIR="$PAIR_DIR" \
+  STAMP="$stamp" \
+  "$CLIENT_SCRIPT" 2>&1 | tee "$PAIR_DIR/$backend.out"
+  local rc=${PIPESTATUS[0]}
+  set -e
+  echo "[$(date -Is)] backend=$backend rc=$rc" | tee -a "$PAIR_LOG"
+  return "$rc"
+}
+
+# llama.cpp is run first so Lucebox numbers are not helped by residual client
+# caches from a previous Lucebox run. Each backend starts and stops its own
+# server, so only one 27B model is resident on the 24 GB card at a time.
+LLAMA_RC=0
+LUCEBOX_RC=0
+run_backend llamacpp || LLAMA_RC=$?
+run_backend lucebox || LUCEBOX_RC=$?
+
+python3 "$SCRIPT_DIR/summarize_backend_pair.py" "$PAIR_DIR" | tee "$PAIR_DIR/summary.md" || true
+
+echo "pair_dir=$PAIR_DIR"
+echo "llamacpp_rc=$LLAMA_RC"
+echo "lucebox_rc=$LUCEBOX_RC"
+
+if [[ "$LLAMA_RC" -ne 0 || "$LUCEBOX_RC" -ne 0 ]]; then
+  exit 1
+fi

--- a/harness/clients/run_claude_code.sh
+++ b/harness/clients/run_claude_code.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=49152}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+: "${CLAUDE_TOOLS:=default}"
+: "${CLAUDE_TIMEOUT:=300}"
+if [[ "${MODEL_SERVER:-}" == "llamacpp" ]]; then
+  : "${LLAMA_COMPAT_PROXY:=anthropic}"
+fi
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT_OUT="$LOG_DIR/claude-code.out"
+CLAUDE_BIN="${CLAUDE_BIN:-$CLIENT_WORK_DIR/clients/claude_code/npm/bin/claude}"
+HOME_DIR="$LOG_DIR/claude-home"
+mkdir -p "$HOME_DIR"
+
+start_lucebox_server
+trap stop_lucebox_server EXIT
+wait_lucebox_server
+
+set +e
+HOME="$HOME_DIR" \
+ANTHROPIC_API_KEY="$API_KEY" \
+ANTHROPIC_BASE_URL="$BASE_URL" \
+CLAUDE_CODE_API_BASE_URL="$BASE_URL" \
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+CLAUDE_CODE_DISABLE_TELEMETRY=1 \
+CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK=1 \
+timeout "${CLAUDE_TIMEOUT}s" "$CLAUDE_BIN" \
+  --print \
+  --output-format json \
+  --model "$MODEL_ID" \
+  --tools "$CLAUDE_TOOLS" \
+  --permission-mode dontAsk \
+  --no-session-persistence \
+  "$PROMPT" \
+  < /dev/null > "$CLIENT_OUT" 2>&1
+RC=$?
+set -e
+
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_claude_llamacpp_decode_check.sh
+++ b/harness/clients/run_claude_llamacpp_decode_check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+RUN_ROOT="${RUN_ROOT:-${RUN_DIR:-/workspace/lucebox-client-harness-runs/claude-llamacpp-decode-check}}"
+TARGET="${TARGET:-$REPO_DIR/dflash/models/Qwen3.6-27B-Q4_K_M.gguf}"
+LLAMA_SERVER_BIN="${LLAMA_SERVER_BIN:-/workspace/llama-cpp-server-build/bin/llama-server}"
+STAMP="${STAMP:-q8_32k_decode_check}"
+PROMPT="${PROMPT:-Reply with exactly: OK_DONE}"
+MARKER="${MARKER:-OK_DONE}"
+
+mkdir -p "$RUN_ROOT"
+
+REPO_DIR="$REPO_DIR" \
+RUN_DIR="$RUN_ROOT" \
+STAMP="$STAMP" \
+TARGET="$TARGET" \
+MODEL_SERVER=llamacpp \
+LLAMA_SERVER_BIN="$LLAMA_SERVER_BIN" \
+LLAMA_COMPAT_PROXY=anthropic \
+LLAMA_COMPAT_MAX_TOKENS=16 \
+LLAMA_CACHE_TYPE_K=q8_0 \
+LLAMA_CACHE_TYPE_V=q8_0 \
+LLAMA_FLASH_ATTN=1 \
+LLAMA_N_GPU_LAYERS=999 \
+LLAMA_PARALLEL=1 \
+LLAMA_CACHE_RAM=0 \
+LLAMA_EXTRA_ARGS="--no-warmup" \
+MAX_CTX=32768 \
+CLAUDE_TIMEOUT=600 \
+PROMPT="$PROMPT" \
+MARKER="$MARKER" \
+"$SCRIPT_DIR/run_claude_code.sh" > "$RUN_ROOT/$STAMP.wrapper.log" 2>&1 || true

--- a/harness/clients/run_claude_llamacpp_matrix.sh
+++ b/harness/clients/run_claude_llamacpp_matrix.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+RUN_ROOT="${RUN_ROOT:-${RUN_DIR:-/workspace/lucebox-client-harness-runs/claude-llamacpp-matrix}}"
+TARGET="${TARGET:-$REPO_DIR/dflash/models/Qwen3.6-27B-Q4_K_M.gguf}"
+LLAMA_SERVER_BIN="${LLAMA_SERVER_BIN:-/workspace/llama-cpp-server-build/bin/llama-server}"
+PROMPT="${PROMPT:-Write exactly 120 words about why a repo-level agent benchmark should run the client harness instead of a handcrafted HTTP request. End with OK_DONE.}"
+MARKER="${MARKER:-OK_DONE}"
+
+mkdir -p "$RUN_ROOT"
+
+run_one() {
+  local name="$1"
+  local ctx="$2"
+  local cache_k="$3"
+  local cache_v="$4"
+  local max_tokens="$5"
+  local extra="${6:-}"
+
+  echo "== $name =="
+  REPO_DIR="$REPO_DIR" \
+  RUN_DIR="$RUN_ROOT" \
+  STAMP="$name" \
+  TARGET="$TARGET" \
+  MODEL_SERVER=llamacpp \
+  LLAMA_SERVER_BIN="$LLAMA_SERVER_BIN" \
+  LLAMA_COMPAT_PROXY=anthropic \
+  LLAMA_COMPAT_MAX_TOKENS="$max_tokens" \
+  LLAMA_CACHE_TYPE_K="$cache_k" \
+  LLAMA_CACHE_TYPE_V="$cache_v" \
+  LLAMA_FLASH_ATTN=1 \
+  LLAMA_N_GPU_LAYERS=999 \
+  LLAMA_PARALLEL=1 \
+  LLAMA_CACHE_RAM=0 \
+  LLAMA_EXTRA_ARGS="--no-warmup $extra" \
+  MAX_CTX="$ctx" \
+  CLAUDE_TIMEOUT=900 \
+  PROMPT="$PROMPT" \
+  MARKER="$MARKER" \
+  "$SCRIPT_DIR/run_claude_code.sh" > "$RUN_ROOT/$name.wrapper.log" 2>&1 || true
+}
+
+run_one tq3_32k_cap192 32768 tq3_0 tq3_0 192
+run_one q8_32k_cap192 32768 q8_0 q8_0 192
+run_one tq3_48k_cap192 49152 tq3_0 tq3_0 192
+run_one q8_48k_cap192 49152 q8_0 q8_0 192
+run_one f16_32k_cap192 32768 f16 f16 192
+
+python3 - "$RUN_ROOT" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+prompt_re = re.compile(r"prompt eval time\s*=.*?/\s*(\d+)\s+tokens.*?,\s*([0-9.]+)\s+tokens per second", re.I)
+decode_re = re.compile(r"^\s*eval time\s*=.*?/\s*(\d+)\s+tokens.*?,\s*([0-9.]+)\s+tokens per second", re.I | re.M)
+rows = []
+
+for run in sorted(p for p in root.iterdir() if p.is_dir()):
+    server = (run / "server.log").read_text(errors="replace") if (run / "server.log").exists() else ""
+    out = (run / "claude-code.out").read_text(errors="replace") if (run / "claude-code.out").exists() else ""
+    wrapper = (root / f"{run.name}.wrapper.log").read_text(errors="replace") if (root / f"{run.name}.wrapper.log").exists() else ""
+    prompts = prompt_re.findall(server)
+    decodes = decode_re.findall(server)
+    usage = {}
+    try:
+        usage = json.loads(out.splitlines()[0]).get("usage", {})
+    except Exception:
+        pass
+    rows.append({
+        "name": run.name,
+        "rc": (re.search(r"^rc=(\d+)$", wrapper, re.M) or ["", ""])[1],
+        "marker": "OK_DONE" in out,
+        "prompt_tokens": int(prompts[-1][0]) if prompts else usage.get("input_tokens"),
+        "prompt_tok_s": float(prompts[-1][1]) if prompts else None,
+        "output_tokens": int(decodes[-1][0]) if decodes else usage.get("output_tokens"),
+        "decode_tok_s": float(decodes[-1][1]) if decodes else None,
+        "preview": " ".join(out.split())[:180],
+    })
+
+print("| profile | rc | marker | prompt tok | prompt tok/s | output tok | decode tok/s | preview |")
+print("| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |")
+for r in rows:
+    preview = r["preview"].replace("|", "\\|")
+    print(f"| {r['name']} | {r['rc']} | {'yes' if r['marker'] else 'no'} | {r['prompt_tokens'] or ''} | {r['prompt_tok_s'] or ''} | {r['output_tokens'] or ''} | {r['decode_tok_s'] or ''} | {preview} |")
+
+(root / "summary.json").write_text(json.dumps(rows, indent=2), encoding="utf-8")
+PY

--- a/harness/clients/run_codex.sh
+++ b/harness/clients/run_codex.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=32768}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+if [[ "${MODEL_SERVER:-}" == "llamacpp" ]]; then
+  : "${LLAMA_COMPAT_PROXY:=responses}"
+fi
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT_OUT="$LOG_DIR/codex.out"
+LAST_MSG="$LOG_DIR/codex-last-message.txt"
+CODEX_BIN="${CODEX_BIN:-$CLIENT_WORK_DIR/clients/codex/npm/bin/codex}"
+CODEX_HOME_DIR="$LOG_DIR/codex-home"
+CODEX_SANDBOX="${CODEX_SANDBOX:-danger-full-access}"
+CODEX_WIRE_API="${CODEX_WIRE_API:-responses}"
+mkdir -p "$CODEX_HOME_DIR"
+
+cat > "$CODEX_HOME_DIR/config.toml" <<TOML
+model = "$MODEL_ID"
+model_provider = "luce"
+approval_policy = "never"
+sandbox_mode = "$CODEX_SANDBOX"
+
+[model_providers.luce]
+name = "Lucebox"
+base_url = "$BASE_URL/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "$CODEX_WIRE_API"
+TOML
+
+start_lucebox_server
+trap stop_lucebox_server EXIT
+wait_lucebox_server
+
+set +e
+HOME="$CODEX_HOME_DIR" \
+CODEX_HOME="$CODEX_HOME_DIR" \
+OPENAI_API_KEY="$API_KEY" \
+timeout 420s "$CODEX_BIN" exec \
+  --skip-git-repo-check \
+  --sandbox "$CODEX_SANDBOX" \
+  --model "$MODEL_ID" \
+  --json \
+  --output-last-message "$LAST_MSG" \
+  "$PROMPT" \
+  < /dev/null > "$CLIENT_OUT" 2>&1
+RC=$?
+set -e
+
+cat "$LAST_MSG" >> "$CLIENT_OUT" 2>/dev/null || true
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_hermes.sh
+++ b/harness/clients/run_hermes.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=98304}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+: "${HERMES_MAX_TURNS:=40}"
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT_OUT="$LOG_DIR/hermes.out"
+HERMES_BIN="${HERMES_BIN:-$CLIENT_WORK_DIR/clients/hermes/home/.local/bin/hermes}"
+HOME_DIR="$LOG_DIR/hermes-home"
+mkdir -p "$HOME_DIR"
+
+cat > "$HOME_DIR/config.yaml" <<YAML
+model:
+  default: "$MODEL_ID"
+  provider: "lucebox"
+  base_url: "$BASE_URL/v1"
+  api_key: "$API_KEY"
+  api_mode: "chat_completions"
+  context_length: $MAX_CTX
+  max_tokens: $MAX_TOKENS
+
+custom_providers:
+  - name: "lucebox"
+    base_url: "$BASE_URL/v1"
+    api_key: "$API_KEY"
+    api_mode: "chat_completions"
+    models:
+      "$MODEL_ID":
+        context_length: $MAX_CTX
+        max_tokens: $MAX_TOKENS
+
+terminal:
+  backend: "local"
+  cwd: "$REPO_DIR"
+  timeout: 180
+  lifetime_seconds: 300
+YAML
+
+cat > "$HOME_DIR/.env" <<ENV
+OPENAI_API_KEY=$API_KEY
+OPENAI_BASE_URL=$BASE_URL/v1
+HERMES_INFERENCE_PROVIDER=lucebox
+HERMES_INFERENCE_MODEL=$MODEL_ID
+HERMES_ACCEPT_HOOKS=1
+HERMES_API_TIMEOUT=600
+HERMES_API_CALL_STALE_TIMEOUT=600
+ENV
+
+start_lucebox_server
+trap stop_lucebox_server EXIT
+wait_lucebox_server
+
+set +e
+cd "$REPO_DIR"
+HOME="$HOME_DIR" \
+HERMES_HOME="$HOME_DIR" \
+OPENAI_API_KEY="$API_KEY" \
+OPENAI_BASE_URL="$BASE_URL/v1" \
+HERMES_INFERENCE_PROVIDER=lucebox \
+HERMES_INFERENCE_MODEL="$MODEL_ID" \
+HERMES_ACCEPT_HOOKS=1 \
+NO_COLOR=1 \
+timeout 420s "$HERMES_BIN" chat \
+  --quiet \
+  --provider lucebox \
+  --model "$MODEL_ID" \
+  --accept-hooks \
+  --yolo \
+  --max-turns "$HERMES_MAX_TURNS" \
+  --source lucebox-harness \
+  --query "$PROMPT" \
+  < /dev/null > "$CLIENT_OUT" 2>&1
+RC=$?
+set -e
+
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_openclaw.sh
+++ b/harness/clients/run_openclaw.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=204800}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${FA_WINDOW:=2048}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT_OUT="$LOG_DIR/openclaw.out"
+OPENCLAW_BIN="${OPENCLAW_BIN:-$CLIENT_WORK_DIR/clients/openclaw/npm/bin/openclaw}"
+HOME_DIR="$LOG_DIR/openclaw-home"
+CONFIG_PATCH="$LOG_DIR/openclaw.patch.json"
+PROVIDER_API="${PROVIDER_API:-openai-completions}"
+OPENCLAW_AGENT_ARGS="${OPENCLAW_AGENT_ARGS:-}"
+OPENCLAW_SUPPORTS_TOOLS="${OPENCLAW_SUPPORTS_TOOLS:-true}"
+mkdir -p "$HOME_DIR"
+
+cat > "$CONFIG_PATCH" <<JSON
+{
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "lucebox": {
+        "baseUrl": "$BASE_URL/v1",
+        "apiKey": "$API_KEY",
+        "auth": "api-key",
+        "api": "$PROVIDER_API",
+        "contextWindow": $MAX_CTX,
+        "maxTokens": $MAX_TOKENS,
+        "models": [
+          {
+            "id": "$MODEL_ID",
+            "name": "Lucebox DFlash",
+            "api": "$PROVIDER_API",
+            "contextWindow": $MAX_CTX,
+            "maxTokens": $MAX_TOKENS,
+            "input": ["text"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "compat": {
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsTools": $OPENCLAW_SUPPORTS_TOOLS,
+              "maxTokensField": "max_tokens"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": "lucebox/$MODEL_ID",
+      "workspace": "$REPO_DIR",
+      "skipBootstrap": true,
+      "contextInjection": "never",
+      "bootstrapMaxChars": 1,
+      "bootstrapTotalMaxChars": 1,
+      "bootstrapPromptTruncationWarning": "off",
+      "experimental": {
+        "localModelLean": true
+      },
+      "compaction": {
+        "mode": "default",
+        "reserveTokens": 2048,
+        "keepRecentTokens": 6000,
+        "reserveTokensFloor": 0,
+        "maxHistoryShare": 0.85,
+        "recentTurnsPreserve": 2,
+        "qualityGuard": {
+          "enabled": false
+        },
+        "postIndexSync": "off",
+        "postCompactionSections": []
+      }
+    }
+  }
+}
+JSON
+
+HOME="$HOME_DIR" "$OPENCLAW_BIN" config patch --file "$CONFIG_PATCH" > "$LOG_DIR/openclaw-config.out" 2>&1
+
+start_lucebox_server
+trap stop_lucebox_server EXIT
+wait_lucebox_server
+
+agent_args=()
+if [[ -n "$OPENCLAW_AGENT_ARGS" ]]; then
+  read -r -a agent_args <<< "$OPENCLAW_AGENT_ARGS"
+fi
+
+set +e
+HOME="$HOME_DIR" \
+OPENAI_API_KEY="$API_KEY" \
+timeout 420s "$OPENCLAW_BIN" agent \
+  --local \
+  --json \
+  --model "lucebox/$MODEL_ID" \
+  --session-id "lucebox-client-harness" \
+  --timeout 300 \
+  "${agent_args[@]}" \
+  --message "$PROMPT" \
+  < /dev/null > "$CLIENT_OUT" 2>&1
+RC=$?
+set -e
+
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_opencode.sh
+++ b/harness/clients/run_opencode.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=86016}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT_OUT="$LOG_DIR/opencode.out"
+EXPORT_OUT="$LOG_DIR/opencode-export.json"
+OPENCODE_BIN="${OPENCODE_BIN:-$CLIENT_WORK_DIR/clients/opencode/npm/bin/opencode}"
+HOME_DIR="$LOG_DIR/opencode-home"
+PROJECT_DIR="$LOG_DIR/opencode-project"
+mkdir -p "$HOME_DIR/.config" "$HOME_DIR/.local/share" "$PROJECT_DIR"
+
+for path in "$REPO_DIR"/* "$REPO_DIR"/.[!.]*; do
+  [[ -e "$path" ]] || continue
+  name="$(basename "$path")"
+  [[ "$name" == ".git" ]] && continue
+  [[ "$name" == "opencode.json" ]] && continue
+  [[ -e "$PROJECT_DIR/$name" ]] || ln -s "$path" "$PROJECT_DIR/$name"
+done
+
+cat > "$PROJECT_DIR/opencode.json" <<JSON
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "model": "lucebox/$MODEL_ID",
+  "small_model": "lucebox/$MODEL_ID",
+  "provider": {
+    "lucebox": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Lucebox",
+      "options": {
+        "baseURL": "$BASE_URL/v1",
+        "apiKey": "$API_KEY",
+        "timeout": 600000,
+        "chunkTimeout": 60000
+      },
+      "models": {
+        "$MODEL_ID": {
+          "name": "Lucebox DFlash",
+          "limit": {
+            "context": $MAX_CTX,
+            "output": $MAX_TOKENS
+          }
+        }
+      }
+    }
+  },
+  "tools": {
+    "write": false,
+    "bash": false
+  }
+}
+JSON
+
+start_lucebox_server
+trap stop_lucebox_server EXIT
+wait_lucebox_server
+
+set +e
+cd "$PROJECT_DIR"
+HOME="$HOME_DIR" \
+XDG_CONFIG_HOME="$HOME_DIR/.config" \
+XDG_DATA_HOME="$HOME_DIR/.local/share" \
+OPENAI_API_KEY="$API_KEY" \
+timeout 300s "$OPENCODE_BIN" run \
+  --pure \
+  --model "lucebox/$MODEL_ID" \
+  --format json \
+  "$PROMPT" \
+  < /dev/null > "$CLIENT_OUT" 2>&1
+RC=$?
+SESSION_ID="$(grep -m1 -o 'ses_[A-Za-z0-9]*' "$CLIENT_OUT" || true)"
+if [[ -n "$SESSION_ID" ]]; then
+  HOME="$HOME_DIR" \
+  XDG_CONFIG_HOME="$HOME_DIR/.config" \
+  XDG_DATA_HOME="$HOME_DIR/.local/share" \
+  "$OPENCODE_BIN" export "$SESSION_ID" > "$EXPORT_OUT" 2>&1 || true
+  cat "$EXPORT_OUT" >> "$CLIENT_OUT"
+fi
+set -e
+
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_openwebui.sh
+++ b/harness/clients/run_openwebui.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=262144}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+source "$SCRIPT_DIR/common.sh"
+
+WEBUI_PORT="${WEBUI_PORT:-18081}"
+WEBUI_BASE="http://127.0.0.1:$WEBUI_PORT"
+CLIENT_OUT="$LOG_DIR/openwebui.out"
+WEBUI_LOG="$LOG_DIR/openwebui.log"
+OPENWEBUI_BIN="${OPENWEBUI_BIN:-$CLIENT_WORK_DIR/clients/openwebui/venv/bin/open-webui}"
+DATA_DIR="$LOG_DIR/openwebui-data"
+REQUEST_JSON="$LOG_DIR/openwebui-request.json"
+AUTH_JSON="$LOG_DIR/openwebui-auth.json"
+AUTH_OUT="$LOG_DIR/openwebui-auth.out"
+WEBUI_ADMIN_EMAIL_VALUE="${WEBUI_ADMIN_EMAIL_VALUE:-admin@localhost}"
+WEBUI_ADMIN_PASSWORD_VALUE="${WEBUI_ADMIN_PASSWORD_VALUE:-admin}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-300}"
+mkdir -p "$DATA_DIR"
+
+start_lucebox_server
+trap 'stop_lucebox_server; [[ -n "${WEBUI_PID:-}" ]] && kill "$WEBUI_PID" 2>/dev/null || true' EXIT
+wait_lucebox_server
+
+WEBUI_SECRET_KEY="lucebox-local-secret" \
+WEBUI_AUTH=False \
+ENABLE_SIGNUP=False \
+WEBUI_ADMIN_EMAIL="$WEBUI_ADMIN_EMAIL_VALUE" \
+WEBUI_ADMIN_PASSWORD="$WEBUI_ADMIN_PASSWORD_VALUE" \
+WEBUI_ADMIN_NAME="Lucebox Harness" \
+DEFAULT_MODELS="$MODEL_ID" \
+OPENAI_API_BASE_URL="$BASE_URL/v1" \
+OPENAI_API_KEY="$API_KEY" \
+DATA_DIR="$DATA_DIR" \
+"$OPENWEBUI_BIN" serve --host 127.0.0.1 --port "$WEBUI_PORT" > "$WEBUI_LOG" 2>&1 &
+WEBUI_PID=$!
+
+for _ in $(seq 1 180); do
+  if curl -fsS "$WEBUI_BASE/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+  if ! kill -0 "$WEBUI_PID" 2>/dev/null; then
+    echo "Open WebUI exited early; log: $WEBUI_LOG" >&2
+    tail -n 120 "$WEBUI_LOG" >&2 || true
+    exit 1
+  fi
+done
+
+WEBUI_ADMIN_EMAIL_VALUE="$WEBUI_ADMIN_EMAIL_VALUE" \
+WEBUI_ADMIN_PASSWORD_VALUE="$WEBUI_ADMIN_PASSWORD_VALUE" \
+python3 - "$AUTH_JSON" <<'PY'
+import json
+import os
+import sys
+
+body = {
+    "email": os.environ["WEBUI_ADMIN_EMAIL_VALUE"],
+    "password": os.environ["WEBUI_ADMIN_PASSWORD_VALUE"],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+AUTH_STATUS=$(curl -sS -o "$AUTH_OUT" -w "%{http_code}" \
+  "$WEBUI_BASE/api/v1/auths/signin" \
+  -H "Content-Type: application/json" \
+  -d @"$AUTH_JSON")
+
+if [[ "$AUTH_STATUS" != 2* ]]; then
+  echo "Open WebUI signin failed with HTTP $AUTH_STATUS" > "$CLIENT_OUT"
+  cat "$AUTH_OUT" >> "$CLIENT_OUT"
+  finish_report "$CLIENT_OUT" 1
+  exit 1
+fi
+
+WEBUI_TOKEN=$(python3 - "$AUTH_OUT" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+print(data.get("token", ""))
+PY
+)
+
+if [[ -z "$WEBUI_TOKEN" ]]; then
+  echo "Open WebUI signin returned no token" > "$CLIENT_OUT"
+  cat "$AUTH_OUT" >> "$CLIENT_OUT"
+  finish_report "$CLIENT_OUT" 1
+  exit 1
+fi
+
+PROMPT="$PROMPT" MODEL_ID="$MODEL_ID" python3 - "$REQUEST_JSON" <<'PY'
+import json
+import os
+import sys
+
+body = {
+    "model": os.environ["MODEL_ID"],
+    "messages": [
+        {"role": "user", "content": os.environ["PROMPT"]},
+    ],
+    "stream": False,
+    "max_tokens": 256,
+    "temperature": 0,
+}
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+set +e
+CHAT_STATUS=$(curl -sS -o "$CLIENT_OUT" -w "%{http_code}" \
+  --max-time "$CURL_MAX_TIME" \
+  "$WEBUI_BASE/openai/chat/completions" \
+  -H "Authorization: Bearer $WEBUI_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @"$REQUEST_JSON")
+RC=$?
+set -e
+
+if [[ "$RC" -eq 0 && "$CHAT_STATUS" != 2* ]]; then
+  RC=1
+fi
+if [[ "$RC" -eq 0 ]] && ! grep -q "$MARKER" "$CLIENT_OUT"; then
+  RC=1
+fi
+
+{
+  echo
+  echo "--- openwebui tail ---"
+  tail -n 120 "$WEBUI_LOG" || true
+} >> "$CLIENT_OUT"
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_openwebui_tools.sh
+++ b/harness/clients/run_openwebui_tools.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=65536}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+: "${MARKER:=OPENWEBUI_TOOL_OK}"
+: "${OPENWEBUI_FUNCTION_CALLING:=native}"
+: "${OPENWEBUI_NATIVE_TOOL_CHOICE:=1}"
+: "${OPENWEBUI_DISABLE_BUILTIN_TOOLS:=1}"
+if [[ -z "${OPENWEBUI_REQUIRE_TOOL_EXECUTION+x}" ]]; then
+  if [[ "$OPENWEBUI_FUNCTION_CALLING" == "native" ]]; then
+    OPENWEBUI_REQUIRE_TOOL_EXECUTION=0
+  else
+    OPENWEBUI_REQUIRE_TOOL_EXECUTION=1
+  fi
+fi
+source "$SCRIPT_DIR/common.sh"
+
+WEBUI_PORT="${WEBUI_PORT:-18081}"
+WEBUI_BASE="http://127.0.0.1:$WEBUI_PORT"
+CLIENT_OUT="$LOG_DIR/openwebui-tools.out"
+WEBUI_LOG="$LOG_DIR/openwebui.log"
+OPENWEBUI_BIN="${OPENWEBUI_BIN:-$CLIENT_WORK_DIR/clients/openwebui/venv/bin/open-webui}"
+DATA_DIR="$LOG_DIR/openwebui-data"
+TOOL_JSON="$LOG_DIR/openwebui-tool-create.json"
+TOOL_CREATE_OUT="$LOG_DIR/openwebui-tool-create.out"
+TOOL_EXEC_LOG="$LOG_DIR/openwebui-tool-exec.log"
+REQUEST_JSON="$LOG_DIR/openwebui-tool-request.json"
+MODEL_JSON="$LOG_DIR/openwebui-model-create.json"
+MODEL_CREATE_OUT="$LOG_DIR/openwebui-model-create.out"
+AUTH_JSON="$LOG_DIR/openwebui-auth.json"
+AUTH_OUT="$LOG_DIR/openwebui-auth.out"
+WEBUI_ADMIN_EMAIL_VALUE="${WEBUI_ADMIN_EMAIL_VALUE:-admin@localhost}"
+WEBUI_ADMIN_PASSWORD_VALUE="${WEBUI_ADMIN_PASSWORD_VALUE:-admin}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-300}"
+TOOL_ID="${TOOL_ID:-lucebox_harness_probe}"
+if [[ "$OPENWEBUI_DISABLE_BUILTIN_TOOLS" == "1" ]]; then
+  WEBUI_MODEL_ID="${OPENWEBUI_MODEL_ID:-${MODEL_ID}-tools}"
+else
+  WEBUI_MODEL_ID="${OPENWEBUI_MODEL_ID:-$MODEL_ID}"
+fi
+mkdir -p "$DATA_DIR"
+
+start_lucebox_server
+trap 'stop_lucebox_server; [[ -n "${WEBUI_PID:-}" ]] && kill "$WEBUI_PID" 2>/dev/null || true' EXIT
+wait_lucebox_server
+
+WEBUI_SECRET_KEY="lucebox-local-secret" \
+WEBUI_AUTH=False \
+ENABLE_SIGNUP=False \
+WEBUI_ADMIN_EMAIL="$WEBUI_ADMIN_EMAIL_VALUE" \
+WEBUI_ADMIN_PASSWORD="$WEBUI_ADMIN_PASSWORD_VALUE" \
+WEBUI_ADMIN_NAME="Lucebox Harness" \
+DEFAULT_MODELS="$MODEL_ID" \
+OPENAI_API_BASE_URL="$BASE_URL/v1" \
+OPENAI_API_KEY="$API_KEY" \
+DATA_DIR="$DATA_DIR" \
+LUCEBOX_OPENWEBUI_TOOL_LOG="$TOOL_EXEC_LOG" \
+"$OPENWEBUI_BIN" serve --host 127.0.0.1 --port "$WEBUI_PORT" > "$WEBUI_LOG" 2>&1 &
+WEBUI_PID=$!
+
+for _ in $(seq 1 180); do
+  if curl -fsS "$WEBUI_BASE/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+  if ! kill -0 "$WEBUI_PID" 2>/dev/null; then
+    echo "Open WebUI exited early; log: $WEBUI_LOG" >&2
+    tail -n 120 "$WEBUI_LOG" >&2 || true
+    exit 1
+  fi
+done
+
+WEBUI_ADMIN_EMAIL_VALUE="$WEBUI_ADMIN_EMAIL_VALUE" \
+WEBUI_ADMIN_PASSWORD_VALUE="$WEBUI_ADMIN_PASSWORD_VALUE" \
+python3 - "$AUTH_JSON" <<'PY'
+import json
+import os
+import sys
+
+body = {
+    "email": os.environ["WEBUI_ADMIN_EMAIL_VALUE"],
+    "password": os.environ["WEBUI_ADMIN_PASSWORD_VALUE"],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+AUTH_STATUS=$(curl -sS -o "$AUTH_OUT" -w "%{http_code}" \
+  "$WEBUI_BASE/api/v1/auths/signin" \
+  -H "Content-Type: application/json" \
+  -d @"$AUTH_JSON")
+
+if [[ "$AUTH_STATUS" != 2* ]]; then
+  echo "Open WebUI signin failed with HTTP $AUTH_STATUS" > "$CLIENT_OUT"
+  cat "$AUTH_OUT" >> "$CLIENT_OUT"
+  finish_report "$CLIENT_OUT" 1
+  exit 1
+fi
+
+WEBUI_TOKEN=$(python3 - "$AUTH_OUT" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+print(data.get("token", ""))
+PY
+)
+
+if [[ -z "$WEBUI_TOKEN" ]]; then
+  echo "Open WebUI signin returned no token" > "$CLIENT_OUT"
+  cat "$AUTH_OUT" >> "$CLIENT_OUT"
+  finish_report "$CLIENT_OUT" 1
+  exit 1
+fi
+
+if [[ "$OPENWEBUI_DISABLE_BUILTIN_TOOLS" == "1" ]]; then
+  MODEL_ID="$MODEL_ID" WEBUI_MODEL_ID="$WEBUI_MODEL_ID" python3 - "$MODEL_JSON" <<'PY'
+import json
+import os
+import sys
+
+model_id = os.environ["MODEL_ID"]
+webui_model_id = os.environ["WEBUI_MODEL_ID"]
+disabled_builtin_tools = {
+    key: False
+    for key in (
+        "time",
+        "knowledge",
+        "chats",
+        "memory",
+        "web_search",
+        "image_generation",
+        "code_interpreter",
+        "notes",
+        "channels",
+        "tasks",
+        "automations",
+        "calendar",
+    )
+}
+body = {
+    "id": webui_model_id,
+    "base_model_id": model_id,
+    "name": webui_model_id,
+    "meta": {
+        "description": "Local Lucebox DFlash model for harness tool testing.",
+        "capabilities": {
+            "builtin_tools": False,
+        },
+        "builtinTools": disabled_builtin_tools,
+    },
+    "params": {},
+    "access_grants": [],
+    "is_active": True,
+}
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+  MODEL_STATUS=$(curl -sS -o "$MODEL_CREATE_OUT" -w "%{http_code}" \
+    "$WEBUI_BASE/api/v1/models/create" \
+    -H "Authorization: Bearer $WEBUI_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @"$MODEL_JSON")
+
+  if [[ "$MODEL_STATUS" != 2* ]]; then
+    echo "Open WebUI model capability setup failed with HTTP $MODEL_STATUS" > "$CLIENT_OUT"
+    cat "$MODEL_CREATE_OUT" >> "$CLIENT_OUT"
+    finish_report "$CLIENT_OUT" 1
+    exit 1
+  fi
+fi
+
+TOOL_ID="$TOOL_ID" python3 - "$TOOL_JSON" <<'PY'
+import json
+import os
+import sys
+
+tool_id = os.environ["TOOL_ID"]
+content = r'''
+from pathlib import Path
+from pydantic import Field
+import json
+import os
+import time
+
+
+class Tools:
+    def get_lucebox_harness_marker(
+        self,
+        question: str = Field(..., description="The harness question that must be answered by this tool."),
+    ) -> str:
+        """
+        Return the Lucebox Open WebUI harness marker and record that this Open WebUI tool executed.
+        """
+        result = {
+            "marker": "OPENWEBUI_TOOL_OK",
+            "readme_heading": "Projects",
+            "dflash_heading": "Luce DFlash",
+            "qwen36_supported": True,
+            "question": question,
+            "ts": int(time.time()),
+        }
+        log_path = os.environ.get("LUCEBOX_OPENWEBUI_TOOL_LOG")
+        if log_path:
+            Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(result, sort_keys=True) + "\n")
+        return "OPENWEBUI_TOOL_RESULT marker=OPENWEBUI_TOOL_OK readme_heading=Projects dflash_heading=Luce_DFlash qwen36_supported=true"
+'''
+
+body = {
+    "id": tool_id,
+    "name": "Lucebox Harness Probe",
+    "content": content,
+    "meta": {
+        "description": "Tool used by the Lucebox harness to verify Open WebUI tool execution."
+    },
+    "access_grants": [],
+}
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+CREATE_STATUS=$(curl -sS -o "$TOOL_CREATE_OUT" -w "%{http_code}" \
+  "$WEBUI_BASE/api/v1/tools/create" \
+  -H "Authorization: Bearer $WEBUI_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @"$TOOL_JSON")
+
+if [[ "$CREATE_STATUS" != 2* ]]; then
+  echo "Open WebUI tool creation failed with HTTP $CREATE_STATUS" > "$CLIENT_OUT"
+  cat "$TOOL_CREATE_OUT" >> "$CLIENT_OUT"
+  finish_report "$CLIENT_OUT" 1
+  exit 1
+fi
+
+OPENWEBUI_TOOL_PROMPT="${OPENWEBUI_TOOL_PROMPT:-Use the Open WebUI tool get_lucebox_harness_marker with question 'verify Lucebox Open WebUI tool execution'. Do not answer from memory. After the tool returns, reply with the marker OPENWEBUI_TOOL_OK and then OK_DONE.}"
+
+OPENWEBUI_TOOL_PROMPT="$OPENWEBUI_TOOL_PROMPT" \
+WEBUI_MODEL_ID="$WEBUI_MODEL_ID" \
+TOOL_ID="$TOOL_ID" \
+MAX_TOKENS="$MAX_TOKENS" \
+OPENWEBUI_FUNCTION_CALLING="$OPENWEBUI_FUNCTION_CALLING" \
+OPENWEBUI_NATIVE_TOOL_CHOICE="$OPENWEBUI_NATIVE_TOOL_CHOICE" \
+python3 - "$REQUEST_JSON" <<'PY'
+import json
+import os
+import sys
+
+function_calling = os.environ.get("OPENWEBUI_FUNCTION_CALLING", "native")
+body = {
+    "model": os.environ["WEBUI_MODEL_ID"],
+    "chat_id": "local:lucebox-openwebui-tools",
+    "id": "assistant-openwebui-tools-1",
+    "user_message": {
+        "id": "user-openwebui-tools-1",
+    },
+    "messages": [
+        {"role": "user", "content": os.environ["OPENWEBUI_TOOL_PROMPT"]},
+    ],
+    "stream": False,
+    "max_tokens": int(os.environ.get("MAX_TOKENS", "512")),
+    "temperature": 0,
+    "tool_ids": [os.environ["TOOL_ID"]],
+    "params": {
+        "function_calling": function_calling,
+    },
+}
+if function_calling == "native" and os.environ.get("OPENWEBUI_NATIVE_TOOL_CHOICE", "1") != "0":
+    body["tool_choice"] = {
+        "type": "function",
+        "function": {
+            "name": "get_lucebox_harness_marker",
+        },
+    }
+with open(sys.argv[1], "w", encoding="utf-8") as f:
+    json.dump(body, f)
+PY
+
+set +e
+CHAT_STATUS=$(curl -sS -o "$CLIENT_OUT" -w "%{http_code}" \
+  --max-time "$CURL_MAX_TIME" \
+  "$WEBUI_BASE/api/chat/completions" \
+  -H "Authorization: Bearer $WEBUI_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @"$REQUEST_JSON")
+RC=$?
+set -e
+
+if [[ "$RC" -eq 0 && "$CHAT_STATUS" != 2* ]]; then
+  RC=1
+fi
+if [[ "$RC" -eq 0 && "$OPENWEBUI_FUNCTION_CALLING" == "native" && "$OPENWEBUI_REQUIRE_TOOL_EXECUTION" == "0" ]]; then
+  if ! grep -q '"tool_calls"' "$CLIENT_OUT" || ! grep -q 'get_lucebox_harness_marker' "$CLIENT_OUT"; then
+    RC=1
+  fi
+else
+  if [[ "$RC" -eq 0 ]] && ! grep -q "$MARKER" "$CLIENT_OUT"; then
+    RC=1
+  fi
+  if [[ "$RC" -eq 0 ]] && { [[ ! -f "$TOOL_EXEC_LOG" ]] || ! grep -q "$MARKER" "$TOOL_EXEC_LOG"; }; then
+    RC=1
+  fi
+fi
+
+{
+  echo "--- request ---"
+  cat "$REQUEST_JSON" || true
+  echo
+  echo
+  echo "--- validation mode ---"
+  echo "function_calling=$OPENWEBUI_FUNCTION_CALLING"
+  echo "require_tool_execution=$OPENWEBUI_REQUIRE_TOOL_EXECUTION"
+  echo
+  if [[ -f "$MODEL_CREATE_OUT" ]]; then
+    echo
+    echo "--- model create response ---"
+    cat "$MODEL_CREATE_OUT" || true
+    echo
+  fi
+  echo
+  echo "--- tool create response ---"
+  cat "$TOOL_CREATE_OUT" || true
+  echo
+  echo "--- tool execution log ---"
+  if [[ -f "$TOOL_EXEC_LOG" ]]; then
+    cat "$TOOL_EXEC_LOG" || true
+  else
+    echo "missing: $TOOL_EXEC_LOG"
+  fi
+  echo
+  echo "--- openwebui tail ---"
+  tail -n 160 "$WEBUI_LOG" || true
+} >> "$CLIENT_OUT"
+
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/run_pi.sh
+++ b/harness/clients/run_pi.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${MAX_CTX:=65536}"
+: "${BUDGET:=22}"
+: "${VERIFY_MODE:=ddtree}"
+: "${EXTRA_SERVER_ARGS:=--lazy-draft}"
+: "${PI_TOOLS:=read,grep,find,ls}"
+source "$SCRIPT_DIR/common.sh"
+
+CLIENT_OUT="$LOG_DIR/pi.out"
+PI_BIN="${PI_BIN:-$CLIENT_WORK_DIR/clients/pi/npm/bin/pi}"
+HOME_DIR="$LOG_DIR/pi-home"
+AGENT_DIR="$HOME_DIR/agent"
+PROVIDER_API="${PROVIDER_API:-openai-responses}"
+mkdir -p "$AGENT_DIR" "$HOME_DIR/sessions"
+
+cat > "$AGENT_DIR/settings.json" <<JSON
+{
+  "compaction": {
+    "enabled": false
+  }
+}
+JSON
+
+cat > "$AGENT_DIR/models.json" <<JSON
+{
+  "providers": {
+    "lucebox": {
+      "baseUrl": "$BASE_URL/v1",
+      "api": "$PROVIDER_API",
+      "apiKey": "$API_KEY",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false,
+        "supportsUsageInStreaming": true,
+        "maxTokensField": "max_tokens"
+      },
+      "models": [
+        {
+          "id": "$MODEL_ID",
+          "name": "Lucebox DFlash",
+          "api": "$PROVIDER_API",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": $MAX_CTX,
+          "maxTokens": $MAX_TOKENS,
+          "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}
+        }
+      ]
+    }
+  }
+}
+JSON
+
+start_lucebox_server
+trap stop_lucebox_server EXIT
+wait_lucebox_server
+
+set +e
+HOME="$HOME_DIR" \
+PI_CODING_AGENT_DIR="$AGENT_DIR" \
+PI_CODING_AGENT_SESSION_DIR="$HOME_DIR/sessions" \
+PI_OFFLINE=1 \
+timeout 300s "$PI_BIN" \
+  --provider lucebox \
+  --model "$MODEL_ID" \
+  --print \
+  --mode json \
+  --tools "$PI_TOOLS" \
+  --no-session \
+  --offline \
+  "$PROMPT" \
+  < /dev/null > "$CLIENT_OUT" 2>&1
+RC=$?
+set -e
+
+finish_report "$CLIENT_OUT" "$RC"
+exit "$RC"

--- a/harness/clients/summarize_backend_pair.py
+++ b/harness/clients/summarize_backend_pair.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Summarize one client harness Lucebox vs llama.cpp backend-pair run."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+LUCEBOX_DONE_RE = re.compile(r"(?:chat|responses|messages) DONE .*? in=(?P<prompt>\d+) out=(?P<out>\d+)")
+LUCEBOX_DECODE_RE = re.compile(r"decode=[^(]*\((?P<tps>[0-9.]+)tok/s\)")
+LUCEBOX_OVERALL_RE = re.compile(r"\s(?P<tps>[0-9.]+) tok/s\s+finish=")
+LUCEBOX_FINISH_RE = re.compile(r"\sfinish=(?P<finish>\S+)")
+LLAMA_PROMPT_RE = re.compile(
+    r"prompt eval time\s*=.*?/\s*(?P<tokens>\d+)\s+tokens.*?,\s*(?P<tps>[0-9.]+)\s+tokens per second",
+    re.I,
+)
+LLAMA_DECODE_RE = re.compile(
+    r"^\s*eval time\s*=.*?/\s*(?P<tokens>\d+)\s+tokens.*?,\s*(?P<tps>[0-9.]+)\s+tokens per second",
+    re.I | re.M,
+)
+PRIMARY_OUTPUT_NAMES = {
+    "claude-code.out",
+    "codex.out",
+    "hermes.out",
+    "opencode.out",
+    "openclaw.out",
+    "openwebui.out",
+    "openwebui-tools.out",
+    "pi.out",
+}
+MARKERS = ("OK_DONE", "lucebox-client-ok", "OPENWEBUI_TOOL_OK")
+MISSING_JSON = object()
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def parse_lucebox_calls(log: str) -> list[dict]:
+    calls = []
+    lines = [line for line in log.splitlines() if " DONE " in line]
+    for line in lines:
+        m = LUCEBOX_DONE_RE.search(line)
+        if not m:
+            continue
+        decode = LUCEBOX_DECODE_RE.search(line)
+        overall = LUCEBOX_OVERALL_RE.search(line)
+        finish = LUCEBOX_FINISH_RE.search(line)
+        calls.append(
+            {
+                "prompt_tokens": int(m.group("prompt")),
+                "output_tokens": int(m.group("out")),
+                "decode_tok_s": float((decode or overall).group("tps")) if (decode or overall) else None,
+                "finish": finish.group("finish") if finish else "",
+                "line": line.strip(),
+            }
+        )
+    return calls
+
+
+def parse_llama_calls(log: str) -> list[dict]:
+    events = []
+    for m in LLAMA_PROMPT_RE.finditer(log):
+        events.append(
+            (
+                m.start(),
+                "prompt",
+                {
+                    "prompt_tokens": int(m.group("tokens")),
+                    "prompt_tok_s": float(m.group("tps")),
+                },
+            )
+        )
+    for m in LLAMA_DECODE_RE.finditer(log):
+        events.append(
+            (
+                m.start(),
+                "decode",
+                {
+                    "output_tokens": int(m.group("tokens")),
+                    "decode_tok_s": float(m.group("tps")),
+                },
+            )
+        )
+    calls: list[dict] = []
+    current: dict = {}
+    for _, kind, values in sorted(events, key=lambda item: item[0]):
+        if kind == "prompt":
+            if current:
+                calls.append(current)
+            current = values
+        elif current:
+            current.update(values)
+            calls.append(current)
+            current = {}
+        else:
+            calls.append(values)
+    if current:
+        calls.append(current)
+    return calls
+
+
+def pick_primary_call(calls: list[dict]) -> dict:
+    if not calls:
+        return {}
+    return max(calls, key=lambda call: (call.get("prompt_tokens", 0), call.get("output_tokens", 0)))
+
+
+def primary_output_paths(run_dir: Path) -> list[Path]:
+    preferred = [run_dir / name for name in sorted(PRIMARY_OUTPUT_NAMES)]
+    found = [path for path in preferred if path.exists()]
+    return found or sorted(run_dir.glob("*.out"))
+
+
+def first_json_value(text: str):
+    decoder = json.JSONDecoder()
+    stripped = text.lstrip()
+    if not stripped:
+        return MISSING_JSON
+    try:
+        value, _ = decoder.raw_decode(stripped)
+    except json.JSONDecodeError:
+        return MISSING_JSON
+    return value
+
+
+def extract_generated_text(text: str) -> str:
+    parts: list[str] = []
+    value = first_json_value(text)
+    if isinstance(value, dict):
+        choices = value.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                message = choice.get("message", {}) if isinstance(choice, dict) else {}
+                content = message.get("content") if isinstance(message, dict) else None
+                if isinstance(content, str):
+                    parts.append(content)
+                tool_calls = message.get("tool_calls") if isinstance(message, dict) else None
+                if isinstance(tool_calls, list):
+                    for call in tool_calls:
+                        fn = call.get("function", {}) if isinstance(call, dict) else {}
+                        name = fn.get("name") if isinstance(fn, dict) else None
+                        args = fn.get("arguments") if isinstance(fn, dict) else None
+                        if name:
+                            parts.append(f"tool_call:{name}")
+                        if isinstance(args, str):
+                            parts.append(args)
+        payloads = value.get("payloads")
+        if isinstance(payloads, list):
+            for payload in payloads:
+                if isinstance(payload, dict) and isinstance(payload.get("text"), str):
+                    parts.append(payload["text"])
+        result = value.get("result")
+        if isinstance(result, str):
+            parts.append(result)
+    elif isinstance(value, str):
+        parts.append(value)
+    elif value is None:
+        return ""
+
+    if not parts:
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("{"):
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                part = event.get("part", {}) if isinstance(event, dict) else {}
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+                elif isinstance(event.get("message"), dict):
+                    message = event["message"]
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        parts.append(content)
+                    elif isinstance(content, list):
+                        for item in content:
+                            if isinstance(item, dict) and isinstance(item.get("text"), str):
+                                parts.append(item["text"])
+
+    if not parts:
+        # Plain-text clients such as Hermes write the generated answer directly.
+        trimmed = []
+        for line in text.splitlines():
+            if line.startswith(("rc=", "model_server=", "run_dir=", "client_out=", "server_log=", "--- ")):
+                break
+            trimmed.append(line)
+        parts.append("\n".join(trimmed).strip())
+    return "\n".join(part for part in parts if part)
+
+
+def marker_ok(text: str) -> bool:
+    return any(marker in text for marker in MARKERS)
+
+
+def tool_call_ok(text: str) -> bool:
+    return "tool_call:" in text or '"tool_calls"' in text
+
+
+def preview(text: str, limit: int = 180) -> str:
+    compact = re.sub(r"\s+", " ", text).strip()
+    return compact[:limit]
+
+
+def find_run(pair_dir: Path, backend: str) -> Path | None:
+    matches = sorted(p for p in pair_dir.iterdir() if p.is_dir() and p.name.endswith(f"-{backend}"))
+    return matches[-1] if matches else None
+
+
+def summarize_backend(pair_dir: Path, backend: str) -> dict:
+    run_dir = find_run(pair_dir, backend)
+    if run_dir is None:
+        return {"backend": backend, "status": "missing"}
+    server_log = read(run_dir / "server.log")
+    output_paths = primary_output_paths(run_dir)
+    client_text = "\n".join(read(p) for p in output_paths)
+    generated_text = extract_generated_text(client_text)
+    calls = parse_lucebox_calls(server_log) if backend == "lucebox" else parse_llama_calls(server_log)
+    metrics = pick_primary_call(calls)
+    rc = "unknown"
+    backend_out = read(pair_dir / f"{backend}.out")
+    m = re.search(r"^rc=(\d+)$", backend_out, flags=re.M)
+    if m:
+        rc = m.group(1)
+    observed_tool_call = tool_call_ok(generated_text) or any(call.get("finish") == "tool_calls" for call in calls)
+    return {
+        "backend": backend,
+        "run_dir": str(run_dir),
+        "rc": rc,
+        "marker_ok": marker_ok(generated_text),
+        "tool_call_ok": observed_tool_call,
+        "generated_preview": preview(generated_text),
+        "calls": calls,
+        **metrics,
+    }
+
+
+def fmt(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: summarize_backend_pair.py PAIR_DIR", file=sys.stderr)
+        return 2
+    pair_dir = Path(sys.argv[1])
+    rows = [summarize_backend(pair_dir, "llamacpp"), summarize_backend(pair_dir, "lucebox")]
+    by_backend = {row["backend"]: row for row in rows}
+    llama_tps = by_backend.get("llamacpp", {}).get("decode_tok_s")
+    luce_tps = by_backend.get("lucebox", {}).get("decode_tok_s")
+    speed_valid = all((row.get("output_tokens") or 0) >= 32 for row in rows)
+    speedup = (
+        luce_tps / llama_tps
+        if speed_valid and isinstance(luce_tps, float) and isinstance(llama_tps, float) and llama_tps
+        else None
+    )
+
+    print("# Backend Pair Summary")
+    print()
+    print(f"Pair dir: `{pair_dir}`")
+    if speedup is not None:
+        print(f"Lucebox / llama.cpp decode speedup: **{speedup:.2f}x**")
+    else:
+        print("Lucebox / llama.cpp decode speedup: not reported for this run (too little generated output on one side).")
+    print()
+    print("| Backend | rc | marker | tool call | prompt tok | output tok | prompt tok/s | decode tok/s | calls | generated preview |")
+    print("| --- | ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |")
+    for row in rows:
+        print(
+            "| {backend} | {rc} | {marker} | {tool_call} | {prompt_tokens} | {output_tokens} | {prompt_tok_s} | {decode_tok_s} | {calls} | {preview} |".format(
+                backend=row["backend"],
+                rc=fmt(row.get("rc")),
+                marker="yes" if row.get("marker_ok") else "no",
+                tool_call="yes" if row.get("tool_call_ok") else "no",
+                prompt_tokens=fmt(row.get("prompt_tokens")),
+                output_tokens=fmt(row.get("output_tokens")),
+                prompt_tok_s=fmt(row.get("prompt_tok_s")),
+                decode_tok_s=fmt(row.get("decode_tok_s")),
+                calls=len(row.get("calls", [])),
+                preview=fmt(row.get("generated_preview", "")).replace("|", "\\|"),
+            )
+        )
+    print()
+    print("```json")
+    print(json.dumps(rows, indent=2, sort_keys=True))
+    print("```")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a publishable harness folder for running real client harnesses against Lucebox on RTX 3090-class machines.

- add per-client launchers for Claude Code, Codex, OpenCode, Hermes Agent, Pi, OpenClaw, and Open WebUI
- add backend-pair comparison helpers for Lucebox vs llama.cpp using the same client request shape
- add lightweight generation benchmark scripts and reproducible prompts
- extend dflash/scripts/server.py with the protocol compatibility needed by those clients: Anthropic Messages, OpenAI Responses, tool-call handling, and selectable verify modes
- bump dflash/deps/llama.cpp to the latest compatible luce-dflash head

## Notes

The launcher defaults are intentionally per-client. They preserve the RTX 3090 profiles observed during harness testing instead of forcing one shared context setting across all clients.

Claude Code uses the real Anthropic Messages client path. Lucebox trims Claude-specific prompt boilerplate by default for local-model reliability; raw prompt testing can be enabled with DFLASH_ANTHROPIC_RAW_SYSTEM=1 and DFLASH_ANTHROPIC_RAW_USER=1.

## Validation

- python3 -m py_compile dflash/scripts/server.py harness/client_test_runner.py harness/clients/llamacpp_compat_proxy.py harness/clients/summarize_backend_pair.py harness/benchmarks/generation_benchmark.py
- find harness -type f -name '*.sh' -exec bash -n {} \;
- checked harness/ contains no generated pycache, logs, tmp files, or .DS_Store

