### PR TITLE
test(mtp): add RED-bar scripts for converter + e2e determinism

### DIFF
--- a/dflash/test/test_mtp_converter.sh
+++ b/dflash/test/test_mtp_converter.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Phase 1 RED test: Gemma4 MTP assistant converter
+# Should FAIL until convert_dflash_to_gguf.py learns --mtp-assistant mode.
+# When this passes, our converter produces a GGUF byte-for-byte equivalent in
+# tensor list and metadata to AtomicChat's pre-converted reference.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SAFETENSORS_DIR="${MTP_SAFETENSORS_DIR:-$ROOT/models/gemma-4-31B-it-assistant}"
+GOLD_GGUF="${MTP_GOLD_GGUF:-$ROOT/models/gemma4-mtp-31B/gemma-4-31B-it-assistant.Q4_K_M.gguf}"
+OUT_GGUF="${MTP_OUT_GGUF:-/tmp/mtp_phase1_ours.gguf}"
+CONVERT="$ROOT/dflash/scripts/convert_dflash_to_gguf.py"
+
+# Sanity: gold reference must exist (downloaded in Phase 0)
+if [ ! -f "$GOLD_GGUF" ]; then
+    echo "SKIP: gold reference missing at $GOLD_GGUF"
+    echo "       (Phase 0 download not yet complete — re-run after spike lands)"
+    exit 77   # autotools "skip" exit code
+fi
+
+# Sanity: source safetensors must exist
+if [ ! -d "$SAFETENSORS_DIR" ]; then
+    echo "SKIP: source safetensors dir missing at $SAFETENSORS_DIR"
+    echo "       (run: hf download google/gemma-4-31B-it-assistant --local-dir $SAFETENSORS_DIR)"
+    exit 77
+fi
+
+echo "[red] running our converter — expected to FAIL until --mtp-assistant lands"
+python3 "$CONVERT" --mtp-assistant "$SAFETENSORS_DIR" "$OUT_GGUF"
+
+# --- Assertion 1: tensor list parity ---
+echo "[assert 1] tensor list matches gold"
+python3 "$ROOT/dflash/deps/llama.cpp/gguf-py/scripts/gguf_dump.py" \
+    --no-tensors "$GOLD_GGUF" 2>&1 | grep -E '^\s+\d+:\s+' | awk '{print $NF}' | sort > /tmp/gold_tensors.txt
+python3 "$ROOT/dflash/deps/llama.cpp/gguf-py/scripts/gguf_dump.py" \
+    --no-tensors "$OUT_GGUF" 2>&1 | grep -E '^\s+\d+:\s+' | awk '{print $NF}' | sort > /tmp/ours_tensors.txt
+diff /tmp/gold_tensors.txt /tmp/ours_tensors.txt
+echo "[assert 1] PASS"
+
+# --- Assertion 2: required tensors present (the v1 set) ---
+echo "[assert 2] required MTP tensors present"
+for t in \
+    mtp.pre_projection.weight \
+    mtp.post_projection.weight \
+    output_norm.weight \
+    mtp.blk.0.attn_norm.weight \
+    mtp.blk.0.wq.weight \
+    mtp.blk.0.wo.weight \
+    mtp.blk.0.ffn_up.weight \
+    mtp.blk.0.ffn_gate.weight \
+    mtp.blk.0.ffn_down.weight \
+    mtp.blk.3.attn_norm.weight \
+    mtp.blk.3.wq.weight ; do
+    grep -q "$t" /tmp/ours_tensors.txt || { echo "MISSING: $t"; exit 1; }
+done
+echo "[assert 2] PASS"
+
+# --- Assertion 3: required metadata keys present (vLLM #41789 guard) ---
+echo "[assert 3] required GGUF metadata keys"
+GOLD_META=$(python3 "$ROOT/dflash/deps/llama.cpp/gguf-py/scripts/gguf_dump.py" "$GOLD_GGUF" 2>&1)
+OURS_META=$(python3 "$ROOT/dflash/deps/llama.cpp/gguf-py/scripts/gguf_dump.py" "$OUT_GGUF" 2>&1)
+for k in \
+    gemma4_assistant.n_embd_backbone \
+    gemma4_assistant.requires_target_arch \
+    gemma4_assistant.attention_k_eq_v ; do
+    echo "$OURS_META" | grep -q "$k" || { echo "MISSING META: $k"; exit 1; }
+done
+# n_embd_backbone must equal target n_embd (5376 for Dense 31B)
+N_EMBD=$(echo "$OURS_META" | grep -oE 'gemma4_assistant.n_embd_backbone[^=]*= *[0-9]+' | grep -oE '[0-9]+$' || echo "0")
+if [ "$N_EMBD" != "5376" ]; then
+    echo "FAIL: n_embd_backbone=$N_EMBD, expected 5376 (Dense 31B target hidden)"
+    exit 1
+fi
+echo "[assert 3] PASS"
+
+# --- Assertion 4: requires_target_arch == "gemma4" (vLLM #41789 guard) ---
+echo "[assert 4] requires_target_arch == gemma4"
+echo "$OURS_META" | grep "gemma4_assistant.requires_target_arch" | grep -q "gemma4" \
+    || { echo "FAIL: target arch mismatch"; exit 1; }
+echo "[assert 4] PASS"
+
+echo "[red→green] all 4 assertions PASS — Phase 1 GREEN"

