### PR TITLE
feat(server): add stop_sequences support for all API formats

### DIFF
--- a/dflash/scripts/test_server_integration.py
+++ b/dflash/scripts/test_server_integration.py
@@ -593,3 +593,103 @@ class TestConsistency:
                 s_content += delta.get("content", "")
 
         assert ns_content.strip() == s_content.strip()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Stop sequences tests
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestStopSequences:
+    """Test stop sequence support across all API formats."""
+
+    def test_stop_string_chat_completions(self):
+        """OpenAI stop as a single string should truncate output."""
+        body = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Count from 1 to 20, one number per line."}],
+            "max_tokens": 200,
+            "temperature": 0,
+            "stop": "\n5",
+        }
+        r = post_json("/v1/chat/completions", body)
+        assert r.status_code == 200
+        data = r.json()
+        content = data["choices"][0]["message"]["content"]
+        # Should have numbers before 5 but stop at/before "5"
+        assert "1" in content
+        assert "\n5" not in content
+        assert data["choices"][0]["finish_reason"] == "stop"
+
+    def test_stop_array_chat_completions(self):
+        """OpenAI stop as array should stop at the first match."""
+        body = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "List fruits: apple, banana, cherry, date, elderberry"}],
+            "max_tokens": 100,
+            "temperature": 0,
+            "stop": ["cherry", "date"],
+        }
+        r = post_json("/v1/chat/completions", body)
+        assert r.status_code == 200
+        content = r.json()["choices"][0]["message"]["content"]
+        assert "cherry" not in content
+        assert "date" not in content
+
+    def test_stop_streaming_chat_completions(self):
+        """Stop sequences should work in streaming mode too."""
+        body = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Count from 1 to 20, one number per line."}],
+            "max_tokens": 200,
+            "temperature": 0,
+            "stop": ["\n5"],
+            "stream": True,
+        }
+        r = post_stream("/v1/chat/completions", body)
+        events = parse_sse_events(r)
+        content = ""
+        finish = None
+        for _, e in events:
+            if e and isinstance(e, dict) and e.get("choices"):
+                delta = e["choices"][0].get("delta", {})
+                content += delta.get("content", "")
+                fr = e["choices"][0].get("finish_reason")
+                if fr:
+                    finish = fr
+        assert "\n5" not in content
+        assert finish == "stop"
+
+    def test_stop_sequences_anthropic(self):
+        """Anthropic stop_sequences field should work."""
+        body = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Count from 1 to 20, one number per line."}],
+            "max_tokens": 200,
+            "temperature": 0,
+            "stop_sequences": ["\n5"],
+        }
+        r = post_json("/v1/messages", body)
+        assert r.status_code == 200
+        data = r.json()
+        # Find text content
+        text = ""
+        for block in data.get("content", []):
+            if block.get("type") == "text":
+                text += block.get("text", "")
+        assert "1" in text
+        assert "\n5" not in text
+
+    def test_stop_no_match(self):
+        """If stop sequences don't match, output should be normal."""
+        body = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Say hello."}],
+            "max_tokens": 20,
+            "temperature": 0,
+            "stop": ["ZZZZUNLIKELY"],
+        }
+        r = post_json("/v1/chat/completions", body)
+        assert r.status_code == 200
+        content = r.json()["choices"][0]["message"]["content"]
+        # Should produce some output since stop didn't match
+        assert len(content) > 0

--- a/dflash/src/server/http_server.cpp
+++ b/dflash/src/server/http_server.cpp
@@ -302,6 +302,30 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
             req.tools = body["tools"];
         }
 
