### PR TITLE
fix(dflash): Detect bare function tool calls in streaming

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -182,6 +182,7 @@ FUNCTION_SIGNATURE_RE = re.compile(
     r"<function=([A-Za-z_][\w.-]*)\((.*?)\)</function>", re.DOTALL)
 TOOL_CODE_RE = re.compile(r"<tool_code>(.*?)</tool_code>", re.DOTALL)
 TOOL_OPEN_TAG = "<tool_call>"
+TOOL_START_TAGS = (TOOL_OPEN_TAG, "<function=", "<tool_code>")
 THINK_OPEN_TAG = "<think>"
 THINK_CLOSE_TAG = "</think>"
 
@@ -1393,7 +1394,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                     accumulated_reasoning = ""
                     accumulated_raw_text = ""
                     stops = normalize_stop(req.stop)
-                    tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
+                    tool_start_tags = TOOL_START_TAGS if req.tools else ()
+                    tag_holdback = max(
+                        len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG),
+                        *(len(tag) for tag in tool_start_tags))
                     stop_holdback = max((len(s) for s in stops), default=0)
                     HOLDBACK = max(tag_holdback, stop_holdback)
                     completion_tokens = 0
@@ -1453,11 +1457,15 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                                 else:  # mode == "content"
                                     think_idx = window.find(THINK_OPEN_TAG)
                                     think_close_idx = window.find(THINK_CLOSE_TAG)
-                                    tool_idx  = window.find(TOOL_OPEN_TAG)
+                                    tool_hits = [
+                                        (window.find(tag), "tool")
+                                        for tag in tool_start_tags
+                                        if window.find(tag) != -1
+                                    ]
                                     hits = [(i, t) for i, t in
                                             ((think_idx, "think"),
-                                             (think_close_idx, "think_close"),
-                                             (tool_idx, "tool")) if i != -1]
+                                             (think_close_idx, "think_close"))
+                                            if i != -1] + tool_hits
                                     if hits:
                                         hits.sort()
                                         idx, which = hits[0]
@@ -2445,7 +2453,10 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                 accumulated_text = ""
                 accumulated_reasoning = ""
                 accumulated_raw_text = ""
-                tag_holdback = max(len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG), len(TOOL_OPEN_TAG))
+                tool_start_tags = TOOL_START_TAGS if chat_req.tools else ()
+                tag_holdback = max(
+                    len(THINK_OPEN_TAG), len(THINK_CLOSE_TAG),
+                    *(len(tag) for tag in tool_start_tags))
                 HOLDBACK = tag_holdback
                 completion_tokens = 0
                 tool_call_active = False
@@ -2478,11 +2489,15 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             else:  # content
                                 think_idx = window.find(THINK_OPEN_TAG)
                                 think_close_idx = window.find(THINK_CLOSE_TAG)
-                                tool_idx = window.find(TOOL_OPEN_TAG)
+                                tool_hits = [
+                                    (window.find(tag), "tool")
+                                    for tag in tool_start_tags
+                                    if window.find(tag) != -1
+                                ]
                                 hits = [(i, t) for i, t in
                                         ((think_idx, "think"),
-                                         (think_close_idx, "think_close"),
-                                         (tool_idx, "tool")) if i != -1]
+                                         (think_close_idx, "think_close"))
+                                        if i != -1] + tool_hits
                                 if hits:
                                     hits.sort()
                                     idx, which = hits[0]

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -622,6 +622,55 @@ def test_chat_completions_streaming_ignores_stray_think_closers(
     assert "</think>" not in text
     assert '"content":"8"' in text or '"content": "8"' in text
 
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_chat_completions_streaming_bare_function_tool_call(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.decode.return_value = (
+        "<function=read_file><parameter=path>x.py</parameter></function>"
+    )
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "read x.py"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+        }],
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    chunks = [
+        json.loads(line[6:])
+        for line in response.text.strip().split("\n\n")
+        if line.startswith("data: ") and line != "data: [DONE]"
+    ]
+    tool_delta = next(
+        c["choices"][0]["delta"]["tool_calls"][0]
+        for c in chunks
+        if c["choices"][0]["delta"].get("tool_calls")
+    )
+    finish = next(
+        c["choices"][0]["finish_reason"]
+        for c in chunks
+        if c["choices"][0].get("finish_reason")
+    )
+    assert tool_delta["function"]["name"] == "read_file"
+    assert json.loads(tool_delta["function"]["arguments"]) == {"path": "x.py"}
+    assert finish == "tool_calls"
+
+
 @patch("server.os.pipe")
 @patch("server.os.read")
 def test_chat_completions_streaming_replays_exact_raw_text_with_reasoning(
@@ -651,6 +700,16 @@ def test_chat_completions_streaming_replays_exact_raw_text_with_reasoning(
     first = client.post("/v1/chat/completions", json={
         "model": MODEL_NAME,
         "messages": [{"role": "user", "content": "read x.py"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                },
+            },
+        }],
         "stream": True,
     })
     assert first.status_code == 200
@@ -843,6 +902,40 @@ def test_responses_streaming_ignores_stray_think_closers(
     text = response.text
     assert "</think>" not in text
     assert '"delta":"8"' in text or '"delta": "8"' in text
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
+def test_responses_streaming_bare_function_tool_call(
+        mock_os_read, mock_pipe, mock_tokenizer, app):
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.decode.return_value = (
+        "<function=read_file><parameter=path>x.py</parameter></function>"
+    )
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/responses", json={
+        "model": MODEL_NAME,
+        "input": "read x.py",
+        "tools": [{
+            "type": "function",
+            "name": "read_file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        }],
+        "stream": True,
+    })
+
+    assert response.status_code == 200
+    text = response.text
+    assert "event: response.output_item.added" in text
+    assert "event: response.function_call_arguments.done" in text
+    assert '"type":"function_call"' in text or '"type": "function_call"' in text
+    assert '"name":"read_file"' in text or '"name": "read_file"' in text
+    assert '\\"path\\": \\"x.py\\"' in text
 
 
 @patch("server.os.pipe")


### PR DESCRIPTION
Fixes Python `server.py` streaming tool-call handling for model output that starts with bare Qwen-style function XML instead of a `<tool_call>` wrapper.

Observed real output:

```xml
<function=read_file>
    <parameter=path>
    ~/Projects/gpu-cpu-hybrid/notes.md
    </parameter>
</function>
```

Current upstream can parse this shape in `parse_tool_calls()`, but the streaming state machine only switches into tool-buffer mode when it sees `<tool_call>`. As a result, bare `<function=...>` output can leak to the user as assistant text instead of being returned as structured OpenAI `delta.tool_calls`.

## Root Cause

The parser supports multiple tool-call shapes:

- `<tool_call>...</tool_call>`
- bare `<function=...>...</function>`
- `<tool_code>{...}</tool_code>`
- JSON tool-call objects

But the streaming detector only looked for:

```text
<tool_call>
```

So streaming did not route bare `<function=` or `<tool_code>` output into the parser.

## Fix

The streaming state machines now treat these as tool-call starts when request `tools` are present:

- `<tool_call>`
- `<function=`
- `<tool_code>`

Detection remains disabled when no tools were supplied, so ordinary XML-like assistant text is not accidentally converted into a tool call.

## Test Plan

Added regression coverage for:

- Chat Completions streaming bare `<function=...>` tool call
- Responses streaming bare `<function=...>` tool call
- existing raw tool-call replay test now includes request `tools`, matching the OpenAI contract
