### PR TITLE
feat(server): reduce layer-split activation memory with backend precision policy

### DIFF
--- a/server/src/common/backend_precision.cpp
+++ b/server/src/common/backend_precision.cpp
@@ -7,7 +7,9 @@
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
+#include <vector>
 
 namespace dflash::common {
 namespace {
@@ -106,36 +108,103 @@ int device_props_for(int device,
 #endif
 }
 
+bool arch_starts_with(const std::string & arch, const char * prefix) {
+    return arch.compare(0, std::strlen(prefix), prefix) == 0;
+}
+
+bool parse_precision_override(const char * env_name, ggml_type & out) {
+    if (!env_name || !env_name[0]) return false;
+    const char * s = std::getenv(env_name);
+    if (!s || !s[0]) return false;
+    if (std::strcmp(s, "f32") == 0 || std::strcmp(s, "F32") == 0) {
+        out = GGML_TYPE_F32;
+        return true;
+    }
+    if (std::strcmp(s, "f16") == 0 || std::strcmp(s, "F16") == 0) {
+        out = GGML_TYPE_F16;
+        return true;
+    }
+    if (std::strcmp(s, "bf16") == 0 || std::strcmp(s, "BF16") == 0) {
+        out = GGML_TYPE_BF16;
+        return true;
+    }
+    std::fprintf(stderr, "[precision] ignoring unsupported %s=%s\n", env_name, s);
+    return false;
+}
+
+void fill_policy_device_info(ggml_backend_t backend,
+                             std::string & backend_name_out,
+                             std::string & device_name_out,
+                             std::string & runtime_arch_out,
+                             int & device_id_out,
+                             int & cuda_sm_out) {
+    backend_name_out = backend_name(backend);
+    const std::string logical_name = backend_device_logical_name(backend);
+    device_name_out = backend_device_description(backend);
+    device_id_out = parse_backend_device_id(logical_name);
+    if (device_id_out < 0) {
+        device_id_out = current_device_id();
+    }
+    cuda_sm_out = device_props_for(
+        device_id_out,
+        device_name_out.empty() ? &device_name_out : nullptr,
+        &runtime_arch_out);
+    if (backend_name_out.empty()) backend_name_out = "unknown";
+    if (device_name_out.empty()) device_name_out = "unknown";
+}
+
 } // namespace
 
 const char * backend_precision_type_name(ggml_type type) {
     return ggml_type_name(type);
 }
 
+ggml_type select_cuda_backend_precision_type_for_sm(int sm) {
+    if (sm >= 80) return GGML_TYPE_BF16;
+    if (sm >= 70 || sm == 60) return GGML_TYPE_F16;
+    return GGML_TYPE_F32;
+}
+
+ggml_type select_hip_activation_precision_type_for_arch(const std::string & arch) {
+    if (arch.empty()) return GGML_TYPE_F32;
+    if (arch_starts_with(arch, "gfx90a") ||
+        arch_starts_with(arch, "gfx94")  ||
+        arch_starts_with(arch, "gfx95")  ||
+        arch_starts_with(arch, "gfx11")  ||
+        arch_starts_with(arch, "gfx12")) {
+        return GGML_TYPE_BF16;
+    }
+    if (arch_starts_with(arch, "gfx9") ||
+        arch_starts_with(arch, "gfx10")) {
+        return GGML_TYPE_F16;
+    }
+    return GGML_TYPE_F32;
+}
+
+ggml_type combine_activation_precision_types(ggml_type a, ggml_type b) {
+    if (a == GGML_TYPE_F32 || b == GGML_TYPE_F32) return GGML_TYPE_F32;
+    if (a == GGML_TYPE_F16 || b == GGML_TYPE_F16) return GGML_TYPE_F16;
+    if (a == GGML_TYPE_BF16 && b == GGML_TYPE_BF16) return GGML_TYPE_BF16;
+    return GGML_TYPE_F32;
+}
+
 BackendPrecisionPolicy select_drafter_precision_policy(ggml_backend_t backend) {
     BackendPrecisionPolicy policy;
-    policy.backend_name = backend_name(backend);
-    const std::string logical_name = backend_device_logical_name(backend);
-    policy.device_name = backend_device_description(backend);
-    policy.device_id = parse_backend_device_id(logical_name);
-    if (policy.device_id < 0) {
-        policy.device_id = current_device_id();
-    }
+    fill_policy_device_info(backend, policy.backend_name, policy.device_name,
+                            policy.runtime_arch, policy.device_id,
+                            policy.cuda_sm);
 
 #if defined(DFLASH27B_BACKEND_CUDA)
-    policy.cuda_sm = device_props_for(
-        policy.device_id,
-        policy.device_name.empty() ? &policy.device_name : nullptr,
-        nullptr);
-    if (policy.cuda_sm >= 80) {
+    const ggml_type type = select_cuda_backend_precision_type_for_sm(policy.cuda_sm);
+    if (type == GGML_TYPE_BF16) {
         policy.weight_type  = GGML_TYPE_BF16;
         policy.compute_type = GGML_TYPE_BF16;
         policy.reason       = "CUDA sm80+ BF16 tensor-core path";
-    } else if (policy.cuda_sm >= 70) {
+    } else if (type == GGML_TYPE_F16 && policy.cuda_sm >= 70) {
         policy.weight_type  = GGML_TYPE_F16;
         policy.compute_type = GGML_TYPE_F16;
         policy.reason       = "CUDA sm70-sm79 F16 tensor-core path";
-    } else if (policy.cuda_sm == 60) {
+    } else if (type == GGML_TYPE_F16) {
         policy.weight_type  = GGML_TYPE_F16;
         policy.compute_type = GGML_TYPE_F16;
         policy.reason       = "CUDA sm60 GP100 F16 path";
@@ -145,10 +214,6 @@ BackendPrecisionPolicy select_drafter_precision_policy(ggml_backend_t backend) {
         policy.reason       = "CUDA legacy compatibility fallback without useful F16/BF16 acceleration";
     }
 #elif defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
-    policy.cuda_sm = device_props_for(
-        policy.device_id,
-        policy.device_name.empty() ? &policy.device_name : nullptr,
-        &policy.runtime_arch);
     policy.weight_type  = GGML_TYPE_BF16;
     policy.compute_type = GGML_TYPE_BF16;
     policy.reason       = "HIP ROCm/ggml BF16-compatible path";
@@ -158,12 +223,92 @@ BackendPrecisionPolicy select_drafter_precision_policy(ggml_backend_t backend) {
     policy.reason       = "portable non-GPU fallback";
 #endif
 
-    if (policy.backend_name.empty()) {
-        policy.backend_name = "unknown";
+    return policy;
+}
+
+BackendActivationPolicy select_common_activation_precision_policy(
+        const std::vector<ggml_backend_t> & backends,
+        bool force_f32,
+        const char * override_env) {
+    if (backends.empty()) {
+        return select_activation_precision_policy(nullptr, force_f32, override_env);
     }
-    if (policy.device_name.empty()) {
-        policy.device_name = "unknown";
+
+    BackendActivationPolicy policy =
+        select_activation_precision_policy(backends.front(), force_f32, override_env);
+    ggml_type common_type = policy.activation_type;
+    bool mixed = false;
+    for (size_t i = 1; i < backends.size(); ++i) {
+        const BackendActivationPolicy shard_policy =
+            select_activation_precision_policy(backends[i], force_f32, override_env);
+        if (shard_policy.activation_type != common_type) {
+            mixed = true;
+        }
+        const ggml_type combined =
+            combine_activation_precision_types(common_type, shard_policy.activation_type);
+        if (combined != common_type) {
+            mixed = true;
+        }
+        common_type = combined;
     }
+    if (mixed) {
+        policy.activation_type = common_type;
+        policy.backend_name = "mixed";
+        policy.device_name = "mixed";
+        policy.runtime_arch = "mixed";
+        policy.device_id = -1;
+        policy.cuda_sm = 0;
+        policy.reason = "common shard-compatible activation path";
+    }
+    return policy;
+}
+
+BackendActivationPolicy select_activation_precision_policy(
+        ggml_backend_t backend,
+        bool force_f32,
+        const char * override_env) {
+    BackendActivationPolicy policy;
+    fill_policy_device_info(backend, policy.backend_name, policy.device_name,
+                            policy.runtime_arch, policy.device_id,
+                            policy.cuda_sm);
+
+    ggml_type override_type = GGML_TYPE_F32;
+    if (!force_f32 && parse_precision_override(override_env, override_type)) {
+        policy.activation_type = override_type;
+        policy.reason = std::string(override_env) + " override";
+        return policy;
+    }
+    if (force_f32) {
+        policy.activation_type = GGML_TYPE_F32;
+        policy.reason = "F32 required by capture/IPC feature boundary";
+        return policy;
+    }
+
+#if defined(DFLASH27B_BACKEND_CUDA)
+    policy.activation_type = select_cuda_backend_precision_type_for_sm(policy.cuda_sm);
+    if (policy.activation_type == GGML_TYPE_BF16) {
+        policy.reason = "CUDA sm80+ BF16 activation path";
+    } else if (policy.activation_type == GGML_TYPE_F16 && policy.cuda_sm >= 70) {
+        policy.reason = "CUDA sm70-sm79 F16 activation path";
+    } else if (policy.activation_type == GGML_TYPE_F16) {
+        policy.reason = "CUDA sm60 GP100 F16 activation path";
+    } else {
+        policy.reason = "CUDA legacy F32 activation fallback";
+    }
+#elif defined(DFLASH27B_BACKEND_HIP) || defined(GGML_USE_HIP)
+    policy.activation_type =
+        select_hip_activation_precision_type_for_arch(policy.runtime_arch);
+    if (policy.activation_type == GGML_TYPE_BF16) {
+        policy.reason = "HIP native BF16 activation path";
+    } else if (policy.activation_type == GGML_TYPE_F16) {
+        policy.reason = "HIP FP16 activation path";
+    } else {
+        policy.reason = "HIP legacy F32 activation fallback";
+    }
+#else
+    policy.activation_type = GGML_TYPE_F32;
+    policy.reason = "portable F32 activation fallback";
+#endif
     return policy;
 }
 

--- a/server/src/common/backend_precision.h
+++ b/server/src/common/backend_precision.h
@@ -4,6 +4,7 @@
 #include "ggml-backend.h"
 
 #include <string>
+#include <vector>
 
 namespace dflash::common {
 
@@ -18,8 +19,29 @@ struct BackendPrecisionPolicy {
     std::string reason;
 };
 
+struct BackendActivationPolicy {
+    ggml_type   activation_type = GGML_TYPE_F32;
+    std::string backend_name;
+    std::string device_name;
+    std::string runtime_arch;
+    int         device_id       = -1;
+    int         cuda_sm         = 0;
+    std::string reason;
+};
+
 BackendPrecisionPolicy select_drafter_precision_policy(ggml_backend_t backend);
+BackendActivationPolicy select_activation_precision_policy(
+    ggml_backend_t backend,
+    bool force_f32 = false,
+    const char * override_env = nullptr);
+BackendActivationPolicy select_common_activation_precision_policy(
+    const std::vector<ggml_backend_t> & backends,
+    bool force_f32 = false,
+    const char * override_env = nullptr);
 
 const char * backend_precision_type_name(ggml_type type);
+ggml_type select_cuda_backend_precision_type_for_sm(int sm);
+ggml_type select_hip_activation_precision_type_for_arch(const std::string & arch);
+ggml_type combine_activation_precision_types(ggml_type a, ggml_type b);
 
 } // namespace dflash::common

--- a/server/src/common/dflash_layer_split_runtime.h
+++ b/server/src/common/dflash_layer_split_runtime.h
@@ -13,6 +13,8 @@
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
 
+#include <vector>
+
 namespace dflash::common {
 
 // ── Runtime configuration (replaces globals) ────────────────────────
@@ -33,7 +35,43 @@ struct ActivationPair {
     ggml_tensor * b = nullptr;
     ggml_backend_t backend = nullptr;
     int n_tokens = 0;
+    ggml_type type = GGML_TYPE_F32;
 };
+
+struct ActivationBuffer {
+    ggml_context * ctx = nullptr;
+    ggml_backend_buffer_t buf = nullptr;
+    ggml_tensor * tensor = nullptr;
+    ggml_backend_t backend = nullptr;
+    int n_tokens = 0;
+    ggml_type type = GGML_TYPE_F32;
+};
+
+inline bool set_activation_tensor_from_f32(ggml_tensor * dst,
+                                           const float * src,
+                                           size_t offset,
+                                           size_t elems) {
+    if (!dst || !src) return false;
+    if (dst->type == GGML_TYPE_F32) {
+        ggml_backend_tensor_set(dst, src, offset, sizeof(float) * elems);
+        return true;
+    }
+    if (dst->type == GGML_TYPE_F16) {
+        std::vector<ggml_fp16_t> tmp(elems);
+        ggml_fp32_to_fp16_row(src, tmp.data(), (int64_t)elems);
+        ggml_backend_tensor_set(dst, tmp.data(), offset,
+                                sizeof(ggml_fp16_t) * elems);
+        return true;
+    }
+    if (dst->type == GGML_TYPE_BF16) {
+        std::vector<ggml_bf16_t> tmp(elems);
+        ggml_fp32_to_bf16_row(src, tmp.data(), (int64_t)elems);
+        ggml_backend_tensor_set(dst, tmp.data(), offset,
+                                sizeof(ggml_bf16_t) * elems);
+        return true;
+    }
+    return false;
+}
 
 inline void activation_pair_free(ActivationPair & p) {
     if (p.buf) { ggml_backend_buffer_free(p.buf); p.buf = nullptr; }
@@ -42,24 +80,36 @@ inline void activation_pair_free(ActivationPair & p) {
     p.b = nullptr;
     p.backend = nullptr;
     p.n_tokens = 0;
+    p.type = GGML_TYPE_F32;
+}
+
+inline void activation_buffer_free(ActivationBuffer & b) {
+    if (b.buf) { ggml_backend_buffer_free(b.buf); b.buf = nullptr; }
+    if (b.ctx) { ggml_free(b.ctx); b.ctx = nullptr; }
+    b.tensor = nullptr;
+    b.backend = nullptr;
+    b.n_tokens = 0;
+    b.type = GGML_TYPE_F32;
 }
 
 inline bool activation_pair_init(ActivationPair & p,
                                  ggml_backend_t backend,
                                  int hidden,
-                                 int n_tokens) {
+                                 int n_tokens,
+                                 ggml_type type = GGML_TYPE_F32) {
     activation_pair_free(p);
     if (n_tokens <= 0 || hidden <= 0) return false;
     p.backend = backend;
     p.n_tokens = n_tokens;
+    p.type = type;
     ggml_init_params ip{};
     ip.mem_size = (size_t)8 * ggml_tensor_overhead() + 16 * 1024;
     ip.mem_buffer = nullptr;
     ip.no_alloc = true;
     p.ctx = ggml_init(ip);
     if (!p.ctx) return false;
-    p.a = ggml_new_tensor_2d(p.ctx, GGML_TYPE_F32, hidden, n_tokens);
-    p.b = ggml_new_tensor_2d(p.ctx, GGML_TYPE_F32, hidden, n_tokens);
+    p.a = ggml_new_tensor_2d(p.ctx, type, hidden, n_tokens);
+    p.b = ggml_new_tensor_2d(p.ctx, type, hidden, n_tokens);
     if (!p.a || !p.b) {
         activation_pair_free(p);
         return false;
@@ -69,6 +119,37 @@ inline bool activation_pair_init(ActivationPair & p,
     p.buf = ggml_backend_alloc_ctx_tensors(p.ctx, backend);
     if (!p.buf) {
         activation_pair_free(p);
+        return false;
+    }
+    return true;
+}
+
+inline bool activation_buffer_init(ActivationBuffer & b,
+                                   ggml_backend_t backend,
+                                   int hidden,
+                                   int n_tokens,
+                                   ggml_type type = GGML_TYPE_F32,
+                                   const char * name = "target_split_activation") {
+    activation_buffer_free(b);
+    if (hidden <= 0 || n_tokens <= 0) return false;
+    b.backend = backend;
+    b.n_tokens = n_tokens;
+    b.type = type;
+    ggml_init_params ip{};
+    ip.mem_size = (size_t)4 * ggml_tensor_overhead() + 16 * 1024;
+    ip.mem_buffer = nullptr;
+    ip.no_alloc = true;
+    b.ctx = ggml_init(ip);
+    if (!b.ctx) return false;
+    b.tensor = ggml_new_tensor_2d(b.ctx, type, hidden, n_tokens);
+    if (!b.tensor) {
+        activation_buffer_free(b);
+        return false;
+    }
+    ggml_set_name(b.tensor, name ? name : "target_split_activation");
+    b.buf = ggml_backend_alloc_ctx_tensors(b.ctx, backend);
+    if (!b.buf) {
+        activation_buffer_free(b);
         return false;
     }
     return true;

--- a/server/src/common/ggml_graph_precision.h
+++ b/server/src/common/ggml_graph_precision.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ggml.h"
+
+namespace dflash::common {
+
+inline ggml_tensor * graph_tensor_f32(ggml_context * ctx, ggml_tensor * x) {
+    if (!x || x->type == GGML_TYPE_F32) {
+        return x;
+    }
+    return ggml_cast(ctx, x, GGML_TYPE_F32);
+}
+
+inline ggml_tensor * rms_norm_input_f32(ggml_context * ctx, ggml_tensor * x) {
+    return graph_tensor_f32(ctx, x);
+}
+
+} // namespace dflash::common

--- a/server/src/gemma4/gemma4_graph.cpp
+++ b/server/src/gemma4/gemma4_graph.cpp
@@ -16,6 +16,7 @@
 //   - Logit softcapping: tanh(logits/cap)*cap
 
 #include "gemma4_internal.h"
+#include "common/ggml_graph_precision.h"
 #include "common/gpu_runtime_compat.h"
 #include "dflash27b.h"
 #include "flashprefill.h"
@@ -36,6 +37,8 @@ static constexpr float GEMMA4_EPS = 1e-6f;
 
 static ggml_tensor * gemma4_rms_norm_mul(ggml_context * ctx, ggml_tensor * x,
                                           ggml_tensor * weight, float eps = GEMMA4_EPS) {
+    x = rms_norm_input_f32(ctx, x);
+    weight = graph_tensor_f32(ctx, weight);
     ggml_tensor * n = ggml_rms_norm(ctx, x, eps);
     return ggml_mul(ctx, n, weight);
 }
@@ -84,7 +87,7 @@ static ggml_tensor * build_gemma4_moe_block(ggml_context * ctx, ggml_tensor * at
     }
 
     // Router: rms_norm(attn_out) * (1/sqrt(n_embd)) * ffn_gate_inp_s → ffn_gate_inp → softmax
-    ggml_tensor * router_in = ggml_rms_norm(ctx, attn_out, w.norm_eps);
+    ggml_tensor * router_in = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, attn_out), w.norm_eps);
     router_in = ggml_scale(ctx, router_in, 1.0f / std::sqrt((float)n_embd));
     if (L.ffn_gate_inp_s) {
         router_in = ggml_mul(ctx, router_in, L.ffn_gate_inp_s);
@@ -196,7 +199,7 @@ static ggml_tensor * build_gemma4_attn_block(
             Kcur = gemma4_rms_norm_mul(ctx, Kcur, L.k_norm, w.norm_eps);
         }
         // V also gets RMSNorm (gemma4 specific)
-        Vcur = ggml_rms_norm(ctx, Vcur, w.norm_eps);
+        Vcur = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, Vcur), w.norm_eps);
 
         Kcur = ggml_rope_ext(ctx, Kcur, positions, freq_factors,
                               head_dim, GGML_ROPE_TYPE_NEOX,
@@ -282,9 +285,10 @@ static ggml_tensor * build_gemma4_layer(
     int capture_idx = -1)  // >=0: write to target_feat at this capture slot
 {
     const Gemma4Layer & L = w.layers[il];
+    ggml_tensor * inp_f32 = graph_tensor_f32(ctx, inp);
 
     // Pre-attn norm
-    ggml_tensor * cur = gemma4_rms_norm_mul(ctx, inp, L.attn_norm, w.norm_eps);
+    ggml_tensor * cur = gemma4_rms_norm_mul(ctx, inp_f32, L.attn_norm, w.norm_eps);
 
     // Attention
     cur = build_gemma4_attn_block(ctx, gf, w, L, cache, il, cur,
@@ -297,7 +301,7 @@ static ggml_tensor * build_gemma4_layer(
     }
 
     // Residual
-    ggml_tensor * attn_out = ggml_add(ctx, cur, inp);
+    ggml_tensor * attn_out = ggml_add(ctx, cur, inp_f32);
 
     // FFN
     const bool is_moe = (L.ffn_gate_inp != nullptr && il >= w.n_layer_dense_lead);
@@ -414,7 +418,7 @@ static ggml_tensor * build_gemma4_per_layer_input(
         (size_t)layer_idx * D * w.per_layer_model_proj->nb[1]);
     ggml_tensor * proj = ggml_mul_mat(ctx, proj_w_layer, embed);
     proj = ggml_scale(ctx, proj, 1.0f / std::sqrt((float)w.n_embd));
-    proj = ggml_rms_norm(ctx, proj, w.norm_eps);
+    proj = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, proj), w.norm_eps);
     ggml_tensor * norm_w = ggml_view_1d(
         ctx, w.per_layer_proj_norm, D, (size_t)layer_idx * D * elt_norm);
     proj = ggml_mul(ctx, proj, norm_w);
@@ -654,7 +658,7 @@ bool gemma4_step(
         proj = ggml_reshape_3d(ctx, proj, D, L, n_tokens);  // [D, L, n_tokens]
 
         // 3. RMS norm on projection (normalizes over ne[0]=D for each (layer, token))
-        proj = ggml_rms_norm(ctx, proj, w.norm_eps);
+        proj = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, proj), w.norm_eps);
         // Reshape norm weight from [D*L] to [D, L] for broadcast mul over n_tokens
         ggml_tensor * norm_w = ggml_reshape_2d(ctx, w.per_layer_proj_norm, D, L);
         proj = ggml_mul(ctx, proj, norm_w);
@@ -837,7 +841,7 @@ bool gemma4_verify_batch(
         ggml_tensor * proj = ggml_mul_mat(ctx, w.per_layer_model_proj, ie);
         proj = ggml_scale(ctx, proj, 1.0f / std::sqrt((float)w.n_embd));
         proj = ggml_reshape_3d(ctx, proj, D, L, n_tokens);
-        proj = ggml_rms_norm(ctx, proj, w.norm_eps);
+        proj = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, proj), w.norm_eps);
         ggml_tensor * norm_w = ggml_reshape_2d(ctx, w.per_layer_proj_norm, D, L);
         proj = ggml_mul(ctx, proj, norm_w);
         per_layer_all = ggml_add(ctx, proj, inp_pl);
@@ -1143,7 +1147,7 @@ bool gemma4_prefill_bsa(
         proj = ggml_reshape_3d(ctx, proj, D_pl, L_pl, S);
 
         // RMS norm on projection
-        proj = ggml_rms_norm(ctx, proj, eps);
+        proj = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, proj), eps);
         ggml_tensor * norm_w = ggml_reshape_2d(ctx, w.per_layer_proj_norm, D_pl, L_pl);
         proj = ggml_mul(ctx, proj, norm_w);
 
@@ -1231,7 +1235,7 @@ bool gemma4_prefill_bsa(
             ggml_set_input(pos_t);
 
             // Pre-attn norm.
-            ggml_tensor * h_norm = ggml_rms_norm(gA, h_view, eps);
+            ggml_tensor * h_norm = ggml_rms_norm(gA, rms_norm_input_f32(gA, h_view), eps);
             h_norm = ggml_mul(gA, h_norm, L.attn_norm);
 
             // Q projection + norm + RoPE.
@@ -1268,7 +1272,7 @@ bool gemma4_prefill_bsa(
                 ggml_tensor * V = L.wv ? ggml_mul_mat(gA, L.wv, h_norm)
                                        : ggml_mul_mat(gA, L.wk, h_norm);
                 V = ggml_reshape_3d(gA, V, D, Hk, cl);
-                V = ggml_rms_norm(gA, V, eps);
+                V = ggml_rms_norm(gA, rms_norm_input_f32(gA, V), eps);
                 V = ggml_reshape_2d(gA, V, kv_dim, cl);
 
                 const size_t kv_esz = ggml_type_size(half_type);

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -2,6 +2,7 @@
 
 #include "gemma4_layer_split_adapter.h"
 
+#include "common/backend_precision.h"
 #include "common/dflash_layer_split_runtime.h"
 #include "common/gguf_inspect.h"
 #include "common/layer_split_utils.h"
@@ -18,49 +19,6 @@
 namespace dflash::common {
 
 namespace {
-
-struct ActivationBuffer {
-    ggml_context * ctx = nullptr;
-    ggml_backend_buffer_t buf = nullptr;
-    ggml_tensor * tensor = nullptr;
-};
-
-void activation_buffer_free(ActivationBuffer & b) {
-    if (b.buf) {
-        ggml_backend_buffer_free(b.buf);
-        b.buf = nullptr;
-    }
-    if (b.ctx) {
-        ggml_free(b.ctx);
-        b.ctx = nullptr;
-    }
-    b.tensor = nullptr;
-}
-
-bool activation_buffer_init(ActivationBuffer & b,
-                            ggml_backend_t backend,
-                            int hidden,
-                            int n_tokens) {
-    activation_buffer_free(b);
-    if (hidden <= 0 || n_tokens <= 0) return false;
-    ggml_init_params ip{};
-    ip.mem_size = (size_t)4 * ggml_tensor_overhead() + 16 * 1024;
-    ip.no_alloc = true;
-    b.ctx = ggml_init(ip);
-    if (!b.ctx) return false;
-    b.tensor = ggml_new_tensor_2d(b.ctx, GGML_TYPE_F32, hidden, n_tokens);
-    if (!b.tensor) {
-        activation_buffer_free(b);
-        return false;
-    }
-    ggml_set_name(b.tensor, "gemma4_target_split_orig_embed");
-    b.buf = ggml_backend_alloc_ctx_tensors(b.ctx, backend);
-    if (!b.buf) {
-        activation_buffer_free(b);
-        return false;
-    }
-    return true;
-}
 
 static bool tensor_ready(const ggml_tensor * t) {
     return t && t->buffer;
@@ -89,6 +47,24 @@ bool Gemma4LayerSplitAdapter::init() {
     if (!init_layer_split_runtime(runtime_cfg, shards_, snapshot_backends_)) {
         return false;
     }
+
+    std::vector<ggml_backend_t> shard_backends;
+    shard_backends.reserve(shards_.size());
+    for (const auto & shard : shards_) shard_backends.push_back(shard.backend);
+    const BackendActivationPolicy activation_policy =
+        select_common_activation_precision_policy(
+            shard_backends, /*force_f32=*/false,
+            "LUCEBOX_LAYER_SPLIT_ACT_TYPE");
+    activation_type_ = activation_policy.activation_type;
+    std::fprintf(stderr, "[gemma4-target-split] activation=%s (%s",
+                 backend_precision_type_name(activation_type_),
+                 activation_policy.reason.c_str());
+    if (!activation_policy.runtime_arch.empty()) {
+        std::fprintf(stderr, ", arch=%s", activation_policy.runtime_arch.c_str());
+    } else if (activation_policy.cuda_sm > 0) {
+        std::fprintf(stderr, ", sm=%d", activation_policy.cuda_sm);
+    }
+    std::fprintf(stderr, ")\n");
 
     for (size_t i = 0; i < shards_.size(); ++i) {
         auto & shard = shards_[i];
@@ -156,14 +132,15 @@ bool Gemma4LayerSplitAdapter::run_forward(
 
     ActivationPair acts;
     if (!activation_pair_init(acts, shards_.front().backend, hidden,
-                              n_tokens_total)) {
+                              n_tokens_total, activation_type_)) {
         std::fprintf(stderr, "[gemma4-target-split] activation alloc failed gpu=%d\n",
                      shards_.front().gpu);
         return false;
     }
     ActivationBuffer orig;
     if (!activation_buffer_init(orig, shards_.front().backend, hidden,
-                                n_tokens_total)) {
+                                n_tokens_total, activation_type_,
+                                "gemma4_target_split_orig_embed")) {
         activation_pair_free(acts);
         return false;
     }
@@ -182,9 +159,16 @@ bool Gemma4LayerSplitAdapter::run_forward(
             }
             for (int j = 0; j < hidden * n; ++j) emb[(size_t)j] *= scale;
             const size_t off = (size_t)i * acts.a->nb[1];
-            const size_t bytes = sizeof(float) * (size_t)hidden * n;
-            ggml_backend_tensor_set(acts.a, emb.data(), off, bytes);
-            ggml_backend_tensor_set(orig.tensor, emb.data(), off, bytes);
+            const size_t elems = (size_t)hidden * (size_t)n;
+            if (!set_activation_tensor_from_f32(acts.a, emb.data(), off, elems) ||
+                !set_activation_tensor_from_f32(orig.tensor, emb.data(), off, elems)) {
+                std::fprintf(stderr,
+                    "[gemma4-target-split] unsupported activation type: %s\n",
+                    ggml_type_name(acts.a->type));
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
         }
     }
 
@@ -203,14 +187,15 @@ bool Gemma4LayerSplitAdapter::run_forward(
         if (shard != current_shard) {
             ActivationPair next_acts;
             if (!activation_pair_init(next_acts, shard->backend, hidden,
-                                      n_tokens_total)) {
+                                      n_tokens_total, activation_type_)) {
                 activation_buffer_free(orig);
                 activation_pair_free(acts);
                 return false;
             }
             ActivationBuffer next_orig;
             if (!activation_buffer_init(next_orig, shard->backend, hidden,
-                                        n_tokens_total)) {
+                                        n_tokens_total, activation_type_,
+                                        "gemma4_target_split_orig_embed")) {
                 activation_pair_free(next_acts);
                 activation_buffer_free(orig);
                 activation_pair_free(acts);

--- a/server/src/gemma4/gemma4_layer_split_adapter.h
+++ b/server/src/gemma4/gemma4_layer_split_adapter.h
@@ -75,6 +75,7 @@ private:
     std::vector<Gemma4LayerSplitShard> shards_;
     std::vector<ggml_backend_t> snapshot_backends_;
     std::vector<Gemma4LayerSplitSnapshot> snapshots_;
+    ggml_type activation_type_ = GGML_TYPE_F32;
     static constexpr int PREFIX_SLOTS = ModelBackend::kMaxSlots;
     SamplerCfg sampler_;
     std::mt19937_64 sampler_rng_{std::random_device{}()};

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -2,6 +2,7 @@
 
 #include "laguna_layer_split_adapter.h"
 
+#include "common/backend_precision.h"
 #include "common/dflash_layer_split_runtime.h"
 #include "common/gguf_inspect.h"
 #include "common/layer_split_utils.h"
@@ -42,6 +43,24 @@ bool LagunaLayerSplitAdapter::init() {
     if (!init_layer_split_runtime(runtime_cfg, shards_, snapshot_backends_)) {
         return false;
     }
+
+    std::vector<ggml_backend_t> shard_backends;
+    shard_backends.reserve(shards_.size());
+    for (const auto & shard : shards_) shard_backends.push_back(shard.backend);
+    const BackendActivationPolicy activation_policy =
+        select_common_activation_precision_policy(
+            shard_backends, /*force_f32=*/false,
+            "LUCEBOX_LAYER_SPLIT_ACT_TYPE");
+    activation_type_ = activation_policy.activation_type;
+    std::fprintf(stderr, "[laguna-target-split] activation=%s (%s",
+                 backend_precision_type_name(activation_type_),
+                 activation_policy.reason.c_str());
+    if (!activation_policy.runtime_arch.empty()) {
+        std::fprintf(stderr, ", arch=%s", activation_policy.runtime_arch.c_str());
+    } else if (activation_policy.cuda_sm > 0) {
+        std::fprintf(stderr, ", sm=%d", activation_policy.cuda_sm);
+    }
+    std::fprintf(stderr, ")\n");
 
     for (size_t i = 0; i < shards_.size(); ++i) {
         auto & shard = shards_[i];
@@ -105,7 +124,7 @@ bool LagunaLayerSplitAdapter::run_forward(
 
     ActivationPair acts;
     if (!activation_pair_init(acts, shards_.front().backend, hidden,
-                              n_tokens_total)) {
+                              n_tokens_total, activation_type_)) {
         std::fprintf(stderr, "[laguna-target-split] activation alloc failed gpu=%d\n",
                      shards_.front().gpu);
         return false;
@@ -122,8 +141,14 @@ bool LagunaLayerSplitAdapter::run_forward(
                 return false;
             }
             const size_t off = (size_t)i * acts.a->nb[1];
-            const size_t bytes = sizeof(float) * (size_t)hidden * n;
-            ggml_backend_tensor_set(acts.a, emb.data(), off, bytes);
+            if (!set_activation_tensor_from_f32(
+                    acts.a, emb.data(), off, (size_t)hidden * (size_t)n)) {
+                std::fprintf(stderr,
+                    "[laguna-target-split] unsupported activation type: %s\n",
+                    ggml_type_name(acts.a->type));
+                activation_pair_free(acts);
+                return false;
+            }
         }
     }
 
@@ -141,7 +166,7 @@ bool LagunaLayerSplitAdapter::run_forward(
         if (shard != current_shard) {
             ActivationPair next_acts;
             if (!activation_pair_init(next_acts, shard->backend, hidden,
-                                      n_tokens_total)) {
+                                      n_tokens_total, activation_type_)) {
                 activation_pair_free(acts);
                 return false;
             }

--- a/server/src/laguna/laguna_layer_split_adapter.h
+++ b/server/src/laguna/laguna_layer_split_adapter.h
@@ -74,6 +74,7 @@ private:
     std::vector<LagunaLayerSplitShard> shards_;
     std::vector<ggml_backend_t> snapshot_backends_;
     std::vector<LagunaLayerSplitSnapshot> snapshots_;
+    ggml_type activation_type_ = GGML_TYPE_F32;
     static constexpr int PREFIX_SLOTS = ModelBackend::kMaxSlots;
     SamplerCfg sampler_;
     std::mt19937_64 sampler_rng_{std::random_device{}()};

--- a/server/src/laguna/laguna_target_graph.cpp
+++ b/server/src/laguna/laguna_target_graph.cpp
@@ -18,6 +18,7 @@
 // for 30+ tokens on B-tree prompt; see Lucebox/Laguna-XS.2-GGUF README).
 
 #include "laguna_internal.h"
+#include "common/ggml_graph_precision.h"
 #include "internal.h"
 #include "dflash27b.h"
 
@@ -283,6 +284,8 @@ void reset_laguna_target_cache(LagunaTargetCache & c) {
 
 static ggml_tensor * laguna_rms_norm_mul(ggml_context * ctx, ggml_tensor * x,
                                           ggml_tensor * weight, float eps = LAGUNA_EPS) {
+    x = rms_norm_input_f32(ctx, x);
+    weight = graph_tensor_f32(ctx, weight);
     ggml_tensor * n = ggml_rms_norm(ctx, x, eps);
     return ggml_mul(ctx, n, weight);
 }
@@ -637,9 +640,10 @@ static ggml_tensor * build_laguna_layer(
     ggml_tensor * attn_mask_swa)
 {
     const LagunaTargetLayer & L = w.layers[il];
+    ggml_tensor * inp_f32 = graph_tensor_f32(ctx, inp);
 
     // Pre-attn norm
-    ggml_tensor * cur = laguna_rms_norm_mul(ctx, inp, L.attn_norm);
+    ggml_tensor * cur = laguna_rms_norm_mul(ctx, inp_f32, L.attn_norm);
 
     // Attention
     const bool is_full = laguna_is_full_attn_layer(w, il);
@@ -648,7 +652,7 @@ static ggml_tensor * build_laguna_layer(
                                     attn_mask, attn_mask_swa, kv_start, n_tokens, is_full);
 
     // Residual
-    ggml_tensor * ffn_inp = ggml_add(ctx, cur, inp);
+    ggml_tensor * ffn_inp = ggml_add(ctx, cur, inp_f32);
 
     // Pre-FFN norm
     cur = laguna_rms_norm_mul(ctx, ffn_inp, L.ffn_norm);

--- a/server/src/qwen35/layer_split_forward.cpp
+++ b/server/src/qwen35/layer_split_forward.cpp
@@ -1,6 +1,7 @@
 // layer_split_forward.cpp — Multi-GPU layer-split forward pass.
 
 #include "layer_split_forward.h"
+#include "common/ggml_graph_precision.h"
 #include "internal.h"
 #include "graph_builders.h"
 #include "dflash_feature_ring.h"
@@ -13,7 +14,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <vector>
 
 namespace dflash::common {
 
@@ -39,8 +39,9 @@ bool compute_target_split_projection(
     ggml_tensor * act_view = ggml_view_2d(
         sg.ctx, act, hidden, n_tokens, act->nb[1],
         (size_t)token_offset * act->nb[1]);
-    ggml_tensor * normed = ggml_rms_norm(sg.ctx, act_view, DFLASH27B_RMS_EPS);
-    normed = ggml_mul(sg.ctx, normed, w.out_norm);
+    ggml_tensor * normed = ggml_rms_norm(
+        sg.ctx, rms_norm_input_f32(sg.ctx, act_view), DFLASH27B_RMS_EPS);
+    normed = ggml_mul(sg.ctx, normed, graph_tensor_f32(sg.ctx, w.out_norm));
     ggml_tensor * logits = ggml_mul_mat(sg.ctx, w.output, normed);
     ggml_set_name(logits, "target_split_logits");
     sg.logits = logits;
@@ -101,15 +102,23 @@ bool run_qwen35_layer_split_forward(
         DraftFeatureMirror * feature_ring,
         std::vector<int32_t> * argmax_out,
         std::vector<float> * logits_out,
-        DFlashDraftIpcClient * remote_draft) {
+        DFlashDraftIpcClient * remote_draft,
+        ggml_type activation_type) {
     if (shards.empty() || tokens.empty()) return false;
     const int hidden = shards.front().weights.n_embd;
     const int vocab = shards.front().weights.n_vocab;
     const int n_tokens_total = (int)tokens.size();
     ubatch = std::max(1, ubatch);
+    if ((feature_ring || remote_draft) && activation_type != GGML_TYPE_F32) {
+        std::fprintf(stderr,
+            "target-split capture requires F32 activation; got %s\n",
+            ggml_type_name(activation_type));
+        return false;
+    }
 
     ActivationPair acts;
-    if (!activation_pair_init(acts, shards.front().backend, hidden, n_tokens_total)) {
+    if (!activation_pair_init(acts, shards.front().backend, hidden, n_tokens_total,
+                              activation_type)) {
         std::fprintf(stderr, "target-split activation alloc failed on gpu %d\n", shards.front().gpu);
         return false;
     }
@@ -126,9 +135,15 @@ bool run_qwen35_layer_split_forward(
                 activation_pair_free(acts);
                 return false;
             }
-            ggml_backend_tensor_set(act_in, emb_buf.data(),
-                                    (size_t)i * act_in->nb[1],
-                                    sizeof(float) * (size_t)hidden * n);
+            if (!set_activation_tensor_from_f32(
+                    act_in, emb_buf.data(), (size_t)i * act_in->nb[1],
+                    (size_t)hidden * (size_t)n)) {
+                std::fprintf(stderr,
+                    "target-split unsupported activation type: %s\n",
+                    ggml_type_name(act_in->type));
+                activation_pair_free(acts);
+                return false;
+            }
         }
     }
 
@@ -144,7 +159,8 @@ bool run_qwen35_layer_split_forward(
         }
         if (shard != current_shard) {
             ActivationPair next_acts;
-            if (!activation_pair_init(next_acts, shard->backend, hidden, n_tokens_total)) {
+            if (!activation_pair_init(next_acts, shard->backend, hidden, n_tokens_total,
+                                      activation_type)) {
                 std::fprintf(stderr, "target-split activation alloc failed on gpu %d\n", shard->gpu);
                 activation_pair_free(acts);
                 return false;

--- a/server/src/qwen35/layer_split_forward.h
+++ b/server/src/qwen35/layer_split_forward.h
@@ -60,7 +60,8 @@ bool run_qwen35_layer_split_forward(
         DraftFeatureMirror * feature_ring = nullptr,
         std::vector<int32_t> * argmax_out = nullptr,
         std::vector<float> * logits_out = nullptr,
-        DFlashDraftIpcClient * remote_draft = nullptr);
+        DFlashDraftIpcClient * remote_draft = nullptr,
+        ggml_type activation_type = GGML_TYPE_F32);
 
 bool run_qwen35_layer_split_forward_from_activation(
         std::vector<Qwen35LayerSplitShard> & shards,

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -2,6 +2,7 @@
 
 #include "qwen35_layer_split_adapter.h"
 
+#include "common/backend_precision.h"
 #include "common/dflash_spec_decode.h"
 #include "common/gguf_inspect.h"
 #include "common/layer_split_utils.h"
@@ -39,6 +40,24 @@ bool Qwen35LayerSplitAdapter::init() {
     if (!init_layer_split_runtime(runtime_cfg, shards_, snapshot_backends_)) {
         return false;
     }
+
+    std::vector<ggml_backend_t> shard_backends;
+    shard_backends.reserve(shards_.size());
+    for (const auto & shard : shards_) shard_backends.push_back(shard.backend);
+    const BackendActivationPolicy activation_policy =
+        select_common_activation_precision_policy(
+            shard_backends, /*force_f32=*/cfg_.run_dflash,
+            "LUCEBOX_LAYER_SPLIT_ACT_TYPE");
+    activation_type_ = activation_policy.activation_type;
+    std::fprintf(stderr, "[target-split] activation=%s (%s",
+                 backend_precision_type_name(activation_type_),
+                 activation_policy.reason.c_str());
+    if (!activation_policy.runtime_arch.empty()) {
+        std::fprintf(stderr, ", arch=%s", activation_policy.runtime_arch.c_str());
+    } else if (activation_policy.cuda_sm > 0) {
+        std::fprintf(stderr, ", sm=%d", activation_policy.cuda_sm);
+    }
+    std::fprintf(stderr, ")\n");
 
     for (auto & shard : shards_) {
         const TargetLoadPlan plan =
@@ -330,7 +349,8 @@ bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
         (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
         /*argmax_out=*/nullptr,
         &prefill_last_logits_,
-        cfg_.run_dflash ? &remote_draft_ : nullptr);
+        cfg_.run_dflash ? &remote_draft_ : nullptr,
+        activation_type_);
 }
 
 bool Qwen35LayerSplitAdapter::snapshot_slot_valid(int slot) const {
@@ -539,9 +559,11 @@ bool Qwen35LayerSplitAdapter::decode_ar(
             return run_qwen35_layer_split_forward(
                 shards_, shards_.front().weights, one, pos, 1, next_tok,
                 cfg_.kq_stride_pad, cfg_.fa_window,
-                cfg_.run_dflash ? &feature_ring_ : nullptr,
+                (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
                 /*argmax_out=*/nullptr,
-                logits_out);
+                logits_out,
+                cfg_.run_dflash ? &remote_draft_ : nullptr,
+                activation_type_);
         },
         [&](int tok) { return is_eos_tok(tok, w); },
         out_tokens, io);

--- a/server/src/qwen35/qwen35_layer_split_adapter.h
+++ b/server/src/qwen35/qwen35_layer_split_adapter.h
@@ -106,6 +106,7 @@ private:
     Qwen35TargetShardIpcClient remote_target_shard_;
     StepGraph draft_sg_;
     StepGraph proj_sg_;
+    ggml_type activation_type_ = GGML_TYPE_F32;
     DrafterContext pflash_drafter_;
     bool pflash_drafter_loaded_ = false;
     static constexpr int PREFIX_SLOTS = ModelBackend::kMaxSlots;

--- a/server/src/qwen35/qwen35_ops.h
+++ b/server/src/qwen35/qwen35_ops.h
@@ -2,12 +2,15 @@
 
 #pragma once
 
+#include "common/ggml_graph_precision.h"
 #include "ggml.h"
 
 namespace dflash::common {
 
 inline ggml_tensor * rms_norm_mul(ggml_context * ctx, ggml_tensor * x,
                                   ggml_tensor * weight, float eps) {
+    x = rms_norm_input_f32(ctx, x);
+    weight = graph_tensor_f32(ctx, weight);
     ggml_tensor * n = ggml_rms_norm(ctx, x, eps);
     return ggml_mul(ctx, n, weight);
 }

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -887,7 +887,7 @@ after_delta_net:
 
     // ── Gated output norm: rms_norm(output) * silu(z_4d)
     ggml_tensor * z_4d = ggml_reshape_4d(ctx, z, head_v_dim, num_v_heads, n_seq_tokens, n_seqs);
-    ggml_tensor * output_n = ggml_rms_norm(ctx, output, w.rms_eps);
+    ggml_tensor * output_n = ggml_rms_norm(ctx, rms_norm_input_f32(ctx, output), w.rms_eps);
     output_n = ggml_mul(ctx, output_n, L.ssm_norm);
     ggml_tensor * z_silu  = ggml_silu(ctx, z_4d);
     output_n = ggml_mul(ctx, output_n, z_silu);
@@ -933,8 +933,9 @@ static ggml_tensor * build_single_layer(
     const int * CAPTURE_LAYERS = w.capture_layer_ids;
     const int N_CAPTURE = w.n_capture_layers;
 
-    ggml_tensor * inpSA = inp;
-    ggml_tensor * cur   = rms_norm_mul(ctx, inp, L.attn_norm, eps);
+    ggml_tensor * inp_f32 = graph_tensor_f32(ctx, inp);
+    ggml_tensor * inpSA = inp_f32;
+    ggml_tensor * cur   = rms_norm_mul(ctx, inp_f32, L.attn_norm, eps);
 
     if (is_attn) {
         int fa_idx = 0;
@@ -1049,10 +1050,11 @@ QwenGraphOutputs build_qwen35_graph(
         const TargetLayer & L = w.layers[il];
         const bool is_attn = (((il + 1) % w.full_attention_interval) == 0);
 
-        ggml_tensor * inpSA = inpL;
+        ggml_tensor * inp_f32 = graph_tensor_f32(ctx, inpL);
+        ggml_tensor * inpSA = inp_f32;
 
         // Pre-attention norm
-        ggml_tensor * cur = rms_norm_mul(ctx, inpL, L.attn_norm, eps);
+        ggml_tensor * cur = rms_norm_mul(ctx, inp_f32, L.attn_norm, eps);
 
         if (is_attn) {
             cur = build_full_attn_block(ctx, gf, w, L, cur, in.positions, w.rope_sections,
@@ -1235,8 +1237,9 @@ QwenLayerPrefnOutputs build_qwen35_layer_prefn(
     const TargetLayer & L = w.layers[layer_idx];
     const bool is_attn = (((layer_idx + 1) % w.full_attention_interval) == 0);
 
-    ggml_tensor * inpSA = inp;
-    ggml_tensor * cur   = rms_norm_mul(ctx, inp, L.attn_norm, eps);
+    ggml_tensor * inp_f32 = graph_tensor_f32(ctx, inp);
+    ggml_tensor * inpSA = inp_f32;
+    ggml_tensor * cur   = rms_norm_mul(ctx, inp_f32, L.attn_norm, eps);
 
     if (is_attn) {
         int fa_idx = 0;

--- a/server/src/qwen35moe/qwen35moe_backend.cpp
+++ b/server/src/qwen35moe/qwen35moe_backend.cpp
@@ -3,6 +3,7 @@
 #include "../common/moe_hybrid_placement.h"
 #include "../common/moe_hybrid_types.h"
 #include "../common/moe_hybrid_types_impl.h"
+#include "common/ggml_graph_precision.h"
 #include "common/sampler.h"
 #include "common/dflash_spec_decode.h"
 #include "dflash_draft_graph.h"
@@ -297,7 +298,8 @@ bool Qwen35MoeBackend::run_pipelined_decode_path(int committed, int n_gen,
     PipelinedDecodeTelemetry tel_layers_accum{};
     int tel_n_tokens = 0;
 
-    // Persistent logits graph (built once, reused per token)
+    // Persistent logits graph (built once, reused per token).
+    // Precision policy (#310): keep the rms-norm input and out_norm in f32.
     StepGraph logits_sg;
     auto project_logits = [&]() -> bool {
         if (!logits_sg.ctx) {
@@ -309,8 +311,13 @@ bool Qwen35MoeBackend::run_pipelined_decode_path(int committed, int n_gen,
             logits_sg.hidden_input = ggml_new_tensor_3d(logits_sg.ctx, GGML_TYPE_F32, hidden, 1, 1);
             ggml_set_input(logits_sg.hidden_input);
             logits_sg.gf = ggml_new_graph_custom(logits_sg.ctx, 1024, false);
-            ggml_tensor * normed = ggml_rms_norm(logits_sg.ctx, logits_sg.hidden_input, target_weights().rms_eps);
-            normed = ggml_mul(logits_sg.ctx, normed, target_weights().out_norm);
+            ggml_tensor * normed = ggml_rms_norm(
+                logits_sg.ctx,
+                rms_norm_input_f32(logits_sg.ctx, logits_sg.hidden_input),
+                target_weights().rms_eps);
+            normed = ggml_mul(
+                logits_sg.ctx, normed,
+                graph_tensor_f32(logits_sg.ctx, target_weights().out_norm));
             logits_sg.logits = ggml_mul_mat(logits_sg.ctx, target_weights().output, normed);
             ggml_set_output(logits_sg.logits);
             ggml_build_forward_expand(logits_sg.gf, logits_sg.logits);
@@ -563,8 +570,13 @@ GenerateResult Qwen35MoeBackend::generate_impl(const GenerateRequest & req,
             logits_sg.hidden_input = ggml_new_tensor_3d(logits_sg.ctx, GGML_TYPE_F32, hidden, 1, 1);
             ggml_set_input(logits_sg.hidden_input);
             logits_sg.gf = ggml_new_graph_custom(logits_sg.ctx, 1024, false);
-            ggml_tensor * normed = ggml_rms_norm(logits_sg.ctx, logits_sg.hidden_input, target_weights().rms_eps);
-            normed = ggml_mul(logits_sg.ctx, normed, target_weights().out_norm);
+            ggml_tensor * normed = ggml_rms_norm(
+                logits_sg.ctx,
+                rms_norm_input_f32(logits_sg.ctx, logits_sg.hidden_input),
+                target_weights().rms_eps);
+            normed = ggml_mul(
+                logits_sg.ctx, normed,
+                graph_tensor_f32(logits_sg.ctx, target_weights().out_norm));
             logits_sg.logits = ggml_mul_mat(logits_sg.ctx, target_weights().output, normed);
             ggml_set_output(logits_sg.logits);
             ggml_build_forward_expand(logits_sg.gf, logits_sg.logits);
@@ -1121,8 +1133,13 @@ bool Qwen35MoeBackend::hybrid_forward_one_token(int32_t tok, int kv_pos,
     proj_sg.hidden_input = ggml_new_tensor_3d(proj_sg.ctx, GGML_TYPE_F32, hidden, 1, 1);
     ggml_set_input(proj_sg.hidden_input);
     proj_sg.gf = ggml_new_graph_custom(proj_sg.ctx, 1024, false);
-    ggml_tensor * normed = ggml_rms_norm(proj_sg.ctx, proj_sg.hidden_input, target_weights().rms_eps);
-    normed = ggml_mul(proj_sg.ctx, normed, target_weights().out_norm);
+    ggml_tensor * normed = ggml_rms_norm(
+        proj_sg.ctx,
+        rms_norm_input_f32(proj_sg.ctx, proj_sg.hidden_input),
+        target_weights().rms_eps);
+    normed = ggml_mul(
+        proj_sg.ctx, normed,
+        graph_tensor_f32(proj_sg.ctx, target_weights().out_norm));
     proj_sg.logits = ggml_mul_mat(proj_sg.ctx, target_weights().output, normed);
     ggml_set_output(proj_sg.logits);
     ggml_build_forward_expand(proj_sg.gf, proj_sg.logits);

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -17,6 +17,7 @@
 #include "server/http_server.h"
 #include "server/chat_template.h"
 #include "common/sampler.h"
+#include "common/backend_precision.h"
 #include "common/backend_ipc.h"
 #include "placement/pflash_placement.h"
 #include "common/io_utils.h"
@@ -1745,6 +1746,37 @@ static void test_validate_layer_split_weights_shape() {
     TEST_ASSERT(validate_device_placement(placement, -1).empty());
 }
 
+static void test_backend_precision_cuda_sm_policy() {
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(90) == GGML_TYPE_BF16);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(80) == GGML_TYPE_BF16);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(75) == GGML_TYPE_F16);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(70) == GGML_TYPE_F16);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(60) == GGML_TYPE_F16);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(62) == GGML_TYPE_F32);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(61) == GGML_TYPE_F32);
+    TEST_ASSERT(select_cuda_backend_precision_type_for_sm(52) == GGML_TYPE_F32);
+}
+
+static void test_backend_precision_hip_arch_policy() {
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx90a") == GGML_TYPE_BF16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx942") == GGML_TYPE_BF16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx950") == GGML_TYPE_BF16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx1100") == GGML_TYPE_BF16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx1200") == GGML_TYPE_BF16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx906") == GGML_TYPE_F16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx1030") == GGML_TYPE_F16);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("gfx803") == GGML_TYPE_F32);
+    TEST_ASSERT(select_hip_activation_precision_type_for_arch("") == GGML_TYPE_F32);
+}
+
+static void test_backend_precision_activation_type_combine() {
+    TEST_ASSERT(combine_activation_precision_types(GGML_TYPE_BF16, GGML_TYPE_BF16) == GGML_TYPE_BF16);
+    TEST_ASSERT(combine_activation_precision_types(GGML_TYPE_BF16, GGML_TYPE_F16) == GGML_TYPE_F16);
+    TEST_ASSERT(combine_activation_precision_types(GGML_TYPE_F16, GGML_TYPE_BF16) == GGML_TYPE_F16);
+    TEST_ASSERT(combine_activation_precision_types(GGML_TYPE_F16, GGML_TYPE_F32) == GGML_TYPE_F32);
+    TEST_ASSERT(combine_activation_precision_types(GGML_TYPE_F32, GGML_TYPE_BF16) == GGML_TYPE_F32);
+}
+
 struct MockLayerSplitAdapter : LayerSplitAdapter {
     int max_ctx = 128;
     bool reset_called = false;
@@ -3355,6 +3387,9 @@ int main() {
     RUN_TEST(test_parse_target_device_list_mixed_backend_multi_remote);
     RUN_TEST(test_parse_target_device_list_single_gpu_is_not_layer_split);
     RUN_TEST(test_validate_layer_split_weights_shape);
+    RUN_TEST(test_backend_precision_cuda_sm_policy);
+    RUN_TEST(test_backend_precision_hip_arch_policy);
+    RUN_TEST(test_backend_precision_activation_type_combine);
     RUN_TEST(test_layer_split_backend_inline_snapshot_and_restore_delta);
     RUN_TEST(test_layer_split_backend_sampling_capability_gate);
     RUN_TEST(test_layer_split_backend_chunks_prefill_by_adapter_limit);


### PR DESCRIPTION
## Summary

This PR reduces long-context target layer-split OOM risk by storing layer-split activation staging buffers in a backend-appropriate dtype instead of always using F32. The graph still casts back to F32 at ggml RMSNorm / norm-weight boundaries, so the lower-precision storage does not change those operator contracts.

The allocation reduced here is `hidden_size * context_tokens * bytes_per_element * staging_buffer_count`. Qwen35 and Laguna currently use two staging buffers; Gemma4 uses three because its per-layer input path also keeps an original embedding staging buffer.

At a 256K context cap, the staging allocation changes from:

- Qwen35 / Qwen3.6-27B / hidden=5120: 10240 MiB -> 5120 MiB.
- Laguna-XS.2 / hidden=2048: 4096 MiB -> 2048 MiB.
- Gemma4 31B / hidden=5376: 16128 MiB -> 8064 MiB.

## Changes

- Add `BackendActivationPolicy` in `common/backend_precision` for target layer-split activation staging.
- Select activation dtype from backend architecture:
  - CUDA Ampere+ and HIP native-BF16 targets -> BF16.
  - CUDA tensor-core / GP100 and HIP gfx9/gfx10 targets without native BF16 -> F16.
  - Older or unknown CUDA/HIP targets -> F32.
- Add `LUCEBOX_LAYER_SPLIT_ACT_TYPE=f32|f16|bf16` as an explicit local override.
- Extend shared layer-split activation buffers to allocate F32, F16, or BF16 tensors and upload F32 embeddings into the selected storage dtype.
- Add `common/ggml_graph_precision.h` for graph-side F32 casts.
- Make Qwen35, Gemma4, and Laguna RMSNorm / norm-weight graph boundaries F32-safe.
- Wire Qwen35, Gemma4, and Laguna target layer-split adapters through the shared activation policy.
- Add no-GPU unit coverage for the CUDA SM and HIP gfx dtype-selection tables.

## Notes

- A real 16K Qwen3.6-27B Q4 HIP layer-split A/B on dual Pro VII reduced request-time peak VRAM from 10199/11224 MiB to 9896/10918 MiB, saving 303/306 MiB across the two cards. This matches the ~313 MiB expected from the sizing formula at 16K.
- Runtime smoke passed on dual Pro VII / gfx906 HIP target layer split with the default F16 activation path for Qwen3.6-27B Q4, Laguna-XS.2 Q4, and Gemma4 31B Q3.
- This PR is intended as a follow-up to #306 and #309: #306 provides the shared layer-split runtime structure, while #309 covers DFlash draft feature mirror storage.
