### PR TITLE
fix(server): honor chunk size in target-split prefill dispatch

### DIFF
--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -57,6 +57,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
             cfg.kq_stride_pad      = args.kq_stride_pad;
             cfg.draft_swa_window   = args.draft_swa_window;
             cfg.draft_ctx_max      = args.draft_ctx_max;
+            cfg.chunk              = args.chunk;
             cfg.max_verify_tokens  = args.ddtree_mode
                 ? std::max<int>(DFLASH27B_DRAFT_BLOCK_SIZE, args.ddtree_budget + 1)
                 : DFLASH27B_DRAFT_BLOCK_SIZE;

--- a/server/src/common/layer_split_backend.cpp
+++ b/server/src/common/layer_split_backend.cpp
@@ -66,6 +66,7 @@ GenerateResult LayerSplitBackend::run_from_state(const GenerateRequest & req,
     if (reset_state) adapter_->reset_request_state();
 
     const int prompt_len = (int)req.prompt.size();
+    const int adapter_chunk = adapter_->prefill_chunk_tokens();
     int last_tok = (base_pos > 0 && prompt_len == 0)
         ? adapter_->current_last_token()
         : -1;
@@ -73,6 +74,9 @@ GenerateResult LayerSplitBackend::run_from_state(const GenerateRequest & req,
     auto t_prefill_start = std::chrono::steady_clock::now();
     while (consumed < prompt_len) {
         int n_tokens = prompt_len - consumed;
+        if (adapter_chunk > 0 && n_tokens > adapter_chunk) {
+            n_tokens = adapter_chunk;
+        }
         if (req.snap_pos >= 0 && req.snap_slot >= 0 &&
             req.snap_pos > base_pos + consumed &&
             req.snap_pos < base_pos + consumed + n_tokens) {

--- a/server/src/common/layer_split_backend.h
+++ b/server/src/common/layer_split_backend.h
@@ -25,6 +25,7 @@ public:
 
     virtual void begin_request(const GenerateRequest & req) { (void)req; }
     virtual void reset_request_state() = 0;
+    virtual int prefill_chunk_tokens() const { return 0; }
     virtual bool prefill(const std::vector<int32_t> & prompt,
                          int base_pos, int & last_tok) = 0;
     virtual bool decode_ar(int last_tok, int committed, int n_gen,

--- a/server/src/gemma4/gemma4_layer_split_adapter.h
+++ b/server/src/gemma4/gemma4_layer_split_adapter.h
@@ -46,6 +46,7 @@ public:
 
     void begin_request(const GenerateRequest & req) override;
     void reset_request_state() override;
+    int prefill_chunk_tokens() const override { return cfg_.chunk > 0 ? cfg_.chunk : 0; }
     bool prefill(const std::vector<int32_t> & prompt,
                  int base_pos, int & last_tok) override;
     bool decode_ar(int last_tok, int committed, int n_gen,

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -173,6 +173,10 @@ void Qwen35LayerSplitAdapter::reset_request_state() {
     for (auto & shard : shards_) reset_target_cache(shard.cache);
 }
 
+int Qwen35LayerSplitAdapter::prefill_chunk_tokens() const {
+    return cfg_.chunk > 0 ? cfg_.chunk : 0;
+}
+
 bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
                                       int base_pos, int & last_tok) {
     if (prompt.empty()) return false;

--- a/server/src/qwen35/qwen35_layer_split_adapter.h
+++ b/server/src/qwen35/qwen35_layer_split_adapter.h
@@ -31,6 +31,7 @@ struct Qwen35LayerSplitAdapterConfig {
     int fa_window = 0;  // 0 = full attention. qwen3.6 full-attn layers must see the whole context; a finite window drops the system prompt/tools -> breaks tool calls.
     int kq_stride_pad = 32;
     int draft_ctx_max = 4096;
+    int chunk = 512;
     int max_verify_tokens = DFLASH27B_DRAFT_BLOCK_SIZE;
     bool run_dflash = false;
     int draft_swa_window = 0;
@@ -50,6 +51,7 @@ public:
 
     void begin_request(const GenerateRequest & req) override;
     void reset_request_state() override;
+    int prefill_chunk_tokens() const override;
     bool prefill(const std::vector<int32_t> & prompt,
                  int base_pos, int & last_tok) override;
     bool decode_ar(int last_tok, int committed, int n_gen,

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1248,6 +1248,7 @@ struct MockLayerSplitAdapter : LayerSplitAdapter {
     bool dflash_called = false;
     int shutdown_calls = 0;
     ModelBackend::CompressRequest last_compress_req;
+    int prefill_chunk = 0;
 
     const char * name() const override { return "mock"; }
     bool init() override { return true; }
@@ -1257,6 +1258,7 @@ struct MockLayerSplitAdapter : LayerSplitAdapter {
         current_pos = 0;
         current_last = -1;
     }
+    int prefill_chunk_tokens() const override { return prefill_chunk; }
     bool prefill(const std::vector<int32_t> & prompt,
                  int base_pos, int & last_tok) override {
         prefill_bases.push_back(base_pos);
@@ -1372,6 +1374,28 @@ static void test_layer_split_backend_inline_snapshot_and_restore_delta() {
     TEST_ASSERT(raw->prefill_sizes[0] == 1);
     TEST_ASSERT(raw->dflash_base == 3);
     TEST_ASSERT(raw->dflash_last == 99);
+}
+
+static void test_layer_split_backend_chunks_prefill_by_adapter_limit() {
+    auto * raw = new MockLayerSplitAdapter();
+    raw->prefill_chunk = 3;
+    LayerSplitBackend backend{std::unique_ptr<LayerSplitAdapter>(raw)};
+
+    GenerateRequest req;
+    req.prompt = {1, 2, 3, 4, 5, 6, 7, 8};
+    req.n_gen = 1;
+    DaemonIO io;
+    GenerateResult result = backend.generate(req, io);
+
+    TEST_ASSERT(result.ok);
+    TEST_ASSERT(raw->prefill_bases.size() == 3);
+    TEST_ASSERT(raw->prefill_sizes.size() == 3);
+    TEST_ASSERT(raw->prefill_bases[0] == 0);
+    TEST_ASSERT(raw->prefill_sizes[0] == 3);
+    TEST_ASSERT(raw->prefill_bases[1] == 3);
+    TEST_ASSERT(raw->prefill_sizes[1] == 3);
+    TEST_ASSERT(raw->prefill_bases[2] == 6);
+    TEST_ASSERT(raw->prefill_sizes[2] == 2);
 }
 
 static void test_layer_split_compress_nopark_uses_default_drafter_path() {
@@ -2660,6 +2684,7 @@ int main() {
     RUN_TEST(test_parse_target_device_list_single_gpu_is_not_layer_split);
     RUN_TEST(test_validate_layer_split_weights_shape);
     RUN_TEST(test_layer_split_backend_inline_snapshot_and_restore_delta);
+    RUN_TEST(test_layer_split_backend_chunks_prefill_by_adapter_limit);
     RUN_TEST(test_layer_split_compress_nopark_uses_default_drafter_path);
     RUN_TEST(test_layer_split_compress_rejects_bad_keep_ratio);
     RUN_TEST(test_layer_split_backend_shutdown_is_idempotent);


### PR DESCRIPTION
## Summary

This PR is a C++ server follow-up to #118 (`fix(dflash): resolve target split prefill OOM from full-prompt logits`). #118 fixed the heaviest full-prompt logits OOM issue in target split prefill. This PR does not introduce a new VRAM optimization path; it carries the same "prefill should not fall back to full-prompt residency" semantics into the current common C++ target-layer-split dispatch layer.

The server already exposes `--chunk`, but the common `LayerSplitBackend` previously passed the whole prompt into each adapter `prefill()` call. This PR makes the prefill chunk limit a common `LayerSplitAdapter` hook and has `LayerSplitBackend` split prompt dispatch before calling the adapter. Qwen35/Qwen3.6 and Gemma4 target-layer-split paths now honor the server chunk setting while preserving snapshot boundaries, restore delta handling, and DFlash decode selection.

## Changes

- Add `LayerSplitAdapter::prefill_chunk_tokens()` as the common target-layer-split hook for adapter prefill chunk limits.
- Update `LayerSplitBackend::run_from_state()` to cap each `adapter->prefill()` call by that adapter chunk limit.
- Wire `BackendArgs::chunk` into the Qwen35/Qwen3.6 layer-split adapter config.
- Have Qwen35/Qwen3.6 and Gemma4 layer-split adapters report their configured prefill chunk.
- Add a unit test proving an 8-token prompt with chunk=3 is dispatched as `3, 3, 2`.
- Leave DFlash/PFlash behavior, IPC transport, precision policy, drafter residency, and disk prefix-cache behavior unchanged.
