### PR TITLE
fix(server): exit cleanly on SIGTERM so the GPU is freed

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -548,6 +548,19 @@ int HttpServer::run() {
         return 1;
     }
 
+    // Non-blocking listen socket so the accept loop polls stopping_ on a short
+    // timeout. This guarantees the loop exits on SIGTERM/SIGINT regardless of
+    // which thread the signal handler runs on (it only sets the atomic flag).
+    {
+        int fl = fcntl(listen_fd_, F_GETFL, 0);
+        if (fl < 0 || fcntl(listen_fd_, F_SETFL, fl | O_NONBLOCK) < 0) {
+            std::fprintf(stderr, "[server] fcntl(O_NONBLOCK) failed: %s\n", strerror(errno));
+            ::close(listen_fd_);
+            listen_fd_ = -1;
+            return 1;
+        }
+    }
+
     std::fprintf(stderr, "[server] listening on http://%s:%d\n",
                  config_.host.c_str(), config_.port);
 
@@ -556,12 +569,22 @@ int HttpServer::run() {
 
     // Accept loop.
     while (!stopping_.load()) {
+        struct pollfd pfd{listen_fd_, POLLIN, 0};
+        int pr = poll(&pfd, 1, 200 /* ms */);
+        if (pr <= 0) {
+            // 0 = timeout (re-check stopping_); <0 with EINTR = signal. Both loop.
+            if (pr < 0 && errno != EINTR) {
+                std::fprintf(stderr, "[server] poll() error: %s\n", strerror(errno));
+            }
+            continue;
+        }
+
         struct sockaddr_in client_sa{};
         socklen_t client_len = sizeof(client_sa);
         int client_fd = accept(listen_fd_, (struct sockaddr *)&client_sa, &client_len);
         if (client_fd < 0) {
             if (stopping_.load()) break;
-            if (errno == EINTR) continue;
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) continue;
             std::fprintf(stderr, "[server] accept() error: %s\n", strerror(errno));
             continue;
         }
@@ -584,10 +607,20 @@ int HttpServer::run() {
     // Wake the worker thread so it can observe stopping_ and exit.
     queue_cv_.notify_all();
 
-    // Wait for all client threads to finish.
+    // Wait for client threads to drain, but bound it: a client mid-stream (long
+    // SSE generation) must not hold the process resident on shutdown. After the
+    // grace period we proceed — detached client threads are torn down on exit.
     {
         std::unique_lock<std::mutex> lk(clients_mu_);
-        clients_cv_.wait(lk, [this]() { return active_clients_.load() == 0; });
+        bool drained = clients_cv_.wait_for(
+            lk, std::chrono::seconds(5),
+            [this]() { return active_clients_.load() == 0; });
+        if (!drained) {
+            std::fprintf(stderr,
+                         "[server] shutdown: %d client thread(s) still active "
+                         "after grace period, exiting anyway\n",
+                         active_clients_.load());
+        }
     }
 
     // Wait for worker to finish.

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -232,13 +232,13 @@ public:
     // Signal the server to stop accepting new connections and drain.
     void shutdown();
 
-    // Async-signal-safe: only sets stopping flag and closes listen socket.
+    // Async-signal-safe: only sets the stopping flag. The accept loop polls
+    // this flag on a short timeout, so it wakes regardless of which thread the
+    // signal is delivered to. (Closing listen_fd_ here is unsafe: on Linux a
+    // close() from another thread does not wake a blocked accept(), and it
+    // races the accept loop's own close on exit.)
     void request_stop() {
         stopping_.store(true, std::memory_order_relaxed);
-        if (listen_fd_ >= 0) {
-            ::close(listen_fd_);
-            listen_fd_ = -1;
-        }
     }
 
 private:


### PR DESCRIPTION
## Problem

Stopping `dflash_server` could leave the process resident with the model still pinned in VRAM, forcing a manual `kill -9`. It also broke llama-swap–style hot-swapping and idle-TTL unloads (the GPU never frees, so the next model can't load).

### Root cause

`SIGTERM`/`SIGINT` is delivered to an **arbitrary** thread. The handler set a `stopping_` flag and `close()`d the listen socket — but on Linux a `close()` from another thread does **not** wake a different thread blocked in `accept()`. When the signal landed off the main thread, the accept loop stayed parked in `accept()` forever, so the process never exited and never released the GPU. When the signal happened to hit the main thread it worked, which is why the hang was intermittent.

## Fix

Make the accept loop wake deterministically, independent of which thread handles the signal:

- **Non-blocking listen socket + `poll(200ms)` accept loop** — re-checks `stopping_` every tick, so it exits within ~200ms of the flag being set no matter where the signal lands.
- **`request_stop()` is now just an atomic flag set** (truly async-signal-safe) — it no longer closes the socket from signal context (which was both unsafe and raced the loop's own close on exit).
- **Bounded client-drain (5s)** on shutdown so a mid-stream SSE request can't hold the process resident either.

Host C++ only — no kernel/backend changes; CUDA and HIP builds are unaffected.

## Verification (NVIDIA A40, fresh build)

Full `dflash_server` build links clean. Real run with Qwen3 BF16 GGUFs:

| Stage | GPU mem |
|---|---|
| idle | 1 MiB |
| load Qwen3-0.6B | 2951 MiB, serving |
| **SIGTERM** | process exits sub-second → **1 MiB** |
| load Qwen3-1.7B (different model) | 5393 MiB, serving |
| **SIGTERM** | → **1 MiB** |

The distinct footprints (2951 vs 5393 MiB) confirm a true sequential swap, and the GPU returns to baseline after each stop — no leftover VRAM, no hang, no manual kill.

Co-Authored-By: WOZCODE <contact@withwoz.com>

🧙 Built with [WOZCODE](https://wozcode.com)