### PR TITLE
fix(cpp-server): harden C++ streaming tool calls

### DIFF
--- a/dflash/src/server/http_server.cpp
+++ b/dflash/src/server/http_server.cpp
@@ -34,6 +34,19 @@ static std::string generate_id(const char * prefix) {
     return buf;
 }
 
+static const char * api_format_name(ApiFormat format) {
+    switch (format) {
+    case ApiFormat::OPENAI_CHAT: return "chat";
+    case ApiFormat::ANTHROPIC:   return "anthropic";
+    case ApiFormat::RESPONSES:   return "responses";
+    default:                     return "unknown";
+    }
+}
+
+static size_t json_array_size(const json & value) {
+    return value.is_array() ? value.size() : 0;
+}
+
 json parse_responses_arguments(const json & item) {
     if (!item.contains("arguments")) return json::object();
     const auto & arguments = item["arguments"];
@@ -396,6 +409,9 @@ void HttpServer::handle_client(int fd) {
 bool HttpServer::route_request(int fd, const HttpRequest & hr) {
     if (hr.method != "POST") return false;
 
+    std::fprintf(stderr, "[server] request path=%s body_bytes=%zu\n",
+                 hr.path.c_str(), hr.body.size());
+
     ParsedRequest req;
     std::string err;
 
@@ -618,6 +634,21 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         return true;
     }
 
+    std::fprintf(stderr,
+        "[server] chat %s format=%s stream=%s msgs=%zu tools=%zu prompt_tokens=%zu "
+        "max_tokens=%d max_ctx=%d thinking=%s stops=%zu model=%s\n",
+        req.response_id.c_str(),
+        api_format_name(req.format),
+        req.stream ? "true" : "false",
+        json_array_size(req.messages),
+        json_array_size(req.tools),
+        req.prompt_tokens.size(),
+        req.max_output,
+        config_.max_ctx,
+        req.thinking_enabled ? "true" : "false",
+        req.stop_sequences.size(),
+        req.model.c_str());
+
     // Set socket non-blocking for send() stall detection during streaming.
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags >= 0) fcntl(fd, F_SETFL, flags | O_NONBLOCK);
@@ -647,6 +678,17 @@ void HttpServer::worker_loop() {
 
         int fd = job->fd;
         const auto & req = job->req;
+        auto started_at = std::chrono::steady_clock::now();
+
+        std::fprintf(stderr,
+            "[server] chat START %s format=%s stream=%s prompt_tokens=%zu "
+            "max_tokens=%d tools=%zu\n",
+            req.response_id.c_str(),
+            api_format_name(req.format),
+            req.stream ? "true" : "false",
+            req.prompt_tokens.size(),
+            req.max_output,
+            json_array_size(req.tools));
 
         // Send SSE headers.
         if (req.stream) {
@@ -842,6 +884,19 @@ void HttpServer::worker_loop() {
             gen_req.snap_slot = snap_slot;
             gen_req.snap_pos = snap_cut;
         }
+
+        std::fprintf(stderr,
+            "[server] chat CACHE %s restore=%s slot=%d prefix_len=%d "
+            "effective_prompt=%zu pflash=%s disk_hit=%s snap_slot=%d snap_pos=%d\n",
+            req.response_id.c_str(),
+            using_restore ? "true" : "false",
+            cache_slot,
+            prefix_len,
+            effective_prompt.size(),
+            pflash_compressed ? "true" : "false",
+            disk_hit ? "true" : "false",
+            snap_slot,
+            snap_cut);
 
         // Set up DaemonIO with on_token callback for streaming + disconnect.
         DaemonIO io;
@@ -1131,6 +1186,38 @@ void HttpServer::worker_loop() {
                          "(prompt=%zu out=%d)\n",
                          req.prompt_tokens.size(), completion_tokens);
         }
+
+        const auto done_at = std::chrono::steady_clock::now();
+        const double elapsed_s =
+            std::chrono::duration<double>(done_at - started_at).count();
+        const int result_tokens = (int)result.tokens.size();
+        const int out_tokens = std::max(completion_tokens, result_tokens);
+        const double tok_s = elapsed_s > 0.0 ? out_tokens / elapsed_s : 0.0;
+        const double decode_tok_s =
+            result.decode_s > 0.0 ? out_tokens / result.decode_s : 0.0;
+        const std::string finish = client_disconnected
+            ? "client_disconnect"
+            : (result.ok ? emitter.finish_reason() : "error");
+
+        std::fprintf(stderr,
+            "[server] chat DONE %s ok=%s in=%zu effective_in=%zu out=%d "
+            "%.1fs %.1f tok/s finish=%s restore=%s slot=%d prefix_len=%d "
+            "prefill=%.1fs decode=%.1fs(%.1ftok/s) error=%s\n",
+            req.response_id.c_str(),
+            result.ok ? "true" : "false",
+            req.prompt_tokens.size(),
+            effective_prompt.size(),
+            out_tokens,
+            elapsed_s,
+            tok_s,
+            finish.c_str(),
+            using_restore ? "true" : "false",
+            cache_slot,
+            prefix_len,
+            result.prefill_s,
+            result.decode_s,
+            decode_tok_s,
+            result.error.empty() ? "-" : result.error.c_str());
 
         // Signal client thread that we're done.
         {

--- a/dflash/src/server/sse_emitter.cpp
+++ b/dflash/src/server/sse_emitter.cpp
@@ -17,7 +17,24 @@ static const char FUNCTION_OPEN[] = "<function=";
 static const char TOOL_CODE_OPEN[] = "<tool_code>";
 static constexpr size_t THINK_OPEN_LEN  = 7;
 static constexpr size_t THINK_CLOSE_LEN = 8;
-static constexpr size_t TOOL_OPEN_LEN   = 11;
+
+static bool has_request_tools(const json & tools) {
+    return tools.is_array() && !tools.empty();
+}
+
+static bool find_tool_start(const std::string & text, size_t & pos) {
+    size_t idx = text.find('<');
+    while (idx != std::string::npos) {
+        if (text.compare(idx, sizeof(TOOL_OPEN) - 1, TOOL_OPEN) == 0 ||
+            text.compare(idx, sizeof(FUNCTION_OPEN) - 1, FUNCTION_OPEN) == 0 ||
+            text.compare(idx, sizeof(TOOL_CODE_OPEN) - 1, TOOL_CODE_OPEN) == 0) {
+            pos = idx;
+            return true;
+        }
+        idx = text.find('<', idx + 1);
+    }
+    return false;
+}
 
 static std::string gen_item_id() {
     static std::atomic<uint64_t> ctr{0};
@@ -316,20 +333,18 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
         }
 
         // mode_ == StreamMode::CONTENT
-        // Look for <think>, </think>, or any supported tool-call opener.
+        // Look for <think>, </think>, or supported tool-call starts.
         size_t think_idx = window_.find(THINK_OPEN);
         size_t think_close_idx = window_.find(THINK_CLOSE);
-        size_t tool_idx = window_.find(TOOL_OPEN);
-        size_t function_idx = window_.find(FUNCTION_OPEN);
-        size_t tool_code_idx = window_.find(TOOL_CODE_OPEN);
+        size_t tool_idx = std::string::npos;
+        bool tool_hit = has_request_tools(tools_) &&
+                        find_tool_start(window_, tool_idx);
 
         struct Hit { size_t pos; int type; };  // type: 0=think, 1=think_close, 2=tool-ish
         std::vector<Hit> hits;
         if (think_idx != std::string::npos)       hits.push_back({think_idx, 0});
         if (think_close_idx != std::string::npos) hits.push_back({think_close_idx, 1});
-        if (tool_idx != std::string::npos)        hits.push_back({tool_idx, 2});
-        if (function_idx != std::string::npos)    hits.push_back({function_idx, 2});
-        if (tool_code_idx != std::string::npos)   hits.push_back({tool_code_idx, 2});
+        if (tool_hit)                             hits.push_back({tool_idx, 2});
 
         if (!hits.empty()) {
             std::sort(hits.begin(), hits.end(),
@@ -349,8 +364,8 @@ std::vector<std::string> SseEmitter::emit_token(const std::string & raw_piece) {
                 // </think> in content — just skip it
                 window_ = window_.substr(h.pos + THINK_CLOSE_LEN);
             } else {
-                // Tool-call shapes can start with <tool_call>, bare
-                // <function=...>, or <tool_code> JSON wrappers.
+                // Tool-call syntax. Keep the full tag/function text buffered
+                // until finish so the parser can validate it.
                 tool_buffer_ = window_.substr(h.pos);
                 window_.clear();
                 mode_ = StreamMode::TOOL_BUFFER;
@@ -541,9 +556,12 @@ std::vector<std::string> SseEmitter::emit_finish(int completion_tokens) {
             default: break;
             }
         } else {
-            // No tool calls found — emit the buffer as content
-            accumulated_content_ += tool_buffer_;
-            emit_content_delta(out, tool_buffer_);
+            // Tool syntax was detected but no valid call parsed. Do not leak
+            // malformed/incomplete XML back to the user as assistant text.
+            std::fprintf(stderr,
+                "[server] tool_call parse failed; suppressing buffered tool text "
+                "request_id=%s format=%d bytes=%zu\n",
+                request_id_.c_str(), (int)format_, tool_buffer_.size());
         }
     }
 

--- a/dflash/src/server/tool_parser.cpp
+++ b/dflash/src/server/tool_parser.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <mutex>
 #include <random>
 #include <regex>
@@ -114,6 +115,16 @@ static bool overlaps(const std::vector<Span> & spans, size_t pos) {
         if (s.start <= pos && pos < s.end) return true;
     }
     return false;
+}
+
+static size_t include_preceding_tool_call_open(const std::string & text, size_t pos) {
+    size_t wrapper = text.rfind("<tool_call>", pos);
+    if (wrapper == std::string::npos) return pos;
+    for (size_t i = wrapper + std::strlen("<tool_call>"); i < pos; i++) {
+        char c = text[i];
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') return pos;
+    }
+    return wrapper;
 }
 
 // ─── Pattern regexes ────────────────────────────────────────────────────
@@ -342,8 +353,9 @@ ToolParseResult parse_tool_calls(const std::string & text, const json & tools) {
             if (overlaps(removals, pos)) continue;
             std::string fn_name = (*it)[1].str();
             std::string params = (*it)[2].str();
+            size_t removal_start = include_preceding_tool_call_open(text, pos);
             add_call(fn_name, parse_xml_params(params, fn_name, tools),
-                     pos, pos + it->length());
+                     removal_start, pos + it->length());
         }
     }
 

--- a/dflash/test/test_server_unit.cpp
+++ b/dflash/test/test_server_unit.cpp
@@ -73,9 +73,36 @@ static const char * current_test = nullptr;
 
 // ─── Helper: create an SseEmitter with minimal config ──────────────────
 
-static SseEmitter make_emitter(ApiFormat fmt, bool thinking = false) {
+static json weather_tools() {
+    return json::array({
+        {{"type", "function"},
+         {"function", {
+             {"name", "get_weather"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"location", {{"type", "string"}}},
+                     {"command", {{"type", "string"}}}
+                 }}
+             }}
+         }}},
+        {{"type", "function"},
+         {"function", {
+             {"name", "terminal"},
+             {"parameters", {
+                 {"type", "object"},
+                 {"properties", {
+                     {"command", {{"type", "string"}}}
+                 }}
+             }}
+         }}}
+    });
+}
+
+static SseEmitter make_emitter(ApiFormat fmt, bool thinking = false,
+                               json tools = json::array()) {
     return SseEmitter(fmt, "test_id_001", "test-model", 10,
-                      json::array(), nullptr, thinking);
+                      tools, nullptr, thinking);
 }
 
 // Concatenate all SSE chunks into a single string.
