### PR TITLE
feat(cpp-server): log C++ chat request lifecycle

### DIFF
--- a/dflash/src/server/http_server.cpp
+++ b/dflash/src/server/http_server.cpp
@@ -34,6 +34,19 @@ static std::string generate_id(const char * prefix) {
     return buf;
 }
 
+static const char * api_format_name(ApiFormat format) {
+    switch (format) {
+    case ApiFormat::OPENAI_CHAT: return "chat";
+    case ApiFormat::ANTHROPIC:   return "anthropic";
+    case ApiFormat::RESPONSES:   return "responses";
+    default:                     return "unknown";
+    }
+}
+
+static size_t json_array_size(const json & value) {
+    return value.is_array() ? value.size() : 0;
+}
+
 json parse_responses_arguments(const json & item) {
     if (!item.contains("arguments")) return json::object();
     const auto & arguments = item["arguments"];
@@ -396,6 +409,9 @@ void HttpServer::handle_client(int fd) {
 bool HttpServer::route_request(int fd, const HttpRequest & hr) {
     if (hr.method != "POST") return false;
 
+    std::fprintf(stderr, "[server] request path=%s body_bytes=%zu\n",
+                 hr.path.c_str(), hr.body.size());
+
     ParsedRequest req;
     std::string err;
 
@@ -618,6 +634,21 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         return true;
     }
 
+    std::fprintf(stderr,
+        "[server] chat %s format=%s stream=%s msgs=%zu tools=%zu prompt_tokens=%zu "
+        "max_tokens=%d max_ctx=%d thinking=%s stops=%zu model=%s\n",
+        req.response_id.c_str(),
+        api_format_name(req.format),
+        req.stream ? "true" : "false",
+        json_array_size(req.messages),
+        json_array_size(req.tools),
+        req.prompt_tokens.size(),
+        req.max_output,
+        config_.max_ctx,
+        req.thinking_enabled ? "true" : "false",
+        req.stop_sequences.size(),
+        req.model.c_str());
+
     // Set socket non-blocking for send() stall detection during streaming.
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags >= 0) fcntl(fd, F_SETFL, flags | O_NONBLOCK);
@@ -647,6 +678,17 @@ void HttpServer::worker_loop() {
 
         int fd = job->fd;
         const auto & req = job->req;
+        auto started_at = std::chrono::steady_clock::now();
+
+        std::fprintf(stderr,
+            "[server] chat START %s format=%s stream=%s prompt_tokens=%zu "
+            "max_tokens=%d tools=%zu\n",
+            req.response_id.c_str(),
+            api_format_name(req.format),
+            req.stream ? "true" : "false",
+            req.prompt_tokens.size(),
+            req.max_output,
+            json_array_size(req.tools));
 
         // Send SSE headers.
         if (req.stream) {
@@ -842,6 +884,19 @@ void HttpServer::worker_loop() {
             gen_req.snap_slot = snap_slot;
             gen_req.snap_pos = snap_cut;
         }
+
+        std::fprintf(stderr,
+            "[server] chat CACHE %s restore=%s slot=%d prefix_len=%d "
+            "effective_prompt=%zu pflash=%s disk_hit=%s snap_slot=%d snap_pos=%d\n",
+            req.response_id.c_str(),
+            using_restore ? "true" : "false",
+            cache_slot,
+            prefix_len,
+            effective_prompt.size(),
+            pflash_compressed ? "true" : "false",
+            disk_hit ? "true" : "false",
+            snap_slot,
+            snap_cut);
 
         // Set up DaemonIO with on_token callback for streaming + disconnect.
         DaemonIO io;
@@ -1131,6 +1186,38 @@ void HttpServer::worker_loop() {
                          "(prompt=%zu out=%d)\n",
                          req.prompt_tokens.size(), completion_tokens);
         }
+
+        const auto done_at = std::chrono::steady_clock::now();
+        const double elapsed_s =
+            std::chrono::duration<double>(done_at - started_at).count();
+        const int result_tokens = (int)result.tokens.size();
+        const int out_tokens = std::max(completion_tokens, result_tokens);
+        const double tok_s = elapsed_s > 0.0 ? out_tokens / elapsed_s : 0.0;
+        const double decode_tok_s =
+            result.decode_s > 0.0 ? out_tokens / result.decode_s : 0.0;
+        const std::string finish = client_disconnected
+            ? "client_disconnect"
+            : (result.ok ? emitter.finish_reason() : "error");
+
+        std::fprintf(stderr,
+            "[server] chat DONE %s ok=%s in=%zu effective_in=%zu out=%d "
+            "%.1fs %.1f tok/s finish=%s restore=%s slot=%d prefix_len=%d "
+            "prefill=%.1fs decode=%.1fs(%.1ftok/s) error=%s\n",
+            req.response_id.c_str(),
+            result.ok ? "true" : "false",
+            req.prompt_tokens.size(),
+            effective_prompt.size(),
+            out_tokens,
+            elapsed_s,
+            tok_s,
+            finish.c_str(),
+            using_restore ? "true" : "false",
+            cache_slot,
+            prefix_len,
+            result.prefill_s,
+            result.decode_s,
+            decode_tok_s,
+            result.error.empty() ? "-" : result.error.c_str());
 
         // Signal client thread that we're done.
         {


### PR DESCRIPTION
I had a quick play with c++ server, what a great improvement over the python server.  Lower VRAM.  I can now run 27B Q5 and trying to push now 98k context on the 3090.  I will see if I can get Q8 and 128k context on the 5090 next.  I had to ask codex to improve the logging for me to understand what is going on while I it use with Hermes.  Below is codex better explanation of this PR.

Adds Python-style request lifecycle logging to the native C++ `dflash_server`.

The C++ server already logged startup/cache internals, but did not clearly show whether agent clients such as Hermes/OpenClaw reached `/v1/chat/completions`, how many prompt/output tokens were involved, whether prefix-cache restore happened, or how the request finished.

This made failures ambiguous: an apparent Hermes/API issue could actually be a CUDA/VRAM failure, model behavior such as `finish=stop`, or a successful tool-call turn.

## Log Shape

New lines include:

```text
[server] request path=/v1/chat/completions body_bytes=...
[server] chat chatcmpl_... format=chat stream=true msgs=... tools=... prompt_tokens=... max_tokens=... max_ctx=... thinking=... stops=... model=...
[server] chat START chatcmpl_...
[server] chat CACHE chatcmpl_... restore=... slot=... prefix_len=... effective_prompt=... pflash=... disk_hit=... snap_slot=... snap_pos=...
[server] chat DONE chatcmpl_... ok=... in=... effective_in=... out=... 12.3s 4.5 tok/s finish=... restore=... slot=... prefix_len=... prefill=... decode=...(...tok/s) error=...
```

## Timing Semantics

This intentionally matches Python `server.py`:

- the main `tok/s` is end-to-end request throughput: `output_tokens / wall_time`
- `prefill=...` reports prefill/cache-restore/generation setup time reported by the backend
- `decode=...(...tok/s)` reports decode-only throughput, which should align more closely with `[spec-decode]` logs

Python’s timing has had known edge cases when stale abandoned-stream tokens polluted a later request. The C++ logs keep the same high-level shape while making decode speed explicit so the end-to-end `tok/s` is not confused with model generation speed.

## Real Debugging Result

The new logs confirmed Hermes was reaching the C++ API:

```text
[server] chat START chatcmpl_0000000000000000 format=chat stream=true prompt_tokens=14052 max_tokens=4096 tools=19
```

The failure was below HTTP/API handling:

```text
CUDA error: unspecified launch failure
```

That distinction was not obvious from the previous C++ logs.