+        // Stop sequences — OpenAI uses "stop" (string or array), Anthropic uses "stop_sequences" (array).
+        if (body.contains("stop")) {
+            auto & stop = body["stop"];
+            if (stop.is_string()) {
+                std::string s = stop.get<std::string>();
+                if (!s.empty()) req.stop_sequences.push_back(s);
+            } else if (stop.is_array()) {
+                for (const auto & item : stop) {
+                    if (item.is_string()) {
+                        std::string s = item.get<std::string>();
+                        if (!s.empty()) req.stop_sequences.push_back(s);
+                    }
+                }
+            }
+        }
+        if (body.contains("stop_sequences") && body["stop_sequences"].is_array()) {
+            for (const auto & item : body["stop_sequences"]) {
+                if (item.is_string()) {
+                    std::string s = item.get<std::string>();
+                    if (!s.empty()) req.stop_sequences.push_back(s);
+                }
+            }
+        }
+
         if (hr.path == "/v1/chat/completions") {
             req.format = ApiFormat::OPENAI_CHAT;
             req.response_id = generate_id("chatcmpl");
@@ -510,7 +534,8 @@ void HttpServer::worker_loop() {
         // Create SSE emitter for streaming state machine.
         SseEmitter emitter(req.format, req.response_id, req.model,
                            (int)req.prompt_tokens.size(), req.tools,
-                           &tool_memory_, req.started_in_thinking);
+                           &tool_memory_, req.started_in_thinking,
+                           req.stop_sequences);
 
         // Emit initial SSE events.
         if (req.stream) {
@@ -707,6 +732,8 @@ void HttpServer::worker_loop() {
                         return false;
                     }
                 }
+                // Stop generation if a stop sequence was hit.
+                if (emitter.stop_hit()) return false;
             }
             return true;
         };
@@ -800,6 +827,7 @@ void HttpServer::worker_loop() {
                 if (raw.size() >= 2 && raw[0] == '<' && raw[1] == '|') continue;
                 std::string text = tokenizer_.token_text(tok);
                 emitter.emit_token(text);
+                if (emitter.stop_hit()) break;
             }
             emitter.emit_finish((int)result.tokens.size());
 

--- a/dflash/src/server/http_server.h
+++ b/dflash/src/server/http_server.h
@@ -84,6 +84,8 @@ struct ParsedRequest {
     // Thinking/reasoning state
     bool                      thinking_enabled = true;
     bool                      started_in_thinking = false;
+    // Stop sequences (OpenAI "stop" + Anthropic "stop_sequences")
+    std::vector<std::string>  stop_sequences;
 };
 
 // ─── HTTP server ────────────────────────────────────────────────────────

--- a/dflash/src/server/sse_emitter.cpp
+++ b/dflash/src/server/sse_emitter.cpp
@@ -3,6 +3,7 @@
 #include "sse_emitter.h"
 #include "utf8_utils.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdio>
@@ -36,7 +37,8 @@ SseEmitter::SseEmitter(ApiFormat format,
                        int prompt_tokens,
                        const json & tools,
                        ToolMemory * tool_memory,
-                       bool started_in_thinking)
+                       bool started_in_thinking,
+                       const std::vector<std::string> & stop_sequences)
     : format_(format)
     , request_id_(request_id)
     , model_name_(model_name)
