### PR TITLE
Honor DFLASH model paths in client harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ All launchers spawn the native C++ HTTP server (`dflash_server`). Override defau
 
 ```bash
 DFLASH_SERVER_BIN=server/build/dflash_server \
+DFLASH_TARGET=server/models/Qwen3.6-27B-Q4_K_M.gguf \
+DFLASH_DRAFT=server/models/draft/dflash-draft-3.6-q4_k_m.gguf \
 MAX_CTX=32768 BUDGET=22 VERIFY_MODE=ddtree \
 harness/clients/run_codex.sh
 ```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ MAX_CTX=32768 BUDGET=22 VERIFY_MODE=ddtree \
 harness/clients/run_codex.sh
 ```
 
+For no-draft targets such as Gemma, set only `DFLASH_TARGET` or pass
+`DRAFT=none`; the harness will not attach the default Qwen draft to a custom
+target.
+
 ## Run the Server
 
 Default: Qwen 3.6-27B Q4_K_M target + Lucebox Q4_K_M DFlash drafter on RTX 3090. DDTree budget=22, TQ3_0 KV cache, sliding FA window 2048. OpenAI-compatible HTTP on `:8000`.

--- a/harness/clients/README.md
+++ b/harness/clients/README.md
@@ -15,10 +15,15 @@ Each launcher starts `server/build/dflash_server`, runs the client, writes logs
 under `/workspace/lucebox-client-harness-runs`, then stops the server.
 
 The launcher will start `server/build/dflash_server` by default, or the path in
-`DFLASH_SERVER_BIN`.
+`DFLASH_SERVER_BIN`. The default model paths are
+`server/models/Qwen3.6-27B-Q4_K_M.gguf` and
+`server/models/draft/dflash-draft-3.6-q4_k_m.gguf`; override them with
+`TARGET`/`DRAFT` or the standard `DFLASH_TARGET`/`DFLASH_DRAFT` env vars.
 
 ```bash
 DFLASH_SERVER_BIN=server/build/dflash_server \
+DFLASH_TARGET=/path/to/Qwen3.6-27B-Q4_K_M.gguf \
+DFLASH_DRAFT=/path/to/dflash-draft-3.6-q4_k_m.gguf \
 MAX_CTX=32768 MAX_TOKENS=512 \
 BUDGET=22 VERIFY_MODE=ddtree \
 harness/clients/run_codex.sh

--- a/harness/clients/README.md
+++ b/harness/clients/README.md
@@ -19,6 +19,9 @@ The launcher will start `server/build/dflash_server` by default, or the path in
 `server/models/Qwen3.6-27B-Q4_K_M.gguf` and
 `server/models/draft/dflash-draft-3.6-q4_k_m.gguf`; override them with
 `TARGET`/`DRAFT` or the standard `DFLASH_TARGET`/`DFLASH_DRAFT` env vars.
+When you set a custom target without setting a draft, the launcher does not
+attach the default Qwen draft. Use `DRAFT=none` explicitly for no-draft targets
+such as Gemma, Laguna, or standalone Qwen3.
 
 ```bash
 DFLASH_SERVER_BIN=server/build/dflash_server \
@@ -26,6 +29,15 @@ DFLASH_TARGET=/path/to/Qwen3.6-27B-Q4_K_M.gguf \
 DFLASH_DRAFT=/path/to/dflash-draft-3.6-q4_k_m.gguf \
 MAX_CTX=32768 MAX_TOKENS=512 \
 BUDGET=22 VERIFY_MODE=ddtree \
+harness/clients/run_codex.sh
+```
+
+Gemma example:
+
+```bash
+DFLASH_TARGET=/path/to/gemma.gguf \
+DRAFT=none \
+MAX_CTX=32768 MAX_TOKENS=512 \
 harness/clients/run_codex.sh
 ```
 

