### PR TITLE
feat(server): add CUDA/HIP mixed backend placement

### DIFF
--- a/dflash/scripts/placement/server_resolver.py
+++ b/dflash/scripts/placement/server_resolver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import MutableMapping
 
+from .backend_device import apply_backend_visible_devices
 from .test_dflash_args import TestDflashLaunchArgs
 
 
@@ -14,13 +15,25 @@ class ServerPlacement:
     daemon_args: list[str]
     prefix_cache_slots: int
     prefill_cache_slots: int
+    target_backend: str
+    draft_backend: str
+    target_visible_devices: str | None
+    draft_visible_devices: str | None
     target_gpu: int | None
     draft_gpu: int | None
     target_gpus: str | None
     target_layer_split: str | None
+    draft_ipc_bin: str | None
+    draft_ipc_gpu: int | None
+    draft_ipc_work_dir: str | None
+    draft_ipc_ring_cap: int | None
     draft_feature_mirror: bool
     peer_access: bool
     cache_slots_disabled: bool = False
+
+    @property
+    def mixed_backend(self) -> bool:
+        return self.target_backend != self.draft_backend
 
     def apply_env(self, env: MutableMapping[str, str]) -> None:
         env.update(self.env_updates)
@@ -28,7 +41,13 @@ class ServerPlacement:
     def log_lines(self) -> list[str]:
         lines = [
             f"  placement = {'target-gpus' if self.target_gpus else 'single-target'}",
+            f"    target_backend = {self.target_backend}",
+            f"    draft_backend  = {self.draft_backend}",
         ]
+        if self.target_visible_devices:
+            lines.append(f"    target_visible_devices = {self.target_visible_devices}")
+        if self.draft_visible_devices:
+            lines.append(f"    draft_visible_devices  = {self.draft_visible_devices}")
         if self.target_gpu is not None:
             lines.append(f"    target_gpu = {self.target_gpu}")
         if self.draft_gpu is not None:
@@ -36,6 +55,12 @@ class ServerPlacement:
         if self.target_gpus:
             lines.append(f"    target_gpus = {self.target_gpus}")
             lines.append(f"    layer_split = {self.target_layer_split or '<default>'}")
+        if self.draft_ipc_bin:
+            lines.append(f"    draft_ipc_bin = {self.draft_ipc_bin}")
+            if self.draft_ipc_gpu is not None:
+                lines.append(f"    draft_ipc_gpu = {self.draft_ipc_gpu}")
+            if self.draft_ipc_ring_cap is not None:
+                lines.append(f"    draft_ipc_ring_cap = {self.draft_ipc_ring_cap}")
         if self.draft_feature_mirror:
             lines.append("    draft_feature_mirror = on")
         if self.peer_access:
@@ -43,16 +68,74 @@ class ServerPlacement:
         return lines
 
 
+def _add_backend_visible_env(env_updates: dict[str, str],
+                             backend: str,
+                             visible_devices: str | None) -> None:
+    if not visible_devices:
+        return
+    updates = apply_backend_visible_devices(
+        backend,
+        visible_devices=visible_devices,
+        base_env={},
+    )
+    conflicts = [
+        key for key, value in updates.items()
+        if key in env_updates and env_updates[key] != value
+    ]
+    if conflicts:
+        names = ", ".join(conflicts)
+        raise ValueError(
+            f"conflicting visible-device placement for {backend}: {names}")
+    env_updates.update(updates)
+
+
 def resolve_server_placement(args) -> ServerPlacement:
     env_updates: dict[str, str] = {}
+    target_backend = args.target_backend
+    draft_backend = args.draft_backend
+    mixed_backend = target_backend != draft_backend
+
+    if (target_backend == draft_backend and
+            args.target_visible_devices and args.draft_visible_devices and
+            args.target_visible_devices != args.draft_visible_devices):
+        raise ValueError(
+            "same-backend target/draft placement cannot use different visible "
+            "device lists in one server process; use --target-gpu/--draft-gpu "
+            "within the shared visible-device list")
+
+    _add_backend_visible_env(
+        env_updates, target_backend, args.target_visible_devices)
+    _add_backend_visible_env(
+        env_updates, draft_backend, args.draft_visible_devices)
+
     if args.target_gpu is not None:
         env_updates["DFLASH_TARGET_GPU"] = str(args.target_gpu)
     if args.draft_gpu is not None:
         env_updates["DFLASH_DRAFT_GPU"] = str(args.draft_gpu)
 