@@ -336,7 +363,7 @@ static void test_emitter_content_only_no_thinking() {
 
 static void test_emitter_tool_buffer_detection() {
     // When the emitter sees <tool_call>, it should buffer and parse tools.
-    auto em = make_emitter(ApiFormat::OPENAI_CHAT, false);
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, false, weather_tools());
     em.emit_start();
     em.emit_token("<tool_call>\n"
                   "<function=get_weather>\n"
@@ -390,6 +417,75 @@ static void test_emitter_anthropic_tool_use_blocks() {
         n_stop++; pos++;
     }
     TEST_ASSERT(n_stop >= 2);
+}
+
+static void test_emitter_bare_function_tool_buffer_detection() {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, false, weather_tools());
+    em.emit_start();
+    em.emit_token("<function=terminal>\n"
+                  "<parameter=command>\n"
+                  "ls -la /tmp/lop/\n"
+                  "</parameter>\n"
+                  "</function>");
+    em.emit_finish(20);
+
+    TEST_ASSERT(!em.tool_calls().empty());
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "terminal");
+        auto args = json::parse(em.tool_calls()[0].arguments);
+        TEST_ASSERT(args["command"] == "ls -la /tmp/lop/");
+    }
+    TEST_ASSERT(em.accumulated_text().find("<function=terminal>") == std::string::npos);
+}
+
+static void test_emitter_does_not_leak_malformed_tool_xml() {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, false, weather_tools());
+    em.emit_start();
+    em.emit_token("Let me list files.\n\n");
+    em.emit_token("<tool_call>\n"
+                  "<function=terminal>\n"
+                  "<parameter=command>\n"
+                  "ls -la /tmp/lop/\n"
+                  "</parameter>");
+    em.emit_finish(20);
+
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().find("Let me list files.") != std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("<tool_call>") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("<function=terminal>") == std::string::npos);
+}
+
+static void test_emitter_parses_tool_call_missing_outer_close() {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, false, weather_tools());
+    em.emit_start();
+    em.emit_token("<tool_call>\n"
+                  "<function=terminal>\n"
+                  "<parameter=command>\n"
+                  "ls -la /tmp/lop/\n"
+                  "</parameter>\n"
+                  "</function>");
+    em.emit_finish(20);
+
+    TEST_ASSERT(!em.tool_calls().empty());
+    if (!em.tool_calls().empty()) {
+        TEST_ASSERT(em.tool_calls()[0].name == "terminal");
+        auto args = json::parse(em.tool_calls()[0].arguments);
+        TEST_ASSERT(args["command"] == "ls -la /tmp/lop/");
+    }
+    TEST_ASSERT(em.accumulated_text().find("<tool_call>") == std::string::npos);
+    TEST_ASSERT(em.accumulated_text().find("<function=terminal>") == std::string::npos);
+}
+
+static void test_emitter_no_tools_keeps_tool_like_text() {
+    auto em = make_emitter(ApiFormat::OPENAI_CHAT, false);
+    em.emit_start();
+    em.emit_token("<function=terminal>\n"
+                  "<parameter=command>ls</parameter>\n"
+                  "</function>");
+    em.emit_finish(20);
+
+    TEST_ASSERT(em.tool_calls().empty());
+    TEST_ASSERT(em.accumulated_text().find("<function=terminal>") != std::string::npos);
 }
 
 static void test_emitter_anthropic_structure() {
@@ -1590,6 +1686,10 @@ int main() {
     RUN_TEST(test_emitter_content_only_no_thinking);
     RUN_TEST(test_emitter_tool_buffer_detection);
     RUN_TEST(test_emitter_anthropic_tool_use_blocks);
+    RUN_TEST(test_emitter_bare_function_tool_buffer_detection);
+    RUN_TEST(test_emitter_does_not_leak_malformed_tool_xml);
+    RUN_TEST(test_emitter_parses_tool_call_missing_outer_close);
+    RUN_TEST(test_emitter_no_tools_keeps_tool_like_text);
     RUN_TEST(test_emitter_anthropic_structure);
     RUN_TEST(test_emitter_responses_structure);
     RUN_TEST(test_emitter_responses_bare_function_tool_call);


### PR DESCRIPTION
I had codex fix some of tool calls last week, it seems there is already been progress to this.  So I asked it to use the upstream which already includes PR #252 and only add the missing things I already had.  Been testing this with Hermes and with my PR #270 as I needed better logging. Below is codex elaboration of this fix:


Follow-up to upstream PR #252 for the native C++ `dflash_server` path.

Upstream PR #252 added C++ streaming detection for:

- `<tool_call>`
- bare `<function=...>`
- `<tool_code>`

This PR keeps that behavior but hardens two remaining edge cases:

- tool-like XML should only enter tool-buffer mode when request tools are present
- malformed/incomplete tool XML should not be emitted back as visible assistant text if parsing fails

## Observed Failure

In testing, the model exposed tool XML as visible assistant text:

```xml
<tool_call>
<function=terminal>
<parameter=command>
ls -la /tmp/lop/
</parameter>
```

That should not be shown as assistant text when the request contains tools. If it parses cleanly, it should become a structured tool call. If it is malformed/incomplete, it should be suppressed rather than leaked.

## Fix

The C++ SSE emitter now:

- detects `<tool_call>`, bare `<function=`, and `<tool_code>` as tool-call starts
- only enables that detection when request tools are present
- suppresses malformed/incomplete buffered tool XML instead of leaking it as visible content
- preserves XML-like text as ordinary assistant content when no tools were supplied

## Tests Added

C++ unit coverage for:

- streaming `<tool_call>...</tool_call>` with request tools
- streaming bare `<function=...>` tool call
- malformed/incomplete tool XML not leaking as assistant content
- no-tools requests preserving XML-like text as ordinary content