@@ -45,9 +47,15 @@ SseEmitter::SseEmitter(ApiFormat format,
     , tool_memory_(tool_memory)
     , mode_(started_in_thinking ? StreamMode::REASONING : StreamMode::CONTENT)
     , active_kind_(started_in_thinking ? "thinking" : "text")
+    , stop_sequences_(stop_sequences)
     , created_at_(unix_timestamp())
     , msg_item_id_(gen_item_id())
-{}
+{
+    // Compute stop holdback: max length of any stop sequence
+    for (const auto & s : stop_sequences_) {
+        if (s.size() > stop_holdback_) stop_holdback_ = s.size();
+    }
+}
 
 // ─── SSE formatting helpers ─────────────────────────────────────────────
 
@@ -165,11 +173,50 @@ std::vector<std::string> SseEmitter::emit_start() {
 // ─── emit_token ─────────────────────────────────────────────────────────
 
 std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
+    if (stop_hit_) return {};  // already stopped
+
     // Sanitize input to prevent json::dump() from throwing on invalid UTF-8.
     std::string piece = utf8_sanitize(raw_piece);
     std::vector<std::string> out;
     accumulated_raw_ += piece;
     window_ += piece;
+
+    // Stop sequence detection (not in tool_buffer mode, matching Python logic).
+    if (!stop_sequences_.empty() && mode_ != StreamMode::TOOL_BUFFER) {
+        size_t best = std::string::npos;
+        for (const auto & seq : stop_sequences_) {
+            size_t pos = window_.find(seq);
+            if (pos != std::string::npos && (best == std::string::npos || pos < best)) {
+                best = pos;
+            }
+        }
+        if (best != std::string::npos) {
+            // Emit everything before the stop sequence
+            std::string pre = window_.substr(0, best);
+            if (!pre.empty()) {
+                if (mode_ == StreamMode::REASONING) {
+                    reasoning_text_ += pre;
+                    switch (format_) {
+                    case ApiFormat::OPENAI_CHAT:
+                        out.push_back(format_openai_delta({{"reasoning_content", pre}}));
+                        break;
+                    case ApiFormat::ANTHROPIC:
+                        out.push_back(sse_event("content_block_delta",
+                            json({{"type", "content_block_delta"}, {"index", block_index_},
+                                  {"delta", {{"type", "thinking_delta"}, {"thinking", pre}}}}).dump()));
+                        break;
+                    default: break;
+                    }
+                } else {
+                    accumulated_content_ += pre;
+                    emit_content_delta(out, pre);
+                }
+            }
+            window_.clear();
+            stop_hit_ = true;
+            return out;
+        }
+    }
 
     // State machine loop — processes the window
     while (true) {
@@ -233,8 +280,8 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 continue;
             }
             // No close tag yet — emit safe prefix if window is large enough
-            if (window_.size() > HOLDBACK) {
-                size_t cut = utf8_safe_len(window_, window_.size() - HOLDBACK);
+            if (window_.size() > std::max(BASE_HOLDBACK, stop_holdback_)) {
+                size_t cut = utf8_safe_len(window_, window_.size() - std::max(BASE_HOLDBACK, stop_holdback_));
                 if (cut == 0) break;  // not enough complete chars yet
                 std::string safe = window_.substr(0, cut);
                 reasoning_text_ += safe;
@@ -305,8 +352,8 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
         }
 
         // No tags found — emit safe prefix
-        if (window_.size() > HOLDBACK) {
-            size_t cut = utf8_safe_len(window_, window_.size() - HOLDBACK);
+        if (window_.size() > std::max(BASE_HOLDBACK, stop_holdback_)) {
+            size_t cut = utf8_safe_len(window_, window_.size() - std::max(BASE_HOLDBACK, stop_holdback_));
             if (cut > 0) {
                 std::string safe = window_.substr(0, cut);
                 accumulated_content_ += safe;
@@ -528,7 +575,8 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens) {
         }
         // stop_reason reflects the model's actual finish: "tool_use" when
         // any tool calls were emitted (downstream SDKs pivot on this to feed
-        // tool_result back), else "end_turn".
+        // tool_result back), else "end_turn". Stop-sequence hits also report
+        // "end_turn" (Anthropic has no dedicated reason for that case).
         const char * stop_reason = tool_calls_.empty() ? "end_turn" : "tool_use";
         json msg_delta = {
             {"type", "message_delta"},
@@ -611,7 +659,8 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens) {
 }
 
 std::string SseEmitter::finish_reason() const {
-    return tool_calls_.empty() ? "stop" : "tool_calls";
+    if (!tool_calls_.empty()) return "tool_calls";
+    return "stop";
 }
 
 }  // namespace dflash::common

--- a/dflash/src/server/sse_emitter.h
+++ b/dflash/src/server/sse_emitter.h
@@ -40,7 +40,8 @@ public:
                int prompt_tokens,
                const json & tools,
                ToolMemory * tool_memory,
-               bool started_in_thinking);
+               bool started_in_thinking,
+               const std::vector<std::string> & stop_sequences = {});
 
     // Emit the initial SSE events (role delta, message_start, etc.)
     // Returns the formatted SSE strings to send.
@@ -55,6 +56,9 @@ public:
 
     // Get the finish_reason for non-streaming responses.
     std::string finish_reason() const;
+
+    // Check if a stop sequence was hit (signals caller to stop generation).
+    bool stop_hit() const { return stop_hit_; }
 
     // Get accumulated content (for non-streaming).
     const std::string & accumulated_text() const { return accumulated_content_; }
@@ -100,12 +104,17 @@ private:
     // Strip leading <think> tag from reasoning (ds4 pattern).
     bool         checked_think_prefix_ = false;
 
+    // Stop sequences support
+    std::vector<std::string> stop_sequences_;
+    size_t       stop_holdback_ = 0;  // max length of any stop sequence
+    bool         stop_hit_ = false;
+
     int64_t      created_at_;
 
     // Responses API IDs
     std::string  msg_item_id_;
 
-    static constexpr size_t HOLDBACK = 12;  // max(len("<tool_call>"), len("</think>"), len("<think>"))
+    static constexpr size_t BASE_HOLDBACK = 12;  // max(len("<tool_call>"), len("</think>"), len("<think>"))
 };
 
 }  // namespace dflash::common