+    if mixed_backend and not args.draft_ipc_bin:
+        raise ValueError(
+            "mixed-backend draft/target placement requires --draft-ipc-bin "
+            "pointing to a test_dflash binary built for the draft backend")
+    if not args.draft_ipc_bin and (
+            args.draft_ipc_gpu is not None or
+            args.draft_ipc_work_dir is not None or
+            args.draft_ipc_ring_cap is not None):
+        raise ValueError(
+            "--draft-ipc-gpu, --draft-ipc-work-dir, and "
+            "--draft-ipc-ring-cap require --draft-ipc-bin")
+    if args.draft_ipc_bin and not args.target_gpus:
+        raise ValueError(
+            "--draft-ipc-bin requires --target-gpus because test_dflash "
+            "draft IPC is implemented for the target-split DFlash daemon path")
+
     daemon_cfg = TestDflashLaunchArgs(
         draft_feature_mirror=args.draft_feature_mirror,
         peer_access=args.peer_access,
+        draft_ipc_bin=str(args.draft_ipc_bin) if args.draft_ipc_bin else None,
+        draft_ipc_gpu=args.draft_ipc_gpu,
+        draft_ipc_work_dir=str(args.draft_ipc_work_dir) if args.draft_ipc_work_dir else None,
+        draft_ipc_ring_cap=args.draft_ipc_ring_cap,
     )
 
     prefix_cache_slots = args.prefix_cache_slots
@@ -67,6 +150,10 @@ def resolve_server_placement(args) -> ServerPlacement:
             target_layer_split=args.target_layer_split,
             target_split_load_draft=True,
             target_split_dflash=True,
+            draft_ipc_bin=str(args.draft_ipc_bin) if args.draft_ipc_bin else None,
+            draft_ipc_gpu=args.draft_ipc_gpu,
+            draft_ipc_work_dir=str(args.draft_ipc_work_dir) if args.draft_ipc_work_dir else None,
+            draft_ipc_ring_cap=args.draft_ipc_ring_cap,
         )
         cache_slots_disabled = prefix_cache_slots > 0 or prefill_cache_slots > 0
         if cache_slots_disabled:
@@ -78,10 +165,18 @@ def resolve_server_placement(args) -> ServerPlacement:
         daemon_args=daemon_cfg.to_cli_args(),
         prefix_cache_slots=prefix_cache_slots,
         prefill_cache_slots=prefill_cache_slots,
+        target_backend=target_backend,
+        draft_backend=draft_backend,
+        target_visible_devices=args.target_visible_devices,
+        draft_visible_devices=args.draft_visible_devices,
         target_gpu=args.target_gpu,
         draft_gpu=args.draft_gpu,
         target_gpus=args.target_gpus,
         target_layer_split=args.target_layer_split,
+        draft_ipc_bin=str(args.draft_ipc_bin) if args.draft_ipc_bin else None,
+        draft_ipc_gpu=args.draft_ipc_gpu,
+        draft_ipc_work_dir=str(args.draft_ipc_work_dir) if args.draft_ipc_work_dir else None,
+        draft_ipc_ring_cap=args.draft_ipc_ring_cap,
         draft_feature_mirror=args.draft_feature_mirror,
         peer_access=args.peer_access,
         cache_slots_disabled=cache_slots_disabled,

--- a/dflash/scripts/server.py
+++ b/dflash/scripts/server.py
@@ -2822,12 +2822,24 @@ def main():
                     help="Disk budget in bytes for persisted full-cache artifacts. "
                          "0 disables budget trimming.")
     ap.add_argument("--daemon", action="store_true")
