### PR TITLE
fix(hip): map Gemma4 BSA runtime calls

### DIFF
--- a/dflash/src/common/gpu_runtime_compat.h
+++ b/dflash/src/common/gpu_runtime_compat.h
@@ -20,6 +20,7 @@
 #define cudaGetErrorString hipGetErrorString
 #define cudaGetLastError hipGetLastError
 #define cudaMalloc hipMalloc
+#define cudaMemcpy2D hipMemcpy2D
 #define cudaMemcpy2DAsync hipMemcpy2DAsync
 #define cudaMemcpyAsync hipMemcpyAsync
 #define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice

--- a/dflash/src/gemma4/gemma4_graph.cpp
+++ b/dflash/src/gemma4/gemma4_graph.cpp
@@ -16,6 +16,7 @@
 //   - Logit softcapping: tanh(logits/cap)*cap
 
 #include "gemma4_internal.h"
+#include "common/gpu_runtime_compat.h"
 #include "dflash27b.h"
 #include "flashprefill.h"
 


### PR DESCRIPTION
## Summary

This PR fixes a HIP build failure in the Gemma4 BSA prefill path.

After the Gemma4 backend landed, HIP builds can reach `gemma4_graph.cpp` and fail because that path uses CUDA runtime names directly, including `cudaMemcpy2D` and `cudaDeviceSynchronize`. Most of the project already routes these CUDA-style names through `gpu_runtime_compat.h`, but Gemma4 did not include that compatibility header and the header did not map the synchronous `cudaMemcpy2D` call yet.

## Changes

- Add `cudaMemcpy2D -> hipMemcpy2D` to `dflash/src/common/gpu_runtime_compat.h`.
- Include `common/gpu_runtime_compat.h` from `dflash/src/gemma4/gemma4_graph.cpp` so the Gemma4 BSA path uses the same CUDA/HIP runtime compatibility layer as the rest of the C++ backend code.

## Notes

- Verified on ROCm 6.3.3 / gfx906 with an initialized submodule checkout: HIP `dflash_server` builds successfully, and a Gemma4 E4B Q4 smoke run loads on `hip:0` and returns a `/v1/chat/completions` response.
- This removes the Gemma4 HIP build blocker hit while validating the rebased mixed-backend work.
