### PR TITLE
fix(test): update MockLayerSplitAdapter::decode_dflash for accept_rate signature

### DIFF
--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -1800,8 +1800,9 @@ struct MockLayerSplitAdapter : LayerSplitAdapter {
     bool supports_cpu_sampling() const override { return sampling_enabled; }
     bool decode_dflash(const std::vector<int32_t> & prompt, int base_pos,
                        int last_tok, int n_gen, std::vector<int32_t> & out_tokens,
-                       const DaemonIO & io) override {
+                       const DaemonIO & io, float & accept_rate_out) override {
         (void)prompt;
+        accept_rate_out = 0.0f;
         dflash_called = true;
         dflash_base = base_pos;
         dflash_last = last_tok;


### PR DESCRIPTION
## Problem

PR #321 added `float & accept_rate_out` to the `LayerSplitAdapter::decode_dflash` virtual (so the layer-split DFlash path reports its acceptance rate). The unit-test `MockLayerSplitAdapter` in `test_server_unit.cpp` still overrides the old signature, so the `test_server_unit` target no longer compiles:

```
test_server_unit.cpp:1801: error: 'bool MockLayerSplitAdapter::decode_dflash(...)' marked 'override', but does not override
```

The CI `Build` job does not compile `test_server_unit`, so this slipped through at merge time. `dflash_server` and the daemons are unaffected.

## Fix

Update the mock override to the new signature and set `accept_rate_out = 0.0f`. One-line behavioral no-op for the mock.

Verified on lucebox2: `cmake --build build-cuda --target test_server_unit` builds and `test_server_unit` passes (1836 assertions, 0 failures).

🧙 Built with [WOZCODE](https://wozcode.com)
