### PR TITLE
fix(server): emit Anthropic tool_use content blocks (non-stream + stream)

### DIFF
--- a/dflash/src/server/http_server.cpp
+++ b/dflash/src/server/http_server.cpp
@@ -827,7 +827,37 @@ void HttpServer::worker_loop() {
                 if (!emitter.reasoning_text().empty()) {
                     content.push_back({{"type", "thinking"}, {"thinking", emitter.reasoning_text()}});
                 }
-                content.push_back({{"type", "text"}, {"text", emitter.accumulated_text()}});
+                // Only emit a text block when there is actual text. When the
+                // model emitted ONLY a tool_call (Qwen3 XML), accumulated_text
+                // is empty — pushing an empty text block confuses Anthropic
+                // SDK clients (they expect tool_use blocks alone).
+                if (!emitter.accumulated_text().empty()) {
+                    content.push_back({{"type", "text"}, {"text", emitter.accumulated_text()}});
+                }
+                // Tool calls — the OPENAI_CHAT branch above does this; the
+                // ANTHROPIC branch was missing the tool_use serialisation,
+                // so stop_reason="tool_use" was returned with empty content.
+                // tc.arguments is a JSON-encoded string; parse to object for
+                // Anthropic's `input` field (Anthropic expects object, not
+                // string). Fall back to empty object on parse failure.
+                if (!emitter.tool_calls().empty()) {
+                    for (const auto & tc : emitter.tool_calls()) {
+                        json input_obj;
+                        try {
+                            input_obj = tc.arguments.empty()
+                                ? json::object()
+                                : json::parse(tc.arguments);
+                        } catch (const std::exception &) {
+                            input_obj = json::object();
+                        }
+                        content.push_back({
+                            {"type",  "tool_use"},
+                            {"id",    tc.id},
+                            {"name",  tc.name},
+                            {"input", input_obj}
+                        });
+                    }
+                }
                 resp = {
                     {"id", req.response_id}, {"type", "message"},
                     {"role", "assistant"}, {"model", req.model},

--- a/dflash/src/server/sse_emitter.cpp
+++ b/dflash/src/server/sse_emitter.cpp
@@ -426,10 +426,50 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens) {
                 out.push_back(format_openai_delta({{"tool_calls", tc_list}}));
                 break;
             }
-            case ApiFormat::ANTHROPIC:
-                // Anthropic doesn't have streaming tool calls in the same way
-                // Tool use blocks would be separate content blocks
+            case ApiFormat::ANTHROPIC: {
+                // Anthropic tool_use is emitted as separate content blocks.
+                // Lifecycle per tool: close the open text/thinking block via
+                // content_block_stop, then for each tool_call emit
+                // content_block_start { type: tool_use, id, name, input: {} },
+                // a content_block_delta { type: input_json_delta, partial_json }
+                // carrying the JSON arguments, finally content_block_stop.
+                //
+                // The initial text/thinking block at index_=0 was opened by
+                // emit_start(); we close it now and bump block_index_ for
+                // each tool_use block we emit.
+                if (!active_kind_.empty()) {
+                    out.push_back(sse_event("content_block_stop",
+                        json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+                    active_kind_.clear();
+                }
+                for (const auto & tc : tool_calls_) {
+                    block_index_++;
+                    json tu_block = {
+                        {"type",  "tool_use"},
+                        {"id",    tc.id},
+                        {"name",  tc.name},
+                        {"input", json::object()}
+                    };
+                    out.push_back(sse_event("content_block_start",
+                        json({{"type", "content_block_start"},
+                              {"index", block_index_},
+                              {"content_block", tu_block}}).dump()));
+                    // Single-shot delta with the full arguments JSON. Clients
+                    // parse this incrementally; emitting it whole is spec-legal
+                    // and avoids partial-JSON splitting heuristics.
+                    if (!tc.arguments.empty()) {
+                        out.push_back(sse_event("content_block_delta",
+                            json({{"type",  "content_block_delta"},
+                                  {"index", block_index_},
+                                  {"delta", {{"type",         "input_json_delta"},
+                                             {"partial_json", tc.arguments}}}}).dump()));
+                    }
+                    out.push_back(sse_event("content_block_stop",
+                        json({{"type", "content_block_stop"},
+                              {"index", block_index_}}).dump()));
+                }
                 break;
+            }
             case ApiFormat::RESPONSES:
                 for (const auto & tc : tool_calls_) {
                     out.push_back(format_responses_event(
@@ -475,13 +515,24 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens) {
     }
 
     case ApiFormat::ANTHROPIC: {
-        // content_block_stop
-        out.push_back(sse_event("content_block_stop",
-            json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
-        // message_delta
+        // content_block_stop only fires if a block is still open. With the
+        // tool_use emission added above, the last text/thinking/tool_use
+        // block may already be closed — in that case active_kind_ is empty
+        // and we skip the redundant close (idempotent, but some Anthropic
+        // SDK clients raise parse errors on duplicate stops at the same
+        // index).
+        if (!active_kind_.empty()) {
+            out.push_back(sse_event("content_block_stop",
+                json({{"type", "content_block_stop"}, {"index", block_index_}}).dump()));
+            active_kind_.clear();
+        }
+        // stop_reason reflects the model's actual finish: "tool_use" when
+        // any tool calls were emitted (downstream SDKs pivot on this to feed
+        // tool_result back), else "end_turn".
+        const char * stop_reason = tool_calls_.empty() ? "end_turn" : "tool_use";
         json msg_delta = {
             {"type", "message_delta"},
-            {"delta", {{"stop_reason", "end_turn"}, {"stop_sequence", nullptr}}},
+            {"delta", {{"stop_reason", stop_reason}, {"stop_sequence", nullptr}}},
             {"usage", {{"output_tokens", completion_tokens}}}
         };
         out.push_back(sse_event("message_delta", msg_delta.dump()));

--- a/dflash/test/test_server_unit.cpp
+++ b/dflash/test/test_server_unit.cpp
@@ -343,6 +343,45 @@ static void test_emitter_tool_buffer_detection() {
     TEST_ASSERT(em.accumulated_text().find("<tool_call>") == std::string::npos);
 }
 
+static void test_emitter_anthropic_tool_use_blocks() {
+    // The Anthropic streaming tool-use branch used to be a no-op; the model
+    // would emit a <tool_call>...</tool_call> block, the parser would detect
+    // it, but no tool_use SSE event was sent. Verify the lifecycle now:
+    //   message_start, content_block_start (text), content_block_stop (text),
+    //   content_block_start (tool_use), content_block_delta (input_json_delta),
+    //   content_block_stop, message_delta(stop_reason="tool_use"), message_stop
+    json tools = json::array();
+    tools.push_back({
+        {"name", "get_weather"},
+        {"description", "weather"},
+        {"input_schema", {{"type", "object"},
+                          {"properties", {{"city", {{"type", "string"}}}}}}}
+    });
+    SseEmitter em(ApiFormat::ANTHROPIC, "req_id", "test-model", 10,
+                  tools, nullptr, /*thinking=*/false);
+    (void)em.emit_start();
+    // Feed Qwen3 XML tool call in chunks so the holdback buffer flushes;
+    // parser will detect <tool_call><function=NAME>...</tool_call>.
+    em.emit_token("<tool_call>\n<function=get_weather>\n");
+    em.emit_token("<parameter=city>\nTokyo\n</parameter>\n");
+    em.emit_token("</function>\n</tool_call>");
+    auto finish = em.emit_finish(20);
+    std::string s = concat(finish);
+
+    TEST_ASSERT(s.find("\"type\":\"tool_use\"")          != std::string::npos);
+    TEST_ASSERT(s.find("\"name\":\"get_weather\"")     != std::string::npos);
+    TEST_ASSERT(s.find("\"type\":\"input_json_delta\"") != std::string::npos);
+    TEST_ASSERT(s.find("Tokyo")                          != std::string::npos);
+    TEST_ASSERT(s.find("\"stop_reason\":\"tool_use\"")  != std::string::npos);
+    TEST_ASSERT(s.find("message_stop")                   != std::string::npos);
+    // Regression guard: at minimum text-block-stop + tool_use-block-stop.
+    size_t n_stop = 0; size_t pos = 0;
+    while ((pos = s.find("content_block_stop", pos)) != std::string::npos) {
+        n_stop++; pos++;
+    }
+    TEST_ASSERT(n_stop >= 2);
+}
+
 static void test_emitter_anthropic_structure() {
     // Verify Anthropic format emits proper event sequence.
     auto em = make_emitter(ApiFormat::ANTHROPIC, false);
@@ -911,6 +950,7 @@ int main() {
     RUN_TEST(test_emitter_reasoning_strips_leading_think_tag);
     RUN_TEST(test_emitter_content_only_no_thinking);
     RUN_TEST(test_emitter_tool_buffer_detection);
+    RUN_TEST(test_emitter_anthropic_tool_use_blocks);
     RUN_TEST(test_emitter_anthropic_structure);
     RUN_TEST(test_emitter_responses_structure);
     RUN_TEST(test_emitter_streaming_openai_has_done);


### PR DESCRIPTION
## Problem

The `/v1/messages` Anthropic endpoint in `dflash_server` sets `stop_reason="tool_use"` correctly when the parser detects a tool call, but the response payload never includes the `tool_use` content blocks. Two places are missing the serialization:

### 1. Non-streaming response builder (`http_server.cpp`)

The `ApiFormat::ANTHROPIC` arm of the response builder only emits `text` and (optionally) `thinking` blocks. Compare to the `OPENAI_CHAT` branch immediately above, which already serialises `emitter.tool_calls()` into `msg[\"tool_calls\"]`. The ANTHROPIC branch was missing the equivalent serialisation. Clients see:

\`\`\`json
{
  \"stop_reason\": \"tool_use\",
  \"content\": [{ \"type\": \"text\", \"text\": \"\" }]
}
\`\`\`

— a tool_use stop with no tool_use block.

### 2. Streaming finish (`sse_emitter.cpp`)

The `ApiFormat::ANTHROPIC` arm of the tool-call dispatch in `emit_finish` was literally a no-op stub:

\`\`\`cpp
case ApiFormat::ANTHROPIC:
    // Anthropic doesn't have streaming tool calls in the same way
    // Tool use blocks would be separate content blocks
    break;
\`\`\`

Clients (claude-agent-sdk, the official Anthropic SDKs) saw the initial text \`content_block_start\`, then a \`content_block_stop\`, then \`message_delta\` with \`stop_reason=end_turn\` — and **no \`tool_use\` events at all**. The model's tool call was silently dropped.

### 3. Trailing \`message_delta\` stop_reason

\`emit_finish\` hard-coded \`stop_reason=\"end_turn\"\` in the final \`message_delta\` regardless of tool calls.

## What this PR does

1. **Non-streaming** — adds tool_use block serialisation to the Anthropic branch, parsing \`tc.arguments\` JSON into the \`input\` object Anthropic expects (object, not string). Falls back to empty object on parse failure.

2. **Streaming** — implements the full Anthropic tool_use lifecycle in \`emit_finish\`:
   - \`content_block_stop\` on the open text/thinking block (if any)
   - For each tool_call:
     - \`content_block_start\` (\`type: tool_use\` with \`id\`/\`name\`/empty \`input\`)
     - \`content_block_delta\` (\`type: input_json_delta\` with arguments JSON)
     - \`content_block_stop\`
   - Tracks via \`active_kind_\` so the final \`emit_finish\` \`content_block_stop\` doesn't double-close.

3. **Trailing stop_reason** — uses \`\"tool_use\"\` when any tool calls were emitted, \`\"end_turn\"\` otherwise.

## Test plan

- [x] New \`test_emitter_anthropic_tool_use_blocks\` unit test exercising the full SSE lifecycle: asserts the byte stream contains a tool_use content block, an \`input_json_delta\` carrying the arguments JSON, and \`stop_reason=tool_use\` in \`message_delta\`. Regression guard on \`content_block_stop\` count (text-block-close + tool_use-block-close).
- [x] End-to-end smoke against \`/v1/messages\` with a get_weather tool: model emits Qwen3 XML, tool_parser converts it, response now contains a proper tool_use block (\`{\"type\":\"tool_use\",\"name\":\"get_weather\",\"input\":{\"city\":\"Tokyo\"}}\`).
- [x] All existing tests still pass (112 → 113 with the new one).

## Impact

Without this fix \`dflash_server\` can't serve any Anthropic-format tool-using client (claude-agent-sdk, Cline, Continue, etc.) — the tool call is generated by the model but lost in serialisation, leaving the client with an empty response and the wrong impression that the model declined to use tools.