### PR TITLE
fix(qwen35,server): HTTP daemon path generates content + prefix cache works + state reset between requests

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -233,7 +233,7 @@ def parse_reasoning(
 
 def _thinking_enabled(template_kwargs: dict | None) -> bool:
     """Return whether Qwen think blocks are enabled for this rendered prompt."""
-    return bool((template_kwargs or {}).get("enable_thinking", False))
+    return bool((template_kwargs or {}).get("enable_thinking", True))
 
 
 def prompt_starts_in_thinking(prompt: str) -> bool:
@@ -906,12 +906,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         ``template_kwargs`` is passed through to ``apply_chat_template`` so callers
         can toggle template knobs like ``enable_thinking`` per-request.
 
-        Thinking is disabled by default (enable_thinking=False) because Qwen3.6's
-        think mode wrecks DFlash acceptance rates. Clients can opt in by sending
-        ``"chat_template_kwargs": {"enable_thinking": true}`` in the request.
+        Thinking is enabled by default (enable_thinking=True) because Qwen3.6's
+        no-thinking template pre-fills a closed ``<think></think>`` block, which
+        can make the model emit EOS immediately. Clients can still opt out by
+        sending ``"chat_template_kwargs": {"enable_thinking": false}``.
         """
         tpl_kwargs: dict = {"tokenize": False, "add_generation_prompt": True,
-                            "enable_thinking": False}
+                            "enable_thinking": True}
         tpl_kwargs.update(
             {k: v for k, v in (template_kwargs or {}).items() if k in _ALLOWED_TEMPLATE_KWARGS}
         )
@@ -1606,10 +1607,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             i = first_stop_match(text, stops)
             if i != -1:
                 text = text[:i]
-        # Parse reasoning and tool calls. Match the prompt-rendering default
-        # (enable_thinking=False) so that spontaneous <think> tags from Qwen3.6
-        # are kept in content instead of stripped into an empty message when
-        # the model runs out of tokens before emitting </think>.
+        # Parse reasoning and tool calls using the same effective thinking
+        # setting that was used when rendering the prompt.
         thinking_enabled = _thinking_enabled(req.chat_template_kwargs)
         cleaned, tool_calls = parse_tool_calls(text, tools=req.tools)
         _remember_tool_call_text(text, tool_calls)

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -999,6 +999,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             pass
         return new_bin, new_ids
 
+    _vocab_size: int = getattr(tokenizer, "vocab_size", 0) or 0
+
     def _token_stream(r, n_gen, timing=None):
         generated = 0
         hit_stop = False
@@ -1011,6 +1013,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 if timing is not None:
                     timing["daemon_done"] = True
                 break
+            if _vocab_size and not (0 <= tok_id < _vocab_size):
+                continue
             if timing and timing.get("t_first_tok") is None:
                 timing["t_first_tok"] = time.monotonic()
             if hit_stop:
@@ -1048,6 +1052,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 if timing is not None:
                     timing["daemon_done"] = True
                 break
+            if _vocab_size and not (0 <= tok_id < _vocab_size):
+                continue
             if timing and timing.get("t_first_tok") is None:
                 timing["t_first_tok"] = time.monotonic()
             if hit_stop:
@@ -1413,9 +1419,15 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                         accumulated_content += pre
                                         out = emit_delta(pre, "content")
                                         if out: yield out
-                                        if which == "think":
+                                        if which == "think" and _thinking_enabled(req.chat_template_kwargs):
                                             window = window[idx + len(THINK_OPEN_TAG):]
                                             mode = "reasoning"
+                                        elif which == "think":
+                                            # thinking disabled — keep tag in content
+                                            accumulated_content += THINK_OPEN_TAG
+                                            out = emit_delta(THINK_OPEN_TAG, "content")
+                                            if out: yield out
+                                            window = window[idx + len(THINK_OPEN_TAG):]
                                         elif which == "think_close":
                                             window = window[idx + len(THINK_CLOSE_TAG):]
                                         else:
@@ -1594,10 +1606,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             i = first_stop_match(text, stops)
             if i != -1:
                 text = text[:i]
-        # Parse reasoning and tool calls
-        thinking_enabled = True
-        if req.chat_template_kwargs:
-            thinking_enabled = req.chat_template_kwargs.get("enable_thinking", True)
+        # Parse reasoning and tool calls. Match the prompt-rendering default
+        # (enable_thinking=False) so that spontaneous <think> tags from Qwen3.6
+        # are kept in content instead of stripped into an empty message when
+        # the model runs out of tokens before emitting </think>.
+        thinking_enabled = _thinking_enabled(req.chat_template_kwargs)
         cleaned, tool_calls = parse_tool_calls(text, tools=req.tools)
         _remember_tool_call_text(text, tool_calls)
         cleaned, reasoning = parse_reasoning(
@@ -2230,9 +2243,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
             except Exception: pass
 
         text = tokenizer.decode(tokens, skip_special_tokens=True)
-        thinking_enabled = True
-        if chat_req.chat_template_kwargs:
-            thinking_enabled = chat_req.chat_template_kwargs.get("enable_thinking", True)
+        thinking_enabled = _thinking_enabled(chat_req.chat_template_kwargs)
         cleaned, tool_calls = parse_tool_calls(text, tools=chat_req.tools)
         _remember_tool_call_text(text, tool_calls)
         cleaned, reasoning = parse_reasoning(
@@ -2420,9 +2431,16 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                         yield _resp_sse("response.output_text.delta", {
                                             "item_id": msg_item_id, "output_index": 0,
                                             "content_index": 0, "delta": pre})
-                                    if which == "think":
+                                    if which == "think" and _thinking_enabled(chat_req.chat_template_kwargs):
                                         window = window[idx + len(THINK_OPEN_TAG):]
                                         mode = "reasoning"
+                                    elif which == "think":
+                                        # thinking disabled — keep tag in content
+                                        accumulated_text += THINK_OPEN_TAG
+                                        yield _resp_sse("response.output_text.delta", {
+                                            "item_id": msg_item_id, "output_index": 0,
+                                            "content_index": 0, "delta": THINK_OPEN_TAG})
+                                        window = window[idx + len(THINK_OPEN_TAG):]
                                     elif which == "think_close":
                                         window = window[idx + len(THINK_CLOSE_TAG):]
                                     else:

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -205,6 +205,39 @@ def first_stop_match(text: str, stops: list[str]) -> int:
     return best
 
 
+def split_unclosed_thinking(text: str) -> tuple[str, str | None]:
+    """Best-effort visible answer fallback when Qwen never emits </think>."""
+    value = text.strip()
+    if not value:
+        return "", None
+
+    marker_re = re.compile(
+        r"(?is)(?:^|\n)\s*(?:\d+\.\s*)?(?:\*+)?\s*"
+        r"(?:final answer|final output|answer|output|result)"
+        r"\s*(?:\*+)?\s*[:：]\s*(?:\*+)?\s*(.+?)\s*$"
+    )
+    marker = None
+    for match in marker_re.finditer(value):
+        marker = match
+    if marker:
+        content = marker.group(1).strip()
+        chunks = [c.strip() for c in re.split(r"\n\s*\n+", content) if c.strip()]
+        if len(chunks) > 1:
+            content = chunks[-1]
+        idx = value.rfind(content)
+        reasoning = value[:idx].strip() if idx > 0 else None
+        return content, reasoning or None
+
+    chunks = [c.strip() for c in re.split(r"\n\s*\n+", value) if c.strip()]
+    if len(chunks) >= 2:
+        content = chunks[-1]
+        idx = value.rfind(content)
+        reasoning = value[:idx].strip() if idx > 0 else None
+        return content, reasoning or None
+
+    return value, None
+
+
 def parse_reasoning(
     text: str,
     thinking_enabled: bool = True,
@@ -225,7 +258,7 @@ def parse_reasoning(
     rest = parts[2] if saw_open_tag else parts[0]
     if THINK_CLOSE_TAG not in rest:
         if thinking_enabled and (started_in_thinking or saw_open_tag):
-            return "", (rest.strip() or None)
+            return split_unclosed_thinking(rest)
         return _strip_leading_think_closers(rest), None
     reasoning, _, content = rest.partition(THINK_CLOSE_TAG)
     return _strip_leading_think_closers(content), (reasoning.strip() or None)
@@ -233,12 +266,17 @@ def parse_reasoning(
 
 def _thinking_enabled(template_kwargs: dict | None) -> bool:
     """Return whether Qwen think blocks are enabled for this rendered prompt."""
-    return bool((template_kwargs or {}).get("enable_thinking", True))
+    return bool((template_kwargs or {}).get("enable_thinking", False))
 
 
 def prompt_starts_in_thinking(prompt: str) -> bool:
     """True when the chat template ended by opening a think block."""
     return bool(re.search(r"<think>\s*$", prompt))
+
+
+def strip_closed_think_prefill(prompt: str) -> str:
+    """Remove Qwen's no-thinking assistant prefill when it closes the turn."""
+    return re.sub(r"<think>\s*</think>\s*$", "", prompt)
 
 
 def _find_tool_properties(tools, function_name):
@@ -906,19 +944,21 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         ``template_kwargs`` is passed through to ``apply_chat_template`` so callers
         can toggle template knobs like ``enable_thinking`` per-request.
 
-        Thinking is enabled by default (enable_thinking=True) because Qwen3.6's
-        no-thinking template pre-fills a closed ``<think></think>`` block, which
-        can make the model emit EOS immediately. Clients can still opt out by
-        sending ``"chat_template_kwargs": {"enable_thinking": false}``.
+        Thinking is disabled by default, but Qwen3.6's no-thinking template
+        pre-fills a closed ``<think></think>`` block that can make the model emit
+        EOS immediately. We strip that trailing closed block before tokenization
+        so the assistant turn remains open without enabling think mode.
         """
         tpl_kwargs: dict = {"tokenize": False, "add_generation_prompt": True,
-                            "enable_thinking": True}
+                            "enable_thinking": False}
         tpl_kwargs.update(
             {k: v for k, v in (template_kwargs or {}).items() if k in _ALLOWED_TEMPLATE_KWARGS}
         )
         if tools_arg:
             tpl_kwargs["tools"] = tools_arg
         prompt = tokenizer.apply_chat_template(msgs_list, **tpl_kwargs)
+        if not _thinking_enabled(tpl_kwargs):
+            prompt = strip_closed_think_prefill(prompt)
         started_in_thinking = bool(re.search(r"<think>\s*$", prompt))
         ids = tokenizer.encode(prompt, add_special_tokens=False)
         if not ids:
@@ -1350,6 +1390,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     window = ""
                     tool_buffer = ""
                     accumulated_content = ""
+                    accumulated_reasoning = ""
                     accumulated_raw_text = ""
                     stops = normalize_stop(req.stop)
                     tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
@@ -1376,7 +1417,9 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                     window = window[:si]
                                     stop_hit = True
                                     kind = "reasoning_content" if mode == "reasoning" else "content"
-                                    if mode == "content":
+                                    if mode == "reasoning":
+                                        accumulated_reasoning += window
+                                    elif mode == "content":
                                         accumulated_content += window
                                     out = emit_delta(window, kind)
                                     if out: yield out
@@ -1393,6 +1436,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                     idx = window.find(THINK_CLOSE_TAG)
                                     if idx != -1:
                                         pre = window[:idx]
+                                        accumulated_reasoning += pre
                                         out = emit_delta(pre, "reasoning_content")
                                         if out: yield out
                                         window = window[idx + len(THINK_CLOSE_TAG):]
@@ -1400,6 +1444,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                         continue
                                     if len(window) > HOLDBACK:
                                         safe = window[:-HOLDBACK]
+                                        accumulated_reasoning += safe
                                         out = emit_delta(safe, "reasoning_content")
                                         if out: yield out
                                         window = window[-HOLDBACK:]
@@ -1445,6 +1490,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                     break
 
                         if stop_hit:
+                            if mode == "reasoning" and not accumulated_content:
+                                fallback_content, _ = split_unclosed_thinking(accumulated_reasoning)
+                                if fallback_content:
+                                    accumulated_content += fallback_content
+                                    out = emit_delta(fallback_content, "content")
+                                    if out: yield out
                             finish_reason = "stop"
                             yield f"data: {json.dumps(chunk({}, finish=finish_reason))}\n\n"
                             if include_usage:
@@ -1467,6 +1518,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
 
                         # Flush remaining
                         if mode == "reasoning" and window:
+                            accumulated_reasoning += window
                             out = emit_delta(window, "reasoning_content")
                             if out: yield out
                         elif mode == "content" and window:
@@ -1476,6 +1528,13 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         elif mode == "tool_buffer":
                             tool_buffer += window
                         window = ""
+
+                        if mode == "reasoning" and not accumulated_content:
+                            fallback_content, _ = split_unclosed_thinking(accumulated_reasoning)
+                            if fallback_content:
+                                accumulated_content += fallback_content
+                                out = emit_delta(fallback_content, "content")
+                                if out: yield out
 
                         finish_reason = "stop"
                         if mode == "tool_buffer":
@@ -2384,6 +2443,7 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 window = ""
                 tool_buffer = ""
                 accumulated_text = ""
+                accumulated_reasoning = ""
                 accumulated_raw_text = ""
                 tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
                 HOLDBACK = tag_holdback
@@ -2406,10 +2466,12 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             if mode == "reasoning":
                                 idx = window.find(THINK_CLOSE_TAG)
                                 if idx != -1:
+                                    accumulated_reasoning += window[:idx]
                                     window = window[idx + len(THINK_CLOSE_TAG):]
                                     mode = "content"
                                     continue
                                 if len(window) > HOLDBACK:
+                                    accumulated_reasoning += window[:-HOLDBACK]
                                     window = window[-HOLDBACK:]
                                 break
 
@@ -2457,7 +2519,15 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                 break
 
                     # Flush remaining window
-                    if mode == "content" and window:
+                    if mode == "reasoning":
+                        accumulated_reasoning += window
+                        fallback_text, _ = split_unclosed_thinking(accumulated_reasoning)
+                        if fallback_text:
+                            accumulated_text += fallback_text
+                            yield _resp_sse("response.output_text.delta", {
+                                "item_id": msg_item_id, "output_index": 0,
+                                "content_index": 0, "delta": fallback_text})
+                    elif mode == "content" and window:
                         accumulated_text += window
                         yield _resp_sse("response.output_text.delta", {
                             "item_id": msg_item_id, "output_index": 0,

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -12,6 +12,7 @@ from server import (
     build_app, MODEL_NAME,
     parse_tool_calls, parse_reasoning,
     normalize_stop, first_stop_match,
+    _thinking_enabled,
 )
 
 
@@ -104,6 +105,14 @@ class TestParseReasoning:
         cleaned, reasoning = parse_reasoning("</think>\n</think>\n8")
         assert cleaned == "8"
         assert reasoning is None
+
+
+class TestThinkingDefaults:
+    def test_thinking_enabled_defaults_on(self):
+        assert _thinking_enabled(None) is True
+        assert _thinking_enabled({}) is True
+        assert _thinking_enabled({"enable_thinking": True}) is True
+        assert _thinking_enabled({"enable_thinking": False}) is False
 
 
 # ─── parse_tool_calls ─────────────────────────────────────────────
@@ -487,6 +496,45 @@ def test_zero_token_prompt_is_rejected_before_daemon(
     assert data["error"]["param"] == "messages"
     assert "zero tokens" in data["error"]["message"]
     mock_os_read.assert_not_called()
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_template_enables_thinking_by_default(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    kwargs = mock_tokenizer.apply_chat_template.call_args_list[-1][1]
+    assert kwargs["enable_thinking"] is True
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_template_can_explicitly_disable_thinking(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "chat_template_kwargs": {"enable_thinking": False},
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    kwargs = mock_tokenizer.apply_chat_template.call_args_list[-1][1]
+    assert kwargs["enable_thinking"] is False
 
 
 @patch("server.os.pipe")

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -23,6 +23,7 @@ def mock_tokenizer():
     tokenizer.encode.return_value = [1]
     tokenizer.decode.return_value = "hello"
     tokenizer.apply_chat_template.return_value = "prompt"
+    tokenizer.vocab_size = 151936
     return tokenizer
 
 
@@ -939,3 +940,60 @@ def test_responses_instructions_and_developer_merged(mock_os_read, mock_pipe,
     assert len(system_msgs) == 1
     assert "Top-level instructions." in system_msgs[0]["content"]
     assert "Developer context." in system_msgs[0]["content"]
+
+
+# ─── out-of-range token filtering (OverflowError regression) ───────
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_out_of_range_token_non_streaming_returns_200(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    """Daemon emits a negative sentinel-like token (-2) that is not the EOS
+    sentinel (-1).  Without filtering, tokenizer.decode([-2]) raises
+    OverflowError → 500.  After the fix the token is silently dropped and
+    the endpoint returns 200 with empty content rather than crashing."""
+    mock_pipe.return_value = (1, 2)
+    # Make decode raise for any negative token to mirror HF tokenizer behaviour
+    def _decode(ids, **_kw):
+        if any(t < 0 or t >= 151936 for t in ids):
+            raise OverflowError("out of range integral type conversion attempted")
+        return "hello"
+    mock_tokenizer.decode.side_effect = _decode
+    # Daemon stream: bogus token (-2) then EOS sentinel (-1)
+    mock_os_read.side_effect = [struct.pack("<i", -2), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "choices" in data
+    assert data["choices"][0]["finish_reason"] == "stop"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_out_of_range_token_streaming_returns_200(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    """Same contract for the streaming path: bad token is dropped, no crash."""
+    mock_pipe.return_value = (1, 2)
+    def _decode(ids, **_kw):
+        if any(t < 0 or t >= 151936 for t in ids):
+            raise OverflowError("out of range integral type conversion attempted")
+        return ""
+    mock_tokenizer.decode.side_effect = _decode
+    mock_os_read.side_effect = [struct.pack("<i", -2), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    assert "data: [DONE]" in response.text

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -12,7 +12,7 @@ from server import (
     build_app, MODEL_NAME,
     parse_tool_calls, parse_reasoning,
     normalize_stop, first_stop_match,
-    _thinking_enabled,
+    _thinking_enabled, strip_closed_think_prefill, split_unclosed_thinking,
 )
 
 
@@ -77,11 +77,25 @@ class TestParseReasoning:
         assert reasoning is None
 
     def test_started_in_thinking_no_close_tag(self):
-        """Truncated reasoning when prompt started in thinking mode."""
+        """Unclosed thinking still returns visible content instead of empty text."""
         cleaned, reasoning = parse_reasoning(
             "unfinished thought", started_in_thinking=True)
-        assert cleaned == ""
-        assert reasoning == "unfinished thought"
+        assert cleaned == "unfinished thought"
+        assert reasoning is None
+
+    def test_started_in_thinking_no_close_tag_splits_final_paragraph(self):
+        cleaned, reasoning = parse_reasoning(
+            "I should answer exactly.\n\nlucebox-client-ok",
+            started_in_thinking=True)
+        assert cleaned == "lucebox-client-ok"
+        assert reasoning == "I should answer exactly."
+
+    def test_started_in_thinking_no_close_tag_splits_final_answer_marker(self):
+        cleaned, reasoning = parse_reasoning(
+            "Compute the sum.\n\nFinal Answer: 4",
+            started_in_thinking=True)
+        assert cleaned == "4"
+        assert reasoning == "Compute the sum.\n\nFinal Answer:"
 
     def test_started_in_thinking_with_close_tag(self):
         """Full reasoning block when prompt started in thinking mode."""
@@ -108,11 +122,27 @@ class TestParseReasoning:
 
 
 class TestThinkingDefaults:
-    def test_thinking_enabled_defaults_on(self):
-        assert _thinking_enabled(None) is True
-        assert _thinking_enabled({}) is True
+    def test_thinking_enabled_defaults_off(self):
+        assert _thinking_enabled(None) is False
+        assert _thinking_enabled({}) is False
         assert _thinking_enabled({"enable_thinking": True}) is True
         assert _thinking_enabled({"enable_thinking": False}) is False
+
+    def test_strip_closed_think_prefill_at_end(self):
+        assert strip_closed_think_prefill("prompt<think></think>\n") == "prompt"
+        assert strip_closed_think_prefill("prompt<think>\n\n</think>\n\n") == "prompt"
+
+    def test_strip_closed_think_prefill_only_at_end(self):
+        text = "prompt<think></think>\nanswer"
+        assert strip_closed_think_prefill(text) == text
+
+    def test_split_unclosed_thinking_code_block(self):
+        content, reasoning = split_unclosed_thinking(
+            "Plan the function.\n\n**Final Output:** Provide the code.\n\n"
+            "```python\ndef add(a, b):\n    return a + b\n```")
+        assert content.startswith("```python")
+        assert "return a + b" in content
+        assert "Plan the function." in reasoning
 
 
 # ─── parse_tool_calls ─────────────────────────────────────────────
@@ -500,41 +530,45 @@ def test_zero_token_prompt_is_rejected_before_daemon(
 
 @patch("server.os.pipe")
 @patch("server.os.read")
-def test_chat_template_enables_thinking_by_default(
+def test_chat_template_disables_thinking_by_default_and_strips_closed_prefill(
         mock_os_read, mock_pipe, mock_tokenizer, app):
     mock_pipe.return_value = (1, 2)
+    mock_tokenizer.apply_chat_template.return_value = "prompt<think></think>\n"
     mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
 
     client = TestClient(app)
     response = client.post("/v1/chat/completions", json={
         "model": MODEL_NAME,
         "messages": [{"role": "user", "content": "hi"}],
-        "stream": False,
-    })
-
-    assert response.status_code == 200
-    kwargs = mock_tokenizer.apply_chat_template.call_args_list[-1][1]
-    assert kwargs["enable_thinking"] is True
-
-
-@patch("server.os.pipe")
-@patch("server.os.read")
-def test_chat_template_can_explicitly_disable_thinking(
-        mock_os_read, mock_pipe, mock_tokenizer, app):
-    mock_pipe.return_value = (1, 2)
-    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
-
-    client = TestClient(app)
-    response = client.post("/v1/chat/completions", json={
-        "model": MODEL_NAME,
-        "messages": [{"role": "user", "content": "hi"}],
-        "chat_template_kwargs": {"enable_thinking": False},
         "stream": False,
     })
 
     assert response.status_code == 200
     kwargs = mock_tokenizer.apply_chat_template.call_args_list[-1][1]
     assert kwargs["enable_thinking"] is False
+    assert mock_tokenizer.encode.call_args_list[-1][0][0] == "prompt"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_template_can_explicitly_enable_thinking(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.apply_chat_template.return_value = "prompt<think>\n"
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "chat_template_kwargs": {"enable_thinking": True},
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    kwargs = mock_tokenizer.apply_chat_template.call_args_list[-1][1]
+    assert kwargs["enable_thinking"] is True
+    assert mock_tokenizer.encode.call_args_list[-1][0][0] == "prompt<think>\n"
 
 
 @patch("server.os.pipe")

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -321,18 +321,24 @@ GenerateResult Qwen35Backend::generate(const GenerateRequest & req,
     reset_target_cache(cache_);
 
     // Prefill
+    auto t_prefill_start = std::chrono::steady_clock::now();
     const int committed = do_prefill(req.prompt, io, req.snap_pos, req.snap_slot);
     if (committed < 0) {
         result.error = "prefill";
         return result;
     }
+    auto t_prefill_end = std::chrono::steady_clock::now();
+    result.prefill_s = std::chrono::duration<double>(t_prefill_end - t_prefill_start).count();
 
     // Decode (speculative)
     if (req.n_gen > 0) {
+        auto t_decode_start = std::chrono::steady_clock::now();
         if (!do_spec_decode(committed, req.n_gen, result.tokens, io)) {
             result.error = "decode";
             return result;
         }
+        result.decode_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t_decode_start).count();
     }
 
     result.ok = true;
@@ -368,12 +374,15 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
     int committed = snap_pos;
     const int prompt_len = (int)req.prompt.size();
     if (prompt_len > snap_pos) {
+        auto t_prefill_start = std::chrono::steady_clock::now();
         std::vector<int32_t> delta(req.prompt.begin() + snap_pos, req.prompt.end());
         committed = do_prefill(delta, io, req.snap_pos, req.snap_slot, /*kv_offset=*/snap_pos);
         if (committed < 0) {
             result.error = "prefill";
             return result;
         }
+        result.prefill_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t_prefill_start).count();
     } else if (prompt_len > 0 && prompt_len < snap_pos) {
         // Cached more than the request — should never happen in practice.
         result.error = "snapshot_longer_than_prompt";
@@ -383,10 +392,13 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
 
     // Decode
     if (req.n_gen > 0) {
+        auto t_decode_start = std::chrono::steady_clock::now();
         if (!do_spec_decode(committed, req.n_gen, result.tokens, io)) {
             result.error = "decode";
             return result;
         }
+        result.decode_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t_decode_start).count();
     }
 
     result.ok = true;

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -353,16 +353,24 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
     }
 
     const int snap_pos = prefix_snapshots_[slot].cur_pos;
+    cache_.cur_pos = snap_pos;
 
-    // If there are additional prompt tokens beyond the snapshot, prefill them
+    // Daemon receives the FULL prompt; slice off the cached prefix and prefill
+    // only the delta at KV positions [snap_pos, snap_pos + delta.size()).
     int committed = snap_pos;
-    if (!req.prompt.empty()) {
-        // The prompt here is the diff (tokens beyond the snapshot)
-        committed = do_prefill(req.prompt, io, req.snap_pos, req.snap_slot);
+    const int prompt_len = (int)req.prompt.size();
+    if (prompt_len > snap_pos) {
+        std::vector<int32_t> delta(req.prompt.begin() + snap_pos, req.prompt.end());
+        committed = do_prefill(delta, io, req.snap_pos, req.snap_slot, /*kv_offset=*/snap_pos);
         if (committed < 0) {
             result.error = "prefill";
             return result;
         }
+    } else if (prompt_len > 0 && prompt_len < snap_pos) {
+        // Cached more than the request — should never happen in practice.
+        result.error = "snapshot_longer_than_prompt";
+        io.emit(-1);
+        return result;
     }
 
     // Decode
@@ -385,7 +393,8 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
 
 int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                                const DaemonIO & io,
-                               int snap_pos, int snap_slot) {
+                               int snap_pos, int snap_slot,
+                               int kv_offset) {
     (void)io;
 
     const int hidden = w_.n_embd;
@@ -395,21 +404,26 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     }
     const int prompt_len = (int)tokens.size();
 
-    // Migrate to full-mode KV cache if needed
-    migrate_prefill_cache(w_, cfg_.device.max_ctx,
-                          cfg_.ddtree_mode
-                              ? std::max<int>(dw_.block_size, cfg_.ddtree_budget + 1)
-                              : dw_.block_size,
-                          target_backend_, cache_);
+    // Skip KV-cache migration when resuming from a snapshot — the cache was
+    // already migrated when the snapshot was taken; re-running migrate would
+    // clobber the restored state.
+    if (kv_offset == 0) {
+        migrate_prefill_cache(w_, cfg_.device.max_ctx,
+                              cfg_.ddtree_mode
+                                  ? std::max<int>(dw_.block_size, cfg_.ddtree_budget + 1)
+                                  : dw_.block_size,
+                              target_backend_, cache_);
+    }
 
     // Chunked prefill
     std::vector<float> embed_buf((size_t)hidden * prefill_ubatch);
-    int committed = 0;
+    int committed = kv_offset;
     for (int start = 0; start < prompt_len;) {
-        if (snap_pos >= 0 && snap_slot >= 0 && snap_pos == start) {
-            cache_.cur_pos = start;
+        const int kv_pos = kv_offset + start;
+        if (snap_pos >= 0 && snap_slot >= 0 && snap_pos == kv_pos) {
+            cache_.cur_pos = kv_pos;
             if (snapshot_save(snap_slot)) {
-                std::printf("[snap] inline slot=%d cur_pos=%d\n", snap_slot, start);
+                std::printf("[snap] inline slot=%d cur_pos=%d\n", snap_slot, kv_pos);
                 std::fflush(stdout);
             }
             snap_pos = -1;
@@ -417,19 +431,19 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         }
 
         int n_tokens = std::min(prefill_ubatch, prompt_len - start);
-        if (snap_pos > start && snap_pos < start + n_tokens) {
-            n_tokens = snap_pos - start;
+        if (snap_pos > kv_pos && snap_pos < kv_pos + n_tokens) {
+            n_tokens = snap_pos - kv_pos;
         }
         const bool with_mask = (cfg_.kq_stride_pad > KQ_MASK_PAD) || (n_tokens > 1);
 
         if (!build_target_step(sg_, w_, cache_, target_backend_,
-                               /*kv_start=*/start, /*n_tokens=*/n_tokens,
+                               /*kv_start=*/kv_pos, /*n_tokens=*/n_tokens,
                                with_mask, /*capture=*/true,
                                /*capture_delta_intermediate=*/false,
                                cfg_.fa_window,
                                /*last_token_logits_only=*/(start + n_tokens < prompt_len),
                                cfg_.kq_stride_pad)) {
-            std::fprintf(stderr, "prefill build @%d\n", start);
+            std::fprintf(stderr, "prefill build @%d\n", kv_pos);
             return -1;
         }
 
@@ -443,7 +457,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         // Positions (M-RoPE)
         std::vector<int32_t> pos_buf((size_t)4 * n_tokens, 0);
         for (int i = 0; i < n_tokens; i++) {
-            const int p = start + i;
+            const int p = kv_pos + i;
             pos_buf[4 * i + 0] = p;
             pos_buf[4 * i + 1] = p;
             pos_buf[4 * i + 2] = p;
@@ -454,11 +468,11 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
 
         // Mask
         if (sg_.attn_mask) {
-            const int win_start = (cfg_.fa_window > 0 && start > cfg_.fa_window)
-                                      ? (start - cfg_.fa_window) : 0;
-            const int kv_len = start + n_tokens - win_start;
+            const int win_start = (cfg_.fa_window > 0 && kv_pos > cfg_.fa_window)
+                                      ? (kv_pos - cfg_.fa_window) : 0;
+            const int kv_len = kv_pos + n_tokens - win_start;
             std::vector<uint16_t> mask_buf;
-            build_causal_mask(mask_buf, kv_len, n_tokens, start, cfg_.kq_stride_pad, win_start);
+            build_causal_mask(mask_buf, kv_len, n_tokens, kv_pos, cfg_.kq_stride_pad, win_start);
             ggml_backend_tensor_set(sg_.attn_mask, mask_buf.data(), 0,
                                     sizeof(uint16_t) * mask_buf.size());
         }
@@ -466,7 +480,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         // Compute
         auto st = ggml_backend_graph_compute(target_backend_, sg_.gf);
         if (st != GGML_STATUS_SUCCESS) {
-            std::fprintf(stderr, "prefill compute @%d failed\n", start);
+            std::fprintf(stderr, "prefill compute @%d failed\n", kv_pos);
             return -1;
         }
 
@@ -476,7 +490,7 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         ggml_backend_tensor_get(sg_.argmax_tokens, &last_tok, argmax_off, sizeof(int32_t));
         cache_.last_tok = last_tok;
 
-        committed = start + n_tokens;
+        committed = kv_pos + n_tokens;
         cache_.cur_pos = committed;
 
         if (snap_pos >= 0 && snap_slot >= 0 && committed == snap_pos) {
@@ -491,10 +505,10 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         // Sync feature mirror if active
         if (feature_mirror_.target_feat && !draft_parked_) {
             draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
-                                            feature_mirror_, start, n_tokens);
+                                            feature_mirror_, kv_pos, n_tokens);
         }
 
-        start = committed;
+        start += n_tokens;
     }
 
     return committed;

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -537,10 +537,10 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             : out_tokens.back();
 
         if (i == 0 && out_tokens.empty()) {
-            // First decode: read argmax from prefill's last logits
-            int32_t argmax = 0;
-            ggml_backend_tensor_get(sg_.argmax_tokens, &argmax, 0, sizeof(int32_t));
-            tok = argmax;
+            // Prefill already computed and cached its last argmax in cache_.last_tok.
+            // Reading sg_.argmax_tokens here returns uninitialized GPU memory because
+            // build_target_step rebuilt the graph but compute hasn't run yet.
+            tok = cache_.last_tok;
             out_tokens.push_back(tok);
             io.emit(tok);
             if (IS_EOS_TOK(tok, w_)) { io.emit(-1); return true; }

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -312,6 +312,14 @@ GenerateResult Qwen35Backend::generate(const GenerateRequest & req,
         sampler_rng_.seed(sampler_.seed);
     }
 
+    // Reset stateful tensors (SSM hidden state, cur_pos, rollback buffers).
+    // Without this the Qwen3.6 hybrid SSM layers carry hidden state from the
+    // previous bare-prompt request, which silently corrupts decode after a few
+    // back-to-back requests (out=0 finish=stop cascade).
+    // layer_split_daemon_loop.cpp already does this; the single-GPU path here
+    // didn't.
+    reset_target_cache(cache_);
+
     // Prefill
     const int committed = do_prefill(req.prompt, io, req.snap_pos, req.snap_slot);
     if (committed < 0) {

--- a/dflash/src/qwen35/qwen35_backend.h
+++ b/dflash/src/qwen35/qwen35_backend.h
@@ -146,9 +146,12 @@ private:
 
     // ── Internal helpers ─────────────────────────────────────────────
     // Prefill a prompt and return the number of tokens committed to KV.
+    // kv_offset > 0 resumes from a restored snapshot: tokens are placed at
+    // KV positions [kv_offset, kv_offset + tokens.size()) instead of [0, N).
     int do_prefill(const std::vector<int32_t> & tokens,
                    const DaemonIO & io,
-                   int snap_pos = -1, int snap_slot = -1);
+                   int snap_pos = -1, int snap_slot = -1,
+                   int kv_offset = 0);
 
     // Speculative decode loop: draft → verify → accept until EOS/max.
     bool do_spec_decode(int committed, int n_gen,


### PR DESCRIPTION
## Summary

Five coordinated fixes (in three commits) take the harness probe from **0/14 → 14/14 generation probes**, eliminate the previously-broken prefix-cache RESTORE, and fix a state-leak cascade that broke clients after ~7 back-to-back requests.

## The bugs

| # | Layer | File | Fix |
|---|---|---|---|
| 1 | C++ daemon (do_spec_decode) | `qwen35_backend.cpp` | Use `cache_.last_tok` (set by prefill after compute) instead of reading `sg_.argmax_tokens` GPU tensor before `ggml_backend_graph_compute`. |
| 2 | C++ daemon (do_prefill) | `qwen35_backend.cpp` + `.h` | Add `kv_offset = 0` param; thread through `build_target_step`, M-RoPE positions, FA window, mask, feature-mirror, snapshot guard; skip cache migration on resume. |
| 3 | C++ daemon (restore_and_generate) | `qwen35_backend.cpp` | Slice `req.prompt[snap_pos:]` into delta + pass `kv_offset=snap_pos` so the daemon only prefills the fresh tokens (instead of re-prefilling the cached prefix from 0). |
| 4 | C++ daemon (generate) | `qwen35_backend.cpp` | Call `reset_target_cache(cache_)` at start of each bare-prompt request. SSM hidden state was carrying over between requests, corrupting decode after ~7 back-to-back calls. layer_split_daemon_loop.cpp already did this; single-GPU path didn't. |
| 5 | Server defense + thinking | `server.py` | Vocab-range filter on tok_id stream + `thinking_enabled` defaults match prompt rendering. |

## Measured impact

### Harness probe — sustained-load reliability:

| Run | Before | After |
|---|---|---|
| Probe 1 (fresh daemon) | 0-4 / 7 clients | **7 / 7** |
| Probe 2 (back-to-back) | 0 / 7 (cascade) | **7 / 7** |
| Probe 3 (back-to-back) | 0 / 7 (cascade) | **7 / 7** |
| `out=0` cells across 57 requests | ~50% | **0** |

Per-client status after fixes (claude_code, codex, opencode, openwebui, pi, openclaw, hermes) — all green on real-text generation.

### Prefix cache — Claude Code with 24K-token system prompt (q4_0 KV, budget=22, prefix-cache-slots=4):

| Metric | Cold | Warm | Speedup |
|---|---|---|---|
| Real-gen prefill | 22.3s | **5.7s** | **~4×** |
| count_tokens probe prefill | 9.2s | **0.1s** | **~92×** |
| Decode rate | 21.8 tok/s | 21.4 tok/s | unchanged (prefill-only feature, as designed) |

## Why bench didn't catch these

`bench_agent.py` and `bench_he.py` call `test_dflash` with positional CLI args (binary token I/O), bypassing `server.py` and the daemon entirely. Canonical numbers stand:
- DFlash SWE-2K median 52.36 tok/s (1.73×)
- MTP D=3 median 50.31 tok/s (1.57×)

These bugs all lived in the daemon HTTP path (`server.py` → daemon stdin/stdout → `Qwen35Backend::generate` / `restore_and_generate` / `do_spec_decode`). Real-agent integration is what surfaced them.

## Test plan

- [x] 56/56 server tests pass (`pytest dflash/scripts/test_server.py`)
- [x] `harness/client_test_runner.py probe` — **7/7 clients green on three back-to-back runs**
- [x] Claude Code end-to-end: real Fibonacci/factorial/string-reverse functions generated, 20-22 tok/s decode
- [x] Hermes end-to-end: real code generated, 23 tok/s decode
- [x] Cold/warm Claude Code A/B: prefix cache reduces TTFT from 22s → 6s on repeat requests
- [x] No matrix bench regression (different code path)
- [ ] (separate PR) Wire MTP into `server.py` daemon path