### PR TITLE
fix(pflash): add legacy CUDA drafter precision fallback

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -261,6 +261,7 @@ add_library(dflash_common STATIC
     src/qwen35/layer_split_daemon_loop.cpp
     src/qwen35/qwen35_daemon.cpp
     src/common/sampler.cpp
+    src/common/backend_precision.cpp
     src/common/daemon_loop.cpp
     src/common/gguf_inspect.cpp
     src/common/backend_factory.cpp

--- a/server/src/common/backend_precision.cpp
+++ b/server/src/common/backend_precision.cpp
@@ -1,0 +1,170 @@
+#include "backend_precision.h"
+
+#if defined(DFLASH27B_BACKEND_CUDA) || defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+#include "gpu_runtime_compat.h"
+#endif
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace dflash::common {
+namespace {
+
+std::string backend_device_description(ggml_backend_t backend) {
+    if (!backend) {
+        return {};
+    }
+    ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+    if (!dev) {
+        return {};
+    }
+    const char * desc = ggml_backend_dev_description(dev);
+    if (desc && desc[0]) {
+        return desc;
+    }
+    return {};
+}
+
+std::string backend_device_logical_name(ggml_backend_t backend) {
+    if (!backend) {
+        return {};
+    }
+    ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+    if (!dev) {
+        return {};
+    }
+    const char * name = ggml_backend_dev_name(dev);
+    return name ? std::string(name) : std::string{};
+}
+
+std::string backend_name(ggml_backend_t backend) {
+    if (!backend) {
+        return {};
+    }
+    ggml_backend_dev_t dev = ggml_backend_get_device(backend);
+    if (!dev) {
+        return {};
+    }
+    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+    const char * name = reg ? ggml_backend_reg_name(reg) : nullptr;
+    return name ? std::string(name) : std::string{};
+}
+
+int parse_backend_device_id(const std::string & logical_name) {
+    if (logical_name.empty()) return -1;
+    size_t end = logical_name.size();
+    while (end > 0 && std::isspace((unsigned char)logical_name[end - 1])) {
+        --end;
+    }
+    size_t begin = end;
+    while (begin > 0 && std::isdigit((unsigned char)logical_name[begin - 1])) {
+        --begin;
+    }
+    if (begin == end) return -1;
+    return std::atoi(logical_name.substr(begin, end - begin).c_str());
+}
+
+int current_device_id() {
+#if defined(DFLASH27B_BACKEND_CUDA) || defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    int device = -1;
+    if (cudaGetDevice(&device) != cudaSuccess || device < 0) {
+        return -1;
+    }
+    return device;
+#else
+    return -1;
+#endif
+}
+
+int device_props_for(int device,
+                     std::string * device_name,
+                     std::string * arch_name) {
+#if defined(DFLASH27B_BACKEND_CUDA) || defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    if (device < 0) {
+        return 0;
+    }
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, device) != cudaSuccess) {
+        return 0;
+    }
+    if (device_name && prop.name[0]) {
+        *device_name = prop.name;
+    }
+#if defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    if (arch_name && prop.gcnArchName[0]) {
+        *arch_name = prop.gcnArchName;
+    }
+#endif
+    return prop.major * 10 + prop.minor;
+#else
+    (void)device;
+    (void)device_name;
+    (void)arch_name;
+    return 0;
+#endif
+}
+
+} // namespace
+
+const char * backend_precision_type_name(ggml_type type) {
+    return ggml_type_name(type);
+}
+
+BackendPrecisionPolicy select_drafter_precision_policy(ggml_backend_t backend) {
+    BackendPrecisionPolicy policy;
+    policy.backend_name = backend_name(backend);
+    const std::string logical_name = backend_device_logical_name(backend);
+    policy.device_name = backend_device_description(backend);
+    policy.device_id = parse_backend_device_id(logical_name);
+    if (policy.device_id < 0) {
+        policy.device_id = current_device_id();
+    }
+
+#if defined(DFLASH27B_BACKEND_CUDA)
+    policy.cuda_sm = device_props_for(
+        policy.device_id,
+        policy.device_name.empty() ? &policy.device_name : nullptr,
+        nullptr);
+    if (policy.cuda_sm >= 80) {
+        policy.weight_type  = GGML_TYPE_BF16;
+        policy.compute_type = GGML_TYPE_BF16;
+        policy.reason       = "CUDA sm80+ BF16 tensor-core path";
+    } else if (policy.cuda_sm >= 70) {
+        policy.weight_type  = GGML_TYPE_F16;
+        policy.compute_type = GGML_TYPE_F16;
+        policy.reason       = "CUDA sm70-sm79 F16 tensor-core path";
+    } else if (policy.cuda_sm == 60) {
+        policy.weight_type  = GGML_TYPE_F16;
+        policy.compute_type = GGML_TYPE_F16;
+        policy.reason       = "CUDA sm60 GP100 F16 path";
+    } else {
+        policy.weight_type  = GGML_TYPE_F32;
+        policy.compute_type = GGML_TYPE_F32;
+        policy.reason       = "CUDA legacy compatibility fallback without useful F16/BF16 acceleration";
+    }
+#elif defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    policy.cuda_sm = device_props_for(
+        policy.device_id,
+        policy.device_name.empty() ? &policy.device_name : nullptr,
+        &policy.runtime_arch);
+    policy.weight_type  = GGML_TYPE_BF16;
+    policy.compute_type = GGML_TYPE_BF16;
+    policy.reason       = "HIP ROCm/ggml BF16-compatible path";
+#else
+    policy.weight_type  = GGML_TYPE_F32;
+    policy.compute_type = GGML_TYPE_F32;
+    policy.reason       = "portable non-GPU fallback";
+#endif
+
+    if (policy.backend_name.empty()) {
+        policy.backend_name = "unknown";
+    }
+    if (policy.device_name.empty()) {
+        policy.device_name = "unknown";
+    }
+    return policy;
+}
+
+} // namespace dflash::common