--- a/harness/clients/common.sh
+++ b/harness/clients/common.sh
@@ -10,8 +10,26 @@ RUN_DIR="${RUN_DIR:-/workspace/lucebox-client-harness-runs}"
 
 DEFAULT_TARGET="$REPO_DIR/server/models/Qwen3.6-27B-Q4_K_M.gguf"
 DEFAULT_DRAFT="$REPO_DIR/server/models/draft/dflash-draft-3.6-q4_k_m.gguf"
-TARGET="${TARGET:-${DFLASH_TARGET:-$DEFAULT_TARGET}}"
-DRAFT="${DRAFT:-${DFLASH_DRAFT:-$DEFAULT_DRAFT}}"
+TARGET_WAS_EXPLICIT=0
+if [[ -n "${TARGET+x}" ]]; then
+  TARGET_WAS_EXPLICIT=1
+elif [[ -n "${DFLASH_TARGET+x}" ]]; then
+  TARGET="$DFLASH_TARGET"
+  TARGET_WAS_EXPLICIT=1
+else
+  TARGET="$DEFAULT_TARGET"
+fi
+if [[ -n "${DRAFT+x}" ]]; then
+  :
+elif [[ -n "${DFLASH_DRAFT+x}" ]]; then
+  DRAFT="$DFLASH_DRAFT"
+elif [[ "$TARGET_WAS_EXPLICIT" == "1" ]]; then
+  # A custom target may be Gemma/Laguna/Qwen3 or another model without a
+  # matching DFlash draft. Avoid attaching the default Qwen draft silently.
+  DRAFT=""
+else
+  DRAFT="$DEFAULT_DRAFT"
+fi
 MODEL_SERVER="${MODEL_SERVER:-lucebox}"
 DFLASH_SERVER_BIN="${DFLASH_SERVER_BIN:-$REPO_DIR/server/build/dflash_server}"
 LLAMA_SERVER_BIN="${LLAMA_SERVER_BIN:-/workspace/llama-cpp-server-build/bin/llama-server}"
@@ -54,6 +72,10 @@ SERVER_LOG="$LOG_DIR/server.log"
 
 mkdir -p "$LOG_DIR"
 
