### PR TITLE
fix(dflash): abandoned stream drain

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -1284,6 +1284,37 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
     def _max_tokens_for(req) -> int:
         return getattr(req, "max_completion_tokens", None) or req.max_tokens
 
+    async def _drain_abandoned_stream(kind: str, request_id: str,
+                                      timing: dict) -> None:
+        """Synchronize the daemon stream after an abandoned SSE response.
+
+        If the client disconnects while the daemon is still generating, the
+        daemon continues writing token IDs to r_pipe. Releasing daemon_lock
+        before consuming the sentinel lets the next request read stale tokens.
+        Drain to -1 here so the next request starts from a clean pipe.
+        """
+        if timing.get("daemon_done"):
+            return
+        loop = asyncio.get_running_loop()
+        drain_fut = loop.run_in_executor(None, _drain_until_sentinel, r_pipe)
+        cancelled = False
+        while True:
+            try:
+                drained = await asyncio.shield(drain_fut)
+                break
+            except asyncio.CancelledError:
+                cancelled = True
+                log.warning(
+                    "%s stream cancellation deferred until daemon sentinel %s",
+                    kind, request_id)
+        timing["daemon_done"] = True
+        timing["abandoned_stream_drained_tokens"] = len(drained)
+        log.warning(
+            "%s stream abandoned %s: drained %d stale daemon tokens",
+            kind, request_id, len(drained))
+        if cancelled:
+            raise asyncio.CancelledError
+
     # ── /v1/chat/completions ────────────────────────────────────────────────
 
     @app.post("/v1/chat/completions")
@@ -1566,6 +1597,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             log.warning(
                                 "stream ended before daemon sentinel; "
                                 "retaining prompt .bin for in-flight daemon read")
+                            await _drain_abandoned_stream(
+                                "chat.stream", completion_id, timing)
 
                     inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
                     _confirm_or_abort_snap(
@@ -1892,6 +1925,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                             log.warning(
                                 "stream ended before daemon sentinel; "
                                 "retaining prompt .bin for in-flight daemon read")
+                            await _drain_abandoned_stream(
+                                "messages.stream", msg_id, timing)
 
                     inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
                     _confirm_or_abort_snap(
@@ -2548,6 +2583,8 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
                         log.warning(
                             "stream ended before daemon sentinel; "
                             "retaining prompt .bin for in-flight daemon read")
+                        await _drain_abandoned_stream(
+                            "responses.stream", response_id, timing)
 
                 inline_snap_ok = _consume_inline_snap_waiter(snap_waiter)
                 _confirm_or_abort_snap(


### PR DESCRIPTION
Fixes a Python `server.py` stream-synchronization bug where an SSE client can disconnect before the dflash daemon has emitted its `-1` sentinel. In that case the daemon continues writing tokens to the shared `r_pipe`, but the Python streaming generator exits and releases `daemon_lock`. The next request can then consume stale tokens from the abandoned request, producing impossible timings and wrong responses.

This PR keeps the daemon protocol synchronized by draining abandoned streams to the sentinel while still holding `daemon_lock`.

## Observed Failure

From a real Hermes run:

```text
05:58:06 INFO dflash.server: chat chatcmpl-eb00d86f14f14b9bb4837826  stream=True ...
[pc] lookup hit slot=0 prefix_len=52622 (of 53215 total)
05:58:59 WARNING dflash.server: stream ended before daemon sentinel; retaining prompt .bin for in-flight daemon read
  [daemon] ok N=53215 gen=247 prefix_len=53024 (RESTORE slot=0) stream_fd=5
```

After that, later requests showed impossible near-zero wall time and consumed output that belonged to earlier daemon work:

```text
05:59:17 INFO dflash.server: chat chatcmpl-affa6ec8564f4ef4b6b1de92  stream=True ...
05:59:17 WARNING dflash.server: inline snapshot ack missing - dropped slot reservation
05:59:17 INFO dflash.server: chat DONE chatcmpl-affa6ec8564f4ef4b6b1de92  in=53217 out=235  0.1s  2170.2 tok/s ...
```

That is not realistic model performance. It is stale token-pipe data from a previously abandoned stream.

## Root Cause

Streaming requests share one daemon token pipe (`r_pipe`) protected by `daemon_lock`.

Normal path:

1. Python sends a daemon command.
2. Python reads token IDs from `r_pipe`.
3. Daemon emits `-1`.
4. Python marks `timing["daemon_done"] = True`.
5. Python releases `daemon_lock`.

Failure path:

1. Client disconnects or cancels the SSE response.
2. Python streaming generator exits before seeing daemon `-1`.
3. Daemon keeps generating and writing token IDs to `r_pipe`.
4. Python releases `daemon_lock`.
5. Next request starts and reads stale token IDs from the previous request.

## Fix

When a streaming response exits before `timing["daemon_done"]`:

- log the existing warning
- drain `r_pipe` to the daemon sentinel using `_drain_until_sentinel`
- keep this drain shielded from cancellation so the server reaches a clean protocol boundary
- only then allow the request to release `daemon_lock`

This does not cancel in-flight GPU work. It is a synchronization fix: the next request starts from a clean daemon pipe instead of inheriting stale output.

## Logging And Timing

The abandoned-stream log should stay at warning level, not debug. A client disconnect is normal, but the server reaching the end of an SSE generator before the daemon sentinel is a protocol synchronization hazard: if it is not handled, the next request can read stale token IDs from the previous request.

This PR does not change timing math and does not count prefix-cache time differently. The low/impossible timings disappear because the next request no longer consumes already-buffered tokens from an abandoned prior stream. Normal cached requests should still report fast prefill when a prefix snapshot is restored, but they should not show impossible decode rates caused by stale pipe data.

The drain log includes how many stale daemon tokens were consumed during cleanup, which is enough evidence for this specific synchronization fix without adding broader empty-response diagnostics to this PR.

## Relationship To Existing Issues

Related issue:

- #167: Investigate streaming prompt-file lifetime race causing empty responses

Related but distinct issue:

- #216: Prefix-cache RESTORE can replay prior completion across requests

#216 fixed RESTORE prompt-delta correctness. This PR addresses a different stale-output path: abandoned streaming responses leaving unread daemon tokens in `r_pipe`.