--- a/server/src/common/backend_precision.h
+++ b/server/src/common/backend_precision.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <string>
+
+namespace dflash::common {
+
+struct BackendPrecisionPolicy {
+    ggml_type   weight_type    = GGML_TYPE_BF16;
+    ggml_type   compute_type   = GGML_TYPE_BF16;
+    std::string backend_name;
+    std::string device_name;
+    std::string runtime_arch;
+    int         device_id      = -1;
+    int         cuda_sm        = 0;
+    std::string reason;
+};
+
+BackendPrecisionPolicy select_drafter_precision_policy(ggml_backend_t backend);
+
+const char * backend_precision_type_name(ggml_type type);
+
+} // namespace dflash::common

--- a/server/src/qwen3/qwen3_backend.cpp
+++ b/server/src/qwen3/qwen3_backend.cpp
@@ -36,13 +36,7 @@ bool create_qwen3_cache(ggml_backend_t backend, const Qwen3DrafterWeights & w,
     out.ctx = ggml_init(ip);
     if (!out.ctx) return false;
 
-    // Use BF16 where available, else F16.
-    const ggml_type half_type =
-#ifdef DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL
-        GGML_TYPE_BF16;
-#else
-        GGML_TYPE_F16;
-#endif
+    const ggml_type half_type = w.compute_type;
 
     out.k.resize(n_layer);
     out.v.resize(n_layer);
@@ -174,17 +168,11 @@ bool Qwen3Backend::do_step(const float * embed, int n_tokens, int kv_start,
     const int H      = w_.n_head;
     const int Hk     = w_.n_head_kv;
     const int D      = w_.head_dim;
-    const int ff     = w_.n_ff;
     const int vocab  = w_.n_vocab;
     const float eps  = 1e-6f;
     const int kv_len = kv_start + n_tokens;
 
-    const ggml_type half_type =
-#ifdef DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL
-        GGML_TYPE_BF16;
-#else
-        GGML_TYPE_F16;
-#endif
+    const ggml_type half_type = w_.compute_type;
 
     // Allocate graph context
     ggml_init_params ip{};

--- a/server/src/qwen3/qwen3_drafter.cpp
+++ b/server/src/qwen3/qwen3_drafter.cpp
@@ -15,6 +15,7 @@
 
 #include "qwen3_drafter.h"
 #include "qwen3_drafter_model.h"
+#include "common/backend_precision.h"
 #include "internal.h"
 
 #include "ggml.h"
@@ -203,9 +204,11 @@ bool load_drafter(const std::string & gguf_path, int /*gpu_layers*/,
     out.loaded = true;
     out.arch = arch;
     std::fprintf(stderr,
-        "[drafter] loaded %s BF16: n_layer=%d n_head=%d n_kv=%d "
+        "[drafter] loaded %s weights=%s compute=%s: n_layer=%d n_head=%d n_kv=%d "
         "n_embd=%d n_ff=%d head_dim=%d vocab=%d gpu=%d\n",
         drafter_arch_name(arch),
+        backend_precision_type_name(out.weights.weight_type),
+        backend_precision_type_name(out.weights.compute_type),
         out.weights.n_layer, out.weights.n_head, out.weights.n_head_kv,
         out.weights.n_embd, out.weights.n_ff, out.weights.head_dim,
         out.weights.n_vocab, out.gpu);

--- a/server/src/qwen3/qwen3_drafter.h
+++ b/server/src/qwen3/qwen3_drafter.h
@@ -35,7 +35,7 @@ const char * drafter_arch_name(DrafterArch arch);
 
 struct DrafterContext {
     ggml_backend_t        backend = nullptr;   // owned (created in load_drafter)
-    Qwen3DrafterWeights   weights;             // BF16 weights on the backend
+    Qwen3DrafterWeights   weights;             // weights on the selected backend
     DrafterArch           arch    = DrafterArch::Qwen3_0p6b;
     void *                arch_state = nullptr;
     int                   gpu = -1;
@@ -43,7 +43,7 @@ struct DrafterContext {
 };
 
 // Load the drafter GGUF (e.g. /opt/lucebox/models/drafter/Qwen3-0.6B-BF16.gguf).
-// Creates a fresh CUDA backend if `backend` is null. Otherwise uses the
+// Creates a fresh GPU backend if `backend` is null. Otherwise uses the
 // caller-provided backend (so the drafter shares the daemon's allocator).
 //
 // `gpu_layers` is accepted for API compat but ignored — every layer goes on
@@ -59,8 +59,8 @@ bool load_drafter(const std::string & gguf_path, int gpu_layers,
 
 void free_drafter(DrafterContext & ctx);
 
-// Free only model weights, keeping the CUDA backend alive for reuse.
-// Avoids repeated ggml backend create/destroy which corrupts CUDA state.
+// Free only model weights, keeping the backend alive for reuse.
+// Avoids repeated ggml backend create/destroy during daemon reuse.
 void free_drafter_weights(DrafterContext & ctx);
 
 // Score importance per token via Liu Q-hook tail attention, then chunk-top-K

--- a/server/src/qwen3/qwen3_drafter_model.h
+++ b/server/src/qwen3/qwen3_drafter_model.h
@@ -1,7 +1,7 @@
 // Custom Qwen3-0.6B drafter forward, in dflash, replacing libllama.
 //
-// Uses our FlashPrefill CUDA kernels for the attention compute. Single
-// process, single CUDA context, single ggml allocator — no Python, no
+// Uses the FlashPrefill dispatch path for the attention compute. Single
+// process, single backend context, single ggml allocator — no Python, no
 // Triton, no subprocess.
 //
 // Public API:
@@ -9,10 +9,9 @@
 //   bool forward_qwen3_drafter_model(weights, ids, out_q_capture, out_k_capture)
 //   void free_qwen3_drafter_model(weights)
 //
-// Status (2026-04-29 session): scaffolding written; full graph + integration
-// is multi-hour work, in progress.
-
 #pragma once
+
+#include "ggml.h"
 
 #include <cstdint>
 #include <string>
@@ -45,6 +44,8 @@ struct Qwen3DrafterWeights {
     ggml_context *        ctx     = nullptr;
     ggml_backend_t        backend = nullptr;
     ggml_backend_buffer_t buf     = nullptr;
+    ggml_type             weight_type  = GGML_TYPE_BF16;
+    ggml_type             compute_type = GGML_TYPE_BF16;
 
     ggml_tensor * tok_embd    = nullptr;  // [hidden, vocab]
     ggml_tensor * out_norm    = nullptr;  // [hidden]
@@ -73,7 +74,7 @@ void free_qwen3_drafter_model(Qwen3DrafterWeights & w);
 // Custom Qwen3-0.6B forward, fused with Liu Q-hook tail attention scoring.
 //
 // Inputs:
-//   w           — loaded weights (must be on a CUDA backend)
+//   w           — loaded weights (must be on the selected GPU backend)
 //   ids         — input token IDs of length S (drafter vocab)
 //   n_lookahead — number of trailing query tokens for tail attention (=8)
 //

--- a/server/src/qwen3/qwen3_graph.cpp
+++ b/server/src/qwen3/qwen3_graph.cpp
@@ -80,7 +80,7 @@ struct HipChunkGraphB {
     ggml_backend_buffer_t buf = nullptr;
 
     ggml_tensor * h_in    = nullptr;   // input: hidden state slice (F32)
-    ggml_tensor * attn_in = nullptr;   // input: attention output slice (BF16)
+    ggml_tensor * attn_in = nullptr;   // input: attention output slice
     ggml_tensor * h_after = nullptr;   // h_in + attn_proj residual (F32)
     ggml_tensor * hf      = nullptr;   // FFN norm result written by custom kernel (F32)
     ggml_tensor * h_next  = nullptr;   // output: updated hidden state (F32)
@@ -129,6 +129,7 @@ bool build_hip_chunk_graph_b(const Qwen3DrafterLayer & L,
                              int hidden,
                              int q_dim,
                              int chunk,
+                             ggml_type compute_type,
                              float eps,
                              HipChunkGraphB & out) {
     ggml_init_params ip{};
@@ -140,7 +141,7 @@ bool build_hip_chunk_graph_b(const Qwen3DrafterLayer & L,
     if (!out.ctx) return false;
 
     out.h_in = ggml_new_tensor_2d(out.ctx, GGML_TYPE_F32, hidden, chunk);
-    out.attn_in = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, q_dim, chunk);
+    out.attn_in = ggml_new_tensor_2d(out.ctx, compute_type, q_dim, chunk);
     ggml_set_input(out.h_in);
     ggml_set_input(out.attn_in);
 
@@ -275,14 +276,7 @@ bool forward_qwen3_drafter_model(
         int64_t d_ql[]  = {(int64_t)D, (int64_t)H,  (int64_t)n_lookahead};
         int64_t d_p[]   = {(int64_t)S};
         int64_t d_mt[]  = {(int64_t)S, (int64_t)n_lookahead};
-        // Use BF16 when rocWMMA or CUDA WMMA flashprefill kernels are compiled.
-        // HIP Phase 1 (q8 ggml fallback) and old CUDA arches stay with F16.
-        const ggml_type half_type =
-#if defined(DFLASH27B_HAVE_CUDA_WMMA_FLASHPREFILL) || defined(DFLASH27B_HAVE_FLASHPREFILL)
-            GGML_TYPE_BF16;
-#else
-            GGML_TYPE_F16;
-#endif
+        const ggml_type half_type = w.compute_type;
         if (!make_pers(w.backend, GGML_TYPE_F32,  2, d_h, hidden_buf) ||
             !make_pers(w.backend, GGML_TYPE_I32,  1, d_p, pos_buf)    ||
             !make_pers(w.backend, GGML_TYPE_F32,  2, d_mt, mask_tail_buf) ||
@@ -536,7 +530,7 @@ bool forward_qwen3_drafter_model(
 #if defined(DFLASH27B_BACKEND_HIP)
         auto tB_setup0 = std::chrono::steady_clock::now();
         HipChunkGraphB gb{};
-        if (!build_hip_chunk_graph_b(L, w.backend, hidden, D * H, chunk_s_ff_v, eps, gb)) {
+        if (!build_hip_chunk_graph_b(L, w.backend, hidden, D * H, chunk_s_ff_v, w.compute_type, eps, gb)) {
             set_last_error("graph B reusable build failed at layer " + std::to_string(il));
             ggml_gallocr_free(galloc); cleanup_all(); return false;
         }

--- a/server/src/qwen3/qwen3_loader.cpp
+++ b/server/src/qwen3/qwen3_loader.cpp
@@ -23,11 +23,13 @@
 // (mirrors the dflash gguf_target_loader pattern).
 
 #include "qwen3_drafter_model.h"
+#include "common/backend_precision.h"
 #include "internal.h"
 
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
+#include <vector>
 #if defined(_WIN32)
 #if !defined(NOMINMAX)
 #define NOMINMAX
@@ -55,10 +57,42 @@ bool copy_tensor_from_file(gguf_context * gctx, const char * name,
         return false;
     }
     const size_t off = gguf_get_tensor_offset(gctx, idx);
-    const size_t bytes = ggml_nbytes(dst);
     const uint8_t * src = (const uint8_t *)mmap_base + data_offset + off;
-    ggml_backend_tensor_set(dst, src, 0, bytes);
-    return true;
+    const ggml_type src_type = gguf_get_tensor_type(gctx, idx);
+    const ggml_type dst_type = dst->type;
+    const int64_t n = ggml_nelements(dst);
+
+    if (src_type == dst_type) {
+        ggml_backend_tensor_set(dst, src, 0, ggml_nbytes(dst));
+        return true;
+    }
+
+    if (src_type == GGML_TYPE_BF16 && dst_type == GGML_TYPE_F16) {
+        std::vector<float> tmp_f32((size_t)n);
+        std::vector<ggml_fp16_t> tmp_f16((size_t)n);
+        ggml_bf16_to_fp32_row((const ggml_bf16_t *)src, tmp_f32.data(), n);
+        ggml_fp32_to_fp16_row(tmp_f32.data(), tmp_f16.data(), n);
+        ggml_backend_tensor_set(dst, tmp_f16.data(), 0, ggml_nbytes(dst));
+        return true;
+    }
+
+    if (src_type == GGML_TYPE_BF16 && dst_type == GGML_TYPE_F32) {
+        std::vector<float> tmp_f32((size_t)n);
+        ggml_bf16_to_fp32_row((const ggml_bf16_t *)src, tmp_f32.data(), n);
+        ggml_backend_tensor_set(dst, tmp_f32.data(), 0, ggml_nbytes(dst));
+        return true;
+    }
+
+    if (src_type == GGML_TYPE_F16 && dst_type == GGML_TYPE_F32) {
+        std::vector<float> tmp_f32((size_t)n);
+        ggml_fp16_to_fp32_row((const ggml_fp16_t *)src, tmp_f32.data(), n);
+        ggml_backend_tensor_set(dst, tmp_f32.data(), 0, ggml_nbytes(dst));
+        return true;
+    }
+
+    std::fprintf(stderr, "[qwen3-0.6b] unsupported tensor conversion for %s: %s -> %s\n",
+                 name, ggml_type_name(src_type), ggml_type_name(dst_type));
+    return false;
 }
 
 uint32_t get_u32(gguf_context * g, const char * key, uint32_t def) {
@@ -79,6 +113,9 @@ bool load_qwen3_drafter_model(const std::string & path,
                               ggml_backend_t backend,
                               Qwen3DrafterWeights & out) {
     out.backend = backend;
+    const BackendPrecisionPolicy precision = select_drafter_precision_policy(backend);
+    out.weight_type = precision.weight_type;
+    out.compute_type = precision.compute_type;
 
     gguf_init_params iparams{ /*no_alloc=*/ false, /*ctx=*/ nullptr };
     gguf_context * gctx = gguf_init_from_file(path.c_str(), iparams);
@@ -116,11 +153,12 @@ bool load_qwen3_drafter_model(const std::string & path,
     const int n_vocab   = out.n_vocab;
     const int q_dim     = n_head * head_dim;
     const int kv_dim    = n_head_kv * head_dim;
+    const ggml_type weight_type = out.weight_type;
 
     // Top-level tensors.
-    out.tok_embd = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_vocab);
+    out.tok_embd = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, n_vocab);
     out.out_norm = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, n_embd);
-    out.output   = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_vocab);
+    out.output   = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, n_vocab);
     ggml_set_name(out.tok_embd, "token_embd.weight");
     ggml_set_name(out.out_norm, "output_norm.weight");
     ggml_set_name(out.output,   "output.weight");
@@ -129,16 +167,16 @@ bool load_qwen3_drafter_model(const std::string & path,
     for (int il = 0; il < n_layer; ++il) {
         auto & L = out.layers[il];
         L.attn_norm = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, n_embd);
-        L.wq        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, q_dim);
-        L.wk        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, kv_dim);
-        L.wv        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, kv_dim);
-        L.wo        = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, q_dim, n_embd);
+        L.wq        = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, q_dim);
+        L.wk        = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, kv_dim);
+        L.wv        = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, kv_dim);
+        L.wo        = ggml_new_tensor_2d(out.ctx, weight_type, q_dim, n_embd);
         L.q_norm    = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, head_dim);
         L.k_norm    = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, head_dim);
         L.ffn_norm  = ggml_new_tensor_1d(out.ctx, GGML_TYPE_F32, n_embd);
-        L.ffn_gate  = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_ff);
-        L.ffn_up    = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_embd, n_ff);
-        L.ffn_down  = ggml_new_tensor_2d(out.ctx, GGML_TYPE_BF16, n_ff, n_embd);
+        L.ffn_gate  = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, n_ff);
+        L.ffn_up    = ggml_new_tensor_2d(out.ctx, weight_type, n_embd, n_ff);
+        L.ffn_down  = ggml_new_tensor_2d(out.ctx, weight_type, n_ff, n_embd);
     }
 
     out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, backend);
