### PR TITLE
Fix Gemma4 layer-split destructor link

### DIFF
--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -71,7 +71,13 @@ Gemma4LayerSplitAdapter::Gemma4LayerSplitAdapter(
         const Gemma4LayerSplitAdapterConfig & cfg)
     : cfg_(cfg) {}
 
-Gemma4LayerSplitAdapter::~Gemma4LayerSplitAdapter() { shutdown(); }
+Gemma4LayerSplitAdapter::~Gemma4LayerSplitAdapter() noexcept {
+    try {
+        shutdown();
+    } catch (...) {
+        // Destructors must not depend on newer libstdc++ termination helpers.
+    }
+}
 
 bool Gemma4LayerSplitAdapter::init() {
     if (!cfg_.target_path || cfg_.device.layer_split_gpus.size() < 2) {

--- a/server/src/gemma4/gemma4_layer_split_adapter.h
+++ b/server/src/gemma4/gemma4_layer_split_adapter.h
@@ -35,7 +35,7 @@ struct Gemma4LayerSplitSnapshot {
 class Gemma4LayerSplitAdapter : public LayerSplitAdapter {
 public:
     explicit Gemma4LayerSplitAdapter(const Gemma4LayerSplitAdapterConfig & cfg);
-    ~Gemma4LayerSplitAdapter() override;
+    ~Gemma4LayerSplitAdapter() noexcept override;
 
     Gemma4LayerSplitAdapter(const Gemma4LayerSplitAdapter &) = delete;
     Gemma4LayerSplitAdapter & operator=(const Gemma4LayerSplitAdapter &) = delete;


### PR DESCRIPTION
## Summary
- make `Gemma4LayerSplitAdapter` destructor explicitly `noexcept`
- catch shutdown exceptions in the destructor so GCC does not emit a dependency on the newer libstdc++ `__cxa_call_terminate` helper

## Verification
- RunPod A40/CUDA 12.4: incremental `cmake --build server/build --target dflash_server -j8` rebuilt `gemma4_layer_split_adapter.cpp.o`, relinked `libdflash_common.a`, and linked `dflash_server` successfully
- RunPod object check: `nm -u CMakeFiles/dflash_common.dir/src/gemma4/gemma4_layer_split_adapter.cpp.o | grep __cxa_call_terminate` produced no output
- local: `git diff --check origin/main..HEAD`
