### PR TITLE
fix(backend_factory): gemma4 path uses draft_device.gpu

### DIFF
--- a/dflash/src/common/backend_factory.cpp
+++ b/dflash/src/common/backend_factory.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
         Gemma4BackendConfig gcfg;
         gcfg.model_path    = args.model_path;
         gcfg.draft_path    = args.draft_path;
-        gcfg.draft_gpu     = args.draft_gpu;
+        gcfg.draft_gpu     = args.draft_device.gpu;
         gcfg.draft_ctx_max = args.draft_ctx_max;
         gcfg.device        = args.device;
         gcfg.stream_fd     = args.stream_fd;


### PR DESCRIPTION
## Summary

- Unbreak main build: `dflash/src/common/backend_factory.cpp:93` referenced removed `BackendArgs::draft_gpu` field
- One-character fix: `args.draft_gpu` → `args.draft_device.gpu`

## Root cause

Merge-order race between two recently-landed PRs:

| Commit | Effect |
|--------|--------|
| `1bfb720` (PR #232, gemma4) | Added `args.draft_gpu` reference in gemma4 branch of `create_backend()` |
| `4aaa065` (PR #236, placement refactor) | Removed `BackendArgs::draft_gpu`, replaced with `BackendArgs::draft_device` — only updated qwen35 caller |

Both PRs passed CI individually. PR #236 merged first, then PR #232 merged after with stale code referencing the deleted field. CI on subsequent PRs (#252) now fails at `dflash_common` compile.

## Test plan

- [ ] PR #252 CI build re-runs and passes (no other changes needed there)
- [ ] Local CUDA / HIP build of `dflash_common`

🧙 Built with [WOZCODE](https://wozcode.com)