### PR TITLE
fix(pflash): correct block-sparse attention output (WMMA layout + stream race)

### DIFF
--- a/server/src/flashprefill_kernels.cu
+++ b/server/src/flashprefill_kernels.cu
@@ -417,16 +417,16 @@ __global__ void sparse_flash_forward_kernel_bf16(
                 }
             }
 
-            // ── Apply causal/seq mask + per-lane rowmax for both row pairs owned ──
-            // sm_8x mma.m16n16k16 acc layout: lane t holds 8 elems mapping to:
-            //   e[0..3]: row = 2*(t/4)+0
-            //   e[4..7]: row = 2*(t/4)+1
-            //   e[0,1,4,5]: col_in_tile = 2*(t%4) + {0,1}
-            //   e[2,3,6,7]: col_in_tile = 2*(t%4) + 8 + {0,1}
+            // ── Apply causal/seq mask + per-lane rowmax for both rows owned ──
+            // MEASURED nvcuda::wmma m16n16k16 f32 accumulator layout (sm_86):
+            //   row(i) = (lane/4) + ((i & 2) ? 8 : 0)
+            //   col(i) = 2*(lane%4) + ((i & 4) ? 8 : 0) + (i & 1)
+            // Each lane owns rows row_a = lane/4 and row_b = lane/4 + 8;
+            // elements i in {0,1,4,5} -> row_a, i in {2,3,6,7} -> row_b.
             const int q = lane >> 2;
             const int c = lane & 3;
-            const int row0_in_warp = 2 * q + 0;
-            const int row1_in_warp = 2 * q + 1;
+            const int row0_in_warp = q;          // row_a
+            const int row1_in_warp = q + 8;      // row_b
             const int row0_g = q_tile_idx * Q_TILE + wid * MMA_M + row0_in_warp;
             const int row1_g = q_tile_idx * Q_TILE + wid * MMA_M + row1_in_warp;
 
