### PR TITLE
fix(server): default thinking ON for agentic (tools-present) turns

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -887,9 +887,18 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
 
         // Determine thinking mode BEFORE rendering so the template can inject
         // the <think>\n\n</think>\n\n block when thinking is disabled.
-        // Default: thinking OFF (Qwen3.6 thinking wrecks
-        // DFlash acceptance rates; clients opt in explicitly).
-        bool enable_thinking = false;
+        // Default: thinking ON for AGENTIC turns (tools present), OFF for plain
+        // chat. Decision turns ("which task next?") need a reasoning budget or
+        // the model EOS-es right after its action preamble with no tool_call,
+        // stalling the agent loop. Measured on 36 real captured agentic turns:
+        // tool-call rate 32/36 -> 36/36 (4 recoveries, 0 regressions); the
+        // older "thinking wrecks DFlash acceptance" claim did not reproduce
+        // (accept-rate equal-or-better with thinking on). Any explicit client
+        // opt-in/out below (reasoning / thinking / chat_template_kwargs) still
+        // overrides this default.
+        bool enable_thinking = body.contains("tools") &&
+                               body["tools"].is_array() &&
+                               !body["tools"].empty();
 
         // Track which fields the request explicitly set, so we can apply
         // §4.3 combined precedence: thinking.budget_tokens beats


### PR DESCRIPTION
## Summary

dflash hard-coded `enable_thinking = false` for **every** request. Agentic "which task should I do next?" **decision turns** therefore got zero reasoning budget, and the model emitted EOS right after its action preamble with **no `tool_call`** — the agent loop then stalled (the user-visible "dflash abruptly stops the moment it needs to do something").

Hermes never sends a thinking opt-in on the wire — confirmed with a logging proxy in front of a live headless Hermes session: `reasoning`, `thinking`, and `chat_template_kwargs` are all absent from the request. So the **server default is what every agentic turn actually gets**.

## What changed

One change in `server/src/server/http_server.cpp`: the `enable_thinking` default becomes **`(tools present)`** — ON for agentic turns, OFF for plain chat — instead of always `false`. Every explicit client opt-in/out (`reasoning.effort`, `thinking.type`, `chat_template_kwargs.enable_thinking`) is evaluated *after* this and still overrides, so behavior only changes when the client is silent about thinking.

## How to review

Read the single hunk in `http_server.cpp` around the `enable_thinking` initialization. Confirm the explicit-override blocks below it are unchanged (they still win). Note the comment update: the prior "thinking wrecks DFlash acceptance rates" rationale did not reproduce under measurement.

## Evidence

Validation method: a logging proxy captured real requests from a live headless Hermes agentic session (`hermes -z "<task>" -m dflash`); each unique tools-present turn was replayed **in isolation** (no concurrency — an earlier confound that masked the effect) against the server.

- **Tool-call rate: 32/36 → 36/36** across 36 unique real agentic turns (4 recoveries, **0 regressions** — every turn that already produced a tool call still does).
- **End-to-end with NO client hint** (exactly what Hermes sends): **6/6** previously-failing turns now produce a tool call — the server auto-enables thinking because tools are present.
- **No-tools chat turn stays thinking-off**: `finish=stop, completion_tokens=11` (no reasoning bloat) — the conditional gate works.
- **Cost**: ~178 reasoning tokens/turn on agentic turns; a worthwhile trade vs. a stalled autonomous agent, and applied only when tools are present.
- **"Wrecks acceptance" claim did not reproduce**: measured accept-rate was equal-or-better with thinking on (0.34 vs 0.24 on reasoning prompts); it only loses on trivial prompts with nothing to reason about, which now stay thinking-off anyway.
- **No regression elsewhere**: the prefix-cache correctness oracle still passes **6/6 bit-identical** on the same binary.

## Verification

Re-runnable:
- `python3 /tmp/verify_server.py` (replays captured fail-turns with baseline client params, plus a no-tools turn) → 6/6 recover, no-tools turn ~11 tokens.
- `python3 /tmp/validate_fix.py` (36-turn baseline-vs-proposed sweep) → 32/36 → 36/36, 0 regressions.
- `python3 dflash_cache_oracle.py dflash dflash-nocache` → 6/6 bit-identical (this change does not disturb cache correctness).
- Build: `cmake --build server/build -j$(nproc)` → exit 0.

## Risks / gaps

- **~178 extra reasoning tokens per agentic turn** (latency cost). Accepted tradeoff: the alternative is a stalled agent, it is scoped to tools-present turns only, and any client can still force thinking off per-request. Out of scope: a finer effort-tier-gated budget could tune this later.
- **Quality of the *reasoned* tool calls** beyond "a tool call is produced" was not exhaustively scored; reasoning-before-acting is expected to help, and the baseline (stalling) was strictly worse. Low risk.
- Behavior change is **default-only**; explicit client settings are unaffected, so existing integrations that set thinking explicitly are not actionable here.

## Collaborators

- Omar Baradei (operator) — reported the failure, directed root-cause and the best-solution mandate.
- Claude (Opus 4.8) — diagnosis, capture harness, validation, fix.
