### PR TITLE
fix(server): normalize Codex Responses tool-call follow-ups

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -696,6 +696,7 @@ if(DFLASH27B_TESTS)
 
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_unit.cpp")
         add_executable(test_server_unit test/test_server_unit.cpp)
+        target_sources(test_server_unit PRIVATE src/server/http_server.cpp)
         target_include_directories(test_server_unit PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
         if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
             target_compile_definitions(test_server_unit PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)

--- a/dflash/src/server/http_server.cpp
+++ b/dflash/src/server/http_server.cpp
@@ -34,6 +34,125 @@ static std::string generate_id(const char * prefix) {
     return buf;
 }
 
+json parse_responses_arguments(const json & item) {
+    if (!item.contains("arguments")) return json::object();
+    const auto & arguments = item["arguments"];
+    if (arguments.is_object()) return arguments;
+    if (arguments.is_string()) {
+        try {
+            return json::parse(arguments.get<std::string>());
+        } catch (const std::exception &) {
+            return json::object();
+        }
+    }
+    return json::object();
+}
+
+std::string render_tool_call_xml(const std::string & name, const json & arguments) {
+    std::string out = "<function=" + name + ">\n";
+    if (arguments.is_object()) {
+        for (const auto & [key, value] : arguments.items()) {
+            out += "<parameter=" + key + ">\n";
+            out += value.is_string() ? value.get<std::string>() : value.dump();
+            out += "\n</parameter>\n";
+        }
+    }
+    out += "</function>\n";
+    return out;
+}
+
+std::vector<ChatMessage> normalize_chat_messages(
+    const json & messages,
+    ApiFormat format,
+    ToolMemory & tool_memory) {
+    std::vector<ChatMessage> chat_msgs;
+    std::vector<std::string> system_parts;
+
+    if (messages.is_array()) {
+        for (const auto & m : messages) {
+            if (format == ApiFormat::RESPONSES && m.is_object()) {
+                std::string item_type = m.value("type", "message");
+                if (item_type == "function_call") {
+                    std::string call_id = m.value("call_id", m.value("id", ""));
+                    std::string raw;
+                    if (!call_id.empty()) {
+                        raw = tool_memory.lookup({call_id});
+                    }
+                    if (raw.empty()) {
+                        raw = render_tool_call_xml(m.value("name", ""),
+                                                   parse_responses_arguments(m));
+                    }
+                    chat_msgs.push_back({"assistant", raw});
+                    continue;
+                }
+                if (item_type == "function_call_output") {
+                    std::string output;
+                    if (m.contains("output") && m["output"].is_string()) {
+                        output = m["output"].get<std::string>();
+                    } else if (m.contains("output")) {
+                        output = m["output"].dump();
+                    }
+                    chat_msgs.push_back({"tool", output,
+                                         m.value("call_id", m.value("id", ""))});
+                    continue;
+                }
+            }
+
+            ChatMessage cm;
+            cm.role = m.value("role", "user");
+
+            bool replayed = false;
+            if (cm.role == "assistant" && m.contains("tool_calls") &&
+                m["tool_calls"].is_array() && !m["tool_calls"].empty()) {
+                std::vector<std::string> call_ids;
+                for (const auto & tc : m["tool_calls"]) {
+                    std::string id = tc.value("id", "");
+                    if (!id.empty()) call_ids.push_back(id);
+                }
+                std::string raw = tool_memory.lookup(call_ids);
+                if (!raw.empty()) {
+                    cm.content = raw;
+                    replayed = true;
+                }
+            }
+
+            if (!replayed) {
+                if (m.contains("content") && m["content"].is_string()) {
+                    cm.content = m["content"].get<std::string>();
+                } else if (m.contains("content") && m["content"].is_array()) {
+                    for (const auto & part : m["content"]) {
+                        std::string ptype = part.value("type", "");
+                        if (ptype == "text" || ptype == "input_text" ||
+                            ptype == "output_text") {
+                            cm.content += part.value("text", "");
+                        }
+                    }
+                }
+            }
+
+            if (format == ApiFormat::RESPONSES &&
+                (cm.role == "system" || cm.role == "developer")) {
+                system_parts.push_back(cm.content);
+            } else {
+                chat_msgs.push_back(std::move(cm));
+            }
+        }
+    } else if (messages.is_string()) {
+        chat_msgs.push_back({"user", messages.get<std::string>()});
+    }
+
+    if (!system_parts.empty()) {
+        std::string merged_system;
+        for (size_t i = 0; i < system_parts.size(); i++) {
+            if (i) merged_system += "\n\n";
+            merged_system += system_parts[i];
+        }
+        chat_msgs.insert(chat_msgs.begin(), {"system", merged_system});
+    }
+
+    return chat_msgs;
+}
+
 // ─── HttpServer ─────────────────────────────────────────────────────────
 
 HttpServer::HttpServer(ModelBackend & backend,
@@ -386,48 +505,8 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         }
 
         // Render messages to text and tokenize.
-        std::vector<ChatMessage> chat_msgs;
-        if (req.messages.is_array()) {
-            for (const auto & m : req.messages) {
-                ChatMessage cm;
-                cm.role = m.value("role", "user");
-
-                // Check for tool memory replay on assistant messages with tool_calls.
-                bool replayed = false;
-                if (cm.role == "assistant" && m.contains("tool_calls") &&
-                    m["tool_calls"].is_array() && !m["tool_calls"].empty()) {
-                    // Extract call IDs for tool memory lookup.
-                    std::vector<std::string> call_ids;
-                    for (const auto & tc : m["tool_calls"]) {
-                        std::string id = tc.value("id", "");
-                        if (!id.empty()) call_ids.push_back(id);
-                    }
-                    std::string raw = tool_memory_.lookup(call_ids);
-                    if (!raw.empty()) {
-                        cm.content = raw;
-                        replayed = true;
-                    }
-                }
-
-                if (!replayed) {
-                    if (m.contains("content") && m["content"].is_string()) {
-                        cm.content = m["content"].get<std::string>();
-                    } else if (m.contains("content") && m["content"].is_array()) {
-                        // Multi-part content (text parts only for now).
-                        for (const auto & part : m["content"]) {
-                            std::string ptype = part.value("type", "");
-                            if (ptype == "text" || ptype == "input_text") {
-                                cm.content += part.value("text", "");
-                            }
-                        }
-                    }
-                }
-                chat_msgs.push_back(std::move(cm));
-            }
-        } else if (req.messages.is_string()) {
-            // Simple string input (Responses API shorthand).
-            chat_msgs.push_back({"user", req.messages.get<std::string>()});
-        }
+        std::vector<ChatMessage> chat_msgs =
+            normalize_chat_messages(req.messages, req.format, tool_memory_);
 
         // Determine thinking mode BEFORE rendering so the template can inject
         // the <think>\n\n</think>\n\n block when thinking is disabled.

--- a/dflash/src/server/sse_emitter.cpp
+++ b/dflash/src/server/sse_emitter.cpp
@@ -13,6 +13,8 @@ namespace dflash::common {
 static const char THINK_OPEN[]  = "<think>";
 static const char THINK_CLOSE[] = "</think>";
 static const char TOOL_OPEN[]   = "<tool_call>";
+static const char FUNCTION_OPEN[] = "<function=";
+static const char TOOL_CODE_OPEN[] = "<tool_code>";
 static constexpr size_t THINK_OPEN_LEN  = 7;
 static constexpr size_t THINK_CLOSE_LEN = 8;
 static constexpr size_t TOOL_OPEN_LEN   = 11;
@@ -314,16 +316,20 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
         }
 
         // mode_ == StreamMode::CONTENT
-        // Look for <think>, </think>, or <tool_call>
+        // Look for <think>, </think>, or any supported tool-call opener.
         size_t think_idx = window_.find(THINK_OPEN);
         size_t think_close_idx = window_.find(THINK_CLOSE);
         size_t tool_idx = window_.find(TOOL_OPEN);
+        size_t function_idx = window_.find(FUNCTION_OPEN);
+        size_t tool_code_idx = window_.find(TOOL_CODE_OPEN);
 
-        struct Hit { size_t pos; int type; };  // type: 0=think, 1=think_close, 2=tool
+        struct Hit { size_t pos; int type; };  // type: 0=think, 1=think_close, 2=tool-ish
         std::vector<Hit> hits;
         if (think_idx != std::string::npos)       hits.push_back({think_idx, 0});
         if (think_close_idx != std::string::npos) hits.push_back({think_close_idx, 1});
         if (tool_idx != std::string::npos)        hits.push_back({tool_idx, 2});
+        if (function_idx != std::string::npos)    hits.push_back({function_idx, 2});
+        if (tool_code_idx != std::string::npos)   hits.push_back({tool_code_idx, 2});
 
         if (!hits.empty()) {
             std::sort(hits.begin(), hits.end(),
@@ -343,7 +349,8 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 // </think> in content — just skip it
                 window_ = window_.substr(h.pos + THINK_CLOSE_LEN);
             } else {
-                // <tool_call>
+                // Tool-call shapes can start with <tool_call>, bare
+                // <function=...>, or <tool_code> JSON wrappers.
                 tool_buffer_ = window_.substr(h.pos);
                 window_.clear();
                 mode_ = StreamMode::TOOL_BUFFER;

--- a/dflash/test/test_server_unit.cpp
+++ b/dflash/test/test_server_unit.cpp
@@ -31,6 +31,13 @@
 using json = nlohmann::json;
 using namespace dflash::common;
 
+namespace dflash::common {
+std::vector<ChatMessage> normalize_chat_messages(
+    const json & messages,
+    ApiFormat format,
+    ToolMemory & tool_memory);
+}
+
 // ─── Test framework (ds4 style) ────────────────────────────────────────
 
 static int test_failures = 0;
@@ -423,6 +430,35 @@ static void test_emitter_responses_structure() {
     TEST_ASSERT(finish_str.find("response.completed") != std::string::npos);
 }
 
+static void test_emitter_responses_bare_function_tool_call() {
+    json tools = json::array({{
+        {"type", "function"},
+        {"name", "exec_command"},
+        {"description", "Run a command"},
+        {"parameters", {
+            {"type", "object"},
+            {"properties", {{"cmd", {{"type", "string"}}}}},
+            {"required", json::array({"cmd"})}
+        }}
+    }});
+    SseEmitter em(ApiFormat::RESPONSES, "resp_test_001", "test-model", 10,
+                  tools, nullptr, false);
+    em.emit_start();
+    em.emit_token("\n\n<function=exec_command>\n<parameter=cmd>\ngit pull\n");
+    em.emit_token("</parameter>\n</function>\n");
+    auto finish = em.emit_finish(8);
+    std::string finish_str = concat(finish);
+
+    TEST_ASSERT(!em.tool_calls().empty());
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "exec_command");
+        auto args = json::parse(em.tool_calls()[0].arguments);
+        TEST_ASSERT(args["cmd"] == "git pull");
+    }
+    TEST_ASSERT(finish_str.find("\"type\":\"function_call\"") != std::string::npos);
+    TEST_ASSERT(finish_str.find("response.function_call_arguments.done") != std::string::npos);
+}
+
 static void test_emitter_streaming_openai_has_done() {
     auto em = make_emitter(ApiFormat::OPENAI_CHAT, false);
     em.emit_start();
@@ -808,6 +844,60 @@ static void test_jinja_render_bad_tools_json_throws() {
     TEST_ASSERT(threw);
 }
 
+static void test_normalize_responses_tool_followup_messages() {
+    ToolMemory tool_memory;
+    const std::string call_id = "call_exec_001";
+    const std::string raw_tool_call =
+        "\n\n<function=exec_command>\n"
+        "<parameter=cmd>\n"
+        "git fetch origin && git status\n"
+        "</parameter>\n"
+        "</function>\n";
+    tool_memory.remember({call_id}, raw_tool_call);
+
+    json messages = json::array({
+        {
+            {"role", "developer"},
+            {"content", json::array({{
+                {"type", "input_text"},
+                {"text", "Developer rules"}
+            }})}
+        },
+        {
+            {"role", "user"},
+            {"content", json::array({{
+                {"type", "input_text"},
+                {"text", "fetch latest code"}
+            }})}
+        },
+        {
+            {"type", "function_call"},
+            {"call_id", call_id},
+            {"name", "exec_command"},
+            {"arguments", R"({"cmd":"git fetch origin && git status"})"}
+        },
+        {
+            {"type", "function_call_output"},
+            {"call_id", call_id},
+            {"output", "Process exited with code 0"}
+        }
+    });
+
+    auto chat_msgs = normalize_chat_messages(messages, ApiFormat::RESPONSES, tool_memory);
+    TEST_ASSERT(chat_msgs.size() == 4);
+    if (chat_msgs.size() == 4) {
+        TEST_ASSERT(chat_msgs[0].role == "system");
+        TEST_ASSERT(chat_msgs[0].content == "Developer rules");
+        TEST_ASSERT(chat_msgs[1].role == "user");
+        TEST_ASSERT(chat_msgs[1].content == "fetch latest code");
+        TEST_ASSERT(chat_msgs[2].role == "assistant");
+        TEST_ASSERT(chat_msgs[2].content == raw_tool_call);
+        TEST_ASSERT(chat_msgs[3].role == "tool");
+        TEST_ASSERT(chat_msgs[3].tool_call_id == call_id);
+        TEST_ASSERT(chat_msgs[3].content == "Process exited with code 0");
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Disk Prefix Cache Tests
 // ═══════════════════════════════════════════════════════════════════════
@@ -1185,6 +1275,7 @@ int main() {
     RUN_TEST(test_emitter_anthropic_tool_use_blocks);
     RUN_TEST(test_emitter_anthropic_structure);
     RUN_TEST(test_emitter_responses_structure);
+    RUN_TEST(test_emitter_responses_bare_function_tool_call);
     RUN_TEST(test_emitter_streaming_openai_has_done);
     RUN_TEST(test_emitter_nonstreaming_accumulates);
     RUN_TEST(test_emitter_anthropic_thinking_blocks);
@@ -1224,6 +1315,7 @@ int main() {
     RUN_TEST(test_jinja_render_bos_eos_threaded);
     RUN_TEST(test_jinja_render_empty_template_throws);
     RUN_TEST(test_jinja_render_bad_tools_json_throws);
+    RUN_TEST(test_normalize_responses_tool_followup_messages);
 
     std::fprintf(stderr, "\n── Disk prefix cache ──\n");
     RUN_TEST(test_disk_cache_config_defaults);


### PR DESCRIPTION
Codex CLI could miss tool calls or loop on follow-up turns when the native server handled Qwen Responses output too literally. Qwen can emit bare `<function=...>` XML without an outer `<tool_call>` wrapper, and Codex sends follow-up `function_call` / `function_call_output` items that must be replayed back into the prompt as assistant/tool turns.

Handle bare `<function=` and `<tool_code>` openers in the SSE emitter so the native Responses path still converts Qwen tool XML into Responses `function_call` events. Normalize Responses follow-up items in `http_server.cpp` by replaying prior function calls as assistant tool-call XML, mapping `function_call_output` items to tool turns, and preserving the system / developer prompt folding used by Codex requests.

Add regression coverage for both failures: bare-function Responses tool calls in the emitter and the Responses follow-up normalization path in the native server flow. Compile `http_server.cpp` into `test_server_unit` so the regression test exercises the production normalization logic directly.