### PR TITLE
server: wire --draft-swa flag + DFLASH27B_DRAFT_SWA env

### DIFF
--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -162,6 +162,9 @@ static void print_usage(const char * prog) {
         "  --draft-ipc-bin <path>         Remote backend IPC daemon for mixed backends\n"
         "  --draft-ipc-work-dir <path>    Remote draft IPC scratch directory\n"
         "  --draft-ipc-ring-cap <N>       Remote draft feature ring capacity\n"
+        "  --draft-swa <N>                Draft sliding-window attention size (0=off; e.g.\n"
+        "                                 2048 for unsloth Qwen3.6 targets, per server/README.md.\n"
+        "                                 Env: DFLASH27B_DRAFT_SWA)\n"
         "  --target-devices <list>        Reserved layer-split devices, e.g. cuda:0,cuda:1\n"
         "  --target-layer-split <weights>  Reserved layer-split weights\n"
         "  --peer-access        Enable peer access for multi-GPU placement\n"
@@ -292,6 +295,8 @@ int main(int argc, char ** argv) {
                 std::fprintf(stderr, "[server] bad --target-device value (expected backend:gpu)\n");
                 return 2;
             }
+        } else if (std::strcmp(argv[i], "--draft-swa") == 0 && i + 1 < argc) {
+            bargs.draft_swa_window = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--draft-device") == 0 && i + 1 < argc) {
             if (!parse_placement_device(argv[++i], bargs.draft_device)) {
                 std::fprintf(stderr, "[server] bad --draft-device value (expected backend:gpu)\n");
@@ -540,6 +545,13 @@ int main(int argc, char ** argv) {
                      sconfig.pflash_threshold, sconfig.pflash_keep_ratio,
                      sconfig.pflash_drafter_gpu,
                      (int)sconfig.pflash_skip_park);
+    }
+
+    // Honor DFLASH27B_DRAFT_SWA env (documented in server/README.md) when --draft-swa is absent.
+    if (bargs.draft_swa_window == 0) {
+        if (const char * e = std::getenv("DFLASH27B_DRAFT_SWA")) {
+            bargs.draft_swa_window = std::atoi(e);
+        }
     }
 
     // Create backend.


### PR DESCRIPTION
## Problem

`server/README.md` documents `DFLASH27B_DRAFT_SWA=2048` as required for sliding-window correctness when pairing the Q8_0 draft with the unsloth Qwen3.6 target. But `dflash_server` never consumed it — there is no CLI flag and no `getenv`, so `BackendArgs::draft_swa_window` is always `0` and the draft SWA window cannot be enabled through the HTTP server.

The plumbing already exists everywhere else: `backend_factory.cpp` copies `args.draft_swa_window` into the per-arch config, and `Qwen35Backend` applies `cfg_.draft_swa_window` (it prints `[draft] SWA layers: N/M (window=W)`). Only the `server_main.cpp` entrypoint was missing the wiring, so the documented env var was a no-op for the server (`test_dflash` exposed it; `dflash_server` did not).

## Change

- Add `--draft-swa <N>` CLI flag → `BackendArgs::draft_swa_window`.
- Honor the documented `DFLASH27B_DRAFT_SWA` env var when the flag is absent.
- Add a help-text line.

## Verification

RTX 5090 (Blackwell sm_120), CUDA 13.2, WSL2 Ubuntu 24.04. Target `unsloth/Qwen3.6-27B-GGUF` (Q4_K_M) + `Lucebox/Qwen3.6-27B-DFlash-GGUF` (q8_0) draft.

- Before: no way to set draft SWA via the server; `[draft] SWA layers:` never printed.
- After (`--draft-swa 2048` or `DFLASH27B_DRAFT_SWA=2048`):
  ```
  [draft]  SWA layers: 4/5 (window=2048)
  ```
  Speculative decode engages (greedy); acceptance length up to ~11 on HumanEval-style prompts.

Connects an already-documented, already-implemented knob to the server CLI/env; no behavior change when unset.