### PR TITLE
fix(server): guard status.html post-build on dflash_server target (unblock CI)

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -745,16 +745,21 @@ if(DFLASH27B_TESTS)
         endif()
 
         # Copy share/status.html next to the binary so it can be found at runtime.
-        add_custom_command(TARGET dflash_server POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E make_directory
-                "$<TARGET_FILE_DIR:dflash_server>/share"
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                "${CMAKE_CURRENT_SOURCE_DIR}/share/status.html"
-                "$<TARGET_FILE_DIR:dflash_server>/share/status.html"
-            COMMENT "Copying status.html to build/share/"
-        )
-        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/share/status.html"
-                DESTINATION share)
+        # Guard on the target: dflash_server is skipped when CURL is absent
+        # (e.g. CI without libcurl-dev), and referencing a missing target in
+        # add_custom_command/install is a hard CMake configure error.
+        if(TARGET dflash_server)
+            add_custom_command(TARGET dflash_server POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<TARGET_FILE_DIR:dflash_server>/share"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${CMAKE_CURRENT_SOURCE_DIR}/share/status.html"
+                    "$<TARGET_FILE_DIR:dflash_server>/share/status.html"
+                COMMENT "Copying status.html to build/share/"
+            )
+            install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/share/status.html"
+                    DESTINATION share)
+        endif()
     endif()
 
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/ipc/backend_ipc_main.cpp")


### PR DESCRIPTION
## Problem

`main` fails the CI **Build (cmake + uv sync --extra megakernel) → Build dflash (smoke + server)** step at configure time:

```
CMake Warning at CMakeLists.txt:723:  CURL not found — skipping dflash_server (passthrough proxy disabled)
CMake Error   at CMakeLists.txt:748 (add_custom_command):
  No TARGET 'dflash_server' has been created in this directory.
```

(e.g. run [27104177622](https://github.com/Luce-Org/lucebox-hub/actions/runs/27104177622/job/79990650664), surfaced on #322's CI.)

## Root cause — interaction of two already-merged PRs

The CI "Build dflash" job runs **without libcurl-dev** by design (`ci.yml`: *"Server unit tests require libcurl-dev; skipped when CURL is absent"*).

- **#294** (`fix(ci): make CURL optional`) made the server target conditional so a no-libcurl box wouldn't break:
  ```cmake
  find_package(CURL QUIET)
  if(NOT CURL_FOUND)
      message(WARNING "CURL not found — skipping dflash_server ...")
  else()
      add_executable(dflash_server ...)   # only exists when CURL is found
  endif()
  ```
- **#322** (`ensure status.html is found from build directory`) then added the status.html copy **after** that `endif()`, outside the guard:
  ```cmake
  add_custom_command(TARGET dflash_server POST_BUILD ...)
  install(FILES ".../status.html" DESTINATION share)
  ```

Neither change is wrong alone. Combined on `main`, when CURL is absent the target is skipped but the post-build copy still references it → hard configure error.

## Fix

Wrap the post-build copy + `install` in `if(TARGET dflash_server)` so they are only emitted when the target exists. This matches #294's intent (a no-CURL build simply skips the server and its post-build steps).

## Verification (clean `main` checkout, lucebox2, CUDA 12.6)

Reproduced the exact CI error with `-DCMAKE_DISABLE_FIND_PACKAGE_CURL=ON` on pristine `main`, then confirmed this patch fixes it:

| Scenario | Before | After |
|---|---|---|
| CURL disabled (= CI) | `No TARGET 'dflash_server'` → **Configuring incomplete** | target skipped → **Configuring done** |
| CURL present (= dev) | (unchanged) | `dflash_server` target created, status.html copied |

🧙 Built with [WOZCODE](https://wozcode.com)