+draft_enabled() {
+  [[ -n "${DRAFT:-}" && "$DRAFT" != "none" && "$DRAFT" != "off" && "$DRAFT" != "0" ]]
+}
+
 start_lucebox_server() {
   if [[ "$MODEL_SERVER" == "llamacpp" ]]; then
     start_llamacpp_server
@@ -80,11 +102,15 @@ start_dflash_native_server() {
     echo "  hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir $REPO_DIR/server/models/" >&2
     return 1
   fi
-  if [[ ! -f "$DRAFT" ]]; then
+  if draft_enabled && [[ ! -f "$DRAFT" ]]; then
     echo "DFlash draft not found: $DRAFT" >&2
     echo "Set DRAFT=/path/to/dflash-draft.gguf or DFLASH_DRAFT=/path/to/dflash-draft.gguf, or download the default:" >&2
     echo "  hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q4_k_m.gguf --local-dir $REPO_DIR/server/models/draft/" >&2
     return 1
+  fi
+  local draft_args=()
+  if draft_enabled; then
+    draft_args=(--draft "$DRAFT")
   fi
   local extra_args=()
   if [[ -n "$EXTRA_SERVER_ARGS" ]]; then
@@ -102,7 +128,7 @@ start_dflash_native_server() {
   export DFLASH27B_KV_K="$CACHE_TYPE_K"
   export DFLASH27B_KV_V="$CACHE_TYPE_V"
   "$DFLASH_SERVER_BIN" "$TARGET" \
-    --draft "$DRAFT" \
+    "${draft_args[@]}" \
     --host "$HOST" \
     --port "$PORT" \
     --max-ctx "$MAX_CTX" \

--- a/harness/clients/common.sh
+++ b/harness/clients/common.sh
@@ -8,8 +8,10 @@ REPO_DIR="${REPO_DIR:-/workspace/lucebox-hub-harness}"
 CLIENT_WORK_DIR="${CLIENT_WORK_DIR:-/workspace/lucebox-harness-work}"
 RUN_DIR="${RUN_DIR:-/workspace/lucebox-client-harness-runs}"
 
-TARGET="${TARGET:-$REPO_DIR/server/models/Qwen3.6-27B-Q4_K_M.gguf}"
-DRAFT="${DRAFT:-$REPO_DIR/server/models/draft/dflash-draft-3.6-q4_k_m.gguf}"
+DEFAULT_TARGET="$REPO_DIR/server/models/Qwen3.6-27B-Q4_K_M.gguf"
+DEFAULT_DRAFT="$REPO_DIR/server/models/draft/dflash-draft-3.6-q4_k_m.gguf"
+TARGET="${TARGET:-${DFLASH_TARGET:-$DEFAULT_TARGET}}"
+DRAFT="${DRAFT:-${DFLASH_DRAFT:-$DEFAULT_DRAFT}}"
 MODEL_SERVER="${MODEL_SERVER:-lucebox}"
 DFLASH_SERVER_BIN="${DFLASH_SERVER_BIN:-$REPO_DIR/server/build/dflash_server}"
 LLAMA_SERVER_BIN="${LLAMA_SERVER_BIN:-/workspace/llama-cpp-server-build/bin/llama-server}"
@@ -72,6 +74,18 @@ start_dflash_native_server() {
     echo "  cmake --build $REPO_DIR/server/build --target dflash_server -j\$(nproc)" >&2
     return 1
   fi
+  if [[ ! -f "$TARGET" ]]; then
+    echo "target GGUF not found: $TARGET" >&2
+    echo "Set TARGET=/path/to/model.gguf or DFLASH_TARGET=/path/to/model.gguf, or download the default:" >&2
+    echo "  hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir $REPO_DIR/server/models/" >&2
+    return 1
+  fi
+  if [[ ! -f "$DRAFT" ]]; then
+    echo "DFlash draft not found: $DRAFT" >&2
+    echo "Set DRAFT=/path/to/dflash-draft.gguf or DFLASH_DRAFT=/path/to/dflash-draft.gguf, or download the default:" >&2
+    echo "  hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q4_k_m.gguf --local-dir $REPO_DIR/server/models/draft/" >&2
+    return 1
+  fi
   local extra_args=()
   if [[ -n "$EXTRA_SERVER_ARGS" ]]; then
     read -r -a extra_args <<< "$EXTRA_SERVER_ARGS"
@@ -107,6 +121,12 @@ start_llamacpp_server() {
     echo "Build it first, for example:" >&2
     echo "  cmake -S $REPO_DIR/server/deps/llama.cpp -B /workspace/llama-cpp-server-build -DGGML_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_CURL=OFF" >&2
     echo "  cmake --build /workspace/llama-cpp-server-build --target llama-server -j2" >&2
+    return 1
+  fi
+  if [[ ! -f "$TARGET" ]]; then
+    echo "target GGUF not found: $TARGET" >&2
+    echo "Set TARGET=/path/to/model.gguf or DFLASH_TARGET=/path/to/model.gguf, or download the default:" >&2
+    echo "  hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q4_K_M.gguf --local-dir $REPO_DIR/server/models/" >&2
     return 1
   fi
   local extra_args=()


### PR DESCRIPTION
Summary:
- let client harness launchers use DFLASH_TARGET/DFLASH_DRAFT as aliases for TARGET/DRAFT
- validate target and draft paths before spawning dflash_server so missing models fail with a clear message
- document the model path overrides in the root and client harness READMEs

Verification:
- bash -n harness/clients/common.sh
- git diff --check
- shell check that DFLASH_TARGET/DFLASH_DRAFT are selected
- shell check that a missing TARGET fails before server spawn