### PR TITLE
fix(cuda): declare F16 FlashPrefill entry for Pascal builds

### DIFF
--- a/dflash/src/flashprefill.h
+++ b/dflash/src/flashprefill.h
@@ -63,8 +63,8 @@ int flash_prefill_forward_bf16(
 
 // Same as flash_prefill_forward_bf16 but operates on F16 (half) tensors.
 // Uses F16 WMMA (m16n8k16) and cooperative shared-memory loads.
-// Compiled when DFLASH27B_HAVE_VOLTA_FLASHPREFILL is defined.
-#ifdef DFLASH27B_HAVE_VOLTA_FLASHPREFILL
+// Compiled when the Volta/Turing WMMA or Pascal scalar F16 path is enabled.
+#if defined(DFLASH27B_HAVE_VOLTA_FLASHPREFILL) || defined(DFLASH27B_HAVE_PASCAL_FLASHPREFILL)
 int flash_prefill_forward_f16(
     const void * Q, const void * K, const void * V, void * O,
     int batch, int seq_len, int n_q_heads, int n_k_heads, int head_dim,


### PR DESCRIPTION
## Summary

This PR fixes the CUDA Pascal / sm61 build for the FlashPrefill F16 entry point.

The implementation already provides a Pascal scalar fallback behind `DFLASH27B_HAVE_PASCAL_FLASHPREFILL`, and the CMake path enables it for sm60-sm69 builds. However, `flashprefill.h` only declared `flash_prefill_forward_f16()` when `DFLASH27B_HAVE_VOLTA_FLASHPREFILL` was set, so Pascal builds could fail while compiling the Qwen3 drafter graph.

## Changes

- Update `dflash/src/flashprefill.h` so `flash_prefill_forward_f16()` is declared when either F16 FlashPrefill implementation is enabled:
  - `DFLASH27B_HAVE_VOLTA_FLASHPREFILL`
  - `DFLASH27B_HAVE_PASCAL_FLASHPREFILL`
- Keep the function signature and runtime dispatch unchanged. This only aligns the header guard with the existing implementation and CMake feature flags.
