### PR TITLE
feat(server): add selectable backend IPC payload transport

### DIFF
--- a/server/src/common/backend_ipc.cpp
+++ b/server/src/common/backend_ipc.cpp
@@ -159,7 +159,7 @@ bool BackendIpcProcess::start(const BackendIpcLaunchConfig & cfg) {
             argv_storage.emplace_back("--shared-payload-fd=" +
                                       std::to_string(shared_payload_fd_));
             argv_storage.emplace_back("--shared-payload-bytes=" +
-                                      std::to_string(shared_payload_bytes_));
+                                      std::to_string(shared_payload_capacity_));
         }
         argv_storage.emplace_back("--stream-fd=" + std::to_string(stream_pipe[1]));
 
@@ -234,6 +234,7 @@ void BackendIpcProcess::close() {
     active_ = false;
     owns_work_dir_ = false;
     shared_payload_bytes_ = 0;
+    shared_payload_capacity_ = 0;
     shared_payload_seq_ = 0;
     resolved_payload_transport_ = BackendIpcPayloadTransport::Stream;
     work_dir_.clear();
@@ -245,27 +246,38 @@ std::string BackendIpcProcess::next_path(const char * prefix) {
 }
 
 bool BackendIpcProcess::write_shared_payload(const void * data, size_t bytes, uint64_t & seq) {
-    if (!shared_payload_map_ || bytes > shared_payload_bytes_) return false;
+    if (!shared_payload_map_ || bytes > shared_payload_capacity_) return false;
     if (bytes > 0 && !data) return false;
+    auto * header = static_cast<BackendIpcSharedPayloadHeader *>(shared_payload_map_);
+    void * payload = static_cast<void *>(
+        static_cast<char *>(shared_payload_map_) + backend_ipc_shared_payload_header_bytes());
     if (bytes > 0) {
-        std::memcpy(shared_payload_map_, data, bytes);
+        std::memcpy(payload, data, bytes);
     }
     seq = ++shared_payload_seq_;
+    header->bytes = (uint64_t)bytes;
+    header->sequence = seq;
     return true;
 }
 
 #if !defined(_WIN32)
 bool BackendIpcProcess::init_shared_payload(size_t bytes) {
     if (bytes == 0) return false;
+    size_t map_bytes = 0;
+    if (!backend_ipc_shared_payload_map_bytes(bytes, map_bytes)) return false;
     int fd = -1;
 #  if defined(__linux__) && defined(SYS_memfd_create)
     fd = (int)::syscall(SYS_memfd_create, "backend-ipc-payload", 0);
 #  endif
     if (fd < 0) {
-        char templ[] = "/tmp/backend-ipc-payload-XXXXXX";
-        fd = ::mkstemp(templ);
+        const char * tmp = std::getenv("TMPDIR");
+        std::string templ = std::string(tmp && *tmp ? tmp : "/tmp") +
+                            "/backend-ipc-payload-XXXXXX";
+        std::vector<char> templ_buf(templ.begin(), templ.end());
+        templ_buf.push_back('\0');
+        fd = ::mkstemp(templ_buf.data());
         if (fd >= 0) {
-            ::unlink(templ);
+            ::unlink(templ_buf.data());
         }
     }
     if (fd < 0) {
@@ -273,22 +285,24 @@ bool BackendIpcProcess::init_shared_payload(size_t bytes) {
                      std::strerror(errno));
         return false;
     }
-    if (::ftruncate(fd, (off_t)bytes) != 0) {
+    if (::ftruncate(fd, (off_t)map_bytes) != 0) {
         std::fprintf(stderr, "backend-ipc shared payload truncate failed: %s\n",
                      std::strerror(errno));
         ::close(fd);
         return false;
     }
-    void * mapped = ::mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    void * mapped = ::mmap(nullptr, map_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (mapped == MAP_FAILED) {
         std::fprintf(stderr, "backend-ipc shared payload mmap failed: %s\n",
                      std::strerror(errno));
         ::close(fd);
         return false;
     }
+    std::memset(mapped, 0, map_bytes);
     shared_payload_fd_ = fd;
     shared_payload_map_ = mapped;
-    shared_payload_bytes_ = bytes;
+    shared_payload_bytes_ = map_bytes;
+    shared_payload_capacity_ = bytes;
     return true;
 }
 

--- a/server/src/common/backend_ipc.h
+++ b/server/src/common/backend_ipc.h
@@ -54,6 +54,21 @@ inline bool backend_ipc_payload_in_bounds(size_t offset,
     return backend_ipc_checked_add_size(offset, bytes, end) && end <= capacity;
 }
 
+struct BackendIpcSharedPayloadHeader {
+    uint64_t sequence = 0;
+    uint64_t bytes = 0;
+};
+
+inline size_t backend_ipc_shared_payload_header_bytes() {
+    return sizeof(BackendIpcSharedPayloadHeader);
+}
+
+inline bool backend_ipc_shared_payload_map_bytes(size_t payload_bytes,
+                                                 size_t & map_bytes) {
+    return backend_ipc_checked_add_size(
+        backend_ipc_shared_payload_header_bytes(), payload_bytes, map_bytes);
+}
+
 struct BackendIpcLaunchConfig {
     std::string bin;
     BackendIpcMode mode = BackendIpcMode::DFlashDraft;
@@ -82,7 +97,7 @@ public:
         return resolved_payload_transport_;
     }
     bool has_shared_payload() const { return shared_payload_map_ != nullptr; }
-    size_t shared_payload_capacity() const { return shared_payload_bytes_; }
+    size_t shared_payload_capacity() const { return shared_payload_capacity_; }
     const std::string & work_dir() const { return work_dir_; }
 
     std::string next_path(const char * prefix);
@@ -101,6 +116,7 @@ private:
     int shared_payload_fd_ = -1;
     void * shared_payload_map_ = nullptr;
     size_t shared_payload_bytes_ = 0;
+    size_t shared_payload_capacity_ = 0;
     uint64_t shared_payload_seq_ = 0;
     BackendIpcPayloadTransport resolved_payload_transport_ =
         BackendIpcPayloadTransport::Stream;

--- a/server/src/common/dflash_draft_ipc.cpp
+++ b/server/src/common/dflash_draft_ipc.cpp
@@ -11,6 +11,7 @@
 #include "ggml-backend.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -66,13 +67,25 @@ size_t draft_ipc_shared_bytes_from_env(size_t required_bytes) {
     if (!raw || !*raw) {
         return required_bytes;
     }
-    if (raw[0] == '-') {
+    const char * p = raw;
+    while (*p == ' ' || *p == '\t' || *p == '\n' ||
+           *p == '\r' || *p == '\f' || *p == '\v') {
+        ++p;
+    }
+    if (*p == '-') {
+        std::fprintf(stderr,
+                     "draft-ipc ignoring negative DFLASH_DRAFT_IPC_SHARED_BYTES=%s\n",
+                     raw);
         return required_bytes;
     }
+    errno = 0;
     char * end = nullptr;
-    const unsigned long long parsed = std::strtoull(raw, &end, 10);
-    if (end == raw || *end != '\0' ||
+    const unsigned long long parsed = std::strtoull(p, &end, 10);
+    if (errno == ERANGE || end == p || *end != '\0' ||
         parsed > (unsigned long long)std::numeric_limits<size_t>::max()) {
+        std::fprintf(stderr,
+                     "draft-ipc ignoring invalid DFLASH_DRAFT_IPC_SHARED_BYTES=%s\n",
+                     raw);
         return required_bytes;
     }
     return std::max((size_t)parsed, required_bytes);

--- a/server/src/common/dflash_draft_ipc_daemon.cpp
+++ b/server/src/common/dflash_draft_ipc_daemon.cpp
@@ -65,19 +65,32 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
     }
 
     void * shared_payload = nullptr;
+    void * shared_payload_data = nullptr;
+    size_t shared_payload_capacity = 0;
+    size_t shared_payload_map_bytes = 0;
     if (shared_payload_fd >= 0 || shared_payload_bytes > 0) {
         if (shared_payload_fd < 0 || shared_payload_bytes == 0) {
             std::fprintf(stderr, "[draft-ipc-daemon] bad shared payload fd/size\n");
             stream_status(stream_fd, -1);
             return 1;
         }
-        shared_payload = ::mmap(nullptr, shared_payload_bytes, PROT_READ | PROT_WRITE,
+        if (!backend_ipc_shared_payload_map_bytes(shared_payload_bytes,
+                                                  shared_payload_map_bytes)) {
+            std::fprintf(stderr, "[draft-ipc-daemon] bad shared payload size\n");
+            stream_status(stream_fd, -1);
+            return 1;
+        }
+        shared_payload = ::mmap(nullptr, shared_payload_map_bytes,
+                                PROT_READ | PROT_WRITE,
                                 MAP_SHARED, shared_payload_fd, 0);
         if (shared_payload == MAP_FAILED) {
             std::fprintf(stderr, "[draft-ipc-daemon] shared payload mmap failed\n");
             stream_status(stream_fd, -1);
             return 1;
         }
+        shared_payload_data =
+            static_cast<char *>(shared_payload) + backend_ipc_shared_payload_header_bytes();
+        shared_payload_capacity = shared_payload_bytes;
     }
 
     ggml_backend_t backend = ggml_backend_cuda_init(std::max(0, draft_gpu));
@@ -85,7 +98,7 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
         std::fprintf(stderr, "[draft-ipc-daemon] backend init failed gpu=%d\n", draft_gpu);
         stream_status(stream_fd, -1);
         if (shared_payload && shared_payload != MAP_FAILED) {
-            ::munmap(shared_payload, shared_payload_bytes);
+            ::munmap(shared_payload, shared_payload_map_bytes);
         }
         return 1;
     }
@@ -104,7 +117,7 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
         stream_status(stream_fd, -1);
         ggml_backend_free(backend);
         if (shared_payload && shared_payload != MAP_FAILED) {
-            ::munmap(shared_payload, shared_payload_bytes);
+            ::munmap(shared_payload, shared_payload_map_bytes);
         }
         return 1;
     }
@@ -118,7 +131,7 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
         free_draft_weights(draft_weights);
         ggml_backend_free(backend);
         if (shared_payload && shared_payload != MAP_FAILED) {
-            ::munmap(shared_payload, shared_payload_bytes);
+            ::munmap(shared_payload, shared_payload_map_bytes);
         }
         return 1;
     }
@@ -375,17 +388,20 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
             uint64_t sequence = 0;
             iss >> capture_idx >> start_pos >> n_tokens >> bytes >> sequence;
             const size_t expected_bytes = (size_t)n_tokens * (size_t)hidden * sizeof(float);
-            if (!iss || sequence == 0 || !shared_payload ||
+            const auto * header =
+                static_cast<const BackendIpcSharedPayloadHeader *>(shared_payload);
+            if (!iss || sequence == 0 || !shared_payload || !shared_payload_data ||
                 capture_idx < 0 || capture_idx >= n_tgt_layers ||
                 start_pos < 0 || n_tokens <= 0 || bytes != expected_bytes ||
-                !backend_ipc_payload_in_bounds(0, bytes, shared_payload_bytes)) {
+                !backend_ipc_payload_in_bounds(0, bytes, shared_payload_capacity) ||
+                header->sequence != sequence || header->bytes != (uint64_t)bytes) {
                 std::fprintf(stderr, "[draft-ipc-daemon] bad feature_slice_shared: %s\n",
                              line.c_str());
                 stream_status(stream_fd, -1);
                 continue;
             }
             std::vector<float> slice(bytes / sizeof(float));
-            std::memcpy(slice.data(), shared_payload, bytes);
+            std::memcpy(slice.data(), shared_payload_data, bytes);
             if (!store_feature_slice(capture_idx, start_pos, n_tokens, slice)) {
                 std::fprintf(stderr, "[draft-ipc-daemon] store feature_slice_shared failed\n");
                 stream_status(stream_fd, -1);
@@ -425,16 +441,19 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
             uint64_t sequence = 0;
             iss >> committed >> ctx_len >> bytes >> sequence;
             const size_t expected_bytes = noise_embed.size() * sizeof(float);
-            if (!iss || sequence == 0 || !shared_payload ||
+            const auto * header =
+                static_cast<const BackendIpcSharedPayloadHeader *>(shared_payload);
+            if (!iss || sequence == 0 || !shared_payload || !shared_payload_data ||
                 committed < 0 || ctx_len <= 0 || ctx_len > feature_ring.cap ||
                 bytes != expected_bytes ||
-                !backend_ipc_payload_in_bounds(0, bytes, shared_payload_bytes)) {
+                !backend_ipc_payload_in_bounds(0, bytes, shared_payload_capacity) ||
+                header->sequence != sequence || header->bytes != (uint64_t)bytes) {
                 std::fprintf(stderr, "[draft-ipc-daemon] bad propose_shared: %s\n",
                              line.c_str());
                 stream_status(stream_fd, -1);
                 continue;
             }
-            std::memcpy(noise_embed.data(), shared_payload, bytes);
+            std::memcpy(noise_embed.data(), shared_payload_data, bytes);
             if (run_proposal(committed, ctx_len) == ProposalResult::StreamFailed) {
                 break;
             }
@@ -472,7 +491,7 @@ int run_dflash_draft_ipc_daemon(const char * draft_path,
     free_draft_weights(draft_weights);
     ggml_backend_free(backend);
     if (shared_payload && shared_payload != MAP_FAILED) {
-        ::munmap(shared_payload, shared_payload_bytes);
+        ::munmap(shared_payload, shared_payload_map_bytes);
     }
     std::fprintf(stderr, "[draft-ipc-daemon] stopped\n");
     return 0;

--- a/server/src/ipc/backend_ipc_main.cpp
+++ b/server/src/ipc/backend_ipc_main.cpp
@@ -6,10 +6,13 @@
 #include "qwen35_target_shard_ipc.h"
 
 #include <algorithm>
+#include <cerrno>
+#include <cctype>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -35,6 +38,47 @@ bool parse_int_list(const char * raw, std::vector<int> & out) {
         begin = end + 1;
     }
     return !out.empty();
+}
+
+bool parse_nonnegative_int(const char * text, int & out) {
+    if (!text || !*text) return false;
+    const char * p = text;
+    while (std::isspace((unsigned char)*p)) ++p;
+    if (*p == '-') return false;
+    errno = 0;
+    char * end = nullptr;
+    const long value = std::strtol(p, &end, 10);
+    if (errno == ERANGE || end == p || *end != '\0' ||
+        value < 0 || value > std::numeric_limits<int>::max()) {
+        return false;
+    }
+    out = (int)value;
+    return true;
+}
+
+bool parse_size_arg(const char * text, size_t & out) {
+    if (!text || !*text) return false;
+    const char * p = text;
+    while (std::isspace((unsigned char)*p)) ++p;
+    if (*p == '-') return false;
+    errno = 0;
+    char * end = nullptr;
+    const unsigned long long value = std::strtoull(p, &end, 10);
+    if (errno == ERANGE || end == p || *end != '\0' ||
+        value > (unsigned long long)std::numeric_limits<size_t>::max()) {
+        return false;
+    }
+    out = (size_t)value;
+    return true;
+}
+
+bool require_value(int & i, int argc, char ** argv, const char * opt, const char *& out) {
+    if (i + 1 >= argc) {
+        std::fprintf(stderr, "[backend-ipc-daemon] missing value for %s\n", opt);
+        return false;
+    }
+    out = argv[++i];
+    return true;
 }
 
 }  // namespace
@@ -95,13 +139,17 @@ int main(int argc, char ** argv) {
     bool enable_dflash = false;
     for (int i = arg_begin; i < argc; i++) {
         if (std::strncmp(argv[i], "--ring-cap=", 11) == 0) {
-            ring_cap = std::atoi(argv[i] + 11);
+            if (!parse_nonnegative_int(argv[i] + 11, ring_cap)) return 2;
         } else if (std::strcmp(argv[i], "--ring-cap") == 0) {
-            if (i + 1 < argc) ring_cap = std::atoi(argv[++i]);
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--ring-cap", value) ||
+                !parse_nonnegative_int(value, ring_cap)) return 2;
         } else if (std::strncmp(argv[i], "--draft-gpu=", 12) == 0) {
-            draft_gpu = std::max(0, std::atoi(argv[i] + 12));
+            if (!parse_nonnegative_int(argv[i] + 12, draft_gpu)) return 2;
         } else if (std::strcmp(argv[i], "--draft-gpu") == 0) {
-            if (i + 1 < argc) draft_gpu = std::max(0, std::atoi(argv[++i]));
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--draft-gpu", value) ||
+                !parse_nonnegative_int(value, draft_gpu)) return 2;
         } else if (std::strncmp(argv[i], "--target-gpu=", 13) == 0) {
             target_gpu = std::max(0, std::atoi(argv[i] + 13));
         } else if (std::strcmp(argv[i], "--target-gpu") == 0) {
@@ -161,23 +209,29 @@ int main(int argc, char ** argv) {
         } else if (std::strcmp(argv[i], "--fa-window") == 0) {
             if (i + 1 < argc) fa_window = std::atoi(argv[++i]);
         } else if (std::strncmp(argv[i], "--stream-fd=", 12) == 0) {
-            stream_fd = std::atoi(argv[i] + 12);
+            if (!parse_nonnegative_int(argv[i] + 12, stream_fd)) return 2;
         } else if (std::strcmp(argv[i], "--stream-fd") == 0) {
-            if (i + 1 < argc) stream_fd = std::atoi(argv[++i]);
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--stream-fd", value) ||
+                !parse_nonnegative_int(value, stream_fd)) return 2;
         } else if (std::strncmp(argv[i], "--payload-fd=", 13) == 0) {
-            payload_fd = std::atoi(argv[i] + 13);
+            if (!parse_nonnegative_int(argv[i] + 13, payload_fd)) return 2;
         } else if (std::strcmp(argv[i], "--payload-fd") == 0) {
-            if (i + 1 < argc) payload_fd = std::atoi(argv[++i]);
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--payload-fd", value) ||
+                !parse_nonnegative_int(value, payload_fd)) return 2;
         } else if (std::strncmp(argv[i], "--shared-payload-fd=", 20) == 0) {
-            shared_payload_fd = std::atoi(argv[i] + 20);
+            if (!parse_nonnegative_int(argv[i] + 20, shared_payload_fd)) return 2;
         } else if (std::strcmp(argv[i], "--shared-payload-fd") == 0) {
-            if (i + 1 < argc) shared_payload_fd = std::atoi(argv[++i]);
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--shared-payload-fd", value) ||
+                !parse_nonnegative_int(value, shared_payload_fd)) return 2;
         } else if (std::strncmp(argv[i], "--shared-payload-bytes=", 23) == 0) {
-            shared_payload_bytes = (size_t)std::strtoull(argv[i] + 23, nullptr, 10);
+            if (!parse_size_arg(argv[i] + 23, shared_payload_bytes)) return 2;
         } else if (std::strcmp(argv[i], "--shared-payload-bytes") == 0) {
-            if (i + 1 < argc) {
-                shared_payload_bytes = (size_t)std::strtoull(argv[++i], nullptr, 10);
-            }
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--shared-payload-bytes", value) ||
+                !parse_size_arg(value, shared_payload_bytes)) return 2;
         } else if (std::strcmp(argv[i], "--enable-dflash") == 0) {
             enable_dflash = true;
         } else {

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -2,6 +2,7 @@
 
 #include "qwen35_target_shard_ipc.h"
 
+#include "common/backend_ipc.h"
 #include "common/dflash_draft_ipc.h"
 #include "common/dflash_layer_split_runtime.h"
 #include "common/io_utils.h"
@@ -77,19 +78,31 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
     }
 
     void * shared_payload = nullptr;
