### PR TITLE
fix(megakernel): include <cuda_fp4.h> for NVFP4 intrinsics on CUDA 12.8+

### DIFF
--- a/megakernel/kernel_gb10_nvfp4.cu
+++ b/megakernel/kernel_gb10_nvfp4.cu
@@ -12,6 +12,7 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
+#include <cuda_fp4.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cublasLt.h>


### PR DESCRIPTION
## Problem

Building `megakernel/kernel_gb10_nvfp4.cu` with CUDA 12.8+ fails because the file uses NVFP4 conversion symbols (`__nv_fp4x2_storage_t`, `__nv_cvt_float2_to_fp4x2`, `__NV_E2M1`) at line 1422 but does not include `<cuda_fp4.h>`. CUDA 12.8 split these declarations out of `cuda_fp8.h` into a dedicated `cuda_fp4.h` header, so the current include set (`cuda_bf16.h`, `cuda_fp8.h`, `cuda_fp16.h`, `cuda_runtime.h`) is no longer sufficient.

### Error (nvcc 12.8.93, before fix)

```
megakernel/kernel_gb10_nvfp4.cu(1422): error: identifier "__nv_fp4x2_storage_t" is undefined
          __nv_fp4x2_storage_t p = __nv_cvt_float2_to_fp4x2(v, __NV_E2M1, cudaRoundNearest);
          ^

megakernel/kernel_gb10_nvfp4.cu(1422): error: identifier "__NV_E2M1" is undefined
          __nv_fp4x2_storage_t p = __nv_cvt_float2_to_fp4x2(v, __NV_E2M1, cudaRoundNearest);
                                                               ^

megakernel/kernel_gb10_nvfp4.cu(1422): error: identifier "__nv_cvt_float2_to_fp4x2" is undefined
          __nv_fp4x2_storage_t p = __nv_cvt_float2_to_fp4x2(v, __NV_E2M1, cudaRoundNearest);
                                   ^

3 errors detected in the compilation of "megakernel/kernel_gb10_nvfp4.cu".
```

## Fix

Add `#include <cuda_fp4.h>` to the CUDA header block. One-line change.

## Scope

The file is gated on `__CUDA_ARCH__ >= 1200` via `#error`, so it is only built when the megakernel CUDAExtension targets Blackwell (sm_120+). The default `uv sync` in CI skips the `megakernel` extra, which is why this regression has not surfaced in automated builds — it only affects developers compiling the megakernel locally against a CUDA 12.8+ toolchain.

## Reproduction

```bash
docker run --rm -v "$PWD:/src" -w /src nvidia/cuda:12.8.1-devel-ubuntu22.04 \
  bash -c 'nvcc -arch=sm_120a -std=c++17 -I/usr/local/cuda/include \
           -c megakernel/kernel_gb10_nvfp4.cu -o /tmp/out.o'
```

Before this patch: 3 fp4-symbol errors as shown above (exit 1).
After this patch: compiles to object file (exit 0), with only unrelated unused-variable warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)