+    ap.add_argument("--target-backend", choices=["cuda", "hip"], default="cuda",
+                    help="Backend for the target test_dflash daemon placement env.")
+    ap.add_argument("--target-visible-devices", default=None,
+                    help="Visible device list for the target backend, e.g. 0,1.")
+    ap.add_argument("--draft-backend", choices=["cuda", "hip"], default="cuda",
+                    help="Backend for draft placement. Different-backend draft "
+                         "requires --draft-ipc-bin.")
+    ap.add_argument("--draft-visible-devices", default=None,
+                    help="Visible device list for the draft backend. For mixed "
+                         "CUDA/HIP placement this is exported alongside the "
+                         "target backend's visible-device env.")
     ap.add_argument("--target-gpu", type=int, default=None,
-                    help="Visible CUDA device id for test_dflash (sets DFLASH_TARGET_GPU)")
+                    help="Backend-local target device id for test_dflash (sets DFLASH_TARGET_GPU)")
     ap.add_argument("--draft-gpu", type=int, default=None,
-                    help="Visible CUDA device id for draft (sets DFLASH_DRAFT_GPU)")
+                    help="Backend-local draft device id (sets DFLASH_DRAFT_GPU)")
     ap.add_argument("--target-gpus", type=str, default=None,
-                    help="Comma-separated target GPU ids for target-layer sharding (passes --target-gpus)")
+                    help="Comma-separated backend-local target GPU ids for target-layer sharding "
+                         "(passes --target-gpus)")
     # nargs='?' so Compose can use a bare `--target-layer-split` line before another
     # flag; const="" means "use test_dflash defaults" (we do not forward an empty value).
     ap.add_argument("--target-layer-split", nargs="?", const="", default=None,
@@ -2838,6 +2850,14 @@ def main():
                     help="Pass --draft-feature-mirror to test_dflash (safe cross-GPU feature path)")
     ap.add_argument("--peer-access", action="store_true",
                     help="Pass --peer-access to test_dflash (prefer P2P memcpy when available)")
