### PR TITLE
fix(qwen35): correct + transparent prefix cache with spec-decode

### DIFF
--- a/server/src/common/backend_factory.h
+++ b/server/src/common/backend_factory.h
@@ -42,7 +42,7 @@ struct BackendArgs {
     int             chunk        = 512;
 
     // qwen35-specific speculative decode options
-    int             fa_window        = 2048;
+    int             fa_window        = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     int             kq_stride_pad    = 32;
     int             draft_swa_window = 0;
     int             draft_ctx_max    = 4096;

--- a/server/src/common/dflash_layer_split_runtime.h
+++ b/server/src/common/dflash_layer_split_runtime.h
@@ -19,7 +19,7 @@ namespace dflash::common {
 
 struct LayerSplitRuntimeConfig {
     int kq_stride_pad  = 32;    // KQ_MASK_PAD default; 256 when TBQ KV active
-    int fa_window      = 2048;  // flash-attn sliding window
+    int fa_window      = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     int draft_ctx_max  = 4096;  // draft context cap
     int draft_swa_window = 0;   // draft SWA window (0 = disabled)
 };

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -618,6 +618,26 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
     const int snap_pos = prefix_snapshots_[slot].cur_pos;
     cache_.cur_pos = snap_pos;
 
+    // FIX(prefix-cache + spec-decode): restore_target_cache brings back KV /
+    // recurrent state / target_feat, but the draft-side feature mirror is left
+    // stale. Without re-syncing it the draft emits -1 -> verify_batch embed
+    // fails -> empty output on every cache hit. Mirror what do_prefill does.
+    if (!draft_parked_) {
+        const int ring_cap = remote_draft_.active() ? remote_draft_.ring_cap()
+                                                     : feature_mirror_.cap;
+        const int n = std::min(cache_.cur_pos, ring_cap);
+        if (n > 0) {
+            const int start = cache_.cur_pos - n;
+            if (remote_draft_.active()) {
+                sync_remote_draft_features(start, n);
+            } else if (feature_mirror_.target_feat && cache_.target_feat) {
+                draft_feature_mirror_sync_range(cache_.target_feat,
+                                                cache_.target_feat_cap,
+                                                feature_mirror_, start, n);
+            }
+        }
+    }
+
     // Daemon receives the FULL prompt; slice off the cached prefix and prefill
     // only the delta at KV positions [snap_pos, snap_pos + delta.size()).
     int committed = snap_pos;
@@ -701,19 +721,31 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     int committed = kv_offset;
     for (int start = 0; start < prompt_len;) {
         const int kv_pos = kv_offset + start;
-        if (snap_pos >= 0 && snap_slot >= 0 && snap_pos == kv_pos) {
-            cache_.cur_pos = kv_pos;
-            if (snapshot_save(snap_slot)) {
-                std::printf("[snap] inline slot=%d cur_pos=%d\n", snap_slot, kv_pos);
-                std::fflush(stdout);
+
+        int n_tokens = std::min(prefill_ubatch, prompt_len - start);
+        // FIX(bug2): do NOT shrink the prefill chunk to snap_pos. Shrinking
+        // realigns every subsequent chunk, changing GPU batch sizes vs the
+        // no-cache path -> FP-nondeterministic state divergence -> different
+        // greedy output on cache hits. Keep uniform chunks. When snap_pos falls
+        // inside this chunk, snapshot at the chunk START boundary kv_pos: the
+        // largest chunk boundary <= snap_pos. That stays (a) chunk-aligned, so
+        // the prefill is bit-identical to the no-cache path, and (b) strictly
+        // within the requested prefix, so a later request that shares only the
+        // system-prompt prefix still restores a valid cross-request hit.
+        // (Rounding UP would push the snapshot to prompt end -> the full prompt
+        // incl. the user message -> a different user msg restores garbage.)
+        if (snap_slot >= 0 && snap_pos >= 0 &&
+            kv_pos <= snap_pos && snap_pos < kv_pos + n_tokens) {
+            if (kv_pos > kv_offset) {   // skip a degenerate short-prefix snapshot
+                cache_.cur_pos = kv_pos;
+                if (snapshot_save(snap_slot)) {
+                    std::printf("[snap] boundary slot=%d cur_pos=%d (req snap_pos=%d)\n",
+                                snap_slot, kv_pos, snap_pos);
+                    std::fflush(stdout);
+                }
             }
             snap_pos = -1;
             snap_slot = -1;
-        }
-
-        int n_tokens = std::min(prefill_ubatch, prompt_len - start);
-        if (snap_pos > kv_pos && snap_pos < kv_pos + n_tokens) {
-            n_tokens = snap_pos - kv_pos;
         }
         const bool with_mask = (cfg_.kq_stride_pad > KQ_MASK_PAD) || (n_tokens > 1);
 
@@ -784,15 +816,6 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
 
         committed = kv_pos + n_tokens;
         cache_.cur_pos = committed;
-
-        if (snap_pos >= 0 && snap_slot >= 0 && committed == snap_pos) {
-            if (snapshot_save(snap_slot)) {
-                std::printf("[snap] inline slot=%d cur_pos=%d\n", snap_slot, committed);
-                std::fflush(stdout);
-            }
-            snap_pos = -1;
-            snap_slot = -1;
-        }
 
         // Sync draft-side features if active.
         if (remote_draft_.active() && !draft_parked_) {

--- a/server/src/qwen35/qwen35_backend.h
+++ b/server/src/qwen35/qwen35_backend.h
@@ -43,7 +43,7 @@ struct Qwen35Config {
     int          stream_fd   = -1;
 
     // FA/KV
-    int          fa_window       = 2048;
+    int          fa_window       = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     int          kq_stride_pad   = 32;   // KQ_MASK_PAD or 256 for TBQ
 
     // Draft

--- a/server/src/qwen35/qwen35_daemon.h
+++ b/server/src/qwen35/qwen35_daemon.h
@@ -19,7 +19,7 @@ struct Qwen35DaemonArgs {
     int          chunk          = 512;
 
     // FA/KV
-    int          fa_window      = 2048;
+    int          fa_window      = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     int          kq_stride_pad  = 32;
 
     // Draft

--- a/server/src/qwen35/qwen35_layer_split_adapter.h
+++ b/server/src/qwen35/qwen35_layer_split_adapter.h
@@ -28,7 +28,7 @@ struct Qwen35LayerSplitAdapterConfig {
     int draft_gpu = 0;
     RemoteDraftConfig remote_draft;
 
-    int fa_window = 2048;
+    int fa_window = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     int kq_stride_pad = 32;
     int draft_ctx_max = 4096;
     int max_verify_tokens = DFLASH27B_DRAFT_BLOCK_SIZE;


### PR DESCRIPTION
## Summary

The dflash prefix cache (`--prefix-cache-slots > 0`) produced corrupted / empty generations on cache hits, which forced it off (`--prefix-cache-slots 0`) and lost the cross-request system-prompt prefill speedup. This fixes three distinct bugs so cache-on output is **bit-identical to no-cache**, then the cache can be safely re-enabled.

### Bugs fixed

1. **Stale draft feature mirror on restore.** `restore_target_cache` restores KV / recurrent state / `target_feat`, but `restore_and_generate` never re-synced the draft-side feature mirror. The draft then emitted token `-1`, `verify_batch`'s embed rejected it, and the whole turn returned empty. Fix: re-sync the mirror tail from the restored `target_feat` (as `do_prefill` already does).

2. **Prefill chunk-shrink → FP-nondeterministic state divergence.** Prefill shrank the ubatch chunk to land exactly on `snap_pos`, which realigned every later chunk and changed GPU batch sizes vs the no-cache path. The resulting FP drift flipped near-tie greedy decisions, so cache-on diverged from cache-off (e.g. an early stop with no tool call). Fix: keep uniform chunks; snapshot at a chunk boundary instead of shrinking.

3. **Snapshot rounding broke cross-request reuse.** Snapshotting at the first boundary `>= snap_pos` pushed the snapshot to prompt end (the full prompt incl. the user message) when the next boundary exceeded `prompt_len`. A later request sharing only the system-prompt prefix then restored a state polluted with the prior user message → garbage → instant EOS. Fix: round **down** to the largest boundary `<= snap_pos` (chunk-aligned AND strictly inside the shared prefix).

Also hardens the `fa_window` struct defaults (2048 → 0) across the qwen35/dflash config structs. `fa_window>0` sparsifies the full-attention layers at decode, dropping the system prompt on long prompts and breaking tool calls; `0` (full attention) is the only correct value for this full-attn model and matches gemma4. The CLI already passes `0`; this just removes the footgun.

## Verification (Qwen3.6-27B-Q4_K_M, RTX 5090)

- **Correctness oracle:** 6/6 cache-on output **bit-identical** to cache-off across single-turn + 5 growing multi-turn conversations.
- **Cross-request** (shared system prompt, different user messages — the realistic case): 4/4 **bit-identical** to cache-off.
- **~18× faster** warm requests (27.75s → 1.5s) by skipping the 17k-token system-prompt prefill.

## Files

- `server/src/qwen35/qwen35_backend.cpp` — the three correctness fixes (mirror re-sync; uniform-chunk + round-down snapshot).
- `server/src/qwen35/{qwen35_backend,qwen35_daemon,qwen35_layer_split_adapter}.h`, `server/src/common/{backend_factory,dflash_layer_split_runtime}.h` — `fa_window` default `2048 → 0`.