--- a/dflash/test/test_server_unit.cpp
+++ b/dflash/test/test_server_unit.cpp
@@ -464,6 +464,142 @@ static void test_emitter_anthropic_thinking_blocks() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
+// Stop sequences tests
+// ═══════════════════════════════════════════════════════════════════════
+
+static SseEmitter make_emitter_with_stops(ApiFormat fmt, bool thinking,
+                                           const std::vector<std::string> & stops) {
+    return SseEmitter(fmt, "test_id_001", "test-model", 10,
+                      json::array(), nullptr, thinking, stops);
+}
+
+static void test_stop_sequence_basic() {
+    // Stop sequence should truncate content at the match point.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {"STOP"});
+    em.emit_token("Hello ");
+    em.emit_token("world ");
+    em.emit_token("STOP");
+    em.emit_token(" more text");  // should be ignored
+
+    TEST_ASSERT(em.stop_hit());
+    em.emit_finish(5);
+    // Content should NOT contain "STOP" or "more text"
+    TEST_ASSERT(em.accumulated_text().find("Hello") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("STOP") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("more") == std::string::npos);
+}
+
+static void test_stop_sequence_mid_token() {
+    // Stop sequence may span multiple tokens due to holdback buffering.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {"END"});
+    em.emit_token("Go ");
+    em.emit_token("to the E");
+    em.emit_token("ND now");
+
+    TEST_ASSERT(em.stop_hit());
+    em.emit_finish(5);
+    TEST_ASSERT(em.accumulated_text().find("Go") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("END") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("now") == std::string::npos);
+}
+
+static void test_stop_sequence_multiple() {
+    // Multiple stop sequences — earliest match wins.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {"AAA", "BB"});
+    em.emit_token("xBBy");
+
+    TEST_ASSERT(em.stop_hit());
+    em.emit_finish(2);
+    TEST_ASSERT(em.accumulated_text() == "x");
+}
+
+static void test_stop_sequence_no_match() {
+    // No stop sequence hit — normal operation.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {"NOMATCH"});
+    em.emit_token("Hello world this is a long text");
+    em.emit_finish(10);
+
+    TEST_ASSERT(!em.stop_hit());
+    TEST_ASSERT(em.accumulated_text().find("Hello") != std::string::npos);
+}
+
+static void test_stop_sequence_empty_list() {
+    // Empty stop list — no effect.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {});
+    em.emit_token("Hello STOP world");
+    em.emit_finish(5);
+
+    TEST_ASSERT(!em.stop_hit());
+    TEST_ASSERT(em.accumulated_text().find("STOP") != std::string::npos);
+}
+
+static void test_stop_sequence_finish_reason() {
+    // finish_reason should be "stop" when stop sequence hit.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {"END"});
+    em.emit_token("content END more");
+
+    TEST_ASSERT(em.stop_hit());
+    em.emit_finish(3);
+    TEST_ASSERT(em.finish_reason() == "stop");
+}
+
+static void test_stop_sequence_streaming_output() {
+    // Streaming: verify the [DONE] is still emitted after stop.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false, {"HALT"});
+    auto start = em.emit_start();
+    em.emit_token("some text HALT rest");
+
+    TEST_ASSERT(em.stop_hit());
+    auto finish = em.emit_finish(5);
+    std::string all = concat(finish);
+    TEST_ASSERT(all.find("[DONE]") != std::string::npos);
+    TEST_ASSERT(all.find("\"finish_reason\":\"stop\"") != std::string::npos);
+}
+
+static void test_stop_sequence_anthropic_format() {
+    // Anthropic format should emit end_turn stop_reason.
+    auto em = make_emitter_with_stops(ApiFormat::ANTHROPIC, false, {"DONE"});
+    em.emit_start();
+    em.emit_token("This is content DONE rest");
+
+    TEST_ASSERT(em.stop_hit());
+    auto finish = em.emit_finish(5);
+    std::string all = concat(finish);
+    TEST_ASSERT(all.find("end_turn") != std::string::npos);
+    TEST_ASSERT(all.find("message_stop") != std::string::npos);
+}
+
+static void test_stop_sequence_in_reasoning_mode() {
+    // Stop sequence in reasoning mode should still stop.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, true, {"CUTOFF"});
+    em.emit_token("Thinking deeply about this CUTOFF answer");
+
+    TEST_ASSERT(em.stop_hit());
+    em.emit_finish(5);
+    TEST_ASSERT(em.reasoning_text().find("Thinking") != std::string::npos);
+    TEST_ASSERT(em.reasoning_text().find("CUTOFF") == std::string::npos);
+}
+
+static void test_stop_sequence_holdback_extends() {
+    // With a long stop sequence, holdback buffer should extend to prevent
+    // emitting text that's part of a stop sequence.
+    auto em = make_emitter_with_stops(ApiFormat::OPENAI_CHAT, false,
+                                       {"LONGSTOPSEQUENCE"});
+    // Feed text token by token — the holdback should prevent premature emission
+    em.emit_token("prefix ");
+    em.emit_token("LONG");
+    em.emit_token("STOP");
+    em.emit_token("SEQUENCE");
+    em.emit_token(" suffix");
+
+    TEST_ASSERT(em.stop_hit());
+    em.emit_finish(10);
+    TEST_ASSERT(em.accumulated_text().find("prefix") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("LONGSTOPSEQUENCE") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("suffix") == std::string::npos);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
 // Prefix cache hash tests (model-free)
 // ═══════════════════════════════════════════════════════════════════════
 
@@ -956,6 +1092,18 @@ int main() {
     RUN_TEST(test_emitter_streaming_openai_has_done);
     RUN_TEST(test_emitter_nonstreaming_accumulates);
     RUN_TEST(test_emitter_anthropic_thinking_blocks);
+
+    std::fprintf(stderr, "\n── Stop sequences ──\n");
+    RUN_TEST(test_stop_sequence_basic);
+    RUN_TEST(test_stop_sequence_mid_token);
+    RUN_TEST(test_stop_sequence_multiple);
+    RUN_TEST(test_stop_sequence_no_match);
+    RUN_TEST(test_stop_sequence_empty_list);
+    RUN_TEST(test_stop_sequence_finish_reason);
+    RUN_TEST(test_stop_sequence_streaming_output);
+    RUN_TEST(test_stop_sequence_anthropic_format);
+    RUN_TEST(test_stop_sequence_in_reasoning_mode);
+    RUN_TEST(test_stop_sequence_holdback_extends);
 
     std::fprintf(stderr, "\n── Prefix cache (hash) ──\n");
     RUN_TEST(test_hash_prefix_deterministic);


### PR DESCRIPTION
Implement stop sequence detection in the SSE emitter streaming state machine, matching the Python server's behavior. Works across all three API formats (OpenAI Chat, Anthropic Messages, Responses).

- Parse 'stop' (string or array) from OpenAI Chat/Responses requests
- Parse 'stop_sequences' (array) from Anthropic Messages requests
- SseEmitter detects stop sequences in the holdback window buffer
- Dynamically extends holdback to max(BASE_HOLDBACK, longest_stop_seq)
- Signals stop_hit() to on_token callback to stop generation immediately
- Non-streaming path also breaks on stop_hit after feeding tokens
- 10 unit tests + 5 HTTP integration tests