### PR TITLE
qwen35: add BSA (block-sparse attention) for full-attention layers during prefill

### DIFF
--- a/dflash/src/internal.h
+++ b/dflash/src/internal.h
@@ -499,6 +499,8 @@ struct QwenGraphInputs {
     int           fa_window = 0;  // sliding window for FA layers: 0 = full attention
     bool          last_token_logits_only = false; // if true, only compute logits for last token (prefill optimization)
     ggml_tensor * parent_ids = nullptr; // [n_tokens] i32; tree mode when non-null
+    bool          use_sparse_attn = false; // use ggml_flash_attn_sparse (BSA) for full-attn layers
+    float         sparse_alpha = 0.12f;   // BSA block-selection threshold (lower = more blocks selected)
 };
 
 struct QwenGraphOutputs {

--- a/dflash/src/qwen35/graph_builders.cpp
+++ b/dflash/src/qwen35/graph_builders.cpp
@@ -92,7 +92,9 @@ bool build_target_step(
     bool capture_delta_intermediate,
     int fa_window,
     bool last_token_logits_only,
-    int kq_stride_pad) {
+    int kq_stride_pad,
+    bool use_sparse_attn,
+    float sparse_alpha) {
     step_graph_free(sg);
 
     ggml_init_params ip{};
@@ -135,6 +137,8 @@ bool build_target_step(
     gi.capture_delta_intermediate = capture_delta_intermediate;
     gi.fa_window                  = fa_window;
     gi.last_token_logits_only     = last_token_logits_only;
+    gi.use_sparse_attn            = use_sparse_attn;
+    gi.sparse_alpha               = sparse_alpha;
 
     QwenGraphOutputs go = build_qwen35_graph(sg.ctx, sg.gf, w, cache, gi);
     if (!go.logits) return false;

--- a/dflash/src/qwen35/graph_builders.h
+++ b/dflash/src/qwen35/graph_builders.h
@@ -53,7 +53,9 @@ bool build_target_step(
     bool capture_delta_intermediate = false,
     int fa_window = 0,
     bool last_token_logits_only = false,
-    int kq_stride_pad = KQ_MASK_PAD);
+    int kq_stride_pad = KQ_MASK_PAD,
+    bool use_sparse_attn = false,
+    float sparse_alpha = 0.12f);
 
 // Full target forward: DDTree tree-verify mode.
 bool build_target_step_tree(

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -13,6 +13,7 @@
 
 #include "ggml-cuda.h"
 #include "common/snapshot_backend.h"
+#include "pflash_ggml_adapter.h"
 
 #include <algorithm>
 #include <chrono>
@@ -36,6 +37,10 @@ Qwen35Backend::~Qwen35Backend() { shutdown(); }
 
 bool Qwen35Backend::init() {
     split_gpus_ = (cfg_.device.gpu != cfg_.draft_gpu);
+
+#if defined(DFLASH27B_HAVE_SM80_FLASHPREFILL) || defined(DFLASH27B_HAVE_FLASHPREFILL)
+    pflash_register_ggml_kernel();
+#endif
 
     target_backend_ = ggml_backend_cuda_init(cfg_.device.gpu);
     if (!target_backend_) {
@@ -478,6 +483,19 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     const int prompt_len = (int)tokens.size();
     prefill_last_logits_valid_ = false;
 
+    // BSA (Block-Sparse Attention) for full-attention layers during prefill.
+    // Requires Q_len == KV_len, so we process the full prompt in one shot (no chunking).
+    // Only for fresh prefill (kv_offset==0) and prompts above threshold.
+    static const int BSA_THRESHOLD = 1024;
+    float bsa_alpha = 0.12f;
+    if (const char * s = std::getenv("DFLASH_FP_ALPHA")) {
+        bsa_alpha = std::atof(s);
+    }
+    const bool use_bsa = (kv_offset == 0) && (prompt_len > BSA_THRESHOLD);
+    if (use_bsa) {
+        prefill_ubatch = prompt_len;  // single-shot, no chunking
+    }
+
     // Skip KV-cache migration when resuming from a snapshot — the cache was
     // already migrated when the snapshot was taken; re-running migrate would
     // clobber the restored state.
@@ -508,7 +526,10 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         if (snap_pos > kv_pos && snap_pos < kv_pos + n_tokens) {
             n_tokens = snap_pos - kv_pos;
         }
-        const bool with_mask = (cfg_.kq_stride_pad > KQ_MASK_PAD) || (n_tokens > 1);
+        // BSA path: no mask needed (causality handled by the kernel).
+        // Dense path: mask required when n_tokens > 1.
+        const bool with_mask = use_bsa ? false
+            : ((cfg_.kq_stride_pad > KQ_MASK_PAD) || (n_tokens > 1));
 
         // Prefill always uses full attention (fa_window=0) so that all
         // positions encode the complete context — critical for tool
@@ -520,7 +541,8 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
                                /*capture_delta_intermediate=*/false,
                                /*fa_window=*/0,
                                /*last_token_logits_only=*/(start + n_tokens < prompt_len),
-                               cfg_.kq_stride_pad)) {
+                               cfg_.kq_stride_pad,
+                               use_bsa, bsa_alpha)) {
             std::fprintf(stderr, "prefill build @%d\n", kv_pos);
             return -1;
         }

--- a/dflash/src/qwen35/qwen35_target_graph.cpp
+++ b/dflash/src/qwen35/qwen35_target_graph.cpp
@@ -471,7 +471,9 @@ static ggml_tensor * build_full_attn_block(
     bool kv_k_rotated = false,
     int fa_window = 0,
     ggml_tensor * q_tail_capture = nullptr,
-    int q_tail_start = 0
+    int q_tail_start = 0,
+    bool use_sparse_attn = false,
+    float sparse_alpha = 0.12f
 ) {
     const int head_dim = w.n_embd_head_k;
     const int n_head = w.n_head;
@@ -616,8 +618,16 @@ static ggml_tensor * build_full_attn_block(
     // a mask shaped [kv_len, n_tokens] with 0 for attendable positions and
     // -inf for positions beyond the causal boundary.
     const float kq_scale = 1.0f / std::sqrt((float)head_dim);
-    ggml_tensor * attn = ggml_flash_attn_ext(ctx, Qfa, Kfa, Vfa, attn_mask,
-                                             kq_scale, 0.0f, 0.0f);
+    ggml_tensor * attn;
+    if (use_sparse_attn) {
+        // BSA path: ggml_flash_attn_sparse handles causality internally.
+        // On sm_80+ with pflash registered, this does block-sparse attention.
+        // On older hardware, falls back to dense FA transparently.
+        attn = ggml_flash_attn_sparse(ctx, Qfa, Kfa, Vfa, kq_scale, sparse_alpha);
+    } else {
+        attn = ggml_flash_attn_ext(ctx, Qfa, Kfa, Vfa, attn_mask,
+                                   kq_scale, 0.0f, 0.0f);
+    }
     // attn: [head_dim, n_head, n_tokens] (permuted)
 
     // Un-rotate the FA output from FWHT-rotated V space (only when V is TQ3).
@@ -1061,7 +1071,9 @@ QwenGraphOutputs build_qwen35_graph(
                                         in.attn_mask, in.kv_start, n_tokens,
                                         cache.kv_k_type, cache.kv_v_type,
                                         cache.kv_k_rotated,
-                                        in.fa_window);
+                                        in.fa_window,
+                                        /*q_tail_capture=*/nullptr, /*q_tail_start=*/0,
+                                        in.use_sparse_attn, in.sparse_alpha);
             fa_idx++;
         } else {
             DeltaNetCapture * cap_ptr = nullptr;


### PR DESCRIPTION
Replace ggml_flash_attn_ext with ggml_flash_attn_sparse in build_full_attn_block for the 16 full-attention layers. When the prompt exceeds 1024 tokens and kv_offset==0 (fresh prefill), process the entire prompt in a single graph pass (no 512-token chunking) so Q_len == KV_len as required by the BSA kernel.

On sm_80+ hardware with pflash registered, this dispatches to block-sparse attention (~3x faster at long contexts). On older hardware (e.g., 2080Ti / sm_75), the ggml_flash_attn_sparse op transparently falls back to dense FA via fattn-sparse.cu.

Changes:
- Register pflash kernel at Qwen35Backend::init() (ifdef sm_80)
- Add use_sparse_attn + sparse_alpha to QwenGraphInputs
- Thread flags through build_target_step → build_qwen35_graph
- BSA threshold + single-shot logic in do_prefill
- Alpha configurable via DFLASH_FP_ALPHA env (default 0.12)