### PR TITLE
bench(scripts): ds4-eval 2-case sweep + long-context KV sweep tooling

### DIFF
--- a/dflash/scripts/bench_long_ctx.py
+++ b/dflash/scripts/bench_long_ctx.py
@@ -1,0 +1,238 @@
+"""
+Long-context sweep: compare Q4_0 vs TQ3_0 KV cache at 32K / 64K / 128K.
+
+Measures prefill time and DFlash decode tok/s at each context length under
+both KV formats. The point is not throughput (TQ3 is slightly slower than
+Q4_0 at short contexts) but memory — TQ3_0 (3.5 bpv) uses 22% less KV than
+Q4_0 (4.5 bpv), enabling longer contexts on the same VRAM budget.
+
+Usage:
+    uv run scripts/bench_long_ctx.py
+    uv run scripts/bench_long_ctx.py --ctx 32768 65536
+    uv run scripts/bench_long_ctx.py --ctx 131072 --kv tq3
+
+Layer-segmented prefill (DFLASH27B_LAYER_PREFILL=1) is used automatically for
+prompts over 8K tokens to reduce peak activation memory.
+"""
+import argparse
+import json
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BIN_SUFFIX = ".exe" if os.name == "nt" else ""
+TARGET = os.environ.get(
+    "DFLASH_TARGET",
+    str(ROOT / "models" / "Qwen3.5-27B-Q4_K_M.gguf"),
+)
+_LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
+DRAFT = None
+TEST_DFLASH = os.environ.get(
+    "DFLASH_BIN",
+    str(ROOT / "build" / f"test_dflash{BIN_SUFFIX}"),
+)
+TMPDIR = Path("/tmp/dflash_bench")
+TMPDIR.mkdir(parents=True, exist_ok=True)
+
+N_GEN = 128       # shorter gen for long-ctx; prefill dominates
+BUDGET = 16       # lower budget reduces per-token SSM memory at long ctx
+
+
+def _resolve_draft() -> str:
+    for candidate in (_LOCAL_DRAFT_ROOT / "model.safetensors", _LOCAL_DRAFT_ROOT):
+        if candidate.is_file():
+            return str(candidate)
+        if candidate.is_dir():
+            for st in candidate.rglob("model.safetensors"):
+                return str(st)
+    raise FileNotFoundError("draft model.safetensors not found under models/draft/")
+
+
+def _require_file(path: str, label: str):
+    if not Path(path).is_file():
+        raise FileNotFoundError(f"{label} not found: {path}")
+
+
+def make_long_prompt(tok, target_len: int) -> list:
+    """Return a list of token IDs of approximately target_len tokens."""
+    # Use a realistic long-form passage so KV patterns are diverse.
+    # Repeat until we have enough, then trim.
+    chunk = (
+        "Large language models use attention mechanisms to relate tokens across "
+        "long contexts. The key-value cache stores intermediate representations "
+        "for each token, allowing efficient autoregressive generation. "
+        "Quantizing this cache trades a small quality loss for substantial "
+        "memory savings, enabling longer effective context windows on the same "
+        "GPU. Speculative decoding with a draft model accelerates generation "
+        "by proposing multiple tokens per step and verifying them in parallel "
+        "against the target model. The acceptance length—average tokens committed "
+        "per verify step—determines the effective speedup. "
+    )
+    chunk_ids = tok.encode(chunk, add_special_tokens=False)
+    repeats = (target_len // len(chunk_ids)) + 2
+    ids = (chunk_ids * repeats)[:target_len]
+    return ids
+
+
+def write_prompt_bin(ids: list, path: Path) -> int:
+    with open(path, "wb") as f:
+        for tok_id in ids:
+            f.write(struct.pack("<i", int(tok_id)))
+    return len(ids)
+
+
+def run_dflash(prompt_path: Path, n_prompt: int, kv_mode: str) -> dict:
+    """Run test_dflash and return parsed stats."""
+    pad = 64
+    max_ctx = ((n_prompt + N_GEN + pad + 255) // 256) * 256
+
+    out_bin = TMPDIR / f"lc_{kv_mode}_out.bin"
+    env = dict(os.environ)
+    env.pop("DFLASH27B_KV_Q4", None)
+    env.pop("DFLASH27B_KV_TQ3", None)
+    if kv_mode == "q4":
+        env["DFLASH27B_KV_Q4"] = "1"
+    elif kv_mode == "tq3":
+        env["DFLASH27B_KV_TQ3"] = "1"
+    # Use layer-segmented prefill for long contexts — reduces peak activation
+    # memory and avoids graph rebuild overhead at full context.
+    if n_prompt > 8192:
+        env["DFLASH27B_LAYER_PREFILL"] = "1"
+    else:
+        env.pop("DFLASH27B_LAYER_PREFILL", None)
+
+    cmd = [
+        TEST_DFLASH, TARGET, DRAFT,
+        str(prompt_path), str(N_GEN), str(out_bin),
+        "--fast-rollback", "--ddtree",
+        f"--ddtree-budget={BUDGET}",
+        f"--max-ctx={max_ctx}",
+    ]
+    print(f"    cmd: ... --ddtree-budget={BUDGET} --max-ctx={max_ctx}", flush=True)
+
+    t0 = time.monotonic()
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=3600)
+    elapsed = time.monotonic() - t0
+
+    if r.returncode != 0:
+        print(f"STDERR tail:\n{r.stderr[-3000:]}")
+        raise RuntimeError(f"test_dflash exited {r.returncode}")
+
+    out = r.stdout
+    # Parse prefill: "[prefill] N tokens in T s" (token-seg or layer-seg)
+    m_pf = re.search(r"\[prefill\](?:\s+layer-seg)?\s+(\d+)\s+tokens in\s+([\d.]+)\s+s", out)
+    m_tps = re.search(r"([\d.]+)\s+tok/s", out)
+    m_al = re.search(r"avg commit/step=([\d.]+)", out)
+
+    if not (m_pf and m_tps and m_al):
+        print("STDOUT tail:", out[-4000:])
+        raise RuntimeError("failed to parse test_dflash output")
+
+    # Estimate KV size based on Qwen3.5-27B architecture:
+    # 28 layers, head_dim=128, n_kv_heads=4, 2 tensors (K+V) per layer.
+    # F16 reference: max_ctx * 28 * 4 * 2 * 128 * 2 bytes
+    f16_bytes = max_ctx * 28 * 4 * 2 * 128 * 2
+    bpv = {"f16": 16, "q4": 4.5, "tq3": 3.5}.get(kv_mode, 16)
+    kv_gb = f16_bytes * bpv / 16 / 1e9
+
+    return {
+        "n_prompt": n_prompt,
+        "max_ctx": max_ctx,
+        "kv_mode": kv_mode,
+        "prefill_s": float(m_pf.group(2)),
+        "tok_s": float(m_tps.group(1)),
+        "al": float(m_al.group(1)),
+        "kv_gb": round(kv_gb, 2),
+        "elapsed_s": round(elapsed, 1),
+    }
+
+
+def main():
+    global DRAFT
+    DRAFT = _resolve_draft()
+    _require_file(TARGET, "target GGUF")
+    _require_file(TEST_DFLASH, "test_dflash binary")
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--ctx", nargs="+", type=int,
+        default=[32768, 65536, 131072],
+        help="Prompt lengths to test (tokens). Default: 32K 64K 128K",
+    )
+    ap.add_argument(
+        "--kv", nargs="+", choices=["q4", "tq3", "f16"],
+        default=["q4", "tq3"],
+        help="KV cache formats to compare. Default: q4 tq3",
+    )
+    ap.add_argument(
+        "--skip-tokenize", action="store_true",
+        help="Reuse cached prompt .bin files from a previous run",
+    )
+    args = ap.parse_args()
+
+    print(f"[bench] target = {TARGET}")
+    print(f"[bench] draft  = {DRAFT}")
+    print(f"[bench] bin    = {TEST_DFLASH}")
+    print(f"[bench] ctx_lengths = {args.ctx}")
+    print(f"[bench] kv_modes    = {args.kv}")
+    print(f"[bench] n_gen={N_GEN}  ddtree_budget={BUDGET}")
+
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B", trust_remote_code=True)
+
+    results = []
+    for ctx_len in args.ctx:
+        prompt_path = TMPDIR / f"long_ctx_{ctx_len}.bin"
+        if args.skip_tokenize and prompt_path.exists():
+            n = ctx_len
+            print(f"\n[bench] ctx={ctx_len}: reusing {prompt_path}")
+        else:
+            ids = make_long_prompt(tok, ctx_len)
+            n = write_prompt_bin(ids, prompt_path)
+            print(f"\n[bench] ctx={ctx_len}: wrote {n} tokens → {prompt_path}")
+
+        for kv in args.kv:
+            print(f"\n[bench] ctx={ctx_len:>7d}  kv={kv} ...", flush=True)
+            try:
+                r = run_dflash(prompt_path, n, kv)
+                results.append(r)
+                print(
+                    f"  prefill={r['prefill_s']:6.1f}s  decode={r['tok_s']:6.1f} tok/s  "
+                    f"AL={r['al']:.2f}  KV≈{r['kv_gb']:.2f} GB"
+                )
+            except Exception as e:
+                print(f"  FAILED: {e}")
+                results.append({
+                    "n_prompt": ctx_len, "kv_mode": kv,
+                    "error": str(e),
+                })
+
+    out_json = TMPDIR / "long_ctx_results.json"
+    out_json.write_text(json.dumps(results, indent=2))
+    print(f"\n[bench] wrote {out_json}")
+
+    # Summary table
+    print("\n=== Long-context sweep summary (RTX 5090 Laptop) ===")
+    print()
+    print(f"{'Ctx':>8s}  {'KV':>5s}  {'Prefill':>8s}  {'Decode tok/s':>13s}  "
+          f"{'AL':>5s}  {'KV size':>8s}")
+    print("-" * 58)
+    for r in results:
+        if "error" in r:
+            print(f"{r['n_prompt']//1024:>7d}K  {r['kv_mode']:>5s}  {'FAILED':>8s}  "
+                  f"{r['error'][:30]}")
+            continue
+        print(
+            f"{r['n_prompt']//1024:>7d}K  {r['kv_mode']:>5s}  "
+            f"{r['prefill_s']:>7.1f}s  {r['tok_s']:>12.1f}  "
+            f"{r['al']:>5.2f}  {r['kv_gb']:>6.2f} GB"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sweep_ds4_2case.sh
+++ b/scripts/sweep_ds4_2case.sh
@@ -185,6 +185,10 @@ PY
     if [ -z "${LUCEBOX_NO_PUSH:-}" ]; then
       local BRANCH=$(git rev-parse --abbrev-ref HEAD)
       local REMOTE=$(git config --get "branch.${BRANCH}.remote" || echo origin)
+      # Fetch + rebase before push — multiple hosts may be pushing
+      # snapshots on the same branch concurrently.
+      git fetch "$REMOTE" "$BRANCH" 2>/dev/null || true
+      git rebase "$REMOTE/$BRANCH" 2>&1 | tail -2 || true
       git push "$REMOTE" "$BRANCH" 2>&1 | tail -2 || true
     fi
   fi

--- a/scripts/sweep_ds4_2case.sh
+++ b/scripts/sweep_ds4_2case.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# scripts/sweep_ds4_2case.sh
+#
+# Local 5-config ds4-eval sweep on the two hard cases (1 GPQA Diamond,
+# 2 SuperGPQA) used as the rebench corpus while bragi/sindri tune
+# thinking-budget + KV-quant + DFlash knobs. Designed to run on any
+# host with `dflash_server` built and the standard Qwen3.6-27B target +
+# GGUF DFlash draft in dflash/models/.
+#
+# Output: one tuning-snapshot pair (.txt + .json) per config under
+# dflash/docs/tuning-snapshots/<host>-rtx*-qwen36-<date>-postmerge-<cfg>.{txt,json}
+# Each pair is auto-committed and pushed to the current branch's
+# remote. The repo-tracked snapshot makes cross-host diffs trivial.
+#
+# Env overrides:
+#   LUCEBOX_HOST           default: $(hostname -s)
+#   LUCEBOX_GPU            default: rtx3090ti  (free-form; for snapshot filename)
+#   LUCEBOX_DATE_TAG       default: $(date +%Y-%m-%d)-postmerge
+#   LUCEBOX_TARGET_GGUF    default: dflash/models/Qwen3.6-27B-Q4_K_M.gguf
+#   LUCEBOX_DRAFT_GGUF     default: dflash/models/draft/dflash-draft-3.6-q8_0.gguf
+#   LUCEBOX_DFLASH_BIN     default: dflash/build/dflash_server
+#   LUCEBOX_PORT           default: 1236
+#   LUCEBOX_MAX_CTX        default: 98304
+#   LUCEBOX_DDTREE_BUDGET  default: 22
+#   LUCEBOX_NO_PUSH=1      skip the git push (commit locally only)
+#   LUCEBOX_NO_COMMIT=1    skip both commit + push (just write files)
+#
+# Quitting:
+#   Ctrl-C kills the current child server cleanly; partially-completed
+#   configs leave a half-snapshot but no commit (atomic per config).
+
+set -uo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$ROOT"
+
+HOST=${LUCEBOX_HOST:-$(hostname -s)}
+GPU=${LUCEBOX_GPU:-rtx3090ti}
+DATE_TAG=${LUCEBOX_DATE_TAG:-$(date +%Y-%m-%d)-postmerge}
+TARGET=${LUCEBOX_TARGET_GGUF:-dflash/models/Qwen3.6-27B-Q4_K_M.gguf}
+DRAFT=${LUCEBOX_DRAFT_GGUF:-dflash/models/draft/dflash-draft-3.6-q8_0.gguf}
+BIN=${LUCEBOX_DFLASH_BIN:-dflash/build/dflash_server}
+PORT=${LUCEBOX_PORT:-1236}
+MAX_CTX=${LUCEBOX_MAX_CTX:-98304}
+BUDGET=${LUCEBOX_DDTREE_BUDGET:-22}
+SNAP_DIR=dflash/docs/tuning-snapshots
+
+# Sanity
+[ -f "$TARGET" ] || { echo "FATAL: target GGUF missing: $TARGET" >&2; exit 1; }
+[ -f "$DRAFT"  ] || { echo "FATAL: draft GGUF missing: $DRAFT"  >&2; exit 1; }
+[ -x "$BIN"    ] || { echo "FATAL: dflash_server binary missing: $BIN — run cmake --build dflash/build --target dflash_server" >&2; exit 1; }
+
+mkdir -p "$SNAP_DIR"
+WORK=$(mktemp -d -t lucebox-sweep.XXXX)
+echo "work=$WORK"
+echo "host=$HOST gpu=$GPU date_tag=$DATE_TAG"
+
+# Reap stale dflash_server
+pkill -9 -f "dflash_server.*--port $PORT" 2>/dev/null
+sleep 2
+
+run_one() {
+  local NAME=$1 CTK=$2 CTV=$3
+  shift 3
+  local DRAFT_ARGS=("$@")
+  local OUT="$WORK/$NAME"
+  mkdir -p "$OUT"
+  local SERVER_LOG="$OUT/server.log"
+  local SPID
+
+  echo "=== $NAME (ctk=$CTK ctv=$CTV draft_args=${DRAFT_ARGS[*]:-<none>}) at $(date '+%H:%M:%S') ==="
+
+  nohup env DFLASH27B_DRAFT_SWA=2048 \
+    "$BIN" "$TARGET" \
+    --host 127.0.0.1 --port "$PORT" \
+    --max-ctx "$MAX_CTX" \
+    --prefix-cache-slots 0 \
+    --think-max-tokens 15488 \
+    --cache-type-k "$CTK" --cache-type-v "$CTV" \
+    "${DRAFT_ARGS[@]}" \
+    > "$SERVER_LOG" 2>&1 &
+  SPID=$!
+  trap "kill -9 $SPID 2>/dev/null" RETURN
+  disown $SPID 2>/dev/null || true
+
+  echo "  waiting for /health (pid=$SPID)..."
+  local START=$(date +%s) ELAPSED=0
+  while ! curl -sf -m 3 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; do
+    kill -0 $SPID 2>/dev/null || { echo "  SERVER DIED during boot"; tail -30 "$SERVER_LOG"; return 1; }
+    sleep 3
+    ELAPSED=$(( $(date +%s) - START ))
+    if [ "$ELAPSED" -gt 240 ]; then
+      echo "  TIMEOUT waiting for /health"
+      kill -9 $SPID 2>/dev/null
+      return 1
+    fi
+  done
+  echo "  /health up after ${ELAPSED}s"
+
+  for c in 1 2; do
+    if [ "$c" = "1" ]; then ID="recNu3MXkvWUzHZr9"; else ID="001b51d76b4d422988f2c11f104a2c6c"; fi
+    echo "  case $c: $ID"
+    python3 dflash/scripts/bench_http_capability.py \
+      --url "http://127.0.0.1:$PORT" \
+      --area ds4-eval \
+      --case-id "$ID" \
+      --model dflash \
+      --min-pass-rate 0.0 \
+      --json-out "$OUT/case${c}.json" \
+      --trace "$OUT/case${c}-trace.txt" \
+      --max-tokens 16000 \
+      --timeout 1800 \
+      --think 2>&1 | tail -3
+  done
+
+  kill $SPID 2>/dev/null; sleep 2; kill -9 $SPID 2>/dev/null || true
+  trap - RETURN
+
+  # Write snapshot pair
+  local SHA=$(git rev-parse --short HEAD)
+  local TXT="$SNAP_DIR/${HOST}-${GPU}-qwen36-${DATE_TAG}-${NAME}.txt"
+  local JSON="$SNAP_DIR/${HOST}-${GPU}-qwen36-${DATE_TAG}-${NAME}.json"
+  HOST="$HOST" CFG="$NAME" SHA="$SHA" CDIR="$OUT" TXT_OUT="$TXT" JSON_OUT="$JSON" python3 - <<'PY'
+import json, os, datetime, pathlib, re
+cfg = os.environ['CFG']; cdir = os.environ['CDIR']
+def load(p):
+    try: return json.load(open(p))
+    except Exception as e: return {"_error": str(e)}
+c1 = load(f"{cdir}/case1.json"); c2 = load(f"{cdir}/case2.json")
+try: serverlog = open(f"{cdir}/server.log").read()
+except: serverlog = ""
+def grep_kv(pat):
+    m = re.search(pat, serverlog)
+    return m.group(1).strip() if m else None
+def row(c):
+    if not c.get("rows"): return {}
+    r = c["rows"][0]
+    keep = ('id','source','given','correct','graded_pass','strict_pass','format_pass',
+            'semantic_hint','wall_s','prompt_tokens','completion_tokens','thinking_tokens',
+            'content_tokens','close_kind','finish_reason','http_status')
+    out = {k: r.get(k) for k in keep}
+    out['correct'] = (r.get('correct') or [None])[0]
+    out['result'] = 'PASS' if r.get('graded_pass') else 'FAIL'
+    return out
+r1, r2 = row(c1), row(c2)
+data = {
+    "schema": "sweep-2case-v1",
+    "captured_at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec='seconds'),
+    "host": os.environ['HOST'],
+    "binary_sha": os.environ['SHA'],
+    "config_name": cfg,
+    "server_knobs": {
+        "cache_type_k": grep_kv(r'cache_type_k\s*=\s*(\S+)'),
+        "cache_type_v": grep_kv(r'cache_type_v\s*=\s*(\S+)'),
+        "max_ctx":      grep_kv(r'max_ctx\s*=\s*(\d+)'),
+        "think_max_tokens": grep_kv(r'think_max_tokens=\s*(\d+)'),
+        "ddtree":       grep_kv(r'ddtree\s*=\s*(\S+)'),
+        "draft":        grep_kv(r'draft\s*=\s*(\S+)'),
+    },
+    "cases": {
+        "case1.GPQA_Diamond.recNu3MXkvWUzHZr9": r1,
+        "case2.SuperGPQA.001b51d76b4d422988f2c11f104a2c6c": r2,
+    },
+}
+pathlib.Path(os.environ['JSON_OUT']).write_text(json.dumps(data, indent=2)+"\n")
+lines = [f"# ds4-eval 2-case sweep snapshot — {data['host']} {cfg}",
+         f"# schema={data['schema']}", "",
+         "[snapshot]",
+         f"schema={data['schema']}", f"captured_at={data['captured_at']}",
+         f"host={data['host']}", f"binary_sha={data['binary_sha']}",
+         f"config_name={data['config_name']}", "", "[server_knobs]"]
+for k,v in data['server_knobs'].items(): lines.append(f"{k}={v}")
+lines.append("")
+for label, r in (("case.1", r1), ("case.2", r2)):
+    lines.append(f"[{label}]")
+    for k,v in r.items(): lines.append(f"{k}={v}")
+    lines.append("")
+pathlib.Path(os.environ['TXT_OUT']).write_text("\n".join(lines))
+print(f"snapshot: {os.environ['TXT_OUT']}")
+PY
+
+  if [ -z "${LUCEBOX_NO_COMMIT:-}" ]; then
+    git add "$TXT" "$JSON"
+    git commit -m "data(ds4-eval): ${HOST} post-merge sweep — config ${NAME}" 2>&1 | tail -2
+    if [ -z "${LUCEBOX_NO_PUSH:-}" ]; then
+      local BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      local REMOTE=$(git config --get "branch.${BRANCH}.remote" || echo origin)
+      git push "$REMOTE" "$BRANCH" 2>&1 | tail -2 || true
+    fi
+  fi
+  echo "=== $NAME done at $(date '+%H:%M:%S') ==="
+}
+
+run_one "A-baseline-rebuild" q4_0 q4_0 --draft "$DRAFT" --ddtree --ddtree-budget "$BUDGET"
+run_one "B-kv-mix"           q8_0 q4_0 --draft "$DRAFT" --ddtree --ddtree-budget "$BUDGET"
+run_one "C-kv-q8"            q8_0 q8_0 --draft "$DRAFT" --ddtree --ddtree-budget "$BUDGET"
+run_one "D-ar-q4kv"          q4_0 q4_0
+run_one "E-ar-kv-mix"        q8_0 q4_0
+echo "=== SWEEP DONE at $(date '+%Y-%m-%d %H:%M:%S') — work=$WORK ==="


### PR DESCRIPTION
## Summary
- `scripts/sweep_ds4_2case.sh` — portable 5-config ds4-eval sweep over the two canonical hard cases (GPQA Diamond `recNu3MXkvWUzHZr9`, SuperGPQA `001b51d76b4d422988f2c11f104a2c6c`). Each config writes a tuning snapshot pair to `dflash/docs/tuning-snapshots/<host>-<gpu>-qwen36-<date>-<cfg>.{txt,json}` and auto-commits + pushes (with fetch+rebase to avoid colliding with parallel hosts).
- `dflash/scripts/bench_long_ctx.py` — long-context Q4_0 vs TQ3_0 KV-cache sweep at 32K/64K/128K. The point is memory savings (TQ3_0 = 3.5bpv vs Q4_0 = 4.5bpv, ~22% smaller KV), not throughput.

## Why
Cross-host ds4-eval comparisons (sindri RTX 3090 Ti vs bragi RTX 5090 Laptop vs vidar DeepSeek V4 Flash vs OpenRouter Qwen3.6-27B) need reproducible config matrices and committable evidence. The script's snapshot artefacts under `dflash/docs/tuning-snapshots/` are diffable with `git diff` across hosts and across binary revisions, which is exactly what we need to verify recent thinking-budget fixes (a44a7bc, 5059fea, a1144dd) flipped case 1 FAIL→PASS and case 2 fmt=False→fmt=True.

Sweep matrix:

| tag | cache-type-k | cache-type-v | DFlash |
|---|---|---|---|
| A-baseline-rebuild | q4_0 | q4_0 | on |
| B-kv-mix | q8_0 | q4_0 | on |
| C-kv-q8 | q8_0 | q8_0 | on |
| D-ar-q4kv | q4_0 | q4_0 | **off** (AR only) |
| E-ar-kv-mix | q8_0 | q4_0 | **off** (AR only) |

## Test plan
- [x] `bash -n scripts/sweep_ds4_2case.sh` (syntax)
- [x] Run config A end-to-end on sindri post-merge — both cases PASS, snapshot committed (`932fe6d`)
- [ ] Run on bragi RTX 5090 Laptop for cross-host comparison
- [ ] Full matrix sweep (A–E) on sindri — in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)