### PR TITLE
feat(server): add C++ backend placement foundation

### DIFF
--- a/dflash/src/common/backend_factory.cpp
+++ b/dflash/src/common/backend_factory.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
         cfg.target_path        = args.model_path;
         cfg.draft_path         = args.draft_path;
         cfg.device             = args.device;
-        cfg.draft_gpu          = args.draft_gpu;
+        cfg.draft_gpu          = args.draft_device.gpu;
         cfg.stream_fd          = args.stream_fd;
         cfg.fa_window          = args.fa_window;
         cfg.kq_stride_pad      = args.kq_stride_pad;

--- a/dflash/src/common/backend_factory.h
+++ b/dflash/src/common/backend_factory.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "model_backend.h"
-#include "device_placement.h"
+#include "placement/placement_config.h"
 
 #include <memory>
 #include <string>
@@ -30,7 +30,7 @@ struct BackendArgs {
 
     // Device placement
     DevicePlacement device;
-    int             draft_gpu    = 0;
+    DevicePlacement draft_device;
 
     // I/O — only used when running under daemon_loop (legacy). The new
     // server passes -1 and uses on_token callbacks instead.

--- a/dflash/src/common/device_placement.h
+++ b/dflash/src/common/device_placement.h
@@ -1,31 +1,6 @@
-// Device placement configuration for model backends.
-//
-// Describes which GPU(s) to use for a model. Supports:
-//   - Single-GPU: just gpu field
-//   - Multi-GPU layer-split: layer_split_gpus + optional weights
-//   - Peer access between GPUs
+// Compatibility include for older common/device_placement.h users.
+// New C++ placement code should include placement/placement_config.h.
 
 #pragma once
 
-#include <vector>
-
-namespace dflash::common {
-
-struct DevicePlacement {
-    int gpu = 0;                              // primary GPU (single-GPU mode)
-
-    // Multi-GPU layer-split. Empty = single GPU mode.
-    std::vector<int>    layer_split_gpus;     // GPU IDs for each shard
-    std::vector<double> layer_split_weights;  // proportional layer distribution (optional)
-
-    bool peer_access = false;                 // enable CUDA peer access between GPUs
-    int  max_ctx     = 8192;                  // max KV cache context length
-
-    bool is_layer_split() const { return layer_split_gpus.size() > 1; }
-
-    int primary_gpu() const {
-        return layer_split_gpus.empty() ? gpu : layer_split_gpus[0];
-    }
-};
-
-}  // namespace dflash::common
+#include "placement/placement_config.h"

--- a/dflash/src/common/layer_split_utils.h
+++ b/dflash/src/common/layer_split_utils.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 
 #include <string>
 #include <utility>

--- a/dflash/src/gemma4/gemma4_backend.h
+++ b/dflash/src/gemma4/gemma4_backend.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "common/model_backend.h"
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 #include "gemma4_internal.h"
 #include "common/sampler.h"
 

--- a/dflash/src/gemma4/gemma4_daemon.h
+++ b/dflash/src/gemma4/gemma4_daemon.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 
 namespace dflash::common {

--- a/dflash/src/laguna/laguna_daemon.h
+++ b/dflash/src/laguna/laguna_daemon.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 #include "ggml.h"
 

--- a/dflash/src/placement/placement_backend.h
+++ b/dflash/src/placement/placement_backend.h
@@ -1,0 +1,54 @@
+// Backend placement identifiers shared by C++ server/runtime code.
+
+#pragma once
+
+#include <string>
+
+namespace dflash::common {
+
+enum class PlacementBackend {
+    Auto,
+    Cuda,
+    Hip,
+};
+
+inline const char * placement_backend_name(PlacementBackend backend) {
+    switch (backend) {
+        case PlacementBackend::Auto: return "auto";
+        case PlacementBackend::Cuda: return "cuda";
+        case PlacementBackend::Hip:  return "hip";
+    }
+    return "auto";
+}
+
+inline bool parse_placement_backend(const std::string & value,
+                                    PlacementBackend & out) {
+    if (value == "auto") {
+        out = PlacementBackend::Auto;
+        return true;
+    }
+    if (value == "cuda") {
+        out = PlacementBackend::Cuda;
+        return true;
+    }
+    if (value == "hip") {
+        out = PlacementBackend::Hip;
+        return true;
+    }
+    return false;
+}
+
+inline PlacementBackend compiled_placement_backend() {
+#if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    return PlacementBackend::Hip;
+#else
+    return PlacementBackend::Cuda;
+#endif
+}
+
+inline bool placement_backend_supported(PlacementBackend backend) {
+    return backend == PlacementBackend::Auto ||
+           backend == compiled_placement_backend();
+}
+
+}  // namespace dflash::common

--- a/dflash/src/placement/placement_config.h
+++ b/dflash/src/placement/placement_config.h
@@ -1,0 +1,105 @@
+// Device placement configuration for model backends.
+//
+// Describes which backend device(s) to use for a model. Supports:
+//   - Single-GPU: backend + gpu fields, exposed as cuda:0 / hip:0 / auto:0
+//   - Multi-GPU layer-split: one backend + layer_split_gpus + optional weights
+//   - Peer access between GPUs
+
+#pragma once
+
+#include "placement_backend.h"
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+struct DevicePlacement {
+    PlacementBackend backend = PlacementBackend::Auto;
+    int gpu = 0;                              // primary GPU (single-GPU mode)
+
+    // Multi-GPU layer-split. Empty = single GPU mode.
+    std::vector<int>    layer_split_gpus;     // GPU IDs for each shard
+    std::vector<double> layer_split_weights;  // proportional layer distribution (optional)
+
+    bool peer_access = false;                 // enable CUDA/HIP peer access between GPUs
+    int  max_ctx     = 8192;                  // max KV cache context length
+
+    bool is_layer_split() const { return layer_split_gpus.size() > 1; }
+
+    int primary_gpu() const {
+        return layer_split_gpus.empty() ? gpu : layer_split_gpus[0];
+    }
+};
+
+inline std::string placement_device_name(const DevicePlacement & device) {
+    return std::string(placement_backend_name(device.backend)) + ":" +
+           std::to_string(device.primary_gpu());
+}
+
+inline bool parse_placement_device(const std::string & value,
+                                   DevicePlacement & out) {
+    const std::size_t sep = value.find(':');
+    if (sep == std::string::npos || sep == 0 || sep + 1 >= value.size()) {
+        return false;
+    }
+
+    PlacementBackend backend = PlacementBackend::Auto;
+    if (!parse_placement_backend(value.substr(0, sep), backend)) {
+        return false;
+    }
+
+    const std::string gpu_text = value.substr(sep + 1);
+    char * end = nullptr;
+    long gpu = std::strtol(gpu_text.c_str(), &end, 10);
+    if (end == gpu_text.c_str() || *end != '\0' || gpu < 0) {
+        return false;
+    }
+
+    out.backend = backend;
+    out.gpu = static_cast<int>(gpu);
+    out.layer_split_gpus.clear();
+    out.layer_split_weights.clear();
+    return true;
+}
+
+inline bool parse_placement_device_list(const std::string & value,
+                                        DevicePlacement & out) {
+    if (value.empty()) return false;
+
+    std::vector<int> gpus;
+    PlacementBackend backend = PlacementBackend::Auto;
+    bool have_backend = false;
+
+    std::size_t begin = 0;
+    while (begin < value.size()) {
+        const std::size_t end = value.find(',', begin);
+        const std::string item = value.substr(
+            begin,
+            end == std::string::npos ? std::string::npos : end - begin);
+        if (item.empty()) return false;
+
+        DevicePlacement parsed;
+        if (!parse_placement_device(item, parsed)) return false;
+        if (!have_backend) {
+            backend = parsed.backend;
+            have_backend = true;
+        } else if (parsed.backend != backend) {
+            return false;
+        }
+        gpus.push_back(parsed.gpu);
+
+        if (end == std::string::npos) break;
+        begin = end + 1;
+    }
+
+    if (gpus.empty()) return false;
+    out.backend = backend;
+    out.gpu = gpus[0];
+    out.layer_split_gpus = gpus.size() > 1 ? gpus : std::vector<int>{};
+    out.layer_split_weights.clear();
+    return true;
+}
+
+}  // namespace dflash::common

--- a/dflash/src/qwen3/qwen3_backend.h
+++ b/dflash/src/qwen3/qwen3_backend.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "common/model_backend.h"
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 #include "qwen3_drafter_model.h"
 #include "qwen3_drafter.h"
 #include "common/sampler.h"

--- a/dflash/src/qwen3/qwen3_daemon.h
+++ b/dflash/src/qwen3/qwen3_daemon.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 
 namespace dflash::common {

--- a/dflash/src/qwen35/qwen35_backend.h
+++ b/dflash/src/qwen35/qwen35_backend.h
@@ -13,7 +13,7 @@
 
 #include "common/model_backend.h"
 #include "common/dflash_target.h"
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 #include "step_graph.h"
 #include "ddtree.h"
 #include "dflash_feature_ring.h"

--- a/dflash/src/qwen35/qwen35_daemon.h
+++ b/dflash/src/qwen35/qwen35_daemon.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 
 namespace dflash::common {

--- a/dflash/src/qwen35/qwen35_layer_split.h
+++ b/dflash/src/qwen35/qwen35_layer_split.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 
 #include <string>
 

--- a/dflash/src/server/server_main.cpp
+++ b/dflash/src/server/server_main.cpp
@@ -9,11 +9,12 @@
 // Usage:
 //   dflash_server <model.gguf> [--draft <draft.gguf>] [--port 8080]
 //                              [--host 0.0.0.0] [--max-ctx 131072]
-//                              [--max-tokens 4096] [--gpu 0]
+//                              [--max-tokens 4096] [--target-device auto:0]
 
 #include "http_server.h"
 #include "common/backend_factory.h"
 #include "common/gguf_inspect.h"
+#include "common/peer_access.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -21,6 +22,7 @@
 #include <csignal>
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace dflash::common;
 
@@ -34,6 +36,67 @@ static void signal_handler(int sig) {
     }
 }
 
+static bool parse_double_list(const char * value, std::vector<double> & out) {
+    out.clear();
+    if (!value || !*value) return false;
+    const char * p = value;
+    while (*p) {
+        char * end = nullptr;
+        double v = std::strtod(p, &end);
+        if (end == p) return false;
+        out.push_back(v);
+        if (*end == '\0') return true;
+        if (*end != ',') return false;
+        p = end + 1;
+        if (!*p) return false;
+    }
+    return !out.empty();
+}
+
+static bool validate_server_placement(const BackendArgs & bargs) {
+    const PlacementBackend compiled = compiled_placement_backend();
+    if (!placement_backend_supported(bargs.device.backend)) {
+        std::fprintf(stderr,
+            "[server] --target-device=%s is unsupported in this binary "
+            "(compiled backend: %s)\n",
+            placement_device_name(bargs.device).c_str(),
+            placement_backend_name(compiled));
+        return false;
+    }
+    if (!placement_backend_supported(bargs.draft_device.backend)) {
+        std::fprintf(stderr,
+            "[server] --draft-device=%s is unsupported in this binary "
+            "(compiled backend: %s)\n",
+            placement_device_name(bargs.draft_device).c_str(),
+            placement_backend_name(compiled));
+        return false;
+    }
+    const PlacementBackend target = bargs.device.backend == PlacementBackend::Auto
+        ? compiled : bargs.device.backend;
+    const PlacementBackend draft = bargs.draft_device.backend == PlacementBackend::Auto
+        ? target : bargs.draft_device.backend;
+    if (target != draft) {
+        std::fprintf(stderr,
+            "[server] mixed target/draft backends are not implemented in the "
+            "native server yet (target=%s draft=%s)\n",
+            placement_backend_name(target), placement_backend_name(draft));
+        return false;
+    }
+    if (!bargs.device.layer_split_gpus.empty()) {
+        std::fprintf(stderr,
+            "[server] target layer split is not implemented in the native "
+            "server yet (--target-devices was provided)\n");
+        return false;
+    }
+    if (!bargs.device.layer_split_weights.empty()) {
+        std::fprintf(stderr,
+            "[server] --target-layer-split requires native target layer split "
+            "support, which is not implemented yet\n");
+        return false;
+    }
+    return true;
+}
+
 static void print_usage(const char * prog) {
     std::fprintf(stderr,
         "Usage: %s <model.gguf> [options]\n"
@@ -44,8 +107,11 @@ static void print_usage(const char * prog) {
         "  --host <addr>        Bind address (default: 0.0.0.0)\n"
         "  --max-ctx <N>        Max context length (default: 131072)\n"
         "  --max-tokens <N>     Default max output tokens (default: 4096)\n"
-        "  --gpu <N>            Target GPU device (default: 0)\n"
-        "  --draft-gpu <N>      Draft GPU device (default: 0)\n"
+        "  --target-device <backend:gpu>  Target device (default: auto:0)\n"
+        "  --draft-device <backend:gpu>   Draft device (default: auto:0)\n"
+        "  --target-devices <list>        Reserved layer-split devices, e.g. cuda:0,cuda:1\n"
+        "  --target-layer-split <weights>  Reserved layer-split weights\n"
+        "  --peer-access        Enable peer access for multi-GPU placement\n"
         "  --chunk <N>          Chunked-prefill chunk size (default: 512)\n"
         "  --fa-window <N>     Flash-attention sliding window (default: 0=full)\n"
         "  --model-name <name>  Model name for /v1/models (default: dflash)\n"
@@ -91,6 +157,8 @@ int main(int argc, char ** argv) {
     bargs.model_path = argv[1];
     std::string cache_type_k;  // explicit --cache-type-k override
     std::string cache_type_v;  // explicit --cache-type-v override
+    bool target_device_seen = false;
+    bool target_devices_seen = false;
 
     for (int i = 2; i < argc; i++) {
         if (std::strcmp(argv[i], "--draft") == 0 && i + 1 < argc) {
@@ -105,10 +173,38 @@ int main(int argc, char ** argv) {
             bargs.device.max_ctx = v;
         } else if (std::strcmp(argv[i], "--max-tokens") == 0 && i + 1 < argc) {
             sconfig.max_tokens = std::atoi(argv[++i]);
-        } else if (std::strcmp(argv[i], "--gpu") == 0 && i + 1 < argc) {
-            bargs.device.gpu = std::atoi(argv[++i]);
-        } else if (std::strcmp(argv[i], "--draft-gpu") == 0 && i + 1 < argc) {
-            bargs.draft_gpu = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--target-device") == 0 && i + 1 < argc) {
+            if (target_devices_seen) {
+                std::fprintf(stderr, "[server] --target-device conflicts with --target-devices\n");
+                return 2;
+            }
+            target_device_seen = true;
+            if (!parse_placement_device(argv[++i], bargs.device)) {
+                std::fprintf(stderr, "[server] bad --target-device value (expected backend:gpu)\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--draft-device") == 0 && i + 1 < argc) {
+            if (!parse_placement_device(argv[++i], bargs.draft_device)) {
+                std::fprintf(stderr, "[server] bad --draft-device value (expected backend:gpu)\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--target-devices") == 0 && i + 1 < argc) {
+            if (target_device_seen) {
+                std::fprintf(stderr, "[server] --target-devices conflicts with --target-device\n");
+                return 2;
+            }
+            target_devices_seen = true;
+            if (!parse_placement_device_list(argv[++i], bargs.device)) {
+                std::fprintf(stderr, "[server] bad --target-devices value (expected backend:gpu[,backend:gpu...])\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--target-layer-split") == 0 && i + 1 < argc) {
+            if (!parse_double_list(argv[++i], bargs.device.layer_split_weights)) {
+                std::fprintf(stderr, "[server] bad --target-layer-split value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--peer-access") == 0) {
+            bargs.device.peer_access = true;
         } else if (std::strcmp(argv[i], "--chunk") == 0 && i + 1 < argc) {
             bargs.chunk = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--fa-window") == 0 && i + 1 < argc) {
@@ -163,6 +259,8 @@ int main(int argc, char ** argv) {
             return 2;
         }
     }
+
+    if (!validate_server_placement(bargs)) return 2;
 
     // Sync max_ctx: if --max-ctx was not provided, use the backend's default.
     // This prevents the HTTP server from accepting prompts larger than the
@@ -231,6 +329,7 @@ int main(int argc, char ** argv) {
     }
 
     // Create backend.
+    g_peer_access_opt_in = bargs.device.peer_access;
     std::fprintf(stderr, "[server] creating backend...\n");
     auto backend = create_backend(bargs);
     if (!backend) {
@@ -248,8 +347,20 @@ int main(int argc, char ** argv) {
     std::fprintf(stderr, "[server] │  model_name      = %s\n", sconfig.model_name.c_str());
     std::fprintf(stderr, "[server] │  max_ctx         = %d\n", sconfig.max_ctx);
     std::fprintf(stderr, "[server] │  max_tokens      = %d\n", sconfig.max_tokens);
-    std::fprintf(stderr, "[server] │  gpu             = %d\n", bargs.device.gpu);
-    std::fprintf(stderr, "[server] │  draft_gpu       = %d\n", bargs.draft_gpu);
+    std::fprintf(stderr, "[server] │  target_device   = %s\n",
+                 placement_device_name(bargs.device).c_str());
+    if (bargs.device.is_layer_split()) {
+        std::fprintf(stderr, "[server] │  target_shards   =");
+        for (int gpu : bargs.device.layer_split_gpus) {
+            std::fprintf(stderr, " %s:%d",
+                         placement_backend_name(bargs.device.backend), gpu);
+        }
+        std::fprintf(stderr, "\n");
+    }
+    std::fprintf(stderr, "[server] │  draft_device    = %s\n",
+                 placement_device_name(bargs.draft_device).c_str());
+    std::fprintf(stderr, "[server] │  peer_access     = %s\n",
+                 bargs.device.peer_access ? "ON" : "off");
     std::fprintf(stderr, "[server] │  chunk           = %d\n", bargs.chunk);
     std::fprintf(stderr, "[server] │  fa_window       = %d\n", bargs.fa_window);
     std::fprintf(stderr, "[server] │  ddtree          = %s\n", bargs.ddtree_mode ? "ON" : "off");


### PR DESCRIPTION
# Summary

This PR adds the C++ backend placement foundation for the native `dflash_server` path, including the minimal server-side plumbing needed to expose and validate placement options.

Before this change, backend placement wiring mainly lived in Python bench/launcher helpers. Those helpers are still useful for bench execution, but the native C++ server also needs its own small placement structure for backend selection, device selection, logging, and unsupported-combination errors.

This PR does not implement CUDA/HIP mixed execution or native target layer split yet. It prepares the native server/runtime surface those follow-up PRs will use.

# Changes

1. Add a dedicated C++ backend placement directory

   New files:

   - `dflash/src/placement/placement_backend.h`
   - `dflash/src/placement/placement_config.h`

   `placement_backend.h` defines `PlacementBackend` (`auto`, `cuda`, `hip`) plus helpers for parsing, logging, compiled-backend detection, and support checks.

   `placement_config.h` owns `DevicePlacement`, including target backend, primary GPU, target layer-split GPU list, split weights, peer-access flag, and max context.

   This is intentionally a directory instead of one larger `common` header. Later backend placement work can add focused files for parsing, validation, runtime application, memory policy, or placement recommendation without growing `server_main.cpp` or `common/device_placement.h`.

2. Keep existing includes compatible

   `dflash/src/common/device_placement.h` is kept as a compatibility include that forwards to `placement/placement_config.h`.

   Existing model/backend code is updated to include the new placement header directly where practical, without turning this PR into a broad include cleanup.

3. Carry draft placement through the C++ backend boundary

   `dflash/src/common/backend_factory.h` now carries a `draft_device` placement next to the target `device` placement.

   This keeps target and draft placement explicit at the native server/backend factory boundary without splitting backend and GPU id into separate public concepts.

4. Add native server backend-device CLI plumbing

   `dflash/src/server/server_main.cpp` now parses:

   - `--target-device <backend:gpu>` such as `cuda:0`, `hip:0`, or `auto:0`
   - `--draft-device <backend:gpu>`
   - `--target-devices <backend:gpu,...>` for the reserved target layer-split surface
   - `--target-layer-split <weights>`
   - `--peer-access`

   The previous split CLI shape (`--target-backend`, `--draft-backend`, `--gpu`, `--draft-gpu`, `--target-gpus`) is removed from the native server surface so backend and device id are expressed as one placement value from the start.

5. Add backend placement logs and clear unsupported errors

   The native server config block now prints target device, draft device, optional target shard devices, and peer-access state.

   `--peer-access` is bridged into the existing runtime peer-access opt-in path before backend creation.

   Unsupported combinations are rejected explicitly instead of being silently ignored:

   - backend different from the compiled backend
   - mixed target/draft backend before mixed execution is implemented
   - target layer split before native server layer-split support is implemented

# Follow-up Path

This PR intentionally includes the first server-side backend placement plumbing. Follow-up feature PRs can build on this native surface instead of adding more ad hoc parsing in `server_main.cpp`.

For native `dflash_server` behavior, C++ backend placement should become the source of truth for accepted backend placement options and explicit unsupported combinations. Existing Python backend placement helpers remain the orchestration layer for bench/launcher flows, visible-device/env setup, and `test_dflash` daemon arguments until native server support catches up.