### PR TITLE
fix(hip): widen flashprefill guard so bf16 forward links on HIP

### DIFF
--- a/dflash/src/flashprefill.cpp
+++ b/dflash/src/flashprefill.cpp
@@ -21,7 +21,7 @@ namespace flashprefill {
 // Each arch-specific source owns its block-select launcher to avoid duplicate
 // CUDA host stubs in multi-arch builds.
 
-#ifdef DFLASH27B_HAVE_SM80_FLASHPREFILL
+#if defined(DFLASH27B_HAVE_FLASHPREFILL) || defined(DFLASH27B_HAVE_SM80_FLASHPREFILL)
 extern "C" {
 void launch_compute_mean_vector_bf16(
     const void * K, void * mean_K,
@@ -226,7 +226,7 @@ namespace {
 inline int cdiv(int a, int b) { return (a + b - 1) / b; }
 }
 
-#ifdef DFLASH27B_HAVE_SM80_FLASHPREFILL
+#if defined(DFLASH27B_HAVE_FLASHPREFILL) || defined(DFLASH27B_HAVE_SM80_FLASHPREFILL)
 // ── BF16 (sm_80+) dispatch: native BF16 WMMA kernels ──
 
 int flash_prefill_forward_bf16(


### PR DESCRIPTION
## Problem

Closes #215.

HIP Phase 2 build on Strix Halo (gfx1151, ROCm 7.2, `-DDFLASH27B_HIP_SM80_EQUIV=ON`) fails to link:

```
ld.lld: error: undefined symbol:
  dflash27b::flashprefill::flash_prefill_forward_bf16(...)
>>> referenced by qwen3_graph.cpp in archive libdflash27b.a
```

## Root cause

Guard asymmetry between definition and call sites:

- **Definition** in `dflash/src/flashprefill.cpp` (lines 24, 229) was guarded by `#ifdef DFLASH27B_HAVE_SM80_FLASHPREFILL` — a CUDA-only macro.
- **Call sites** in `qwen3_graph.cpp` and `pflash_ggml_adapter.cpp` already use the wider `#if defined(DFLASH27B_HAVE_FLASHPREFILL) || defined(DFLASH27B_HAVE_SM80_FLASHPREFILL)`.

CMake's HIP Phase 2 block sets `DFLASH27B_HAVE_FLASHPREFILL=1` but **not** `DFLASH27B_HAVE_SM80_FLASHPREFILL` (CUDA path sets both). So on HIP the call sites compile, the definition gets preprocessed out, and the linker fails. CUDA builds and HIP Phase 1 are unaffected.

## Fix

Widen both guards in `flashprefill.cpp` to the form the call sites already use. The function body is already HIP-ready (`#ifdef DFLASH27B_BACKEND_HIP` sub-branches, rocWMMA Phase 4 `extern "C"` decls).

## Testing

Cannot test locally — no Strix Halo hardware on hand. Issue reporter (@javi2375) verified on gfx1151 / ROCm 7.2.0: build completes through `test_dflash` and `nm` shows the symbol exported (`T`) from `flashprefill.cpp.o`.

CUDA build path is unchanged (both macros still defined there).

Follow-up to #119.

🧙 Built with [WOZCODE](https://wozcode.com)