+    void * shared_payload_data = nullptr;
+    size_t shared_payload_capacity = 0;
+    size_t shared_payload_map_bytes = 0;
     if (shared_payload_fd >= 0 || shared_payload_bytes > 0) {
         if (shared_payload_fd < 0 || shared_payload_bytes == 0) {
             std::fprintf(stderr, "[qwen35-target-shard-daemon] bad shared payload fd/size\n");
             stream_status(stream_fd, -1);
             return 1;
         }
-        shared_payload = ::mmap(nullptr, shared_payload_bytes, PROT_READ | PROT_WRITE,
+        if (!backend_ipc_shared_payload_map_bytes(shared_payload_bytes,
+                                                  shared_payload_map_bytes)) {
+            std::fprintf(stderr, "[qwen35-target-shard-daemon] bad shared payload size\n");
+            stream_status(stream_fd, -1);
+            return 1;
+        }
+        shared_payload = ::mmap(nullptr, shared_payload_map_bytes, PROT_READ | PROT_WRITE,
                                 MAP_SHARED, shared_payload_fd, 0);
         if (shared_payload == MAP_FAILED) {
             std::fprintf(stderr, "[qwen35-target-shard-daemon] shared payload mmap failed\n");
             stream_status(stream_fd, -1);
             return 1;
         }
+        shared_payload_data =
+            static_cast<char *>(shared_payload) + backend_ipc_shared_payload_header_bytes();
+        shared_payload_capacity = shared_payload_bytes;
     }
 
     std::vector<Qwen35LayerSplitShard> shards(gpus.size());
@@ -106,7 +119,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
             stream_status(stream_fd, -1);
             free_qwen35_layer_split_shards(shards);
             if (shared_payload && shared_payload != MAP_FAILED) {
-                ::munmap(shared_payload, shared_payload_bytes);
+                ::munmap(shared_payload, shared_payload_map_bytes);
             }
             return 1;
         }