+    ap.add_argument("--draft-ipc-bin", type=Path, default=None,
+                    help="Path to a test_dflash binary built for the remote draft backend.")
+    ap.add_argument("--draft-ipc-gpu", type=int, default=None,
+                    help="GPU id passed to the remote draft IPC daemon.")
+    ap.add_argument("--draft-ipc-work-dir", type=Path, default=None,
+                    help="Work directory for host-file IPC with the remote draft daemon.")
+    ap.add_argument("--draft-ipc-ring-cap", type=int, default=None,
+                    help="Feature-ring capacity for the remote draft daemon.")
     ap.add_argument("--no-thinking", action="store_true",
                     help="Server-level guard: prevent any request from enabling thinking mode "
                          "via chat_template_kwargs. Useful on hardware (e.g. gfx1151/Strix Halo) "
@@ -2856,7 +2876,10 @@ def main():
     if args.fa_window is not None:
         os.environ["DFLASH27B_FA_WINDOW"] = str(args.fa_window)
 
-    placement = resolve_server_placement(args)
+    try:
+        placement = resolve_server_placement(args)
+    except ValueError as exc:
+        raise SystemExit(f"invalid placement config: {exc}") from exc
     placement.apply_env(os.environ)
 
     if args.prefill_compression != "off":
@@ -2875,9 +2898,14 @@ def main():
     # DFlash/DDTree flags on archs that lack a spec-decode draft. Same
     # binary serves every arch.
     arch = _arch_from_gguf(args.target)
+    if args.draft_ipc_bin and arch in _LAGUNA_ARCHES:
+        raise SystemExit("draft IPC placement is only supported on the qwen35/qwen36 server path")
 
     if not args.bin.is_file():
         raise SystemExit(f"binary not found at {args.bin} (arch={arch})")
+    if placement.draft_ipc_bin:
+        if not args.draft_ipc_bin.is_file():
+            raise SystemExit(f"draft IPC binary not found at {args.draft_ipc_bin}")
 
     if arch in _LAGUNA_ARCHES:
         # No DFlash draft model exists for laguna yet; test_dflash'́s

--- a/dflash/scripts/test_server_placement.py
+++ b/dflash/scripts/test_server_placement.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from placement.server_resolver import resolve_server_placement
+
+
+def _args(**overrides):
+    base = dict(
+        target_backend="cuda",
+        draft_backend="cuda",
+        target_visible_devices=None,
+        draft_visible_devices=None,
+        target_gpu=None,
+        draft_gpu=None,
+        target_gpus=None,
+        target_layer_split=None,
+        draft_feature_mirror=False,
+        peer_access=False,
+        draft_ipc_bin=None,
+        draft_ipc_gpu=None,
+        draft_ipc_work_dir=None,
+        draft_ipc_ring_cap=None,
+        prefix_cache_slots=1,
+        prefill_cache_slots=0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_same_backend_visible_devices_share_one_process_env():
+    placement = resolve_server_placement(_args(
+        target_visible_devices="0,1",
+        target_gpu=0,
+        draft_gpu=1,
+    ))
+
+    assert placement.env_updates["CUDA_VISIBLE_DEVICES"] == "0,1"
+    assert placement.env_updates["DFLASH_TARGET_GPU"] == "0"
+    assert placement.env_updates["DFLASH_DRAFT_GPU"] == "1"
+    assert placement.mixed_backend is False
+
+
+def test_same_backend_rejects_conflicting_visible_devices():
+    with pytest.raises(ValueError, match="same-backend target/draft placement"):
+        resolve_server_placement(_args(
+            target_visible_devices="0",
+            draft_visible_devices="1",
+        ))
+
+
+def test_mixed_backend_requires_draft_ipc_binary():
+    with pytest.raises(ValueError, match="requires --draft-ipc-bin"):
+        resolve_server_placement(_args(
+            target_backend="cuda",
+            draft_backend="hip",
+            target_visible_devices="0,1",
+            draft_visible_devices="0",
+        ))
+
+
+def test_mixed_backend_exports_both_backend_visible_envs_and_ipc_args():
+    placement = resolve_server_placement(_args(
+        target_backend="cuda",
+        draft_backend="hip",
+        target_visible_devices="0,1",
+        draft_visible_devices="0",
+        target_gpus="0,1",
+        target_layer_split="1,1",
+        draft_ipc_bin=Path("/opt/lucebox/hip/test_dflash"),
+        draft_ipc_gpu=0,
+        draft_ipc_work_dir=Path("/tmp/dflash-ipc"),
+        draft_ipc_ring_cap=8192,
+    ))
+
+    assert placement.mixed_backend is True
+    assert placement.env_updates["CUDA_VISIBLE_DEVICES"] == "0,1"
+    assert placement.env_updates["HIP_VISIBLE_DEVICES"] == "0"
+    assert placement.env_updates["ROCR_VISIBLE_DEVICES"] == "0"
+    assert "--target-gpus=0,1" in placement.daemon_args
+    assert "--target-layer-split=1,1" in placement.daemon_args
+    assert "--target-split-load-draft" in placement.daemon_args
+    assert "--target-split-dflash" in placement.daemon_args
+    assert "--draft-ipc-bin=/opt/lucebox/hip/test_dflash" in placement.daemon_args
+    assert "--draft-ipc-gpu=0" in placement.daemon_args
+    assert "--draft-ipc-work-dir=/tmp/dflash-ipc" in placement.daemon_args
+    assert "--draft-ipc-ring-cap=8192" in placement.daemon_args
+    assert placement.prefix_cache_slots == 0
+    assert placement.cache_slots_disabled is True

--- a/dflash/src/common/backend_factory.h
+++ b/dflash/src/common/backend_factory.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "model_backend.h"
-#include "device_placement.h"
+#include "placement/placement_config.h"
 
 #include <memory>
 #include <string>
@@ -30,6 +30,7 @@ struct BackendArgs {
 
     // Device placement
     DevicePlacement device;
+    PlacementBackend draft_backend = PlacementBackend::Auto;
     int             draft_gpu    = 0;
 
     // I/O — only used when running under daemon_loop (legacy). The new

--- a/dflash/src/common/device_placement.h
+++ b/dflash/src/common/device_placement.h
@@ -1,31 +1,6 @@
-// Device placement configuration for model backends.
-//
-// Describes which GPU(s) to use for a model. Supports:
-//   - Single-GPU: just gpu field
-//   - Multi-GPU layer-split: layer_split_gpus + optional weights
-//   - Peer access between GPUs
+// Compatibility include for older common/device_placement.h users.
+// New C++ placement code should include placement/placement_config.h.
 
 #pragma once
 
-#include <vector>
-
-namespace dflash27b {
-
-struct DevicePlacement {
-    int gpu = 0;                              // primary GPU (single-GPU mode)
-
-    // Multi-GPU layer-split. Empty = single GPU mode.
-    std::vector<int>    layer_split_gpus;     // GPU IDs for each shard
-    std::vector<double> layer_split_weights;  // proportional layer distribution (optional)
-
-    bool peer_access = false;                 // enable CUDA peer access between GPUs
-    int  max_ctx     = 8192;                  // max KV cache context length
-
-    bool is_layer_split() const { return layer_split_gpus.size() > 1; }
-
-    int primary_gpu() const {
-        return layer_split_gpus.empty() ? gpu : layer_split_gpus[0];
-    }
-};
-
-}  // namespace dflash27b
+#include "placement/placement_config.h"

--- a/dflash/src/common/layer_split_utils.h
+++ b/dflash/src/common/layer_split_utils.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 
 #include <string>
 #include <utility>

--- a/dflash/src/gemma4/gemma4_backend.h
+++ b/dflash/src/gemma4/gemma4_backend.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "common/model_backend.h"
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 #include "gemma4_internal.h"
 #include "common/sampler.h"
 

--- a/dflash/src/gemma4/gemma4_daemon.h
+++ b/dflash/src/gemma4/gemma4_daemon.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 
 namespace dflash27b {

--- a/dflash/src/laguna/laguna_daemon.h
+++ b/dflash/src/laguna/laguna_daemon.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 #include "ggml.h"
 

--- a/dflash/src/placement/placement_backend.h
+++ b/dflash/src/placement/placement_backend.h
@@ -1,0 +1,54 @@
+// Backend placement identifiers shared by C++ server/runtime code.
+
+#pragma once
+
+#include <string>
+
+namespace dflash27b {
+
+enum class PlacementBackend {
+    Auto,
+    Cuda,
+    Hip,
+};
+
+inline const char * placement_backend_name(PlacementBackend backend) {
+    switch (backend) {
+        case PlacementBackend::Auto: return "auto";
+        case PlacementBackend::Cuda: return "cuda";
+        case PlacementBackend::Hip:  return "hip";
+    }
+    return "auto";
+}
+
+inline bool parse_placement_backend(const std::string & value,
+                                    PlacementBackend & out) {
+    if (value == "auto") {
+        out = PlacementBackend::Auto;
+        return true;
+    }
+    if (value == "cuda") {
+        out = PlacementBackend::Cuda;
+        return true;
+    }
+    if (value == "hip") {
+        out = PlacementBackend::Hip;
+        return true;
+    }
+    return false;
+}
+
+inline PlacementBackend compiled_placement_backend() {
+#if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    return PlacementBackend::Hip;
+#else
+    return PlacementBackend::Cuda;
+#endif
+}
+
+inline bool placement_backend_supported(PlacementBackend backend) {
+    return backend == PlacementBackend::Auto ||
+           backend == compiled_placement_backend();
+}
+
+}  // namespace dflash27b

--- a/dflash/src/placement/placement_config.h
+++ b/dflash/src/placement/placement_config.h
@@ -1,0 +1,34 @@
+// Device placement configuration for model backends.
+//
+// Describes which GPU(s) to use for a model. Supports:
+//   - Single-GPU: just gpu field
+//   - Multi-GPU layer-split: layer_split_gpus + optional weights
+//   - Peer access between GPUs
+
+#pragma once
+
+#include "placement_backend.h"
+
+#include <vector>
+
+namespace dflash27b {
+
+struct DevicePlacement {
+    PlacementBackend backend = PlacementBackend::Auto;
+    int gpu = 0;                              // primary GPU (single-GPU mode)
+
+    // Multi-GPU layer-split. Empty = single GPU mode.
+    std::vector<int>    layer_split_gpus;     // GPU IDs for each shard
+    std::vector<double> layer_split_weights;  // proportional layer distribution (optional)
+
+    bool peer_access = false;                 // enable CUDA/HIP peer access between GPUs
+    int  max_ctx     = 8192;                  // max KV cache context length
+
+    bool is_layer_split() const { return layer_split_gpus.size() > 1; }
+
+    int primary_gpu() const {
+        return layer_split_gpus.empty() ? gpu : layer_split_gpus[0];
+    }
+};
+
+}  // namespace dflash27b

--- a/dflash/src/qwen3/qwen3_backend.h
+++ b/dflash/src/qwen3/qwen3_backend.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "common/model_backend.h"
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 #include "qwen3_drafter_model.h"
 #include "qwen3_drafter.h"
 #include "common/sampler.h"

--- a/dflash/src/qwen3/qwen3_daemon.h
+++ b/dflash/src/qwen3/qwen3_daemon.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 
 namespace dflash27b {

--- a/dflash/src/qwen35/qwen35_backend.h
+++ b/dflash/src/qwen35/qwen35_backend.h
@@ -13,7 +13,7 @@
 
 #include "common/model_backend.h"
 #include "common/dflash_target.h"
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 #include "step_graph.h"
 #include "ddtree.h"
 #include "dflash_feature_ring.h"

--- a/dflash/src/qwen35/qwen35_daemon.h
+++ b/dflash/src/qwen35/qwen35_daemon.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "device_placement.h"
+#include "placement/placement_config.h"
 #include <string>
 
 namespace dflash27b {

--- a/dflash/src/qwen35/qwen35_layer_split.h
+++ b/dflash/src/qwen35/qwen35_layer_split.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include "common/device_placement.h"
+#include "placement/placement_config.h"
 
 #include <string>
 

--- a/dflash/src/server/server_main.cpp
+++ b/dflash/src/server/server_main.cpp
@@ -14,14 +14,98 @@
 #include "http_server.h"
 #include "common/backend_factory.h"
 #include "common/gguf_inspect.h"
+#include "common/peer_access.h"
 
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace dflash27b;
+
+static bool parse_int_list(const char * value, std::vector<int> & out) {
+    out.clear();
+    if (!value || !*value) return false;
+    const char * p = value;
+    while (*p) {
+        char * end = nullptr;
+        long v = std::strtol(p, &end, 10);
+        if (end == p) return false;
+        out.push_back((int)v);
+        if (*end == '\0') return true;
+        if (*end != ',') return false;
+        p = end + 1;
+        if (!*p) return false;
+    }
+    return !out.empty();
+}
+
+static bool parse_double_list(const char * value, std::vector<double> & out) {
+    out.clear();
+    if (!value || !*value) return false;
+    const char * p = value;
+    while (*p) {
+        char * end = nullptr;
+        double v = std::strtod(p, &end);
+        if (end == p) return false;
+        out.push_back(v);
+        if (*end == '\0') return true;
+        if (*end != ',') return false;
+        p = end + 1;
+        if (!*p) return false;
+    }
+    return !out.empty();
+}
+
+static bool parse_backend_arg(const char * value, PlacementBackend & out) {
+    return value && parse_placement_backend(value, out);
+}
+
+static bool validate_server_placement(const BackendArgs & bargs) {
+    const PlacementBackend compiled = compiled_placement_backend();
+    if (!placement_backend_supported(bargs.device.backend)) {
+        std::fprintf(stderr,
+            "[server] --target-backend=%s is unsupported in this binary "
+            "(compiled backend: %s)\n",
+            placement_backend_name(bargs.device.backend),
+            placement_backend_name(compiled));
+        return false;
+    }
+    if (!placement_backend_supported(bargs.draft_backend)) {
+        std::fprintf(stderr,
+            "[server] --draft-backend=%s is unsupported in this binary "
+            "(compiled backend: %s)\n",
+            placement_backend_name(bargs.draft_backend),
+            placement_backend_name(compiled));
+        return false;
+    }
+    const PlacementBackend target = bargs.device.backend == PlacementBackend::Auto
+        ? compiled : bargs.device.backend;
+    const PlacementBackend draft = bargs.draft_backend == PlacementBackend::Auto
+        ? target : bargs.draft_backend;
+    if (target != draft) {
+        std::fprintf(stderr,
+            "[server] mixed target/draft backends are not implemented in the "
+            "native server yet (target=%s draft=%s)\n",
+            placement_backend_name(target), placement_backend_name(draft));
+        return false;
+    }
+    if (!bargs.device.layer_split_gpus.empty()) {
+        std::fprintf(stderr,
+            "[server] target layer split is not implemented in the native "
+            "server yet (--target-gpus was provided)\n");
+        return false;
+    }
+    if (!bargs.device.layer_split_weights.empty()) {
+        std::fprintf(stderr,
+            "[server] --target-layer-split requires native target layer split "
+            "support, which is not implemented yet\n");
+        return false;
+    }
+    return true;
+}
 
 static void print_usage(const char * prog) {
     std::fprintf(stderr,
@@ -35,6 +119,11 @@ static void print_usage(const char * prog) {
         "  --max-tokens <N>     Default max output tokens (default: 4096)\n"
         "  --gpu <N>            Target GPU device (default: 0)\n"
         "  --draft-gpu <N>      Draft GPU device (default: 0)\n"
+        "  --target-backend <auto|cuda|hip>  Target backend (default: auto)\n"
+        "  --draft-backend <auto|cuda|hip>   Draft backend (default: auto)\n"
+        "  --target-gpus <ids>  Reserved target layer-split GPU list (comma-separated)\n"
+        "  --target-layer-split <weights>  Reserved layer-split weights\n"
+        "  --peer-access        Enable peer access for multi-GPU placement\n"
         "  --chunk <N>          Chunked-prefill chunk size (default: 512)\n"
         "  --fa-window <N>     Flash-attention sliding window (default: 0=full)\n"
         "  --model-name <name>  Model name for /v1/models (default: dflash)\n"
@@ -86,6 +175,28 @@ int main(int argc, char ** argv) {
             bargs.device.gpu = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--draft-gpu") == 0 && i + 1 < argc) {
             bargs.draft_gpu = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--target-backend") == 0 && i + 1 < argc) {
+            if (!parse_backend_arg(argv[++i], bargs.device.backend)) {
+                std::fprintf(stderr, "[server] bad --target-backend value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--draft-backend") == 0 && i + 1 < argc) {
+            if (!parse_backend_arg(argv[++i], bargs.draft_backend)) {
+                std::fprintf(stderr, "[server] bad --draft-backend value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--target-gpus") == 0 && i + 1 < argc) {
+            if (!parse_int_list(argv[++i], bargs.device.layer_split_gpus)) {
+                std::fprintf(stderr, "[server] bad --target-gpus value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--target-layer-split") == 0 && i + 1 < argc) {
+            if (!parse_double_list(argv[++i], bargs.device.layer_split_weights)) {
+                std::fprintf(stderr, "[server] bad --target-layer-split value\n");
+                return 2;
+            }
+        } else if (std::strcmp(argv[i], "--peer-access") == 0) {
+            bargs.device.peer_access = true;
         } else if (std::strcmp(argv[i], "--chunk") == 0 && i + 1 < argc) {
             bargs.chunk = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--fa-window") == 0 && i + 1 < argc) {
@@ -128,6 +239,8 @@ int main(int argc, char ** argv) {
             return 2;
         }
     }
+
+    if (!validate_server_placement(bargs)) return 2;
 
     // Sync max_ctx: if --max-ctx was not provided, use the backend's default.
     // This prevents the HTTP server from accepting prompts larger than the
@@ -187,6 +300,7 @@ int main(int argc, char ** argv) {
     }
 
     // Create backend.
+    g_peer_access_opt_in = bargs.device.peer_access;
     std::fprintf(stderr, "[server] creating backend...\n");
     auto backend = create_backend(bargs);
     if (!backend) {
@@ -204,8 +318,14 @@ int main(int argc, char ** argv) {
     std::fprintf(stderr, "[server] │  model_name      = %s\n", sconfig.model_name.c_str());
     std::fprintf(stderr, "[server] │  max_ctx         = %d\n", sconfig.max_ctx);
     std::fprintf(stderr, "[server] │  max_tokens      = %d\n", sconfig.max_tokens);
+    std::fprintf(stderr, "[server] │  target_backend = %s\n",
+                 placement_backend_name(bargs.device.backend));
     std::fprintf(stderr, "[server] │  gpu             = %d\n", bargs.device.gpu);
+    std::fprintf(stderr, "[server] │  draft_backend  = %s\n",
+                 placement_backend_name(bargs.draft_backend));
     std::fprintf(stderr, "[server] │  draft_gpu       = %d\n", bargs.draft_gpu);
+    std::fprintf(stderr, "[server] │  peer_access     = %s\n",
+                 bargs.device.peer_access ? "ON" : "off");
     std::fprintf(stderr, "[server] │  chunk           = %d\n", bargs.chunk);
     std::fprintf(stderr, "[server] │  fa_window       = %d\n", bargs.fa_window);
     std::fprintf(stderr, "[server] │  ddtree          = %s\n", bargs.ddtree_mode ? "ON" : "off");


### PR DESCRIPTION
# Summary

This PR adds server-side CUDA/HIP mixed draft-target placement for the existing `test_dflash` daemon path.

This draft is stacked on top of #236 (`feat(server): add C++ backend placement foundation`).

Before this change, `server.py` could pass target GPU, draft GPU, target layer split, feature mirror, and peer-access flags into `test_dflash`, but it still assumed one backend environment for the whole daemon. That meant CUDA-only and HIP-only server launches worked, but a CUDA target with a HIP draft, or a HIP target with a CUDA draft, had no clear server-level configuration surface.

Now the server can resolve target and draft backend placement separately, export the correct visible-device environment for each backend, and forward the draft IPC options needed by the mixed-backend DFlash path.

# Changes

- Add server CLI fields for backend-aware placement:
  - `--target-backend cuda|hip`
  - `--target-visible-devices`
  - `--draft-backend cuda|hip`
  - `--draft-visible-devices`
- Add server CLI fields for the remote draft daemon path:
  - `--draft-ipc-bin`
  - `--draft-ipc-gpu`
  - `--draft-ipc-work-dir`
  - `--draft-ipc-ring-cap`
- Extend `placement.server_resolver` so it:
  - logs resolved target and draft backends;
  - maps CUDA placement to `CUDA_VISIBLE_DEVICES`;
  - maps HIP placement to `HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES`;
  - rejects conflicting same-backend visible-device lists in one server process;
  - requires `--draft-ipc-bin` when target and draft backends differ;
  - forwards draft IPC args into the `test_dflash` daemon launch args.
- Keep target layer split within one backend binary. Mixed backend draft execution uses the existing remote draft IPC path; it does not split target layers across CUDA and HIP.
- Add focused resolver tests for same-backend placement, invalid same-backend conflicts, missing mixed-backend IPC config, and CUDA/HIP mixed placement arg/env generation.

# Behavior

CUDA-only and HIP-only server configurations keep the existing behavior.

For mixed CUDA/HIP draft-target placement, the server now requires an explicit draft-side `test_dflash` binary built for the draft backend. The target daemon receives the existing `--target-gpus`, `--target-split-load-draft`, `--target-split-dflash`, and `--draft-ipc-*` flags, so the cross-backend boundary stays at the draft IPC feature exchange instead of trying to load CUDA and HIP into one process.

The native C++ server remains single-backend for now and still rejects cross-backend target/draft placement. This PR enables mixed backend support through the existing Python OpenAI-compatible server plus `test_dflash` daemon path.

# Notes

- The current checks cover the server-side placement resolver, CLI parsing surface, generated daemon args, and CUDA/HIP visible-device environment mapping.
- A dedicated SSH validation machine with RTX 3090 + Strix Halo is available in principle, but formal mixed-backend hardware validation should be added after access is opened for this PR.
- Planned hardware validation target: one direction with CUDA target + HIP draft, and the reverse direction with HIP target + CUDA draft, using the existing draft IPC boundary.