--- a/dflash/test/test_mtp_converter.sh
+++ b/dflash/test/test_mtp_converter.sh
@@ -32,9 +32,9 @@ python3 "$CONVERT" --mtp-assistant "$SAFETENSORS_DIR" "$OUT_GGUF"
 # --- Assertion 1: tensor list parity ---
 echo "[assert 1] tensor list matches gold"
 python3 "$ROOT/dflash/deps/llama.cpp/gguf-py/scripts/gguf_dump.py" \
-    --no-tensors "$GOLD_GGUF" 2>&1 | grep -E '^\s+\d+:\s+' | awk '{print $NF}' | sort > /tmp/gold_tensors.txt
+    --no-tensors "$GOLD_GGUF" 2>&1 | grep -E '^\s+[0-9]+:\s+' | awk '{print $NF}' | sort > /tmp/gold_tensors.txt
 python3 "$ROOT/dflash/deps/llama.cpp/gguf-py/scripts/gguf_dump.py" \
-    --no-tensors "$OUT_GGUF" 2>&1 | grep -E '^\s+\d+:\s+' | awk '{print $NF}' | sort > /tmp/ours_tensors.txt
+    --no-tensors "$OUT_GGUF" 2>&1 | grep -E '^\s+[0-9]+:\s+' | awk '{print $NF}' | sort > /tmp/ours_tensors.txt
 diff /tmp/gold_tensors.txt /tmp/ours_tensors.txt
 echo "[assert 1] PASS"
 
@@ -76,8 +76,9 @@ echo "[assert 3] PASS"
 
 # --- Assertion 4: requires_target_arch == "gemma4" (vLLM #41789 guard) ---
 echo "[assert 4] requires_target_arch == gemma4"
-echo "$OURS_META" | grep "gemma4_assistant.requires_target_arch" | grep -q "gemma4" \
-    || { echo "FAIL: target arch mismatch"; exit 1; }
+arch_val=$(echo "$OURS_META" | grep "gemma4_assistant.requires_target_arch" | awk -F'"' '{print $2}')
+[ "$arch_val" = "gemma4" ] \
+    || { echo "FAIL: target arch mismatch (got '$arch_val', want 'gemma4')"; exit 1; }
 echo "[assert 4] PASS"
 
 echo "[red→green] all 4 assertions PASS — Phase 1 GREEN"