@@ -128,7 +141,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
             stream_status(stream_fd, -1);
             free_qwen35_layer_split_shards(shards);
             if (shared_payload && shared_payload != MAP_FAILED) {
-                ::munmap(shared_payload, shared_payload_bytes);
+                ::munmap(shared_payload, shared_payload_map_bytes);
             }
             return 1;
         }
@@ -153,7 +166,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
             free_snapshot_backends();
             free_qwen35_layer_split_shards(shards);
             if (shared_payload && shared_payload != MAP_FAILED) {
-                ::munmap(shared_payload, shared_payload_bytes);
+                ::munmap(shared_payload, shared_payload_map_bytes);
             }
             return 1;
         }
@@ -186,7 +199,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
     if (shards.empty()) {
         stream_status(stream_fd, -1);
         if (shared_payload && shared_payload != MAP_FAILED) {
-            ::munmap(shared_payload, shared_payload_bytes);
+            ::munmap(shared_payload, shared_payload_map_bytes);
         }
         return 1;
     }
@@ -318,13 +331,16 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
             uint64_t seq = 0;
             iss >> base_pos >> n_tokens >> want_argmax >> want_logits >> bytes >> seq;
             if (!(iss >> want_captures)) want_captures = 0;
-            (void)seq;
             const size_t expected_bytes =
                 (size_t)n_tokens * (size_t)hidden * sizeof(float);
