### PR TITLE
fix(draft): read rope_theta from config.json in safetensors loader

### DIFF
--- a/server/src/draft/draft_safetensors_loader.cpp
+++ b/server/src/draft/draft_safetensors_loader.cpp
@@ -30,6 +30,7 @@
 #include "internal.h"
 
 #include <climits>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -462,6 +463,7 @@ static bool build_prefers_bf16_projection() {
 // HuggingFace models always ship config.json alongside the weights.
 // Returns 0.0f and prints a warning if the key is missing or the file is absent.
 static float read_rope_theta_from_config(const std::string & st_path) {
+    // Find directory: everything up to and including the last '/' (or '\' on Windows).
     std::string dir = st_path;
     const size_t slash = dir.find_last_of("/\\");
     if (slash != std::string::npos) dir.resize(slash + 1); else dir = "./";
@@ -473,11 +475,14 @@ static float read_rope_theta_from_config(const std::string & st_path) {
                      cfg_path.c_str());
         return 0.0f;
     }
+    // Read entire file into a string then do a simple key scan.
+    // A full JSON parser is overkill; we just look for "rope_theta": <number>.
     std::string buf;
     char tmp[4096];
     while (std::fgets(tmp, sizeof(tmp), f)) buf += tmp;
     std::fclose(f);
 
+    // Search for "rope_theta" key.
     const char * key = "\"rope_theta\"";
     size_t pos = buf.find(key);
     if (pos == std::string::npos) {
@@ -485,6 +490,7 @@ static float read_rope_theta_from_config(const std::string & st_path) {
                      cfg_path.c_str());
         return 0.0f;
     }
+    // Skip past the key, optional whitespace, colon, optional whitespace, then parse number.
     pos += std::strlen(key);
     while (pos < buf.size() && (buf[pos] == ' ' || buf[pos] == '\t' || buf[pos] == '\n' || buf[pos] == '\r')) pos++;
     if (pos >= buf.size() || buf[pos] != ':') {
@@ -494,7 +500,7 @@ static float read_rope_theta_from_config(const std::string & st_path) {
     pos++;
     while (pos < buf.size() && (buf[pos] == ' ' || buf[pos] == '\t' || buf[pos] == '\n' || buf[pos] == '\r')) pos++;
     float val = 0.0f;
-    if (std::sscanf(buf.c_str() + pos, "%f", &val) != 1 || val <= 0.0f) {
+    if (std::sscanf(buf.c_str() + pos, "%f", &val) != 1 || !std::isfinite(val) || val <= 0.0f) {
         std::fprintf(stderr, "[draft-st] WARNING: invalid rope_theta value in %s\n", cfg_path.c_str());
         return 0.0f;
     }

--- a/server/src/draft/draft_safetensors_loader.cpp
+++ b/server/src/draft/draft_safetensors_loader.cpp
@@ -458,6 +458,49 @@ static bool build_prefers_bf16_projection() {
 #endif
 }
 
+// Read rope_theta from config.json in the same directory as the .safetensors file.
+// HuggingFace models always ship config.json alongside the weights.
+// Returns 0.0f and prints a warning if the key is missing or the file is absent.
+static float read_rope_theta_from_config(const std::string & st_path) {
+    std::string dir = st_path;
+    const size_t slash = dir.find_last_of("/\\");
+    if (slash != std::string::npos) dir.resize(slash + 1); else dir = "./";
+    const std::string cfg_path = dir + "config.json";
+
+    FILE * f = std::fopen(cfg_path.c_str(), "r");
+    if (!f) {
+        std::fprintf(stderr, "[draft-st] WARNING: config.json not found at %s — rope_theta unknown\n",
+                     cfg_path.c_str());
+        return 0.0f;
+    }
+    std::string buf;
+    char tmp[4096];
+    while (std::fgets(tmp, sizeof(tmp), f)) buf += tmp;
+    std::fclose(f);
+
+    const char * key = "\"rope_theta\"";
+    size_t pos = buf.find(key);
+    if (pos == std::string::npos) {
+        std::fprintf(stderr, "[draft-st] WARNING: rope_theta not found in %s — rope will be wrong\n",
+                     cfg_path.c_str());
+        return 0.0f;
+    }
+    pos += std::strlen(key);
+    while (pos < buf.size() && (buf[pos] == ' ' || buf[pos] == '\t' || buf[pos] == '\n' || buf[pos] == '\r')) pos++;
+    if (pos >= buf.size() || buf[pos] != ':') {
+        std::fprintf(stderr, "[draft-st] WARNING: malformed rope_theta in %s\n", cfg_path.c_str());
+        return 0.0f;
+    }
+    pos++;
+    while (pos < buf.size() && (buf[pos] == ' ' || buf[pos] == '\t' || buf[pos] == '\n' || buf[pos] == '\r')) pos++;
+    float val = 0.0f;
+    if (std::sscanf(buf.c_str() + pos, "%f", &val) != 1 || val <= 0.0f) {
+        std::fprintf(stderr, "[draft-st] WARNING: invalid rope_theta value in %s\n", cfg_path.c_str());
+        return 0.0f;
+    }
+    return val;
+}
+
 } // namespace
 
 bool load_draft_safetensors(const std::string & path,
@@ -504,6 +547,11 @@ bool load_draft_safetensors(const std::string & path,
     // head_dim=128/n_head_kv=8. The header already contains the authoritative
     // tensor shapes, so infer from that instead of inheriting target dims.
     if (!infer_draft_dims_from_safetensors(st, out)) return false;
+    out.rope_theta = read_rope_theta_from_config(path);
+    if (out.rope_theta == 0.0f) {
+        set_last_error("draft safetensors: rope_theta missing from config.json — cannot load");
+        return false;
+    }
     if (target) {
         out.mask_token_id = target->mask_token_id;
         if (out.n_embd != target->n_embd) {


### PR DESCRIPTION
Commit 03aeda5 correctly removed the hardcoded 10M default and made rope_theta come from GGUF metadata, but did not update the safetensors loader path. With rope_theta defaulting to 0.0f, powf(0, -small) = +inf in the rope kernel, producing NaN in every Q and K and causing all draft hidden states to be NaN — spec-decode fails immediately.

Fix: read rope_theta from config.json in the same directory as the .safetensors file. HF models always ship config.json alongside weights. Load fails hard if the key is missing, matching the GGUF loader's behaviour.