@@ -149,6 +187,17 @@ bool load_qwen3_drafter_model(const std::string & path,
         out.ctx = nullptr;
         return false;
     }
+
+    std::fprintf(stderr,
+        "[qwen3-0.6b] precision weights=%s compute=%s backend=%s device=%s id=%d arch=%s reason=%s\n",
+        backend_precision_type_name(out.weight_type),
+        backend_precision_type_name(out.compute_type),
+        precision.backend_name.c_str(),
+        precision.device_name.c_str(),
+        precision.device_id,
+        precision.runtime_arch.empty() ? "-" : precision.runtime_arch.c_str(),
+        precision.reason.c_str());
+    std::fflush(stderr);
 
     // mmap the GGUF data section.
     const size_t data_off = gguf_get_data_offset(gctx);


### PR DESCRIPTION
## Summary

This PR fixes Qwen3 PFlash drafter precision selection on legacy CUDA devices. Newer CUDA cards keep BF16/F16 paths, while CUDA sm61/P4-class devices use a conservative F32 fallback to avoid invalid runtime paths during real PFlash compression.

## Changes

- Add `src/common/backend_precision.{h,cpp}` as a shared runtime policy helper for drafter precision selection.
- Use backend runtime properties instead of hardcoded compile-time assumptions:
  - CUDA sm80+ selects BF16.
  - CUDA sm70-sm79 selects F16.
  - CUDA sm60 / GP100-class selects F16.
  - CUDA sm61 / P4/P40/GTX10-class and older CUDA fall back to F32.
  - HIP keeps the existing ROCm/ggml default path.
- Store the selected `weight_type` and `compute_type` in `Qwen3DrafterWeights`.
- Convert GGUF BF16 tensors to F16 or F32 at Qwen3 drafter load time when the selected policy requires it.
- Thread the selected compute type through Qwen3 persistent buffers, KV/cache allocation, target-side Qwen3 backend buffers, and the HIP chunk graph input.
- Update drafter logs so the actual loaded weight/compute precision is visible during startup.
- Clean up stale CUDA/BF16-only comments in the Qwen3 drafter headers.

## Notes

HIP is intentionally left on the existing ROCm/ggml path. In our testing, the HIP backend can adapt the BF16-compatible path to the best available architecture behavior, so this PR does not add a manual HIP architecture split.

Local validation: CUDA sm61 build passed.