-            if (shared_payload && shared_payload != MAP_FAILED &&
-                bytes == expected_bytes && bytes <= shared_payload_bytes) {
+            const auto * header =
+                static_cast<const BackendIpcSharedPayloadHeader *>(shared_payload);
+            if (shared_payload && shared_payload != MAP_FAILED && shared_payload_data &&
+                seq != 0 && bytes == expected_bytes &&
+                backend_ipc_payload_in_bounds(0, bytes, shared_payload_capacity) &&
+                header->sequence == seq && header->bytes == (uint64_t)bytes) {
                 host_act.assign(bytes / sizeof(float), 0.0f);
-                std::memcpy(host_act.data(), shared_payload, bytes);
+                std::memcpy(host_act.data(), shared_payload_data, bytes);
                 payload_ok = true;
             }
         } else {
@@ -468,7 +484,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
     free_snapshot_backends();
     free_qwen35_layer_split_shards(shards);
     if (shared_payload && shared_payload != MAP_FAILED) {
-        ::munmap(shared_payload, shared_payload_bytes);
+        ::munmap(shared_payload, shared_payload_map_bytes);
     }
     return 0;
 #endif

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1800,8 +1800,9 @@ struct MockLayerSplitAdapter : LayerSplitAdapter {
     bool supports_cpu_sampling() const override { return sampling_enabled; }
     bool decode_dflash(const std::vector<int32_t> & prompt, int base_pos,
                        int last_tok, int n_gen, std::vector<int32_t> & out_tokens,
-                       const DaemonIO & io) override {
+                       const DaemonIO & io, float & accept_rate_out) override {
         (void)prompt;
+        accept_rate_out = 0.0f;
         dflash_called = true;
         dflash_base = base_pos;
         dflash_last = last_tok;
@@ -2417,6 +2418,21 @@ static void test_backend_ipc_payload_bounds() {
     TEST_ASSERT(!backend_ipc_payload_in_bounds(9, 8, 16));
     TEST_ASSERT(!backend_ipc_payload_in_bounds(
         std::numeric_limits<size_t>::max(), 1, 16));
+}
+
+static void test_backend_ipc_shared_payload_map_sizing() {
+    size_t map_bytes = 0;
+    TEST_ASSERT(backend_ipc_shared_payload_map_bytes(1024, map_bytes));
+    TEST_ASSERT(map_bytes == 1024 + backend_ipc_shared_payload_header_bytes());
+
+    BackendIpcSharedPayloadHeader header;
+    header.sequence = 7;
+    header.bytes = 1024;
+    TEST_ASSERT(header.sequence == 7);
+    TEST_ASSERT(header.bytes == 1024);
+
+    TEST_ASSERT(!backend_ipc_shared_payload_map_bytes(
+        std::numeric_limits<size_t>::max(), map_bytes));
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -3338,6 +3354,13 @@ int main() {
     RUN_TEST(test_backend_ipc_payload_pipe_round_trip);
     RUN_TEST(test_backend_ipc_payload_transport_parse);
     RUN_TEST(test_backend_ipc_payload_bounds);
+
+    std::fprintf(stderr, "\n── Backend IPC ──\n");
+    RUN_TEST(test_backend_ipc_rejects_file_work_dir);
+    RUN_TEST(test_backend_ipc_payload_pipe_round_trip);
+    RUN_TEST(test_backend_ipc_payload_transport_parse);
+    RUN_TEST(test_backend_ipc_payload_bounds);
+    RUN_TEST(test_backend_ipc_shared_payload_map_sizing);
 
     std::fprintf(stderr, "\n── Jinja chat template ──\n");
     RUN_TEST(test_jinja_render_basic);


### PR DESCRIPTION
## Summary

This PR adds explicit backend IPC data-payload transport modes: `stream`, `shared`, and `auto`, so the IPC path can choose between low fixed memory cost and lower large-payload copy cost.

`stream` keeps the existing stream/file-backed payload path. It has very low fixed host-memory cost, but large activation payloads pay more stream/read/write copy overhead, so it remains the conservative default. `shared` uses a shared fd + `mmap` payload buffer. It reduces host-side IPC copies and improves large payload transport latency, but it has a fixed host-memory buffer cost, so it is an explicit mode. `auto` requests the minimum safe shared buffer for the current DFlash IPC configuration first, then falls back to `stream` if the shared buffer cannot be allocated.

The immediate integration is DFlash draft IPC input payloads. More generally, this makes IPC transport an explicit mode switch, so additional transport choices can be added later without changing the high-level command shape.

## Changes

- Extend `backend_ipc.h/.cpp` with shared fd creation, `mmap` mapping, daemon remapping, cleanup, Linux `memfd_create`, and unlinked temporary-file fallback.
- Add bounded payload helpers for size overflow checks and in-bounds checks.
- Add explicit payload transport modes:
  - `stream`: existing stream/file-backed payload transport.
  - `shared`: shared fd + `mmap` payload transport.
  - `auto`: try shared transport first, then fall back to `stream` if shared buffer allocation fails.
- Let DFlash draft IPC create an optional shared payload buffer during daemon startup and pass `--shared-payload-fd` / `--shared-payload-bytes` when shared transport is enabled.
- Keep DFlash draft IPC default on `stream`; `DFLASH_DRAFT_IPC_TRANSPORT=shared` requires the shared buffer path, while `DFLASH_DRAFT_IPC_TRANSPORT=auto` can fall back to `stream`.
- Size the DFlash shared buffer from the current IPC payload shape instead of using a fixed default. `DFLASH_DRAFT_IPC_SHARED_BYTES` can raise the requested capacity, but not below the minimum required for the configured DFlash IPC payload.
- Add `feature_slice_shared` and `propose_shared` daemon commands for shared input payloads.
- Preserve existing stream and file-backed commands as fallback.
- Keep daemon readiness, status, and hidden-output replies on the existing stream fd.
- Update backend IPC daemon argument parsing for the new shared fd/size arguments.
- Add unit coverage for transport parsing, overflow checks, and bounds checks.

## Notes

Transport A/B on a 16K Qwen/Qwen3.6-27B F16/BF16 hidden-state-equivalent payload (`160 MiB`) showed shared mmap reducing host-side IPC copy from about `320 MiB` to `160 MiB` per handoff. Measured transport time improved by `11.85%` for CUDA->CUDA and `10.70%` for CUDA->HIP. A 64 KiB sanity check showed shared mmap does not materially regress small payload latency, but the practical value is activation-sized payload transport.

Validation for this slice covers CUDA sm61 and HIP ROCm 6.3.3/gfx906 transport smokes, including same-backend and CUDA<->HIP cross-backend `allreduce-auto` routes.
