### PR TITLE
feat(server): use native qwen35 PFlash compression

### DIFF
--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -284,32 +284,15 @@ bool Qwen35Backend::snapshot_adopt(int slot, ggml_context * ctx,
 
 // ── Compress (pflash) ───────────────────────────────────────────────────
 
-bool Qwen35Backend::handle_compress(const std::string & line, const DaemonIO & io) {
-    // Check for "nopark" suffix (must be a separate token, not part of a path)
-    bool skip_park = (line.size() >= 16 &&
-                      line.compare(line.size() - 7, 7, " nopark") == 0);
-
-    // Parse: "compress <path> <keep_x1000> <drafter_gguf> [nopark]"
-    char ppath[1024];
-    int  keep_x1000 = 0;
-    char drafter_path[1024] = {0};
-    const int n = std::sscanf(line.c_str() + 9, "%1023s %d %1023s",
-                               ppath, &keep_x1000, drafter_path);
-    if (n < 2) {
-        std::fprintf(stderr, "[compress] bad args\n");
-        io.emit(-1);
-        return false;
-    }
-
-    const char * dpath = (n >= 3 && drafter_path[0])
-        ? drafter_path
-        : "/opt/lucebox/models/drafter/Qwen3-0.6B-BF16.gguf";
+ModelBackend::CompressResult Qwen35Backend::compress(const CompressRequest & req) {
+    CompressResult result;
+    if (req.input_ids.empty() || req.drafter_path.empty()) return result;
 
     // Park target+draft to free VRAM for the drafter (unless skip_park).
     // Also destroy the main target step graph allocator to release its CUDA buffer.
     const bool was_target_parked = target_parked_;
     const bool was_draft_parked  = draft_parked_;
-    if (!skip_park) {
+    if (!req.skip_park) {
         step_graph_destroy(sg_);
         if (!target_parked_) park("target");
         if (!draft_parked_)  park("draft");
@@ -328,45 +311,70 @@ bool Qwen35Backend::handle_compress(const std::string & line, const DaemonIO & i
     // creates the backend + loads weights; subsequent calls reuse them.
     if (!drafter_loaded_) {
         // drafter_ctx_.backend == nullptr → load_drafter creates its own
-        std::fprintf(stderr, "[compress] loading drafter from %s ...\n", dpath);
-        if (!load_drafter(dpath, /*gpu_layers=*/999, drafter_ctx_)) {
+        std::fprintf(stderr, "[compress] loading drafter from %s ...\n",
+                     req.drafter_path.c_str());
+        if (!load_drafter(req.drafter_path, /*gpu_layers=*/999, drafter_ctx_)) {
             std::fprintf(stderr, "[compress] drafter init failed: %s\n",
                          dflash27b_last_error());
-            io.emit(-1);
-            if (!skip_park) {
+            if (!req.skip_park) {
                 if (!was_target_parked) unpark("target");
                 if (!was_draft_parked)  unpark("draft");
             }
-            return false;
+            return result;
         }
         drafter_loaded_ = true;
         std::fprintf(stderr, "[compress] drafter ready\n");
     }
 
-    std::vector<int32_t> tokens = read_int32_file(ppath);
-    bool ok = false;
-    if (!tokens.empty()) {
-        const float keep = (float)keep_x1000 / 1000.0f;
-        auto compressed = drafter_score_and_compress(drafter_ctx_, tokens, keep);
-        ok = !compressed.empty();
-        if (ok) {
-            std::fprintf(stderr, "[compress] %zu -> %zu tokens\n",
-                          tokens.size(), compressed.size());
-            for (int32_t t : compressed) io.emit(t);
-        }
+    result.compressed_ids = drafter_score_and_compress(
+        drafter_ctx_, req.input_ids, req.keep_ratio);
+    result.ok = !result.compressed_ids.empty();
+    if (result.ok) {
+        std::fprintf(stderr, "[compress] %zu -> %zu tokens\n",
+                     req.input_ids.size(), result.compressed_ids.size());
     }
-    io.emit(-1);
 
     // Keep drafter loaded (own backend + weights persist), matching test_dflash.
     // ~1.4 GB stays resident but avoids reload cost on subsequent compresses.
 
     // Restore park state
-    if (!skip_park) {
+    if (!req.skip_park) {
         if (!was_target_parked) unpark("target");
         if (!was_draft_parked)  unpark("draft");
     }
 
-    return ok;
+    return result;
+}
+
+bool Qwen35Backend::handle_compress(const std::string & line, const DaemonIO & io) {
+    // Check for "nopark" suffix (must be a separate token, not part of a path)
+    bool skip_park = (line.size() >= 16 &&
+                      line.compare(line.size() - 7, 7, " nopark") == 0);
+
+    // Parse: "compress <path> <keep_x1000> <drafter_gguf> [nopark]"
+    char ppath[1024];
+    int  keep_x1000 = 0;
+    char drafter_path[1024] = {0};
+    const int n = std::sscanf(line.c_str() + 9, "%1023s %d %1023s",
+                               ppath, &keep_x1000, drafter_path);
+    if (n < 2) {
+        std::fprintf(stderr, "[compress] bad args\n");
+        io.emit(-1);
+        return false;
+    }
+
+    CompressRequest req;
+    req.input_ids = read_int32_file(ppath);
+    req.keep_ratio = (float)keep_x1000 / 1000.0f;
+    req.drafter_path = (n >= 3 && drafter_path[0])
+        ? drafter_path
+        : "/opt/lucebox/models/drafter/Qwen3-0.6B-BF16.gguf";
+    req.skip_park = skip_park;
+
+    CompressResult result = compress(req);
+    for (int32_t t : result.compressed_ids) io.emit(t);
+    io.emit(-1);
+    return result.ok;
 }
 
 void Qwen35Backend::free_drafter() {

--- a/dflash/src/qwen35/qwen35_backend.h
+++ b/dflash/src/qwen35/qwen35_backend.h
@@ -97,6 +97,7 @@ public:
                         ggml_backend_buffer_t buf, int cur_pos,
                         int32_t last_tok = -1) override;
 
+    CompressResult compress(const CompressRequest & req) override;
     bool handle_compress(const std::string & line,
                          const DaemonIO & io) override;
     void free_drafter() override;


### PR DESCRIPTION
## Summary

This PR makes the Qwen35 C++ server use the native typed PFlash compression path.

The C++ HTTP server already has PFlash options and calls `backend_.compress(...)`, but Qwen35 did not override that typed API yet. As a result, Qwen35 requests still went through the generic fallback, which wrote drafter-token IDs to a temporary file and rebuilt the old string-based `compress ...` daemon command before entering the existing Qwen35 compression logic.

After this change, Qwen35 handles C++ server PFlash requests directly from in-memory token IDs, while keeping the legacy stdin daemon command compatible.

## Changes

- Add `Qwen35Backend::compress(const CompressRequest & req)`.
  - Uses the typed in-process request from the C++ HTTP server.
  - Accepts drafter-tokenized `input_ids` directly instead of requiring a temporary token file.
  - Lazy-loads and reuses the Qwen3 PFlash drafter through the existing Qwen35 drafter lifecycle.
  - Preserves the current Qwen35 park/unpark policy for target and draft state.
  - Destroys the target step graph before parking so its compute buffer can be released before drafter loading/compression.
  - Returns compressed token IDs through `CompressResult`, matching the typed server path.

- Keep `Qwen35Backend::handle_compress(...)` for the existing daemon protocol.
  - It still parses the legacy `compress <path> <keep_x1000> <drafter_gguf> [nopark]` command.
  - It now converts that command into a `CompressRequest` and delegates to the typed `compress(...)` implementation.
  - Existing stdin daemon users keep the same command behavior and sentinel output.

- No user-facing PFlash flag changes.
  - Existing server flags such as `--prefill-compression`, `--prefill-keep-ratio`, `--prefill-drafter`, and `--prefill-skip-park` stay unchanged.
  - This PR only removes the unnecessary temp-file/string-command detour for the Qwen35 C++ server path.

## Notes

- Smoke-tested on HIP/gfx906 and CUDA/sm61 with a qwen35-family 21B IQ1 target model and Qwen3-0.6B BF16 drafter. Both paths returned valid completions; the HIP log also showed `818 -> 146 -> 146` compression evidence.
- This PR keeps the change scoped to Qwen35 PFlash native compression. It does not add PFlash drafter placement or PFlash draft/target split support; mixed-backend placement, PFlash drafter placement, and target layer split work remain separate PRs.
