### PR TITLE
fix: capture daemon stderr in DflashClient error messages

### DIFF
--- a/optimizations/pflash/pflash/dflash_client.py
+++ b/optimizations/pflash/pflash/dflash_client.py
@@ -116,10 +116,12 @@ class DflashClient:
         if sys.platform == "win32":
             self.proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                          stdout=subprocess.PIPE,
+                                         stderr=subprocess.STDOUT,
                                          close_fds=False, env=env)
         else:
             self.proc = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                          stdout=subprocess.PIPE,
+                                         stderr=subprocess.STDOUT,
                                          pass_fds=(self.w_pipe,), env=env)
         self._start_stdout_reader()
         os.close(self.w_pipe)


### PR DESCRIPTION
## Summary

- Adds `stderr=subprocess.STDOUT` to the subprocess call that launches the dflash daemon
- Previously, daemon errors printed to stderr were silently lost; users only saw a generic boot failure message
- With this change, the actual daemon error (e.g., safetensors shape mismatch) is included in the Python RuntimeError

Fixes #233

## Test Plan

- [x] Verified Python syntax is valid