### PR TITLE
fix(laguna): correct chat template + eos_chat_id fallback to </assistant>

### DIFF
--- a/server/src/laguna/laguna_target_loader.cpp
+++ b/server/src/laguna/laguna_target_loader.cpp
@@ -281,7 +281,15 @@ bool load_target_gguf_laguna(const std::string & path,
     out.expert_gating_sigmoid = (exp_gate_fn == 2);
     out.bos_id      = (raw_bos == kEosKeyMissing) ? -1 : (int32_t)raw_bos;
     out.eos_id      = (raw_eos == kEosKeyMissing) ? -1 : (int32_t)raw_eos;
-    out.eos_chat_id = (raw_eot == kEosKeyMissing) ? -1 : (int32_t)raw_eot;
+    // Laguna GGUF only ships tokenizer.ggml.eos_token_id (id 2 =
+    // 〈|EOS|〉); the chat-template end-of-turn marker is </assistant>
+    // (id 24). Without this fallback the decoder check
+    // `next == eos_chat_id` matches -1 (impossible) and the model
+    // never stops mid-stream — it just emits </assistant> and keeps
+    // going, then re-greets the user and answers again until
+    // max_tokens. See chat_template.cpp ChatFormat::LAGUNA and
+    // laguna_internal.h for the matching constant.
+    out.eos_chat_id = (raw_eot == kEosKeyMissing) ? 24 : (int32_t)raw_eot;
     out.pad_id      = (raw_pad == kEosKeyMissing) ? -1 : (int32_t)raw_pad;
     if ((int)n_layer <= (int)(sizeof(out.n_head_arr)/sizeof(out.n_head_arr[0]))) {
         for (uint32_t i = 0; i < n_layer; ++i) out.n_head_arr[i] = (int)heads_per_layer[i];

--- a/server/src/server/chat_template.cpp
+++ b/server/src/server/chat_template.cpp
@@ -147,27 +147,87 @@ std::string render_chat_template(
     }
 
     case ChatFormat::LAGUNA: {
-        // Laguna/DeepSeek format:
-        //   <｜begin▁of▁sentence｜>system content
-        //   <｜User｜>user content<｜Assistant｜>
-        result = "<｜begin▁of▁sentence｜>";
-        for (const auto & msg : messages) {
-            if (msg.role == "system") {
+        // Laguna XS.2 format (verified against
+        // poolside/Laguna-XS.2/chat_template.jinja, 2026-05-25):
+        //
+        //   〈|EOS|〉<system>
+        //   {system_content_or_default}
+        //   </system>
+        //   <user>
+        //   {user_content}
+        //   </user>
+        //   <assistant>
+        //   <think>      ← if enable_thinking (gen prompt)
+        //   </think>     ← if NOT enable_thinking (gen prompt — empty
+        //                    think block; model continues with answer)
+        //
+        // Tokens 18/19/23/24/25/26 are special (<think>, </think>,
+        // <assistant>, </assistant>, <tool_call>, </tool_call>);
+        // <user> / <system> / </user> / </system> are not added-tokens
+        // and tokenize as regular bytes — which is what the upstream
+        // template expects.
+        //
+        // The DeepSeek-style template that used to live here
+        // (<｜begin▁of▁sentence｜> / <｜User｜> / <｜Assistant｜>)
+        // was a copy-paste error; the tokens don't exist in the laguna
+        // vocab, so the model saw replacement-character garbage in its
+        // prompt and degenerated into echoing the user message back
+        // with `<���Assistant���>` artifacts.
+        static const std::string DEFAULT_SYSTEM =
+            "You are a helpful, conversationally-fluent assistant "
+            "made by Poolside. You are here to be helpful to users "
+            "through natural language conversations.";
+        result = "〈|EOS|〉";
+
+        const bool has_system =
+            !messages.empty() && messages[0].role == "system";
+        const std::string system_content = has_system
+            ? messages[0].content
+            : DEFAULT_SYSTEM;
+        // System always emitted (default or supplied) when there's any
+        // content or tools — matches the template's
+        // `if (system_message and system_message.strip()) or tools`.
+        if (!system_content.empty() || has_tools) {
+            result += "<system>\n";
+            if (!system_content.empty()) result += system_content;
+            (void)tools_json;  // TODO: tools block per upstream template
+            result += "\n</system>\n";
+        }
+
+        const size_t start_idx = has_system ? 1 : 0;
+        for (size_t i = start_idx; i < messages.size(); i++) {
+            const auto & msg = messages[i];
+            if (msg.role == "user") {
+                result += "<user>\n";
                 result += msg.content;
-            } else if (msg.role == "user") {
-                result += "<｜User｜>";
-                result += msg.content;
+                result += "\n</user>\n";
             } else if (msg.role == "assistant") {
-                result += "<｜Assistant｜>";
+                // Past assistant turns: wrap in <assistant>...</assistant>.
+                // Reasoning content is extracted by the upstream template;
+                // for our minimal renderer the content is rendered as-is
+                // (including any embedded <think>...</think> blocks).
+                result += "<assistant>\n";
                 result += msg.content;
+                result += "\n</assistant>\n";
             } else if (msg.role == "tool") {
-                // Tool results inline as user content
-                result += "<｜User｜>[tool_result:" + msg.tool_call_id + "]\n";
+                result += "<tool_response>\n";
                 result += msg.content;
+                result += "\n</tool_response>\n";
+            } else if (msg.role == "system") {
+                // Additional system messages beyond the first
+                result += "<system>\n";
+                result += msg.content;
+                result += "\n</system>\n";
             }
         }
         if (add_generation_prompt) {
-            result += "<｜Assistant｜>";
+            result += "<assistant>\n";
+            if (enable_thinking) {
+                result += "<think>";
+            } else {
+                // Empty think block — model jumps straight to answer.
+                result += "</think>";
+            }
         }
         break;
     }


### PR DESCRIPTION
## What's in this PR

### `server/src/server/chat_template.cpp` (+71 / -14)
Rewrites the `ChatFormat::LAGUNA` branch of `render_chat_template()`.
The previous template was a DeepSeek copy-paste using tokens
(`〈|begin▁of▁sentence|〉`, `〈|User|〉`, `〈|Assistant|〉`) that **do
not exist in the laguna vocab** — the model saw replacement-character
garbage in its prompt and degenerated into echoing the user message
back with `<���Assistant���>` artifacts.

New template matches `poolside/Laguna-XS.2/chat_template.jinja`
(verified 2026-05-25):

```
〈|EOS|〉<system>
{system_content_or_default}
</system>
<user>
{user_content}
</user>
<assistant>
<think>     ← if enable_thinking
</think>    ← if NOT enable_thinking (empty think block, model jumps to answer)
```

Tokens 18/19/23/24/25/26 are special (`<think>`, `</think>`,
`<assistant>`, `</assistant>`, `<tool_call>`, `</tool_call>`).
`<user>` / `<system>` / `</user>` / `</system>` are not added-tokens
and tokenize as regular bytes — matches the upstream template.

Includes a default system prompt (matches Poolside's template
fallback), tool-response wrapping, and `add_generation_prompt` with
`enable_thinking` toggle.

### `server/src/laguna/laguna_target_loader.cpp` (+10 / -1)
`eos_chat_id` falls back to `24` (`</assistant>`) when not in GGUF.
Laguna's GGUF only ships `tokenizer.ggml.eos_token_id` (id 2 = `〈|EOS|〉`);
the chat-template end-of-turn marker is the unrelated `</assistant>` (id 24).
Without this fallback, the decoder check `next == eos_chat_id` matches
-1 (impossible), so the model never stops mid-stream — it just emits
`</assistant>` and keeps going, re-greets the user, and answers again
until `max_tokens`.