### PR TITLE
ci: run GPU tests on self-hosted lucebox3 (3090 + Radeon 8060S)

### DIFF
--- a/.github/ci/hip_smoke.cpp
+++ b/.github/ci/hip_smoke.cpp
@@ -1,0 +1,41 @@
+// Self-contained HIP kernel correctness smoke for the lucebox3 Strix Halo iGPU
+// (Radeon 8060S, gfx1151). Compiled and run by the gpu-tests-amd CI job to
+// prove the ROCm/HIP compute path actually executes on AMD hardware (GitHub
+// hosted runners have no GPU). No model weights, deterministic, fast.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+
+__global__ void vadd(const float* a, const float* b, float* c, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) c[i] = a[i] + b[i];
+}
+
+#define CK(x) do { hipError_t e = (x); if (e != hipSuccess) { \
+    fprintf(stderr, "HIP error at line %d: %s\n", __LINE__, hipGetErrorString(e)); \
+    return 2; } } while (0)
+
+int main() {
+    hipDeviceProp_t p;
+    CK(hipGetDeviceProperties(&p, 0));
+    printf("HIP device 0: %s (%s, %d CUs)\n", p.name, p.gcnArchName, p.multiProcessorCount);
+
+    const int n = 1 << 20;
+    const size_t sz = n * sizeof(float);
+    float *ha = (float*)malloc(sz), *hb = (float*)malloc(sz), *hc = (float*)malloc(sz);
+    for (int i = 0; i < n; i++) { ha[i] = 1.0f * i; hb[i] = 2.0f * i; }
+
+    float *da, *db, *dc;
+    CK(hipMalloc(&da, sz)); CK(hipMalloc(&db, sz)); CK(hipMalloc(&dc, sz));
+    CK(hipMemcpy(da, ha, sz, hipMemcpyHostToDevice));
+    CK(hipMemcpy(db, hb, sz, hipMemcpyHostToDevice));
+    vadd<<<(n + 255) / 256, 256>>>(da, db, dc, n);
+    CK(hipGetLastError());
+    CK(hipDeviceSynchronize());
+    CK(hipMemcpy(hc, dc, sz, hipMemcpyDeviceToHost));
+
+    int bad = 0;
+    for (int i = 0; i < n; i++) if (hc[i] != 3.0f * i) bad++;
+    printf(bad ? "FAIL: %d mismatches\n" : "PASS: vadd correct on %d elements\n", bad ? bad : n);
+    return bad ? 1 : 0;
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,19 +154,26 @@ jobs:
         # safe and fast in CI. This is the execution the hosted jobs cannot do.
         run: ./server/build/test_flash_attn_sparse
 
-      # Optional model-backed end-to-end smoke, disabled by default: it needs
-      # the 16 GB Qwen3.6-27B GGUF + draft staged on the runner. To enable,
-      # stage the weights on lucebox3, set repo variable LUCEBOX_MODELS_DIR, and
-      # uncomment. Mark continue-on-error so a heavy/flaky run never blocks PRs.
+      # Optional model-backed end-to-end smoke (real spec-decode on the 3090),
+      # disabled by default because it builds dflash_server and lazy-loads the
+      # ~16 GB Qwen3.6-27B target + draft (~1-2 min). The weights are already
+      # staged at /opt/models on lucebox3 (override with repo var
+      # LUCEBOX_MODELS_DIR). Verified working on the runner. To enable, uncomment;
+      # continue-on-error keeps a heavy/slow run from ever blocking a PR.
       # - name: dflash end-to-end smoke (model-backed)
       #   continue-on-error: true
+      #   env:
+      #     MODELS: ${{ vars.LUCEBOX_MODELS_DIR || '/opt/models' }}
       #   run: |
       #     cd server
-      #     cmake --build build --target test_dflash -j"$(nproc)"
-      #     ./build/test_dflash \
-      #       "${{ vars.LUCEBOX_MODELS_DIR }}/Qwen3.6-27B-Q4_K_M.gguf" \
-      #       "${{ vars.LUCEBOX_MODELS_DIR }}/draft" \
-      #       test/prompt_ids.bin
+      #     cmake --build build --target dflash_server -j"$(nproc)"
+      #     ./build/dflash_server "$MODELS/Qwen3.6-27B-Q4_K_M.gguf" \
+      #       --draft "$MODELS/draft/dflash-draft-3.6-q4_k_m.gguf" --port 8099 &
+      #     SRV=$!; trap 'kill $SRV 2>/dev/null' EXIT
+      #     for i in $(seq 1 90); do curl -sf localhost:8099/v1/models >/dev/null && break; sleep 2; done
+      #     curl -sf --max-time 240 localhost:8099/v1/completions \
+      #       -H 'Content-Type: application/json' \
+      #       -d '{"prompt":"The capital of France is","max_tokens":8}' | grep -q '"text"'
 
   gpu-tests-amd:
     name: GPU tests (self-hosted Radeon 8060S, gfx1151 / ROCm)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,84 @@ jobs:
           import qwen35_megakernel_bf16_C as M
           print('megakernel sm_86 .so loads:', M.__file__)
           "
+
+  gpu-tests:
+    name: GPU tests (self-hosted RTX 3090, sm_86)
+    # Runs only after the GitHub-hosted jobs pass. Those compile the dflash
+    # kernels for sm_86 but execute on GPU-less VMs, so the kernel never runs.
+    # This job lands on lucebox3 (RTX 3090) and actually executes it.
+    needs: [uv-workspace, build]
+    runs-on: [self-hosted, gpu, sm86]
+    timeout-minutes: 30
+    # The box has a single physical GPU: serialize GPU jobs across PRs instead
+    # of letting concurrent runs clobber each other.
+    concurrency:
+      group: lucebox3-gpu-runner
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: GPU smoke (nvidia-smi)
+        run: nvidia-smi --query-gpu=name,driver_version,memory.total,power.limit --format=csv
+
+      - name: Build GPU test binary (sm_86, runner-local CUDA)
+        # Uses the runner's own nvcc (/usr/bin/nvcc); no Jimver download since
+        # lucebox3 already has the CUDA toolkit installed.
+        run: |
+          cd server
+          cmake -B build \
+            -DCMAKE_CUDA_ARCHITECTURES="86" \
+            -DDFLASH27B_ENABLE_BSA=OFF \
+            -DDFLASH27B_FA_ALL_QUANTS=OFF \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --target test_flash_attn_sparse -j"$(nproc)"
+
+      - name: Run flash-attn sparse kernel test on the 3090
+        # Self-contained kernel correctness test (no model weights), so it is
+        # safe and fast in CI. This is the execution the hosted jobs cannot do.
+        run: ./server/build/test_flash_attn_sparse
+
+      # Optional model-backed end-to-end smoke, disabled by default: it needs
+      # the 16 GB Qwen3.6-27B GGUF + draft staged on the runner. To enable,
+      # stage the weights on lucebox3, set repo variable LUCEBOX_MODELS_DIR, and
+      # uncomment. Mark continue-on-error so a heavy/flaky run never blocks PRs.
+      # - name: dflash end-to-end smoke (model-backed)
+      #   continue-on-error: true
+      #   run: |
+      #     cd server
+      #     cmake --build build --target test_dflash -j"$(nproc)"
+      #     ./build/test_dflash \
+      #       "${{ vars.LUCEBOX_MODELS_DIR }}/Qwen3.6-27B-Q4_K_M.gguf" \
+      #       "${{ vars.LUCEBOX_MODELS_DIR }}/draft" \
+      #       test/prompt_ids.bin
+
+  gpu-tests-amd:
+    name: GPU tests (self-hosted Radeon 8060S, gfx1151 / ROCm)
+    # Companion to gpu-tests: exercises the OTHER half of lucebox3 - the Strix
+    # Halo iGPU - via ROCm/HIP. GitHub-hosted runners cannot touch an AMD GPU at
+    # all. The runner is pinned to ROCm 6.4.4 on kernel 6.14 (ROCm 7.2 page-
+    # faults on gfx1151); hipcc is not on the runner's minimal PATH, so it is
+    # invoked by absolute path.
+    needs: [uv-workspace, build]
+    runs-on: [self-hosted, rocm, gfx1151]
+    timeout-minutes: 20
+    # Same single box as gpu-tests: serialize GPU jobs across PRs.
+    concurrency:
+      group: lucebox3-gpu-runner
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ROCm smoke (rocminfo sees gfx1151)
+        run: /opt/rocm/bin/rocminfo | grep -E "Name:|Marketing Name:" | grep -iE "gfx1151|Radeon 8060S"
+
+      - name: Build + run HIP vector-add on the Radeon 8060S
+        # Self-contained HIP kernel correctness test (no model weights). This is
+        # the execution the GitHub-hosted jobs cannot do.
+        run: |
+          /opt/rocm/bin/hipcc --offload-arch=gfx1151 -O2 \
+            -o "$RUNNER_TEMP/hip_smoke" .github/ci/hip_smoke.cpp
+          "$RUNNER_TEMP/hip_smoke"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,15 @@ jobs:
     # Runs only after the GitHub-hosted jobs pass. Those compile the dflash
     # kernels for sm_86 but execute on GPU-less VMs, so the kernel never runs.
     # This job lands on lucebox3 (RTX 3090) and actually executes it.
+    #
+    # SECURITY: a self-hosted runner must never execute untrusted fork code.
+    # This guard restricts the job to same-repo PRs (head repo == this repo)
+    # and manual dispatch, so fork PRs against this public repo skip it
+    # entirely and never run on the box. The ubuntu-latest jobs above still
+    # run for forks (safe, ephemeral GitHub VMs).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: [uv-workspace, build]
     runs-on: [self-hosted, gpu, sm86]
     timeout-minutes: 30
@@ -166,6 +175,12 @@ jobs:
     # all. The runner is pinned to ROCm 6.4.4 on kernel 6.14 (ROCm 7.2 page-
     # faults on gfx1151); hipcc is not on the runner's minimal PATH, so it is
     # invoked by absolute path.
+    #
+    # SECURITY: same fork guard as gpu-tests - never execute untrusted fork
+    # code on the self-hosted box. Fork PRs skip this job.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: [uv-workspace, build]
     runs-on: [self-hosted, rocm, gfx1151]
     timeout-minutes: 20


### PR DESCRIPTION
## What

Adds two **self-hosted** CI jobs that run on `lucebox3`, so the GPU code paths are actually *executed* on hardware instead of only cross-compiled (GitHub-hosted `ubuntu-latest` runners have no GPU).

- **`gpu-tests`** — `runs-on: [self-hosted, gpu, sm86]`. Builds and runs `test_flash_attn_sparse` on the **RTX 3090** (sm_86) using the runner's local CUDA toolkit.
- **`gpu-tests-amd`** — `runs-on: [self-hosted, rocm, gfx1151]`. Compiles and runs `.github/ci/hip_smoke.cpp` (a self-contained HIP vector-add) on the **Strix Halo Radeon 8060S** (gfx1151) via `/opt/rocm/bin/hipcc`.

Both jobs `needs: [uv-workspace, build]` (they only run after the existing hosted jobs pass) and share one `concurrency` group so the single physical box runs at most one GPU job at a time.

## Why

The existing `build` job compiles the dflash CUDA kernels for `sm_86`, but hosted runners can't execute them. lucebox3 has a real 3090 and a Strix Halo iGPU, so these jobs give actual GPU execution coverage for both backends.

## Runner / infra notes

- Runner labels: `self-hosted, Linux, X64, gpu, cuda, sm86, rtx3090, strix-halo, gfx1151, rocm, hip`.
- AMD side is pinned on the box to **ROCm 6.4.4 + kernel 6.14** (ROCm 7.2 page-faults on gfx1151, a known upstream bug). `hipcc` is not on the runner's minimal PATH, hence the absolute path.
- This repo is public, so its Actions fork-PR policy was set to **require approval for all external contributors** before a fork PR can run on the self-hosted box.

## Test

Both smokes verified green directly on lucebox3: `test_flash_attn_sparse` passes on the 3090, and the HIP vector-add prints `PASS` on gfx1151.

🧙 Built with [WOZCODE](https://wozcode.com)