--- a/dflash/test/test_mtp_e2e.sh
+++ b/dflash/test/test_mtp_e2e.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Phase 3 RED test: --draft-method mtp produces byte-identical output to
+# --draft-method none (target-only) at temp=0 seed=0.
+#
+# Before Phase 3 GREEN: --draft-method mtp is unrecognized; binary exits ≥1.
+# After Phase 3 GREEN: token sequences match exactly; this passes.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="$ROOT/dflash/build/test_gemma4_dflash"
+TARGET="${MTP_TARGET:-$ROOT/models/gemma-4-31B-it-Q4_K_M.gguf}"
+MTP="${MTP_HEAD:-$ROOT/models/gemma4-mtp-31B/gemma-4-31B-it-assistant.Q4_K_M.gguf}"
+PROMPT_FILE="${MTP_PROMPT:-$ROOT/dflash/test/data/chat_2k.txt}"
+
+# Skip cleanly if any input is missing
+if [ ! -x "$BIN" ]; then
+    echo "[skip] test_gemma4_dflash binary missing at $BIN — build first"
+    exit 77
+fi
+if [ ! -f "$TARGET" ]; then
+    echo "[skip] target GGUF missing at $TARGET"
+    exit 77
+fi
+if [ ! -f "$MTP" ]; then
+    echo "[skip] MTP head missing at $MTP — Phase 0 spike not done"
+    exit 77
+fi
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "[skip] prompt file missing at $PROMPT_FILE"
+    exit 77
+fi
+
+OUT_BASELINE=/tmp/mtp_e2e_baseline.tokens
+OUT_MTP=/tmp/mtp_e2e_mtp.tokens
+COMMON_ARGS=(
+    --model "$TARGET"
+    --kv-k tq3_0 --kv-v tq3_0
+    --pflash
+    --tokens-file "$PROMPT_FILE"
+    --n-predict 64
+    --temp 0
+    --seed 0
+    --print-tokens-only
+)
+
+echo "[run] target-only (baseline)"
+"$BIN" "${COMMON_ARGS[@]}" --draft-method none > "$OUT_BASELINE" 2>&1 || {
+    echo "FAIL: baseline run errored — see $OUT_BASELINE"
+    tail -10 "$OUT_BASELINE"
+    exit 1
+}
+
+echo "[run] --draft-method mtp"
+"$BIN" "${COMMON_ARGS[@]}" --draft-method mtp --mtp "$MTP" > "$OUT_MTP" 2>&1 || {
+    echo "FAIL: --draft-method mtp errored (expected before Phase 3 GREEN)"
+    tail -10 "$OUT_MTP"
+    exit 1
+}
+
+# Extract just the token IDs (assume binary outputs one token id per line on stdout)
+grep -E '^[0-9]+$' "$OUT_BASELINE" > /tmp/mtp_e2e_baseline.ids
+grep -E '^[0-9]+$' "$OUT_MTP"      > /tmp/mtp_e2e_mtp.ids
+
+echo "[diff] comparing token streams"
+if diff -u /tmp/mtp_e2e_baseline.ids /tmp/mtp_e2e_mtp.ids > /tmp/mtp_e2e_diff.txt ; then
+    echo "[red->green] token streams identical (Phase 3 GREEN)"
+    exit 0
+else
+    LEN_B=$(wc -l < /tmp/mtp_e2e_baseline.ids)
+    LEN_M=$(wc -l < /tmp/mtp_e2e_mtp.ids)
+    DIFF_LINES=$(wc -l < /tmp/mtp_e2e_diff.txt)
+    echo "FAIL: streams differ"
+    echo "  baseline tokens: $LEN_B"
+    echo "  mtp      tokens: $LEN_M"
+    echo "  diff lines:     $DIFF_LINES"
+    head -30 /tmp/mtp_e2e_diff.txt
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Two shell test scripts carved out of #241 per @howard0su's review request to split the rename PR from the test additions.

## What's added

- `dflash/test/test_mtp_converter.sh` — **Phase 1 RED** test for `convert_dflash_to_gguf.py --mtp-assistant` mode. Validates the converter's GGUF output matches the AtomicChat gold reference on (1) tensor list, (2) required MTP tensors, (3) required GGUF metadata keys, (4) `requires_target_arch == "gemma4"`. Exits **77** (autotools skip code) cleanly if the gold reference at `$MTP_GOLD_GGUF` is missing.

- `dflash/test/test_mtp_e2e.sh` — **Phase 3 RED** test for `--draft-method mtp` byte-identical output vs `--draft-method none` at `temp=0 seed=0`. Exits **77** cleanly if the `test_gemma4_dflash` binary or the model files are missing.

## Safe to land now

Both scripts:
- Use `#!/usr/bin/env bash` + `set -euo pipefail`
- Have no C++ namespace dependencies
- Exit 77 (skip) when prerequisites aren't on disk
- Have no global state, no side effects beyond writing to `/tmp`

They'll turn GREEN when the corresponding MTP work lands. Until then they're CI-stable skips.

## Not in this PR

The third test file flagged in #241, `dflash/test/test_flash_attn_sparse_mask.cpp`, is deferred. It's a TDD red-bar that intentionally references symbols (`flash_prefill_forward_bf16_masked()`, 6-arg `ggml_flash_attn_sparse()`) that don't exist yet, so adding it to main without the spike that turns it green would leave a permanently broken build target. It will ship with the sparse-mask spike PR.