### PR TITLE
feat(dflash): add default chat thinking toggle

### DIFF
--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -112,6 +112,14 @@ def _print_hip_budget_advisory(budget: int) -> None:
         print(f"  [hip] {arch}: no advisory; using budget={budget}", flush=True)
 
 
+def _parse_bool(value: str | bool | None) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _extra_daemon_has_target_sharding(extra: list[str] | None) -> bool:
     """True if we spawn test_dflash with multi-GPU target layer split."""
     if not extra:
@@ -658,6 +666,10 @@ def _anthropic_tools_to_openai(tools: list[dict] | None) -> list[ToolDef] | None
 DEFAULT_MAX_TOKENS = int(os.environ.get("DFLASH_DEFAULT_MAX_TOKENS", 4096))
 
 
+def _default_chat_enable_thinking() -> bool:
+    return _parse_bool(os.environ.get("DFLASH_ENABLE_THINKING"))
+
+
 class ChatRequest(BaseModel):
     model: str = MODEL_NAME
     messages: list[ChatMessage]
@@ -995,9 +1007,11 @@ def build_app(target: Path, draft: Path | None, bin_path: Path, budget: int, max
         pre-fills a closed ``<think></think>`` block that can make the model emit
         EOS immediately. We strip that trailing closed block before tokenization
         so the assistant turn remains open without enabling think mode.
+        Deployments can opt in globally with DFLASH_ENABLE_THINKING=1 or
+        per request with ``chat_template_kwargs.enable_thinking``.
         """
         tpl_kwargs: dict = {"tokenize": False, "add_generation_prompt": True,
-                            "enable_thinking": False}
+                            "enable_thinking": _default_chat_enable_thinking()}
         tpl_kwargs.update(
             {k: v for k, v in (template_kwargs or {}).items() if k in _ALLOWED_TEMPLATE_KWARGS}
         )
@@ -2799,6 +2813,8 @@ def main():
     ap.add_argument("--fa-window", type=int, default=None,
                     help="Sliding window for FA layers. 0 = full attention.")
     ap.add_argument("--tokenizer", type=str, default=None)
+    ap.add_argument("--enable-thinking", nargs="?", const="true", default=None,
+                    metavar="BOOL")
     ap.add_argument("--lazy-draft", action="store_true",
                     help="Park decode draft (~3.3 GB) when idle; unpark/park "
                          "around each generate to free VRAM for longer context.")
@@ -2855,6 +2871,9 @@ def main():
 
     if args.fa_window is not None:
         os.environ["DFLASH27B_FA_WINDOW"] = str(args.fa_window)
+    if args.enable_thinking is not None:
+        os.environ["DFLASH_ENABLE_THINKING"] = (
+            "1" if _parse_bool(args.enable_thinking) else "0")
 
     placement = resolve_server_placement(args)
     placement.apply_env(os.environ)

--- a/dflash/scripts/test_server.py
+++ b/dflash/scripts/test_server.py
@@ -573,6 +573,28 @@ def test_chat_template_can_explicitly_enable_thinking(
 
 @patch("server.os.pipe")
 @patch("server.os.read")
+def test_chat_template_can_enable_thinking_by_env(
+        mock_os_read, mock_pipe, mock_tokenizer, app, monkeypatch):
+    monkeypatch.setenv("DFLASH_ENABLE_THINKING", "1")
+    mock_pipe.return_value = (1, 2)
+    mock_tokenizer.apply_chat_template.return_value = "prompt<think>\n"
+    mock_os_read.side_effect = [struct.pack("<i", 10), struct.pack("<i", -1)]
+
+    client = TestClient(app)
+    response = client.post("/v1/chat/completions", json={
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": False,
+    })
+
+    assert response.status_code == 200
+    kwargs = mock_tokenizer.apply_chat_template.call_args_list[-1][1]
+    assert kwargs["enable_thinking"] is True
+    assert mock_tokenizer.encode.call_args_list[-1][0][0] == "prompt<think>\n"
+
+
+@patch("server.os.pipe")
+@patch("server.os.read")
 def test_chat_completions_streaming(mock_os_read, mock_pipe, mock_tokenizer, app):
     mock_pipe.return_value = (1, 2)
     mock_tokenizer.apply_chat_template.return_value = "<think>\n"


### PR DESCRIPTION
Adds a server-level opt-in for enabling Qwen thinking mode by default for Chat Completions, while preserving the current default of no-thinking mode.

This is useful for clients such as OpenWebUI that may not forward nested request fields like:

```json
{
  "chat_template_kwargs": {
    "enable_thinking": true
  }
}
```

## Configuration

Enable by environment variable:

```bash
DFLASH_ENABLE_THINKING=1
```

Or by CLI:

```bash
python3 scripts/server.py ... --enable-thinking
python3 scripts/server.py ... --enable-thinking=true
```

Explicit disable is also accepted:

```bash
python3 scripts/server.py ... --enable-thinking=false
```

Per-request `chat_template_kwargs.enable_thinking` still overrides the server default.

## Notes

This controls the Qwen chat-template thinking mode and whether generated `<think>...</think>` output is exposed as `reasoning_content`. It does not guarantee the model will never write reasoning-like prose in normal visible `content`; that can still happen if the model is prompted that way.
