### PR TITLE
fix(common): retry empty spec-decode output through AR

### DIFF
--- a/server/src/common/daemon_loop.cpp
+++ b/server/src/common/daemon_loop.cpp
@@ -292,7 +292,7 @@ int run_daemon(ModelBackend & backend, const DaemonLoopArgs & args) {
             req.do_sample = do_sample;
             req.stream    = false;
 
-            auto result = backend.generate(req, io);
+            auto result = backend.generate_with_empty_spec_fallback(req, io);
             if (!result.ok) {
                 std::printf("err %s\n", result.error.c_str());
                 std::fflush(stdout);
@@ -349,7 +349,7 @@ int run_daemon(ModelBackend & backend, const DaemonLoopArgs & args) {
             req.snap_pos  = snap_pos;
             req.snap_slot = snap_slot;
 
-            auto result = backend.restore_and_generate(slot, req, io);
+            auto result = backend.restore_and_generate_with_empty_spec_fallback(slot, req, io);
             if (!result.ok) {
                 std::printf("err %s\n", result.error.c_str());
                 std::fflush(stdout);
@@ -398,7 +398,7 @@ int run_daemon(ModelBackend & backend, const DaemonLoopArgs & args) {
             req.snap_pos  = snap_pos;
             req.snap_slot = snap_slot;
 
-            auto result = backend.generate(req, io);
+            auto result = backend.generate_with_empty_spec_fallback(req, io);
             if (!result.ok) {
                 io.emit(-1);
                 std::printf("err %s\n", result.error.c_str());

--- a/server/src/common/layer_split_backend.cpp
+++ b/server/src/common/layer_split_backend.cpp
@@ -103,7 +103,9 @@ GenerateResult LayerSplitBackend::run_from_state(const GenerateRequest & req,
             return result;
         }
         auto t_decode_start = std::chrono::steady_clock::now();
-        const bool ok = adapter_->can_dflash_decode()
+        const bool use_dflash = !req.force_ar_decode && adapter_->can_dflash_decode();
+        if (use_dflash) result.spec_decode_ran = true;
+        const bool ok = use_dflash
             ? adapter_->decode_dflash(req.prompt, base_pos, last_tok, req.n_gen,
                                       result.tokens, out_io)
             : adapter_->decode_ar(last_tok, base_pos + (int)req.prompt.size(), req.n_gen,

--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
 #include <functional>
 #include <string>
 #include <vector>
@@ -100,6 +101,10 @@ struct GenerateRequest {
     const std::vector<int32_t> * hint_tokens = nullptr;
     // Optional thinking-budget hook — see BudgetHook docs above.
     BudgetHook                 budget_hook;
+    // Common retry knob. Upper layers set this after a speculative decode
+    // path returns success but emits no tokens, so each backend can route the
+    // retry through its existing AR path without copying retry policy.
+    bool                       force_ar_decode = false;
 };
 
 struct GenerateResult {
@@ -149,6 +154,18 @@ struct ModelBackend {
     virtual GenerateResult generate(const GenerateRequest & req,
                                      const DaemonIO & io) = 0;
 
+    GenerateResult generate_with_empty_spec_fallback(const GenerateRequest & req,
+                                                     const DaemonIO & io) {
+        GenerateResult result = generate(req, io);
+        if (!should_retry_empty_spec_decode(req, result)) return result;
+
+        std::fprintf(stderr,
+            "[backend] spec-decode produced zero tokens; retrying with AR decode\n");
+        GenerateRequest retry = req;
+        retry.force_ar_decode = true;
+        return merge_empty_spec_retry_result(result, generate(retry, io));
+    }
+
     // ── Snapshots ────────────────────────────────────────────────────
     // With right-sized CPU-resident snapshots, each slot costs only
     // ~(cur_pos × 5 KB) of system RAM, so we can afford many slots.
@@ -164,6 +181,41 @@ struct ModelBackend {
     virtual GenerateResult restore_and_generate(int slot,
                                                  const GenerateRequest & req,
                                                  const DaemonIO & io) = 0;
+
+    GenerateResult restore_and_generate_with_empty_spec_fallback(
+            int slot, const GenerateRequest & req, const DaemonIO & io) {
+        GenerateResult result = restore_and_generate(slot, req, io);
+        if (!should_retry_empty_spec_decode(req, result)) return result;
+
+        std::fprintf(stderr,
+            "[backend] restored spec-decode produced zero tokens; retrying with AR decode\n");
+        GenerateRequest retry = req;
+        retry.force_ar_decode = true;
+        return merge_empty_spec_retry_result(result,
+                                             restore_and_generate(slot, retry, io));
+    }
+
+    static bool should_retry_empty_spec_decode(const GenerateRequest & req,
+                                               const GenerateResult & result) {
+        return req.n_gen > 0
+            && !req.force_ar_decode
+            && result.ok
+            && result.spec_decode_ran
+            && result.tokens.empty();
+    }
+
+    static GenerateResult merge_empty_spec_retry_result(
+            const GenerateResult & first, GenerateResult retry) {
+        retry.prefill_s += first.prefill_s;
+        retry.decode_s += first.decode_s;
+        retry.accept_rate = first.accept_rate;
+        retry.spec_decode_ran = first.spec_decode_ran || retry.spec_decode_ran;
+        retry.budget_forced_close =
+            first.budget_forced_close || retry.budget_forced_close;
+        retry.degenerate_decode_close =
+            first.degenerate_decode_close || retry.degenerate_decode_close;
+        return retry;
+    }
 
     // ── Snapshot serialization (for ondisk prefix cache) ─────────────
     // Read-only reference to a snapshot's ggml tensors for serialization.

--- a/server/src/gemma4/gemma4_backend.cpp
+++ b/server/src/gemma4/gemma4_backend.cpp
@@ -657,12 +657,14 @@ GenerateResult Gemma4Backend::generate(const GenerateRequest & req,
     auto t_decode_start = std::chrono::steady_clock::now();
     if (req.n_gen > 0) {
         // Try speculative decode if draft is available and temp==0
-        const bool can_spec = dflash_target_
+        const bool can_spec = !req.force_ar_decode
+            && dflash_target_
             && !draft_parked_
             && feature_mirror_.target_feat
             && !sampler_.needs_logit_processing();
 
         if (can_spec) {
+            result.spec_decode_ran = true;
             if (!do_spec_decode(committed, req.n_gen, result.tokens, out_io,
                                 &req.budget_hook,
                                 &result.budget_forced_close)) {
@@ -835,12 +837,14 @@ GenerateResult Gemma4Backend::restore_and_generate(int slot,
     // Generate
     auto t_decode_start = std::chrono::steady_clock::now();
     if (req.n_gen > 0) {
-        const bool can_spec = dflash_target_
+        const bool can_spec = !req.force_ar_decode
+            && dflash_target_
             && !draft_parked_
             && feature_mirror_.target_feat
             && sampler_.temp == 0.0f;
 
         if (can_spec) {
+            result.spec_decode_ran = true;
             if (!do_spec_decode(committed, req.n_gen, result.tokens, out_io,
                                 &req.budget_hook,
                                 &result.budget_forced_close)) {

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -577,13 +577,22 @@ GenerateResult Qwen35Backend::generate(const GenerateRequest & req,
         // without sacrificing spec-decode throughput for the bulk of
         // generation. Most requests never hit the tail because the
         // model closes </think> naturally well before the budget edge.
-        if (!do_spec_decode(committed, req.n_gen, result.tokens, out_io,
+        {
+        bool _sd_ok = do_spec_decode(committed, req.n_gen, result.tokens, out_io,
                              result.accept_rate, result.spec_decode_ran,
                              req.hint_tokens, &req.budget_hook,
                              &result.budget_forced_close,
-                             &result.degenerate_decode_close)) {
+                             &result.degenerate_decode_close);
+        if (_sd_ok && result.tokens.empty()) {
+            // FIX: spec-decode degenerate empty (EOS as first token) on certain
+            // agentic turns -> fall back to AR decode, which is verified to produce
+            // correct non-empty output for exactly these contexts (temp-0 parity).
+            _sd_ok = do_ar_decode(committed, req.n_gen, result.tokens, out_io, req.budget_hook, &result.budget_forced_close, &result.degenerate_decode_close);
+        }
+        if (!_sd_ok) {
             result.error = "decode";
             return result;
+        }
         }
         result.decode_s = std::chrono::duration<double>(
             std::chrono::steady_clock::now() - t_decode_start).count();
@@ -668,13 +677,22 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
         // without sacrificing spec-decode throughput for the bulk of
         // generation. Most requests never hit the tail because the
         // model closes </think> naturally well before the budget edge.
-        if (!do_spec_decode(committed, req.n_gen, result.tokens, out_io,
+        {
+        bool _sd_ok = do_spec_decode(committed, req.n_gen, result.tokens, out_io,
                              result.accept_rate, result.spec_decode_ran,
                              req.hint_tokens, &req.budget_hook,
                              &result.budget_forced_close,
-                             &result.degenerate_decode_close)) {
+                             &result.degenerate_decode_close);
+        if (_sd_ok && result.tokens.empty()) {
+            // FIX: spec-decode degenerate empty (EOS as first token) on certain
+            // agentic turns -> fall back to AR decode, which is verified to produce
+            // correct non-empty output for exactly these contexts (temp-0 parity).
+            _sd_ok = do_ar_decode(committed, req.n_gen, result.tokens, out_io, req.budget_hook, &result.budget_forced_close, &result.degenerate_decode_close);
+        }
+        if (!_sd_ok) {
             result.error = "decode";
             return result;
+        }
         }
         result.decode_s = std::chrono::duration<double>(
             std::chrono::steady_clock::now() - t_decode_start).count();

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -577,22 +577,23 @@ GenerateResult Qwen35Backend::generate(const GenerateRequest & req,
         // without sacrificing spec-decode throughput for the bulk of
         // generation. Most requests never hit the tail because the
         // model closes </think> naturally well before the budget edge.
-        {
-        bool _sd_ok = do_spec_decode(committed, req.n_gen, result.tokens, out_io,
-                             result.accept_rate, result.spec_decode_ran,
-                             req.hint_tokens, &req.budget_hook,
-                             &result.budget_forced_close,
-                             &result.degenerate_decode_close);
-        if (_sd_ok && result.tokens.empty()) {
-            // FIX: spec-decode degenerate empty (EOS as first token) on certain
-            // agentic turns -> fall back to AR decode, which is verified to produce
-            // correct non-empty output for exactly these contexts (temp-0 parity).
-            _sd_ok = do_ar_decode(committed, req.n_gen, result.tokens, out_io, req.budget_hook, &result.budget_forced_close, &result.degenerate_decode_close);
+        bool decode_ok = false;
+        if (req.force_ar_decode) {
+            decode_ok = do_ar_decode(committed, req.n_gen, result.tokens, out_io,
+                                     req.budget_hook,
+                                     &result.budget_forced_close,
+                                     &result.degenerate_decode_close);
+            out_io.emit(-1);
+        } else {
+            decode_ok = do_spec_decode(committed, req.n_gen, result.tokens, out_io,
+                                       result.accept_rate, result.spec_decode_ran,
+                                       req.hint_tokens, &req.budget_hook,
+                                       &result.budget_forced_close,
+                                       &result.degenerate_decode_close);
         }
-        if (!_sd_ok) {
+        if (!decode_ok) {
             result.error = "decode";
             return result;
-        }
         }
         result.decode_s = std::chrono::duration<double>(
             std::chrono::steady_clock::now() - t_decode_start).count();
@@ -677,22 +678,23 @@ GenerateResult Qwen35Backend::restore_and_generate(int slot,
         // without sacrificing spec-decode throughput for the bulk of
         // generation. Most requests never hit the tail because the
         // model closes </think> naturally well before the budget edge.
-        {
-        bool _sd_ok = do_spec_decode(committed, req.n_gen, result.tokens, out_io,
-                             result.accept_rate, result.spec_decode_ran,
-                             req.hint_tokens, &req.budget_hook,
-                             &result.budget_forced_close,
-                             &result.degenerate_decode_close);
-        if (_sd_ok && result.tokens.empty()) {
-            // FIX: spec-decode degenerate empty (EOS as first token) on certain
-            // agentic turns -> fall back to AR decode, which is verified to produce
-            // correct non-empty output for exactly these contexts (temp-0 parity).
-            _sd_ok = do_ar_decode(committed, req.n_gen, result.tokens, out_io, req.budget_hook, &result.budget_forced_close, &result.degenerate_decode_close);
+        bool decode_ok = false;
+        if (req.force_ar_decode) {
+            decode_ok = do_ar_decode(committed, req.n_gen, result.tokens, out_io,
+                                     req.budget_hook,
+                                     &result.budget_forced_close,
+                                     &result.degenerate_decode_close);
+            out_io.emit(-1);
+        } else {
+            decode_ok = do_spec_decode(committed, req.n_gen, result.tokens, out_io,
+                                       result.accept_rate, result.spec_decode_ran,
+                                       req.hint_tokens, &req.budget_hook,
+                                       &result.budget_forced_close,
+                                       &result.degenerate_decode_close);
         }
-        if (!_sd_ok) {
+        if (!decode_ok) {
             result.error = "decode";
             return result;
-        }
         }
         result.decode_s = std::chrono::duration<double>(
             std::chrono::steady_clock::now() - t_decode_start).count();

--- a/server/src/qwen35moe/qwen35moe_backend.cpp
+++ b/server/src/qwen35moe/qwen35moe_backend.cpp
@@ -822,13 +822,15 @@ GenerateResult Qwen35MoeBackend::generate(const GenerateRequest & req,
         auto t_decode_start = std::chrono::steady_clock::now();
 
         // Check if hybrid spec-decode is available
-        const bool can_hybrid_spec = cfg_.draft_path
+        const bool can_hybrid_spec = !req.force_ar_decode
+            && cfg_.draft_path
             && !is_draft_parked()
             && feature_mirror().target_feat
             && sampler_config().temp == 0.0f
             && draft_weights().block_size > 0;
 
         if (can_hybrid_spec) {
+            result.spec_decode_ran = true;
             // Sync prefill features to mirror before spec-decode
             if (target_cache().target_feat) {
                 draft_feature_mirror_sync_range(target_cache().target_feat,

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -1385,7 +1385,7 @@ void HttpServer::worker_loop() {
                 cold_req.snap_pos = cold_boundary;  // save at end of prefix
                 DaemonIO cold_io;
                 cold_io.stream_fd = -1;
-                auto cold_result = backend_.generate(cold_req, cold_io);
+                auto cold_result = backend_.generate_with_empty_spec_fallback(cold_req, cold_io);
                 if (cold_result.ok && backend_.snapshot_used(DISK_STAGING_SLOT)) {
                     disk_cache_.learn_layout(DISK_STAGING_SLOT);
                     std::vector<int32_t> prefix_tokens(effective_prompt.begin(),
@@ -1510,9 +1510,9 @@ void HttpServer::worker_loop() {
 
         GenerateResult result;
         if (using_restore) {
-            result = backend_.restore_and_generate(cache_slot, gen_req, io);
+            result = backend_.restore_and_generate_with_empty_spec_fallback(cache_slot, gen_req, io);
         } else {
-            result = backend_.generate(gen_req, io);
+            result = backend_.generate_with_empty_spec_fallback(gen_req, io);
         }
 
         // Lazy-draft: park decode draft after generate to free VRAM.

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -2413,6 +2413,79 @@ static void test_usage_timings_omitted_when_null() {
     TEST_ASSERT(finish_str.find("[DONE]") != std::string::npos);
 }
 
+// ModelBackend common empty-spec retry tests
+// ═══════════════════════════════════════════════════════════════════════
+
+struct EmptySpecRetryBackend : MockBackend {
+    int generate_calls = 0;
+    int restore_calls = 0;
+    bool generate_saw_force_ar = false;
+    bool restore_saw_force_ar = false;
+
+    GenerateResult generate(const GenerateRequest & req,
+                            const DaemonIO &) override {
+        generate_calls++;
+        GenerateResult result;
+        result.ok = true;
+        if (req.force_ar_decode) {
+            generate_saw_force_ar = true;
+            result.tokens = {42};
+        } else {
+            result.spec_decode_ran = true;
+        }
+        return result;
+    }
+
+    GenerateResult restore_and_generate(int, const GenerateRequest & req,
+                                        const DaemonIO &) override {
+        restore_calls++;
+        GenerateResult result;
+        result.ok = true;
+        if (req.force_ar_decode) {
+            restore_saw_force_ar = true;
+            result.tokens = {84};
+        } else {
+            result.spec_decode_ran = true;
+        }
+        return result;
+    }
+};
+
+static void test_model_backend_retries_empty_spec_generate_once_with_ar() {
+    EmptySpecRetryBackend backend;
+    GenerateRequest req;
+    req.prompt = {1, 2, 3};
+    req.n_gen = 4;
+    DaemonIO io;
+
+    GenerateResult result = backend.generate_with_empty_spec_fallback(req, io);
+
+    TEST_ASSERT(result.ok);
+    TEST_ASSERT(result.tokens.size() == 1);
+    TEST_ASSERT(result.tokens[0] == 42);
+    TEST_ASSERT(result.spec_decode_ran);
+    TEST_ASSERT(backend.generate_calls == 2);
+    TEST_ASSERT(backend.generate_saw_force_ar);
+}
+
+static void test_model_backend_retries_empty_spec_restore_once_with_ar() {
+    EmptySpecRetryBackend backend;
+    GenerateRequest req;
+    req.prompt = {1, 2, 3};
+    req.n_gen = 4;
+    DaemonIO io;
+
+    GenerateResult result =
+        backend.restore_and_generate_with_empty_spec_fallback(7, req, io);
+
+    TEST_ASSERT(result.ok);
+    TEST_ASSERT(result.tokens.size() == 1);
+    TEST_ASSERT(result.tokens[0] == 84);
+    TEST_ASSERT(result.spec_decode_ran);
+    TEST_ASSERT(backend.restore_calls == 2);
+    TEST_ASSERT(backend.restore_saw_force_ar);
+}
+
 // GenerateResult.accept_rate plumbing tests (Day 1 of bandit MVP)
 // ═══════════════════════════════════════════════════════════════════════
 
@@ -2640,6 +2713,10 @@ int main() {
     RUN_TEST(test_usage_timings_responses_streaming);
     RUN_TEST(test_usage_timings_zero_decode_no_div_by_zero);
     RUN_TEST(test_usage_timings_omitted_when_null);
+
+    std::fprintf(stderr, "\n── ModelBackend empty-spec retry ──\n");
+    RUN_TEST(test_model_backend_retries_empty_spec_generate_once_with_ar);
+    RUN_TEST(test_model_backend_retries_empty_spec_restore_once_with_ar);
 
     std::fprintf(stderr, "\n── GenerateResult.accept_rate ──\n");
     RUN_TEST(test_generate_result_accept_rate_defaults_to_zero);


### PR DESCRIPTION
## Summary

dflash speculative decoding can emit **EOS as the very first token** on certain agentic decision turns, returning an **empty completion** (0 tokens, `finish=stop`, no `tool_call`). The agent loop then has nothing to run and stalls.

At temperature 0, spec-decode output must match autoregressive (AR) greedy output. On the captured qwen35 cases it does not, so this is treated as a spec-decode correctness failure for the empty-output class.

## What changed

Follow-up to review feedback asking whether the fallback can live in a common upper layer:

- Added shared `ModelBackend` wrappers for `generate` and `restore_and_generate` that detect `ok && spec_decode_ran && tokens.empty()` and retry once with `GenerateRequest::force_ar_decode`.
- Routed the daemon loop and HTTP server through those common wrappers.
- Made spec-capable backends honor `force_ar_decode` instead of duplicating the empty-output retry at backend call sites: qwen35, gemma4, layer-split, and qwen35moe hybrid.
- Preserved spec-decode telemetry on the retry result so accept-rate/session logic still sees that spec decode was attempted.
- Added unit coverage for the common generate and restore retry wrappers.

## How to review

Start with `server/src/common/model_backend.h`: this is now the shared retry policy. Then check the call sites in `daemon_loop.cpp` and `http_server.cpp`, and finally the backend-specific changes, which should only be mechanism: skip spec decode when `force_ar_decode` is set.

## Evidence

Original qwen35 root-cause validation was isolated with a reproducible stateless lane (`dflash-nocache`, no prefix-cache cross-request state). On 55 real captured agentic turns:

- 9 turns produced empty output under spec-decode deterministically.
- The same 9 turns produced correct non-empty output on the AR path and on stock llama.cpp Q6.
- After the fallback, 9/9 empty turns produced non-empty output byte-identical to AR.
- Full 55-turn sweep: empty count 9 -> 0, zero regressions to empty, tool-call set unchanged.
- Prefix-cache correctness oracle remained 6/6 bit-identical.

## Verification

- Local hygiene: `git diff --check HEAD~1..HEAD` passed.
- Local prerequisites fixed for follow-up work: `cmake` is installed locally (`cmake version 4.3.3`) and local submodules are initialized recursively.
- Clean GPU-host verification on taro in isolated worktree `/tmp/lucebox-pr314-verify-20260530T220140` at `f4a0d8b567f3318def29dc2b2a119b9eda63cd5b`.
- CUDA/toolchain proof: CUDA 13.3 `nvcc` on RTX 5090 (`NVIDIA GeForce RTX 5090`, driver `595.71.05`).
- Configure passed:
  `CUDACXX=/usr/local/cuda-13.3/bin/nvcc CUDAToolkit_ROOT=/usr/local/cuda-13.3 cmake -S server -B server/build-pr314 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=120 -DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.3/bin/nvcc -DCUDAToolkit_ROOT=/usr/local/cuda-13.3`
- Unit target passed:
  `cmake --build server/build-pr314 --target test_server_unit -j$(nproc)` and `./server/build-pr314/test_server_unit` -> `1620 assertions, 0 failures`, `ALL PASSED`.
- Server target passed:
  `cmake --build server/build-pr314 --target dflash_server -j$(nproc)` -> built `server/build-pr314/dflash_server`.

## Risks / gaps

- Scope is still the empty-output failure only. Other stalls that emit an action preamble and then stop with no tool call remain separate.
- The failing case now retries at the common request boundary, so it may pay a full AR retry cost. Normal non-empty spec-decode turns do not hit the retry path.
- The underlying first-token spec-decode divergence is treated, not root-caused, in the verify path.

## Collaborators

- Omar Baradei (operator) — reported the failure, directed the fix.
- Claude (Opus 4.8) — initial reproducible eval, root-cause isolation, and qwen35 fallback.
- Codex — common-layer refactor responding to review feedback.
