### PR TITLE
docs: sharpen Why this exists section copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,6 @@ Local AI should be the default, not a privilege. Private data, no per-token bill
 
 Nothing was built for local AI inference. Most machines bolt a stock GPU onto a desktop CPU and run a stock runtime, never tuning the kernels to the silicon underneath. On the same 27B model, a DGX Spark or Mac Studio leaves four to six times the real throughput on the table. General-purpose frameworks won the last decade because hand-tuning per chip cost more than it returned: one stack, decent on everything, great on nothing. Speculative decoding, speculative prefill, and fused megakernels turn idle silicon into 3-10× speedups, but they stay locked to BF16 weights on data-center GPUs. Consumer cards inherit the leftovers.
 
-AI-assisted development flips that calculus. Lucebox ports those speculative methods down to quantized GGUF on consumer cards, one chip and one model family at a time. Apache 2.0 source, full writeups, reproducible benchmarks.
-
 **See the benchmarks and the machine at [lucebox.com](https://lucebox.com).**
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -266,11 +266,11 @@ uv run --directory megakernel python final_bench.py
 
 ## Why this exists
 
-Local AI should be a default, not a privilege: private data, no per-token bill, no vendor lock-in. The hardware to run capable models already sits on desks. The software to extract real throughput from those chips doesn't.
+Local AI should be the default, not a privilege. Private data, no per-token bill, no vendor lock-in. The hardware to run capable models already sits on desks. The software to get real throughput out of those chips does not.
 
-General-purpose frameworks dominated the last decade because hand-tuning kernels per chip was too expensive to justify. One stack, decent on everything, great on nothing. Speculative decoding, speculative prefill, fused megakernels are the methods that turn idle silicon into 3-10× speedups, but they stay locked to BF16 weights on data-center GPUs.
+General-purpose frameworks won the last decade because hand-tuning kernels for every chip cost more than it returned. One stack, decent on everything, great on nothing. Speculative decoding, speculative prefill, and fused megakernels are what turn idle silicon into 3-10× speedups, and they stay locked to BF16 weights on data-center GPUs. Consumer cards inherit the leftovers.
 
-AI-assisted development flips that calculus. Rewrites that took a quarter now fit in a release cycle. Lucebox ports those speculative methods down to quantized GGUF on consumer cards, one chip and one model family at a time. Apache 2.0 source, full writeup, reproducible benchmarks.
+AI-assisted development flips that calculus. Rewrites that took a quarter now fit in a release cycle. Lucebox ports those speculative methods down to quantized GGUF on consumer cards, one chip and one model family at a time. Apache 2.0 source, full writeups, reproducible benchmarks.
 
 <p align="center">
   <a href="https://lucebox.com"><img src="assets/lucebox.png" alt="Lucebox local AI PC" width="85%" /></a>

--- a/README.md
+++ b/README.md
@@ -266,13 +266,11 @@ uv run --directory megakernel python final_bench.py
 
 ## Why this exists
 
-Local AI should be the default, not a privilege. Private data, no per-token bill, no vendor lock-in. The case only gets stronger: coding agents now burn $100 to $1000 per developer every month, regulated teams cannot ship source code or patient records to a cloud LLM, and open weights like Qwen3.6, GLM-4.6, and DeepSeek V4-Flash are catching the closed frontier fast. The hardware to run them already sits on desks. The software to get real throughput out of it does not.
+Local AI should be the default, not a privilege. Private data, no per-token bill, no vendor lock-in. The hardware to run capable models already sits on desks. The software to get real throughput out of it does not.
 
-Nothing was built for local AI inference. Most machines bolt a stock GPU onto a desktop CPU and run a stock runtime, missing the dGPU-and-unified-memory pairing local AI needs and never tuning the kernels to the silicon underneath. On the same 27B model, a DGX Spark or Mac Studio leaves four to six times the real throughput on the table, simply because the stack was never tuned.
+Nothing was built for local AI inference. Most machines bolt a stock GPU onto a desktop CPU and run a stock runtime, never tuning the kernels to the silicon underneath. On the same 27B model, a DGX Spark or Mac Studio leaves four to six times the real throughput on the table. General-purpose frameworks won the last decade because hand-tuning per chip cost more than it returned: one stack, decent on everything, great on nothing. Speculative decoding, speculative prefill, and fused megakernels turn idle silicon into 3-10× speedups, but they stay locked to BF16 weights on data-center GPUs. Consumer cards inherit the leftovers.
 
-General-purpose frameworks won the last decade because hand-tuning kernels for every chip cost more than it returned. One stack, decent on everything, great on nothing. Speculative decoding, speculative prefill, and fused megakernels are what turn idle silicon into 3-10× speedups, and they stay locked to BF16 weights on data-center GPUs. Consumer cards inherit the leftovers.
-
-AI-assisted development flips that calculus. Rewrites that took a quarter now fit in a release cycle. Lucebox ports those speculative methods down to quantized GGUF on consumer cards, one chip and one model family at a time. Apache 2.0 source, full writeups, reproducible benchmarks.
+AI-assisted development flips that calculus. Lucebox ports those speculative methods down to quantized GGUF on consumer cards, one chip and one model family at a time. Apache 2.0 source, full writeups, reproducible benchmarks.
 
 **See the benchmarks and the machine at [lucebox.com](https://lucebox.com).**
 

--- a/README.md
+++ b/README.md
@@ -266,11 +266,15 @@ uv run --directory megakernel python final_bench.py
 
 ## Why this exists
 
-Local AI should be the default, not a privilege. Private data, no per-token bill, no vendor lock-in. The hardware to run capable models already sits on desks. The software to get real throughput out of those chips does not.
+Local AI should be the default, not a privilege. Private data, no per-token bill, no vendor lock-in. The case only gets stronger: coding agents now burn $100 to $1000 per developer every month, regulated teams cannot ship source code or patient records to a cloud LLM, and open weights like Qwen3.6, GLM-4.6, and DeepSeek V4-Flash are catching the closed frontier fast. The hardware to run them already sits on desks. The software to get real throughput out of it does not.
+
+Nothing was built for local AI inference. Most machines bolt a stock GPU onto a desktop CPU and run a stock runtime, missing the dGPU-and-unified-memory pairing local AI needs and never tuning the kernels to the silicon underneath. On the same 27B model, a DGX Spark or Mac Studio leaves four to six times the real throughput on the table, simply because the stack was never tuned.
 
 General-purpose frameworks won the last decade because hand-tuning kernels for every chip cost more than it returned. One stack, decent on everything, great on nothing. Speculative decoding, speculative prefill, and fused megakernels are what turn idle silicon into 3-10× speedups, and they stay locked to BF16 weights on data-center GPUs. Consumer cards inherit the leftovers.
 
 AI-assisted development flips that calculus. Rewrites that took a quarter now fit in a release cycle. Lucebox ports those speculative methods down to quantized GGUF on consumer cards, one chip and one model family at a time. Apache 2.0 source, full writeups, reproducible benchmarks.
+
+**See the benchmarks and the machine at [lucebox.com](https://lucebox.com).**
 
 <p align="center">
   <a href="https://lucebox.com"><img src="assets/lucebox.png" alt="Lucebox local AI PC" width="85%" /></a>


### PR DESCRIPTION
Polishes the **Why this exists** section of the README. No substance changes, voice only, brought in line with the website copy.

## Changes
- Tighter opening: "should be the default, not a privilege", short declarative cadence.
- Reframed the gap with the website's framing and added the closing line **"Consumer cards inherit the leftovers."**
- Minor edits: "won the last decade", "cost more than it returned", "full writeups".

## Notes for review
@davide221 happy to tweak tone, this is a light copy pass we can iterate on.