### PR TITLE
feat(server): add mixed-backend PFlash phase split

### DIFF
--- a/dflash/CMakeLists.txt
+++ b/dflash/CMakeLists.txt
@@ -240,6 +240,7 @@ add_library(dflash_common STATIC
     src/common/dflash_capture.cpp
     src/common/dflash_draft_ipc.cpp
     src/common/dflash_draft_ipc_daemon.cpp
+    src/common/pflash_drafter_ipc.cpp
     src/common/dflash_draft_graph.cpp
     src/common/dflash_spec_decode.cpp
     src/qwen35/graph_builders.cpp
@@ -675,6 +676,7 @@ if(DFLASH27B_TESTS)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/ipc/backend_ipc_main.cpp")
         add_executable(backend_ipc_daemon
             src/ipc/backend_ipc_main.cpp
+            src/common/pflash_drafter_ipc_daemon.cpp
         )
         target_include_directories(backend_ipc_daemon PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
         if(DFLASH27B_GPU_BACKEND STREQUAL "hip")

--- a/dflash/src/common/backend_factory.cpp
+++ b/dflash/src/common/backend_factory.cpp
@@ -21,6 +21,10 @@ bool arch_supports_remote_draft(const std::string & arch) {
     return arch == "qwen35";
 }
 
+bool arch_supports_pflash_compression(const std::string & arch) {
+    return arch == "qwen35" || arch == "qwen3";
+}
+
 std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
     if (!args.model_path) {
         std::fprintf(stderr, "[backend_factory] model_path is null\n");

--- a/dflash/src/common/backend_factory.h
+++ b/dflash/src/common/backend_factory.h
@@ -65,5 +65,6 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args);
 std::string detect_arch(const char * model_path);
 
 bool arch_supports_remote_draft(const std::string & arch);
+bool arch_supports_pflash_compression(const std::string & arch);
 
 }  // namespace dflash::common

--- a/dflash/src/common/backend_ipc.cpp
+++ b/dflash/src/common/backend_ipc.cpp
@@ -22,6 +22,7 @@ namespace dflash::common {
 const char * backend_ipc_mode_name(BackendIpcMode mode) {
     switch (mode) {
         case BackendIpcMode::DFlashDraft: return "dflash-draft";
+        case BackendIpcMode::PFlashCompress: return "pflash-compress";
     }
     return "unknown";
 }
@@ -29,6 +30,10 @@ const char * backend_ipc_mode_name(BackendIpcMode mode) {
 bool parse_backend_ipc_mode(const std::string & value, BackendIpcMode & out) {
     if (value == "dflash-draft") {
         out = BackendIpcMode::DFlashDraft;
+        return true;
+    }
+    if (value == "pflash-compress") {
+        out = BackendIpcMode::PFlashCompress;
         return true;
     }
     return false;

--- a/dflash/src/common/backend_ipc.h
+++ b/dflash/src/common/backend_ipc.h
@@ -18,6 +18,7 @@ namespace dflash::common {
 
 enum class BackendIpcMode {
     DFlashDraft,
+    PFlashCompress,
 };
 
 const char * backend_ipc_mode_name(BackendIpcMode mode);

--- a/dflash/src/common/model_backend.h
+++ b/dflash/src/common/model_backend.h
@@ -143,7 +143,8 @@ struct ModelBackend {
         std::vector<int32_t> input_ids;      // drafter-tokenized prompt
         float                keep_ratio;      // fraction to keep (0.0–1.0)
         std::string          drafter_path;    // GGUF path (for lazy-load)
-        bool                 skip_park;       // true on ≥32GB GPUs
+        int                  drafter_gpu = 0;  // backend-local GPU for PFlash drafter
+        bool                 skip_park = false; // true on >=32GB GPUs
     };
 
     struct CompressResult {

--- a/dflash/src/common/pflash_drafter_ipc.cpp
+++ b/dflash/src/common/pflash_drafter_ipc.cpp
@@ -1,0 +1,90 @@
+// pflash_drafter_ipc.cpp - PFlash drafter IPC client + daemon body.
+
+#include "pflash_drafter_ipc.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace dflash::common {
+
+bool PFlashDrafterIpcClient::start(
+        const std::string & bin,
+        const std::string & drafter_path,
+        int drafter_gpu,
+        const std::string & work_dir) {
+#if defined(_WIN32)
+    (void)bin; (void)drafter_path; (void)drafter_gpu; (void)work_dir;
+    std::fprintf(stderr, "PFlash drafter IPC is only implemented on POSIX hosts\n");
+    return false;
+#else
+    close();
+    if (bin.empty() || drafter_path.empty()) return false;
+    BackendIpcLaunchConfig launch;
+    launch.bin = bin;
+    launch.mode = BackendIpcMode::PFlashCompress;
+    launch.payload_path = drafter_path;
+    launch.work_dir = work_dir;
+    launch.args.push_back("--draft-gpu=" + std::to_string(std::max(0, drafter_gpu)));
+    if (!process_.start(launch)) {
+        std::fprintf(stderr, "pflash-ipc backend process start failed\n");
+        return false;
+    }
+    active_ = true;
+    std::fprintf(stderr, "[pflash-ipc] ready bin=%s gpu=%d work_dir=%s\n",
+                 bin.c_str(), drafter_gpu, process_.work_dir().c_str());
+    return true;
+#endif
+}
+
+bool PFlashDrafterIpcClient::compress(
+        const std::vector<int32_t> & input_ids,
+        float keep_ratio,
+        std::vector<int32_t> & compressed_ids) {
+#if defined(_WIN32)
+    (void)input_ids; (void)keep_ratio; (void)compressed_ids;
+    return false;
+#else
+    compressed_ids.clear();
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0 || input_ids.empty()) return false;
+
+    const std::string path = process_.next_path("pflash_tokens");
+    if (!write_int32_file(path, input_ids)) {
+        std::fprintf(stderr, "pflash-ipc write tokens failed: %s\n", path.c_str());
+        return false;
+    }
+    int keep_x1000 = (int)std::lround(std::max(0.0f, keep_ratio) * 1000.0f);
+    keep_x1000 = std::max(0, std::min(1000, keep_x1000));
+
+    std::fprintf(cmd, "compress %d %s\n", keep_x1000, path.c_str());
+    std::fflush(cmd);
+
+    int32_t status = -1;
+    bool ok = read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
+    if (ok) {
+        int32_t n_out = -1;
+        ok = read_exact_fd(stream_fd, &n_out, sizeof(n_out)) && n_out > 0;
+        if (ok) {
+            compressed_ids.assign((size_t)n_out, 0);
+            ok = read_exact_fd(stream_fd, compressed_ids.data(),
+                               compressed_ids.size() * sizeof(int32_t));
+        }
+    }
+    std::remove(path.c_str());
+    if (!ok) {
+        std::fprintf(stderr, "pflash-ipc compress failed status=%d\n", status);
+        compressed_ids.clear();
+        close();
+    }
+    return ok;
+#endif
+}
+
+void PFlashDrafterIpcClient::close() {
+    process_.close();
+    active_ = false;
+}
+
+} // namespace dflash::common

--- a/dflash/src/common/pflash_drafter_ipc.h
+++ b/dflash/src/common/pflash_drafter_ipc.h
@@ -1,0 +1,47 @@
+// pflash_drafter_ipc.h - PFlash drafter IPC client + daemon entry.
+//
+// Used when target and PFlash drafter run on different compiled backends
+// (for example CUDA target + HIP drafter). The parent sends drafter-tokenized
+// prompt IDs to the daemon and receives compressed drafter token IDs back.
+
+#pragma once
+
+#include "backend_ipc.h"
+#include "io_utils.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+class PFlashDrafterIpcClient {
+public:
+    PFlashDrafterIpcClient() = default;
+    PFlashDrafterIpcClient(const PFlashDrafterIpcClient &) = delete;
+    PFlashDrafterIpcClient & operator=(const PFlashDrafterIpcClient &) = delete;
+    ~PFlashDrafterIpcClient() { close(); }
+
+    bool start(const std::string & bin,
+               const std::string & drafter_path,
+               int drafter_gpu,
+               const std::string & work_dir);
+
+    bool compress(const std::vector<int32_t> & input_ids,
+                  float keep_ratio,
+                  std::vector<int32_t> & compressed_ids);
+
+    bool active() const { return active_; }
+    void close();
+
+private:
+    BackendIpcProcess process_;
+    bool active_ = false;
+};
+
+int run_pflash_drafter_ipc_daemon(const char * drafter_path,
+                                  int drafter_gpu,
+                                  int stream_fd);
+
+} // namespace dflash::common

--- a/dflash/src/common/pflash_drafter_ipc_daemon.cpp
+++ b/dflash/src/common/pflash_drafter_ipc_daemon.cpp
@@ -1,0 +1,92 @@
+// pflash_drafter_ipc_daemon.cpp - PFlash drafter IPC daemon body.
+
+#include "pflash_drafter_ipc.h"
+
+#include "dflash27b.h"
+#include "dflash_draft_ipc.h"
+#include "qwen3/qwen3_drafter.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <iostream>
+#include <sstream>
+
+namespace dflash::common {
+
+int run_pflash_drafter_ipc_daemon(const char * drafter_path,
+                                  int drafter_gpu,
+                                  int stream_fd) {
+#if defined(_WIN32)
+    (void)drafter_path; (void)drafter_gpu; (void)stream_fd;
+    std::fprintf(stderr, "PFlash drafter IPC daemon is only implemented on POSIX hosts\n");
+    return 2;
+#else
+    if (!drafter_path || stream_fd < 0) {
+        std::fprintf(stderr,
+            "usage: backend_ipc_daemon --backend-ipc-mode=pflash-compress <drafter.gguf> "
+            "--stream-fd=FD [--draft-gpu=N]\n");
+        return 2;
+    }
+
+    DrafterContext ctx;
+    if (!load_drafter(drafter_path, /*gpu_layers=*/999, std::max(0, drafter_gpu), ctx)) {
+        std::fprintf(stderr, "[pflash-ipc-daemon] drafter load failed: %s\n",
+                     dflash27b_last_error());
+        stream_status(stream_fd, -1);
+        return 1;
+    }
+
+    std::fprintf(stderr, "[pflash-ipc-daemon] ready gpu=%d\n", std::max(0, drafter_gpu));
+    stream_status(stream_fd, 0);
+
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        std::istringstream iss(line);
+        std::string cmd;
+        iss >> cmd;
+        if (cmd == "quit" || cmd == "exit") break;
+        if (cmd == "compress") {
+            int keep_x1000 = 0;
+            iss >> keep_x1000;
+            std::string path = read_line_tail(iss);
+            if (keep_x1000 < 0 || keep_x1000 > 1000 || path.empty()) {
+                std::fprintf(stderr, "[pflash-ipc-daemon] bad compress: %s\n",
+                             line.c_str());
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            auto input_ids = read_int32_file(path);
+            if (input_ids.empty()) {
+                std::fprintf(stderr, "[pflash-ipc-daemon] read tokens failed: %s\n",
+                             path.c_str());
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            const float keep = (float)keep_x1000 / 1000.0f;
+            auto compressed = drafter_score_and_compress(ctx, input_ids, keep);
+            if (compressed.empty()) {
+                std::fprintf(stderr, "[pflash-ipc-daemon] compress returned empty\n");
+                stream_status(stream_fd, -1);
+                continue;
+            }
+            const int32_t n_out = (int32_t)compressed.size();
+            if (!stream_status(stream_fd, 0) ||
+                !write_exact_fd(stream_fd, &n_out, sizeof(n_out)) ||
+                !write_exact_fd(stream_fd, compressed.data(),
+                                compressed.size() * sizeof(int32_t))) {
+                std::fprintf(stderr, "[pflash-ipc-daemon] stream write failed\n");
+                break;
+            }
+            continue;
+        }
+        std::fprintf(stderr, "[pflash-ipc-daemon] unknown command: %s\n", line.c_str());
+        stream_status(stream_fd, -1);
+    }
+
+    free_drafter(ctx);
+    std::fprintf(stderr, "[pflash-ipc-daemon] stopped\n");
+    return 0;
+#endif
+}
+
+} // namespace dflash::common

--- a/dflash/src/ipc/backend_ipc_main.cpp
+++ b/dflash/src/ipc/backend_ipc_main.cpp
@@ -2,6 +2,7 @@
 
 #include "backend_ipc.h"
 #include "dflash_draft_ipc.h"
+#include "pflash_drafter_ipc.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -34,7 +35,10 @@ int main(int argc, char ** argv) {
     } else {
         std::fprintf(stderr,
             "usage: %s --backend-ipc-mode=dflash-draft <draft.safetensors|draft.gguf> "
-            "--ring-cap=N --stream-fd=FD [--draft-gpu=N]\n",
+            "--ring-cap=N --stream-fd=FD [--draft-gpu=N]\n"
+            "   or: %s --backend-ipc-mode=pflash-compress <drafter.gguf> "
+            "--stream-fd=FD [--draft-gpu=N]\n",
+            argv[0],
             argv[0]);
         return 2;
     }
@@ -64,6 +68,8 @@ int main(int argc, char ** argv) {
     switch (mode) {
         case BackendIpcMode::DFlashDraft:
             return run_dflash_draft_ipc_daemon(payload_path, ring_cap, draft_gpu, stream_fd);
+        case BackendIpcMode::PFlashCompress:
+            return run_pflash_drafter_ipc_daemon(payload_path, draft_gpu, stream_fd);
     }
     std::fprintf(stderr, "[backend-ipc-daemon] unsupported mode\n");
     return 2;

--- a/dflash/src/placement/pflash_placement.h
+++ b/dflash/src/placement/pflash_placement.h
@@ -1,0 +1,43 @@
+// PFlash drafter placement resolution for native server/runtime code.
+
+#pragma once
+
+#include "placement_config.h"
+#include "remote_draft_config.h"
+
+namespace dflash::common {
+
+struct PFlashDrafterPlacement {
+    PlacementBackend target_backend = PlacementBackend::Auto;
+    PlacementBackend drafter_backend = PlacementBackend::Auto;
+    int drafter_gpu = 0;
+    bool remote_drafter = false;
+    RemoteDraftConfig remote;
+};
+
+inline bool pflash_drafter_placement_used(bool pflash_enabled,
+                                          bool has_decode_draft) {
+    return pflash_enabled || has_decode_draft;
+}
+
+inline PFlashDrafterPlacement resolve_pflash_drafter_placement(
+        const DevicePlacement & target_device,
+        const DevicePlacement & drafter_device,
+        const RemoteDraftConfig & remote,
+        bool pflash_enabled) {
+    PFlashDrafterPlacement out;
+    const PlacementBackend compiled = compiled_placement_backend();
+    out.target_backend = target_device.backend == PlacementBackend::Auto
+        ? compiled : target_device.backend;
+    out.drafter_backend = drafter_device.backend == PlacementBackend::Auto
+        ? out.target_backend : drafter_device.backend;
+    out.drafter_gpu = drafter_device.gpu;
+    out.remote_drafter = pflash_enabled &&
+                         out.target_backend != out.drafter_backend;
+    if (out.remote_drafter) {
+        out.remote = remote;
+    }
+    return out;
+}
+
+}  // namespace dflash::common

--- a/dflash/src/qwen3/qwen3_backend.cpp
+++ b/dflash/src/qwen3/qwen3_backend.cpp
@@ -955,7 +955,7 @@ ModelBackend::CompressResult Qwen3Backend::compress(const CompressRequest & req)
     if (!req.skip_park && !parked_) park("target");
 
     if (!drafter_loaded_) {
-        if (!load_drafter(req.drafter_path, 999, drafter_ctx_)) {
+        if (!load_drafter(req.drafter_path, 999, req.drafter_gpu, drafter_ctx_)) {
             std::fprintf(stderr, "[compress] load failed: %s\n", dflash27b_last_error());
             if (!req.skip_park && !was_parked) unpark("target");
             return result;

--- a/dflash/src/qwen3/qwen3_drafter.cpp
+++ b/dflash/src/qwen3/qwen3_drafter.cpp
@@ -121,33 +121,58 @@ const char * drafter_arch_name(DrafterArch arch) {
 
 bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
                   DrafterContext & out) {
-    return load_drafter(gguf_path, /*gpu_layers=*/999, DrafterArch::Qwen3_0p6b, out);
+    return load_drafter(gguf_path, /*gpu_layers=*/999, /*gpu=*/0, out);
+}
+
+bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
+                  int gpu, DrafterContext & out) {
+    return load_drafter(gguf_path, /*gpu_layers=*/999, DrafterArch::Qwen3_0p6b, gpu, out);
 }
 
 bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
                   DrafterArch arch, DrafterContext & out) {
+    return load_drafter(gguf_path, /*gpu_layers=*/999, arch, /*gpu=*/0, out);
+}
+
+bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
+                  DrafterArch arch, int gpu, DrafterContext & out) {
+    if (gpu < 0) {
+        set_last_error("load_drafter: negative GPU index");
+        return false;
+    }
     if (out.loaded) {
         set_last_error("drafter already loaded");
         return false;
     }
+    if (out.backend && out.gpu >= 0 && out.gpu != gpu) {
+        set_last_error("load_drafter: backend already bound to a different GPU");
+        return false;
+    }
 
-    // If caller didn't supply a backend, spin up our own CUDA one. Sharing
+    // If caller didn't supply a backend, spin up our own GPU backend. Sharing
     // would be ideal but we don't have a handle to the daemon's backend
-    // through this API. Same-process CUDA pools coexist fine — fragmentation
-    // is the only cost, and we free everything in free_drafter.
+    // through this API. Same-process GPU pools coexist fine; fragmentation is
+    // the only cost, and we free everything in free_drafter.
     if (!out.backend) {
         size_t n_dev = ggml_backend_dev_count();
+        int seen_gpu = 0;
         for (size_t i = 0; i < n_dev; ++i) {
             ggml_backend_dev_t dev = ggml_backend_dev_get(i);
             if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
-                out.backend = ggml_backend_dev_init(dev, nullptr);
-                break;
+                if (seen_gpu == gpu) {
+                    out.backend = ggml_backend_dev_init(dev, nullptr);
+                    break;
+                }
+                seen_gpu++;
             }
         }
         if (!out.backend) {
-            set_last_error("load_drafter: no GPU backend available");
+            set_last_error("load_drafter: requested GPU backend unavailable");
             return false;
         }
+        out.gpu = gpu;
+    } else if (out.gpu < 0) {
+        out.gpu = gpu;
     }
 
     if (arch == DrafterArch::Qwen35_0p8b) {
@@ -161,11 +186,11 @@ bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
         out.arch = arch;
         std::fprintf(stderr,
             "[drafter] loaded %s qwen35: n_layer=%d n_head=%d n_head_kv=%d "
-            "n_embd=%d n_ff=%d head_dim=%d vocab=%d\n",
+            "n_embd=%d n_ff=%d head_dim=%d vocab=%d gpu=%d\n",
             drafter_arch_name(arch),
             st->weights.n_layer, st->weights.n_head, st->weights.n_head_kv,
             st->weights.n_embd, st->weights.n_ff, st->weights.n_embd_head_k,
-            st->weights.n_vocab);
+            st->weights.n_vocab, out.gpu);
         std::fflush(stderr);
         return true;
     }
@@ -179,11 +204,11 @@ bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
     out.arch = arch;
     std::fprintf(stderr,
         "[drafter] loaded %s BF16: n_layer=%d n_head=%d n_kv=%d "
-        "n_embd=%d n_ff=%d head_dim=%d vocab=%d\n",
+        "n_embd=%d n_ff=%d head_dim=%d vocab=%d gpu=%d\n",
         drafter_arch_name(arch),
         out.weights.n_layer, out.weights.n_head, out.weights.n_head_kv,
         out.weights.n_embd, out.weights.n_ff, out.weights.head_dim,
-        out.weights.n_vocab);
+        out.weights.n_vocab, out.gpu);
     std::fflush(stderr);
 
 #if defined(DFLASH27B_BACKEND_HIP)
@@ -202,6 +227,7 @@ void free_drafter(DrafterContext & ctx) {
         ggml_backend_free(ctx.backend);
         ctx.backend = nullptr;
     }
+    ctx.gpu = -1;
 }
 
 void free_drafter_weights(DrafterContext & ctx) {

--- a/dflash/src/qwen3/qwen3_drafter.h
+++ b/dflash/src/qwen3/qwen3_drafter.h
@@ -38,6 +38,7 @@ struct DrafterContext {
     Qwen3DrafterWeights   weights;             // BF16 weights on the backend
     DrafterArch           arch    = DrafterArch::Qwen3_0p6b;
     void *                arch_state = nullptr;
+    int                   gpu = -1;
     bool                  loaded  = false;
 };
 
@@ -50,7 +51,11 @@ struct DrafterContext {
 bool load_drafter(const std::string & gguf_path, int gpu_layers,
                   DrafterContext & out);
 bool load_drafter(const std::string & gguf_path, int gpu_layers,
+                  int gpu, DrafterContext & out);
+bool load_drafter(const std::string & gguf_path, int gpu_layers,
                   DrafterArch arch, DrafterContext & out);
+bool load_drafter(const std::string & gguf_path, int gpu_layers,
+                  DrafterArch arch, int gpu, DrafterContext & out);
 
 void free_drafter(DrafterContext & ctx);
 

--- a/dflash/src/qwen35/qwen35_backend.cpp
+++ b/dflash/src/qwen35/qwen35_backend.cpp
@@ -359,7 +359,8 @@ ModelBackend::CompressResult Qwen35Backend::compress(const CompressRequest & req
         // drafter_ctx_.backend == nullptr → load_drafter creates its own
         std::fprintf(stderr, "[compress] loading drafter from %s ...\n",
                      req.drafter_path.c_str());
-        if (!load_drafter(req.drafter_path, /*gpu_layers=*/999, drafter_ctx_)) {
+        if (!load_drafter(req.drafter_path, /*gpu_layers=*/999,
+                          req.drafter_gpu, drafter_ctx_)) {
             std::fprintf(stderr, "[compress] drafter init failed: %s\n",
                          dflash27b_last_error());
             if (!req.skip_park) {

--- a/dflash/src/server/http_server.cpp
+++ b/dflash/src/server/http_server.cpp
@@ -680,6 +680,25 @@ void HttpServer::worker_loop() {
         const auto & req = job->req;
         auto started_at = std::chrono::steady_clock::now();
 
+        auto finish_job = [&]() {
+            std::lock_guard<std::mutex> lk(job->mu);
+            job->done = true;
+            job->cv.notify_one();
+        };
+        auto fail_request = [&](int status, const std::string & message) {
+            std::fprintf(stderr, "[server] request failed: %s\n", message.c_str());
+            if (req.stream) {
+                json err = {{"error", {{"message", message}, {"type", "server_error"}}}};
+                const std::string chunk = "data: " + err.dump() + "\n\n";
+                send_all(fd, chunk.data(), chunk.size());
+                const char done[] = "data: [DONE]\n\n";
+                send_all(fd, done, sizeof(done) - 1);
+            } else {
+                send_error(fd, status, message);
+            }
+            finish_job();
+        };
+
         std::fprintf(stderr,
             "[server] chat START %s format=%s stream=%s prompt_tokens=%zu "
             "max_tokens=%d tools=%zu\n",
@@ -694,9 +713,7 @@ void HttpServer::worker_loop() {
         if (req.stream) {
             if (!send_sse_headers(fd)) {
                 // Client already disconnected before we started.
-                std::lock_guard<std::mutex> lk(job->mu);
-                job->done = true;
-                job->cv.notify_one();
+                finish_job();
                 continue;
             }
         }
@@ -717,9 +734,7 @@ void HttpServer::worker_loop() {
                 }
             }
             if (!start_ok) {
-                std::lock_guard<std::mutex> lk(job->mu);
-                job->done = true;
-                job->cv.notify_one();
+                finish_job();
                 continue;
             }
         }
@@ -750,21 +765,40 @@ void HttpServer::worker_loop() {
                     // effective_prompt stays as req.prompt_tokens — the cached KV
                     // state will be restored via cache_slot below.
                 } else {
+                    std::string compression_error;
                     // 1. Decode prompt to text using target tokenizer
                     std::string prompt_text = tokenizer_.decode(req.prompt_tokens);
 
                     // 2. Re-encode with drafter tokenizer
                     auto drafter_ids = drafter_tokenizer_->encode(prompt_text);
 
-                    if (!drafter_ids.empty()) {
+                    if (drafter_ids.empty()) {
+                        compression_error = "PFlash drafter tokenizer produced an empty prompt";
+                    } else {
                         // 3. Compress via typed API
                         ModelBackend::CompressRequest creq;
                         creq.input_ids = std::move(drafter_ids);
                         creq.keep_ratio = config_.pflash_keep_ratio;
                         creq.drafter_path = config_.pflash_drafter_path;
+                        creq.drafter_gpu = config_.pflash_drafter_gpu;
                         creq.skip_park = config_.pflash_skip_park;
 
-                        auto cresult = backend_.compress(creq);
+                        ModelBackend::CompressResult cresult;
+                        if (config_.pflash_remote_drafter) {
+                            if (!pflash_remote_.active() &&
+                                !pflash_remote_.start(config_.pflash_remote.ipc_bin,
+                                                       config_.pflash_drafter_path,
+                                                       config_.pflash_drafter_gpu,
+                                                       config_.pflash_remote.work_dir)) {
+                                compression_error = "remote PFlash drafter start failed";
+                            } else {
+                                cresult.ok = pflash_remote_.compress(
+                                    creq.input_ids, creq.keep_ratio,
+                                    cresult.compressed_ids);
+                            }
+                        } else {
+                            cresult = backend_.compress(creq);
+                        }
 
                         // 4. Decode compressed IDs with drafter tokenizer
                         if (cresult.ok && !cresult.compressed_ids.empty()) {
@@ -780,7 +814,15 @@ void HttpServer::worker_loop() {
                                 n_prompt, (int)cresult.compressed_ids.size(),
                                 (int)effective_prompt.size(),
                                 100.0 * effective_prompt.size() / n_prompt);
+                        } else if (compression_error.empty()) {
+                            compression_error = config_.pflash_remote_drafter
+                                ? "remote PFlash drafter compression failed"
+                                : "PFlash compression failed";
                         }
+                    }
+                    if (!pflash_compressed && !compression_error.empty()) {
+                        fail_request(500, compression_error);
+                        continue;
                     }
                 }
             }
@@ -1220,11 +1262,7 @@ void HttpServer::worker_loop() {
             result.error.empty() ? "-" : result.error.c_str());
 
         // Signal client thread that we're done.
-        {
-            std::lock_guard<std::mutex> lk(job->mu);
-            job->done = true;
-            job->cv.notify_one();
-        }
+        finish_job();
     }
 }
 

--- a/dflash/src/server/http_server.h
+++ b/dflash/src/server/http_server.h
@@ -18,6 +18,8 @@
 #include "prefix_cache.h"
 #include "disk_prefix_cache.h"
 #include "api_types.h"
+#include "placement/remote_draft_config.h"
+#include "common/pflash_drafter_ipc.h"
 #include <nlohmann/json.hpp>
 
 #include <atomic>
@@ -55,7 +57,10 @@ struct ServerConfig {
     int         pflash_threshold = 32000;   // token count threshold for AUTO mode
     float       pflash_keep_ratio = 0.05f;  // fraction of tokens to keep
     std::string pflash_drafter_path;        // path to drafter GGUF (Qwen3-0.6B)
-    bool        pflash_skip_park = false;   // skip park/unpark for ≥32GB GPUs
+    int         pflash_drafter_gpu = 0;     // backend-local GPU for PFlash drafter
+    bool        pflash_remote_drafter = false; // use IPC drafter for mixed backends
+    RemoteDraftConfig pflash_remote;        // IPC binary/work-dir for remote PFlash drafter
+    bool        pflash_skip_park = false;   // skip park/unpark for >=32GB GPUs
     bool        lazy_draft      = false;   // park decode draft when idle to save VRAM
 
     // Disk prefix cache
@@ -166,6 +171,7 @@ private:
     Tokenizer *      drafter_tokenizer_ = nullptr;  // pflash drafter (optional)
     ServerConfig     config_;
     ChatFormat       chat_format_;
+    PFlashDrafterIpcClient pflash_remote_;
     ToolMemory       tool_memory_;
     PrefixCache      prefix_cache_;
     DiskPrefixCache  disk_cache_;

--- a/dflash/src/server/server_main.cpp
+++ b/dflash/src/server/server_main.cpp
@@ -1,7 +1,8 @@
 // dflash_server — native C++ HTTP server for dflash::common.
 //
-// Replaces the Python server.py for production use. Owns the ModelBackend
-// directly (no subprocess, no pipe protocol), enabling:
+// Replaces the Python server.py for production use. Owns the target
+// ModelBackend directly, while optional draft/PFlash IPC paths can be used
+// for mixed-backend placement. The direct target path enables:
 //   - Immediate client-disconnect cancellation (via send() failure)
 //   - Lower latency (no IPC overhead)
 //   - Single binary deployment
@@ -16,12 +17,12 @@
 #include "common/backend_factory.h"
 #include "common/gguf_inspect.h"
 #include "common/peer_access.h"
+#include "placement/pflash_placement.h"
 
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <csignal>
 #include <memory>
 #include <string>
 #include <vector>
@@ -55,7 +56,8 @@ static bool parse_double_list(const char * value, std::vector<double> & out) {
     return !out.empty();
 }
 
-static bool validate_server_placement(const BackendArgs & bargs) {
+static bool validate_server_placement(const BackendArgs & bargs,
+                                      const ServerConfig & sconfig) {
     const PlacementBackend compiled = compiled_placement_backend();
     if (!placement_backend_supported(bargs.device.backend)) {
         std::fprintf(stderr,
@@ -65,17 +67,23 @@ static bool validate_server_placement(const BackendArgs & bargs) {
             placement_backend_name(compiled));
         return false;
     }
-    const PlacementBackend target = bargs.device.backend == PlacementBackend::Auto
-        ? compiled : bargs.device.backend;
-    const PlacementBackend draft = bargs.draft_device.backend == PlacementBackend::Auto
-        ? target : bargs.draft_device.backend;
+    const bool pflash_enabled =
+        sconfig.pflash_mode != ServerConfig::PflashMode::OFF;
+    const PFlashDrafterPlacement pflash_placement =
+        resolve_pflash_drafter_placement(
+            bargs.device, bargs.draft_device, bargs.remote_draft,
+            pflash_enabled);
+    const PlacementBackend target = pflash_placement.target_backend;
+    const PlacementBackend draft = pflash_placement.drafter_backend;
+    const bool draft_placement_used =
+        pflash_drafter_placement_used(pflash_enabled, bargs.draft_path != nullptr);
     if (!bargs.remote_draft.enabled() && bargs.remote_draft.has_aux_options()) {
         std::fprintf(stderr,
             "[server] --draft-ipc-work-dir and --draft-ipc-ring-cap require "
             "--draft-ipc-bin\n");
         return false;
     }
-    if (target != draft) {
+    if (draft_placement_used && target != draft) {
         if (!bargs.remote_draft.enabled()) {
             std::fprintf(stderr,
                 "[server] mixed target/draft backends require --draft-ipc-bin "
@@ -83,9 +91,10 @@ static bool validate_server_placement(const BackendArgs & bargs) {
                 placement_backend_name(target), placement_backend_name(draft));
             return false;
         }
-        if (!bargs.draft_path) {
+        if (!bargs.draft_path && !pflash_enabled) {
             std::fprintf(stderr,
-                "[server] mixed target/draft backends require --draft <path>\n");
+                "[server] mixed target/draft backends require --draft <path> "
+                "or --prefill-compression with --prefill-drafter\n");
             return false;
         }
     } else if (bargs.remote_draft.enabled()) {
@@ -94,7 +103,8 @@ static bool validate_server_placement(const BackendArgs & bargs) {
             "backends (target=%s draft=%s)\n",
             placement_backend_name(target), placement_backend_name(draft));
         return false;
-    } else if (!placement_backend_supported(bargs.draft_device.backend)) {
+    } else if (draft_placement_used &&
+               !placement_backend_supported(bargs.draft_device.backend)) {
         std::fprintf(stderr,
             "[server] --draft-device=%s is unsupported in this binary "
             "(compiled backend: %s)\n",
@@ -264,6 +274,8 @@ int main(int argc, char ** argv) {
                 sconfig.pflash_mode = ServerConfig::PflashMode::AUTO;
             else if (std::strcmp(mode, "always") == 0)
                 sconfig.pflash_mode = ServerConfig::PflashMode::ALWAYS;
+            else if (std::strcmp(mode, "off") == 0)
+                sconfig.pflash_mode = ServerConfig::PflashMode::OFF;
             else {
                 std::fprintf(stderr, "[server] unknown --prefill-compression mode: '%s' (expected: auto, always, off)\n", mode);
                 print_usage(argv[0]);
@@ -330,9 +342,9 @@ int main(int argc, char ** argv) {
         }
     }
 
-    if (!validate_server_placement(bargs)) return 2;
+    if (!validate_server_placement(bargs, sconfig)) return 2;
 
-    if (bargs.remote_draft.enabled()) {
+    if (bargs.remote_draft.enabled() && bargs.draft_path) {
         const std::string arch = detect_arch(bargs.model_path);
         if (arch.empty()) {
             std::fprintf(stderr,
@@ -353,6 +365,13 @@ int main(int argc, char ** argv) {
     if (sconfig.max_ctx <= 0) {
         sconfig.max_ctx = bargs.device.max_ctx;
     }
+    const PFlashDrafterPlacement pflash_placement =
+        resolve_pflash_drafter_placement(
+            bargs.device, bargs.draft_device, bargs.remote_draft,
+            sconfig.pflash_mode != ServerConfig::PflashMode::OFF);
+    sconfig.pflash_drafter_gpu = pflash_placement.drafter_gpu;
+    sconfig.pflash_remote_drafter = pflash_placement.remote_drafter;
+    sconfig.pflash_remote = pflash_placement.remote;
 
     // ── Apply environment defaults (mirrors server.py logic) ────────────
     // Explicit --cache-type-k/v override via env vars.
@@ -407,9 +426,24 @@ int main(int argc, char ** argv) {
             std::fprintf(stderr, "[server] drafter tokenizer load failed\n");
             return 1;
         }
-        std::fprintf(stderr, "[server] pflash: mode=%s threshold=%d keep=%.3f skip_park=%d\n",
+        if (sconfig.pflash_remote_drafter) {
+            if (!bargs.remote_draft.enabled()) {
+                std::fprintf(stderr,
+                    "[server] mixed-backend PFlash requires --draft-ipc-bin\n");
+                return 2;
+            }
+            const std::string arch = detect_arch(bargs.model_path);
+            if (!arch_supports_pflash_compression(arch)) {
+                std::fprintf(stderr,
+                    "[server] model architecture '%s' does not support PFlash compression\n",
+                    arch.c_str());
+                return 2;
+            }
+        }
+        std::fprintf(stderr, "[server] pflash: mode=%s threshold=%d keep=%.3f drafter_gpu=%d skip_park=%d\n",
                      sconfig.pflash_mode == ServerConfig::PflashMode::AUTO ? "auto" : "always",
                      sconfig.pflash_threshold, sconfig.pflash_keep_ratio,
+                     sconfig.pflash_drafter_gpu,
                      (int)sconfig.pflash_skip_park);
     }
 
@@ -422,7 +456,8 @@ int main(int argc, char ** argv) {
         std::fprintf(stderr, "[server] backend creation failed\n");
         return 1;
     }
-    if (bargs.remote_draft.enabled() && !backend->supports_remote_draft()) {
+    if (bargs.remote_draft.enabled() && bargs.draft_path &&
+        !backend->supports_remote_draft()) {
         std::fprintf(stderr,
             "[server] detected model backend does not support remote draft execution\n");
         backend->shutdown();
@@ -452,7 +487,7 @@ int main(int argc, char ** argv) {
     std::fprintf(stderr, "[server] │  draft_device    = %s\n",
                  placement_device_name(bargs.draft_device).c_str());
     std::fprintf(stderr, "[server] │  draft_exec      = %s\n",
-                 bargs.remote_draft.enabled() ? "remote-ipc" : "local");
+                 bargs.remote_draft.enabled() && bargs.draft_path ? "remote-ipc" : "local");
     if (bargs.remote_draft.enabled()) {
         std::fprintf(stderr, "[server] │  draft_ipc_bin  = %s\n",
                      bargs.remote_draft.ipc_bin.c_str());
@@ -486,15 +521,18 @@ int main(int argc, char ** argv) {
         sconfig.pflash_mode == ServerConfig::PflashMode::AUTO ? "auto" :
         sconfig.pflash_mode == ServerConfig::PflashMode::ALWAYS ? "always" : "off");
     if (pflash_enabled) {
-    std::fprintf(stderr, "[server] │  pflash_threshold= %d\n", sconfig.pflash_threshold);
-    std::fprintf(stderr, "[server] │  pflash_keep     = %.3f\n", sconfig.pflash_keep_ratio);
-    std::fprintf(stderr, "[server] │  pflash_drafter  = %s\n", sconfig.pflash_drafter_path.c_str());
-    std::fprintf(stderr, "[server] │  pflash_skip_park= %s\n", sconfig.pflash_skip_park ? "ON" : "off");
-    std::fprintf(stderr, "[server] │  fp_use_bsa      = %s\n", getenv("DFLASH_FP_USE_BSA") ? "ON" : "off");
-    std::fprintf(stderr, "[server] │  fp_alpha        = %s\n", getenv("DFLASH_FP_ALPHA") ? getenv("DFLASH_FP_ALPHA") : "0.12 (default)");
+        std::fprintf(stderr, "[server] │  pflash_threshold= %d\n", sconfig.pflash_threshold);
+        std::fprintf(stderr, "[server] │  pflash_keep     = %.3f\n", sconfig.pflash_keep_ratio);
+        std::fprintf(stderr, "[server] │  pflash_drafter  = %s\n", sconfig.pflash_drafter_path.c_str());
+        std::fprintf(stderr, "[server] │  pflash_drafter_gpu= %d\n", sconfig.pflash_drafter_gpu);
+        std::fprintf(stderr, "[server] │  pflash_drafter_exec= %s\n",
+                     sconfig.pflash_remote_drafter ? "remote-ipc" : "local");
+        std::fprintf(stderr, "[server] │  pflash_skip_park= %s\n", sconfig.pflash_skip_park ? "ON" : "off");
+        std::fprintf(stderr, "[server] │  fp_use_bsa      = %s\n", getenv("DFLASH_FP_USE_BSA") ? "ON" : "off");
+        std::fprintf(stderr, "[server] │  fp_alpha        = %s\n", getenv("DFLASH_FP_ALPHA") ? getenv("DFLASH_FP_ALPHA") : "0.12 (default)");
     }
     if (bargs.draft_path) {
-    std::fprintf(stderr, "[server] │  lazy_draft      = %s\n", sconfig.lazy_draft ? "ON" : "off");
+        std::fprintf(stderr, "[server] │  lazy_draft      = %s\n", sconfig.lazy_draft ? "ON" : "off");
     }
     std::fprintf(stderr, "[server] ╰─────────────────────────────────────────────────────╯\n\n");
 

--- a/dflash/test/test_server_unit.cpp
+++ b/dflash/test/test_server_unit.cpp
@@ -18,6 +18,7 @@
 #include "server/chat_template.h"
 #include "common/sampler.h"
 #include "common/backend_ipc.h"
+#include "placement/pflash_placement.h"
 #include <nlohmann/json.hpp>
 
 #include <cmath>
@@ -847,6 +848,91 @@ static void test_pflash_threshold_always_mode() {
     bool should = (cfg.pflash_mode == ServerConfig::PflashMode::ALWAYS) ||
                   (cfg.pflash_mode == ServerConfig::PflashMode::AUTO && n_prompt >= cfg.pflash_threshold);
     TEST_ASSERT(should);
+}
+
+static void test_pflash_placement_same_backend_local() {
+    DevicePlacement target;
+    target.backend = compiled_placement_backend();
+    target.gpu = 0;
+    DevicePlacement drafter;
+    drafter.backend = target.backend;
+    drafter.gpu = 2;
+    RemoteDraftConfig remote;
+    remote.ipc_bin = "/tmp/backend_ipc_daemon";
+
+    auto placement = resolve_pflash_drafter_placement(
+        target, drafter, remote, /*pflash_enabled=*/true);
+    TEST_ASSERT(placement.target_backend == target.backend);
+    TEST_ASSERT(placement.drafter_backend == target.backend);
+    TEST_ASSERT(placement.drafter_gpu == 2);
+    TEST_ASSERT(!placement.remote_drafter);
+    TEST_ASSERT(!placement.remote.enabled());
+}
+
+static void test_pflash_placement_mixed_backend_remote() {
+    DevicePlacement target;
+    target.backend = PlacementBackend::Cuda;
+    target.gpu = 0;
+    DevicePlacement drafter;
+    drafter.backend = PlacementBackend::Hip;
+    drafter.gpu = 1;
+    RemoteDraftConfig remote;
+    remote.ipc_bin = "/tmp/backend_ipc_daemon";
+    remote.work_dir = "/tmp/pflash-ipc";
+
+    auto placement = resolve_pflash_drafter_placement(
+        target, drafter, remote, /*pflash_enabled=*/true);
+    TEST_ASSERT(placement.target_backend == PlacementBackend::Cuda);
+    TEST_ASSERT(placement.drafter_backend == PlacementBackend::Hip);
+    TEST_ASSERT(placement.drafter_gpu == 1);
+    TEST_ASSERT(placement.remote_drafter);
+    TEST_ASSERT(placement.remote.enabled());
+    TEST_ASSERT(placement.remote.work_dir == "/tmp/pflash-ipc");
+}
+
+static void test_pflash_placement_auto_draft_follows_target() {
+    DevicePlacement target;
+    target.backend = PlacementBackend::Hip;
+    target.gpu = 0;
+    DevicePlacement drafter;
+    drafter.backend = PlacementBackend::Auto;
+    drafter.gpu = 3;
+    RemoteDraftConfig remote;
+    remote.ipc_bin = "/tmp/backend_ipc_daemon";
+
+    auto placement = resolve_pflash_drafter_placement(
+        target, drafter, remote, /*pflash_enabled=*/true);
+    TEST_ASSERT(placement.target_backend == PlacementBackend::Hip);
+    TEST_ASSERT(placement.drafter_backend == PlacementBackend::Hip);
+    TEST_ASSERT(placement.drafter_gpu == 3);
+    TEST_ASSERT(!placement.remote_drafter);
+}
+
+static void test_pflash_placement_disabled_never_remote() {
+    DevicePlacement target;
+    target.backend = PlacementBackend::Cuda;
+    DevicePlacement drafter;
+    drafter.backend = PlacementBackend::Hip;
+    RemoteDraftConfig remote;
+    remote.ipc_bin = "/tmp/backend_ipc_daemon";
+
+    auto placement = resolve_pflash_drafter_placement(
+        target, drafter, remote, /*pflash_enabled=*/false);
+    TEST_ASSERT(placement.target_backend == PlacementBackend::Cuda);
+    TEST_ASSERT(placement.drafter_backend == PlacementBackend::Hip);
+    TEST_ASSERT(!placement.remote_drafter);
+    TEST_ASSERT(!placement.remote.enabled());
+}
+
+static void test_pflash_placement_usage_gate() {
+    TEST_ASSERT(!pflash_drafter_placement_used(
+        /*pflash_enabled=*/false, /*has_decode_draft=*/false));
+    TEST_ASSERT(pflash_drafter_placement_used(
+        /*pflash_enabled=*/false, /*has_decode_draft=*/true));
+    TEST_ASSERT(pflash_drafter_placement_used(
+        /*pflash_enabled=*/true, /*has_decode_draft=*/false));
+    TEST_ASSERT(pflash_drafter_placement_used(
+        /*pflash_enabled=*/true, /*has_decode_draft=*/true));
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1747,6 +1833,11 @@ int main() {
     RUN_TEST(test_pflash_compress_result_defaults);
     RUN_TEST(test_pflash_threshold_auto_mode);
     RUN_TEST(test_pflash_threshold_always_mode);
+    RUN_TEST(test_pflash_placement_same_backend_local);
+    RUN_TEST(test_pflash_placement_mixed_backend_remote);
+    RUN_TEST(test_pflash_placement_auto_draft_follows_target);
+    RUN_TEST(test_pflash_placement_disabled_never_remote);
+    RUN_TEST(test_pflash_placement_usage_gate);
 
     std::fprintf(stderr, "\n── Jinja chat template ──\n");
     RUN_TEST(test_jinja_render_basic);


### PR DESCRIPTION
## Summary

This PR adds native C++ server support for PFlash phase split with CUDA/HIP mixed-backend drafter placement.

Previously, C++ server PFlash compression could only use the target backend's in-process drafter path. That forced the PFlash drafter to follow the target backend/device, so the server could not place the target model and PFlash drafter on different CUDA/HIP backends or different backend-local GPUs.

After this change, `--draft-device <backend:gpu>` is also used as the PFlash drafter placement when `--prefill-compression` is enabled. Same-backend PFlash still uses the local typed `backend_.compress(...)` path, while mixed-backend PFlash runs the drafter through the backend-neutral IPC process layer from #261.

## Changes

- Add a PFlash compression mode to the shared backend IPC process.
  - Add `PFlashDrafterIpcClient`.
  - Add `pflash-compress` as a second mode on the shared `backend_ipc_daemon` process layer from #261.
  - The server sends drafter-tokenized prompt IDs to the daemon and receives compressed drafter token IDs back.
  - Mixed-backend PFlash requires `--draft-ipc-bin`; missing IPC config fails early with a clear error.
  - A failed remote PFlash IPC compression closes the IPC client so a later request can start a fresh daemon.

- Make PFlash use the server's draft placement surface.
  - `--draft-device <backend:gpu>` now controls the PFlash drafter placement when `--prefill-compression` is enabled.
  - `--prefill-compression off` is accepted without requiring `--prefill-drafter`.
  - Startup logs show the resolved PFlash drafter GPU and whether PFlash drafter execution is local or remote IPC.

- Add a focused C++ placement helper for PFlash drafter resolution.
  - New `src/placement/pflash_placement.h` resolves target backend, drafter backend, backend-local drafter GPU, and whether the drafter must run through remote IPC.
  - Drafter placement is only validated when it is actually used by decode draft or PFlash; target-only startup is not blocked by an unused `--draft-device`.

- Pass backend-local drafter GPU selection through the PFlash compression path.
  - `CompressRequest` now carries the resolved drafter GPU.
  - The Qwen3-based PFlash drafter loader can select a backend-local GPU instead of always binding GPU 0.
  - Qwen35 PFlash compression passes the same drafter GPU through the typed compression path.

- Make required PFlash compression failure explicit.
  - When PFlash is selected for a request, drafter startup / IPC / compression failures now return a request error instead of silently falling back to the uncompressed prompt.
  - This avoids false-positive validation where the server returns HTTP 200 while PFlash placement or mixed-backend IPC was actually not working.

## Notes

- Depends on the native mixed-backend placement foundation from #246 and the backend-neutral IPC process layer from #261.
- Checked CUDA sm61 and ROCm 6.3.3 / gfx906 HIP builds for `dflash_server`, `backend_ipc_daemon`, and `test_server_unit`; unit tests passed on both builds.
- Runtime smoke passed with a qwen35-family 21B IQ1 target and Qwen3-0.6B BF16 PFlash drafter, using CUDA target on Tesla P4 and HIP remote drafter on Pro VII; non-streaming `/v1/chat/completions` returned HTTP 200 with PFlash remote IPC enabled.
- The reverse HIP-target/CUDA-drafter direction was also exercised with the same `pflash-compress` IPC mode. On this local P4 setup it passes after applying the separate legacy-CUDA F32 drafter compatibility patch; that compatibility patch is intentionally kept out of this PR and should land separately.