@@ -435,16 +435,15 @@ __global__ void sparse_flash_forward_kernel_bf16(
             for (int nt = 0; nt < NNK; ++nt) {
                 #pragma unroll
                 for (int i = 0; i < 8; ++i) {
-                    int col_pair = i & 1;
-                    int col_off  = ((i >> 1) & 1) ? 8 : 0;
-                    int col_in_tile = 2 * c + col_pair + col_off;
+                    int col_in_tile = 2 * c + ((i & 4) ? 8 : 0) + (i & 1);
                     int col_g = k_lo + nt * MMA_N + col_in_tile;
-                    int rg = (i < 4) ? row0_g : row1_g;
+                    bool is_b = (i & 2);
+                    int rg = is_b ? row1_g : row0_g;
                     bool valid = (col_g < seq_len);
                     if (is_diag) valid = valid && (col_g <= rg);
                     if (!valid) S_frag[nt].x[i] = -INFINITY;
-                    if (i < 4) lm0 = fmaxf(lm0, S_frag[nt].x[i]);
-                    else       lm1 = fmaxf(lm1, S_frag[nt].x[i]);
+                    if (is_b) lm1 = fmaxf(lm1, S_frag[nt].x[i]);
+                    else      lm0 = fmaxf(lm0, S_frag[nt].x[i]);
                 }
             }
             // Reduce rowmax across the 4 lanes of the quad (lanes with same q value).
@@ -481,15 +480,14 @@ __global__ void sparse_flash_forward_kernel_bf16(
             for (int nt = 0; nt < NNK; ++nt) {
                 #pragma unroll
                 for (int i = 0; i < 8; ++i) {
-                    int col_pair = i & 1;
-                    int col_off  = ((i >> 1) & 1) ? 8 : 0;
-                    int col_in_tile = 2 * c + col_pair + col_off;
+                    int col_in_tile = 2 * c + ((i & 4) ? 8 : 0) + (i & 1);
                     int col_in_KTILE = nt * MMA_N + col_in_tile;
+                    bool is_b = (i & 2);
                     float v = S_frag[nt].x[i];
-                    float mn = (i < 4) ? m_new0 : m_new1;
+                    float mn = is_b ? m_new1 : m_new0;
                     float p = (v == -INFINITY) ? 0.0f : exp2f(v - mn);
-                    if (i < 4) rs0 += p; else rs1 += p;
-                    int p_row = wid * MMA_M + ((i < 4) ? row0_in_warp : row1_in_warp);
+                    if (is_b) rs1 += p; else rs0 += p;
+                    int p_row = wid * MMA_M + (is_b ? row1_in_warp : row0_in_warp);
                     P_sh[(size_t)p_row * K_TILE + col_in_KTILE] = __float2bfloat16(p);
                 }
             }
@@ -508,15 +506,16 @@ __global__ void sparse_flash_forward_kernel_bf16(
                 row_l[row1_warp] = alpha1 * l_old1 + rs1;
             }
 
-            // Frag-direct rescale of O accumulator
+            // Frag-direct rescale of O accumulator (same acc layout as S):
+            //   i in {0,1,4,5} -> row_a (alpha0); i in {2,3,6,7} -> row_b (alpha1)
             #pragma unroll
             for (int d = 0; d < NDK; ++d) {
                 O_frag[d].x[0] *= alpha0;
                 O_frag[d].x[1] *= alpha0;
-                O_frag[d].x[2] *= alpha0;
-                O_frag[d].x[3] *= alpha0;
-                O_frag[d].x[4] *= alpha1;
-                O_frag[d].x[5] *= alpha1;
+                O_frag[d].x[2] *= alpha1;
+                O_frag[d].x[3] *= alpha1;
+                O_frag[d].x[4] *= alpha0;
+                O_frag[d].x[5] *= alpha0;
                 O_frag[d].x[6] *= alpha1;
                 O_frag[d].x[7] *= alpha1;
             }

--- a/server/test/test_flash_attn_sparse.cpp
+++ b/server/test/test_flash_attn_sparse.cpp
@@ -104,7 +104,10 @@ static bool test_sparse_matches_dense(ggml_backend_t backend, int S, int H, int 
         if (diff > max_diff) max_diff = diff;
     }
 
-    const bool pass = max_diff < 1e-3f && !any_nonfinite;
+    // The sparse kernel accumulates and writes its output in BF16, whose ~2^-8
+    // mantissa precision floors the achievable diff against the F16 dense
+    // reference at roughly 4e-3. 5e-3 leaves a little headroom over that floor.
+    const bool pass = max_diff < 5e-3f && !any_nonfinite;
     printf("[test] S=%d H=%d Hk=%d D=%d max_diff=%.6f nonfinite=%s %s\n",
            S, H, Hk, D, max_diff,
            any_nonfinite ? "YES" : "no",


### PR DESCRIPTION
## What

`GGML_OP_FLASH_ATTN_SPARSE` (the pFlash block-sparse attention used for drafter prefill scoring) produced **wrong output** vs a dense-attention reference. The `test_flash_attn_sparse` dense-vs-sparse check (run on the self-hosted GPU runner, see #347) caught it: gross per-block errors at every length, plus a sequence-length-dependent collapse to ~1.0 error at long context (S=4096 → max_diff 0.9998).

Two **independent root causes**, both fixed:

### 1. WMMA accumulator-fragment layout (this repo, `sparse_flash_forward_kernel_bf16`)
The kernel indexes the `nvcuda::wmma` `m16n16k16` accumulator fragment **directly** (`S_frag.x[i]`) for causal masking, P-matrix construction, and the O rescale — using a hand-assumed element→(row,col) layout that is **wrong for sm_86 / CUDA 12**. The fragment layout is opaque, so I measured it on-device and corrected all three spots:
```
row(i) = lane/4 + ((i & 2) ? 8 : 0)
col(i) = 2*(lane%4) + ((i & 4) ? 8 : 0) + (i & 1)
```
This alone dropped per-block `max_diff` from ~0.66 to ~0.004.

### 2. Cross-stream race (ggml submodule → Luce-Org/llama.cpp-dflash-ggml#14)
`ggml_cuda_flash_attn_sparse` converts Q/K/V on `ctx.stream()`, but pFlash launches on the **default stream** with no synchronization (ggml streams are non-blocking). At larger S the conversions hadn't completed when pFlash read them. This PR bumps the submodule to the event-based ordering fix.

### Test tolerance
Relaxed `1e-3 → 5e-3`. The sparse kernel emits **BF16**, whose ~2⁻⁸ precision floors the diff against the F16 dense reference at ~4e-3 — the old bound was below what BF16 can represent, so it could never pass even when correct.

## Result (on lucebox3 RTX 3090)

| S | before | after |
|---|---|---|
| 256 | 0.662 | **0.0046 PASS** |
| 1024 | 0.673 | **0.0037 PASS** |
| 4096 | 0.9998 | **0.0040 PASS** |

`ALL TESTS PASSED`.

## Notes
- **Depends on Luce-Org/llama.cpp-dflash-ggml#14** — the submodule pointer here points at that fix branch; finalize to the merged `luce-dflash` commit before merging.
- The submodule bump also advances `luce-dflash` `b896cf6 → 3890634` (already-merged PR #13).

🧙 Built with [WOZCODE](https://wozcode.com)