### PR TITLE
feat(server): add mixed-backend DFlash disk prefix cache for target layer split

### DIFF
--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -727,6 +727,7 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     ggml_tensor * dflash_feature_data = nullptr;
     Qwen35TargetShardSnapshotData remote_import;
     int max_remote_shard = -1;
+    std::vector<int> remote_tensor_counts;
     if (mixed_target_split) {
         remote_import.cur_pos = cur_pos;
         remote_import.last_tok = last_tok;
@@ -823,6 +824,10 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                     ggml_backend_tensor_get(t, remote_tensor.data.data(), 0, nbytes);
                     remote_import.tensors.push_back(std::move(remote_tensor));
                     max_remote_shard = std::max(max_remote_shard, remote_shard);
+                    if (remote_shard >= (int)remote_tensor_counts.size()) {
+                        remote_tensor_counts.resize((size_t)remote_shard + 1, 0);
+                    }
+                    remote_tensor_counts[(size_t)remote_shard]++;
                 }
             }
         }
@@ -863,6 +868,12 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
             return fail();
         }
         remote_import.shard_count = max_remote_shard + 1;
+        if (remote_tensor_counts.size() != (size_t)remote_import.shard_count) {
+            return fail();
+        }
+        for (int count : remote_tensor_counts) {
+            if (count <= 0) return fail();
+        }
         remote_import.logits = snapshot_prefill_logits_[(size_t)slot];
         if (!remote_target_shard_.snapshot_import(slot, remote_import)) {
             return fail();

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -726,11 +726,20 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     ggml_tensor * dflash_feature_meta = nullptr;
     ggml_tensor * dflash_feature_data = nullptr;
     Qwen35TargetShardSnapshotData remote_import;
-    int max_remote_shard = -1;
     std::vector<int> remote_tensor_counts;
     if (mixed_target_split) {
+        const size_t local_shard_count = shards_.size();
+        const size_t total_shard_count = cfg_.device.layer_split_gpus.size();
+        if (total_shard_count <= local_shard_count ||
+            total_shard_count - local_shard_count >
+                (size_t)std::numeric_limits<int>::max()) {
+            return false;
+        }
+        remote_import.shard_count =
+            (int)(total_shard_count - local_shard_count);
         remote_import.cur_pos = cur_pos;
         remote_import.last_tok = last_tok;
+        remote_tensor_counts.assign((size_t)remote_import.shard_count, 0);
     }
 
     auto fail = [&]() {
@@ -805,7 +814,7 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                 char * end = nullptr;
                 const long parsed = std::strtol(name + 2, &end, 10);
                 if (end && *end == '_' && parsed >= (long)shards_.size() &&
-                    parsed <= (long)std::numeric_limits<int>::max()) {
+                    parsed < (long)shards_.size() + remote_import.shard_count) {
                     const int remote_shard = (int)parsed - (int)shards_.size();
                     const char * raw_name = end + 1;
                     if (!raw_name[0] || t->type >= GGML_TYPE_COUNT) {
@@ -823,10 +832,6 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                     remote_tensor.data.assign(nbytes, 0);
                     ggml_backend_tensor_get(t, remote_tensor.data.data(), 0, nbytes);
                     remote_import.tensors.push_back(std::move(remote_tensor));
-                    max_remote_shard = std::max(max_remote_shard, remote_shard);
-                    if (remote_shard >= (int)remote_tensor_counts.size()) {
-                        remote_tensor_counts.resize((size_t)remote_shard + 1, 0);
-                    }
                     remote_tensor_counts[(size_t)remote_shard]++;
                 }
             }
@@ -864,10 +869,9 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                             sizeof(float) *
                                 snapshot_prefill_logits_[(size_t)slot].size());
     if (mixed_target_split) {
-        if (remote_import.tensors.empty() || max_remote_shard < 0) {
+        if (remote_import.tensors.empty()) {
             return fail();
         }
-        remote_import.shard_count = max_remote_shard + 1;
         if (remote_tensor_counts.size() != (size_t)remote_import.shard_count) {
             return fail();
         }

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string>
 
 namespace dflash::common {
@@ -395,7 +396,7 @@ bool Qwen35LayerSplitAdapter::snapshot_save(int slot) {
         snapshot_free(slot);
         return false;
     }
-    if (!use_mixed_target_split() && !rebuild_disk_snapshot(slot)) {
+    if (!rebuild_disk_snapshot(slot)) {
         snapshot_free(slot);
         return false;
     }
@@ -487,7 +488,7 @@ bool Qwen35LayerSplitAdapter::snapshot_restore(int slot) {
 }
 
 bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
-    if (!snapshot_slot_valid(slot) || use_mixed_target_split()) return false;
+    if (!snapshot_slot_valid(slot)) return false;
     if (disk_snapshot_contexts_.size() != (size_t)PREFIX_SLOTS ||
         disk_snapshot_buffers_.size() != (size_t)PREFIX_SLOTS ||
         disk_snapshot_backends_.size() != (size_t)PREFIX_SLOTS) {
@@ -507,6 +508,28 @@ bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
     }
 
     const auto & snaps = prefix_snapshots_[(size_t)slot];
+    const bool mixed_target_split = use_mixed_target_split();
+    Qwen35TargetShardSnapshotData remote_snapshot;
+    if (mixed_target_split) {
+        if (!remote_target_shard_.snapshot_export(slot, remote_snapshot) ||
+            remote_snapshot.shard_count <= 0 ||
+            remote_snapshot.cur_pos <= 0 ||
+            remote_snapshot.tensors.empty() ||
+            remote_snapshot.logits.empty()) {
+            return false;
+        }
+        if (snaps.empty() || !snaps.front().ctx ||
+            remote_snapshot.cur_pos != snaps.front().cur_pos) {
+            return false;
+        }
+        for (const auto & t : remote_snapshot.tensors) {
+            if (t.shard < 0 || t.shard >= remote_snapshot.shard_count ||
+                t.name.empty() || t.name.size() >= (size_t)GGML_MAX_NAME ||
+                t.type >= GGML_TYPE_COUNT || t.data.empty()) {
+                return false;
+            }
+        }
+    }
     const bool has_dflash_features = cfg_.run_dflash && cfg_.draft_path;
     const DraftFeatureSnapshot * draft_snap = nullptr;
     if (has_dflash_features) {
@@ -529,6 +552,7 @@ bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
             n_tensors++;
         }
     }
+    n_tensors += remote_snapshot.tensors.size();
 
     ggml_init_params ip{};
     ip.mem_size = ggml_tensor_overhead() * (n_tensors + 8) + 4096;
@@ -542,6 +566,12 @@ bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
     };
     std::vector<CopyPair> copies;
     copies.reserve(n_tensors);
+    struct RemoteCopy {
+        const Qwen35TargetShardSnapshotTensor * src = nullptr;
+        ggml_tensor * dst = nullptr;
+    };
+    std::vector<RemoteCopy> remote_copies;
+    remote_copies.reserve(remote_snapshot.tensors.size());
 
     for (size_t shard_idx = 0; shard_idx < snaps.size(); ++shard_idx) {
         const auto & snap = snaps[shard_idx];
@@ -557,6 +587,23 @@ bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
             ggml_set_name(dst, name.c_str());
             copies.push_back({src, dst});
         }
+    }
+    for (const auto & src : remote_snapshot.tensors) {
+        ggml_tensor * dst = ggml_new_tensor(
+            ctx, (ggml_type)src.type, 4, src.ne);
+        if (!dst) {
+            ggml_free(ctx);
+            return false;
+        }
+        if (ggml_nbytes(dst) != src.data.size()) {
+            ggml_free(ctx);
+            return false;
+        }
+        const std::string name =
+            "ls" + std::to_string(snaps.size() + (size_t)src.shard) +
+            "_" + src.name;
+        ggml_set_name(dst, name.c_str());
+        remote_copies.push_back({&src, dst});
     }
 
     const auto & logits = snapshot_prefill_logits_[(size_t)slot];
@@ -613,6 +660,10 @@ bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
             offset += chunk;
         }
     }
+    for (const RemoteCopy & cp : remote_copies) {
+        ggml_backend_tensor_set(cp.dst, cp.src->data.data(), 0,
+                                cp.src->data.size());
+    }
     ggml_backend_tensor_set(logits_t, logits.data(), 0,
                             sizeof(float) * logits.size());
     if (draft_meta_t && draft_data_t && draft_snap) {
@@ -636,9 +687,12 @@ bool Qwen35LayerSplitAdapter::rebuild_disk_snapshot(int slot) {
 
 ModelBackend::SnapshotRef Qwen35LayerSplitAdapter::snapshot_ref(int slot) const {
     ModelBackend::SnapshotRef ref;
-    if (use_mixed_target_split()) return ref;
     if (!snapshot_used(slot)) return ref;
     if (slot < 0 || slot >= (int)disk_snapshot_contexts_.size()) return ref;
+    if (!disk_snapshot_contexts_[(size_t)slot] ||
+        !disk_snapshot_buffers_[(size_t)slot]) {
+        return ref;
+    }
     ref.ctx = disk_snapshot_contexts_[(size_t)slot];
     ref.buf = disk_snapshot_buffers_[(size_t)slot];
     ref.cur_pos = snapshot_cur_pos(slot);
@@ -653,8 +707,8 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                                              ggml_backend_buffer_t buf,
                                              int cur_pos,
                                              int32_t last_tok) {
-    if (use_mixed_target_split() || !snapshot_slot_valid(slot) || !ctx ||
-        !buf || cur_pos <= 0) {
+    const bool mixed_target_split = use_mixed_target_split();
+    if (!snapshot_slot_valid(slot) || !ctx || !buf || cur_pos <= 0) {
         return false;
     }
     snapshot_free(slot);
@@ -671,12 +725,21 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     ggml_tensor * logits_tensor = nullptr;
     ggml_tensor * dflash_feature_meta = nullptr;
     ggml_tensor * dflash_feature_data = nullptr;
+    Qwen35TargetShardSnapshotData remote_import;
+    int max_remote_shard = -1;
+    if (mixed_target_split) {
+        remote_import.cur_pos = cur_pos;
+        remote_import.last_tok = last_tok;
+    }
 
     auto fail = [&]() {
         for (auto & snap : snaps) snap = PrefixSnapshot{};
         snapshot_prefill_logits_[(size_t)slot].clear();
         snapshot_prefill_logit_tensors_[(size_t)slot].clear();
         free_draft_feature_snapshot(slot);
+        if (mixed_target_split) {
+            remote_target_shard_.snapshot_free(slot);
+        }
         return false;
     };
 
@@ -735,6 +798,33 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                    shard_idx >= 0 && shard_idx < (int)shards_.size()) {
             snapshot_prefill_logit_tensors_[(size_t)slot][(size_t)shard_idx] = t;
             logits_tensor = t;
+        } else if (mixed_target_split) {
+            const char * name = t->name;
+            if (name[0] == 'l' && name[1] == 's') {
+                char * end = nullptr;
+                const long parsed = std::strtol(name + 2, &end, 10);
+                if (end && *end == '_' && parsed >= (long)shards_.size() &&
+                    parsed <= (long)std::numeric_limits<int>::max()) {
+                    const int remote_shard = (int)parsed - (int)shards_.size();
+                    const char * raw_name = end + 1;
+                    if (!raw_name[0] || t->type >= GGML_TYPE_COUNT) {
+                        return fail();
+                    }
+                    Qwen35TargetShardSnapshotTensor remote_tensor;
+                    remote_tensor.shard = remote_shard;
+                    remote_tensor.name = raw_name;
+                    remote_tensor.type = (uint32_t)t->type;
+                    for (int d = 0; d < 4; ++d) {
+                        remote_tensor.ne[d] = t->ne[d];
+                    }
+                    const size_t nbytes = ggml_nbytes(t);
+                    if (nbytes == 0) return fail();
+                    remote_tensor.data.assign(nbytes, 0);
+                    ggml_backend_tensor_get(t, remote_tensor.data.data(), 0, nbytes);
+                    remote_import.tensors.push_back(std::move(remote_tensor));
+                    max_remote_shard = std::max(max_remote_shard, remote_shard);
+                }
+            }
         }
     }
 
@@ -768,6 +858,16 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
                             0,
                             sizeof(float) *
                                 snapshot_prefill_logits_[(size_t)slot].size());
+    if (mixed_target_split) {
+        if (remote_import.tensors.empty() || max_remote_shard < 0) {
+            return fail();
+        }
+        remote_import.shard_count = max_remote_shard + 1;
+        remote_import.logits = snapshot_prefill_logits_[(size_t)slot];
+        if (!remote_target_shard_.snapshot_import(slot, remote_import)) {
+            return fail();
+        }
+    }
 
     if (cfg_.run_dflash && cfg_.draft_path) {
         if (!dflash_feature_meta || !dflash_feature_data ||
@@ -814,9 +914,15 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     disk_snapshot_contexts_[(size_t)slot] = ctx;
     disk_snapshot_buffers_[(size_t)slot] = buf;
     disk_snapshot_backends_[(size_t)slot] = nullptr;
-    std::fprintf(stderr,
-                 "[target-split] adopted disk snapshot slot=%d shards=%zu pos=%d\n",
-                 slot, shards_.size(), cur_pos);
+    if (mixed_target_split) {
+        std::fprintf(stderr,
+                     "[target-split] adopted disk snapshot slot=%d local_shards=%zu remote_shards=%d pos=%d\n",
+                     slot, shards_.size(), remote_import.shard_count, cur_pos);
+    } else {
+        std::fprintf(stderr,
+                     "[target-split] adopted disk snapshot slot=%d shards=%zu pos=%d\n",
+                     slot, shards_.size(), cur_pos);
+    }
     return true;
 }
 

--- a/server/src/qwen35/qwen35_target_shard_ipc.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc.cpp
@@ -534,17 +534,32 @@ bool Qwen35TargetShardIpcClient::snapshot_import(
     }
     const int32_t n_tensors = (int32_t)data.tensors.size();
     const int32_t logits_count = (int32_t)data.logits.size();
+    for (const auto & t : data.tensors) {
+        if (t.shard < 0 || t.shard >= data.shard_count ||
+            t.name.empty() || t.name.size() >= (size_t)GGML_MAX_NAME ||
+            t.data.size() > (size_t)std::numeric_limits<uint64_t>::max()) {
+            return false;
+        }
+    }
     std::fprintf(cmd, "prefix_snapshot_import %d %d %d %d %d %d\n",
                  slot, data.cur_pos, data.last_tok, data.shard_count,
                  n_tensors, logits_count);
     std::fflush(cmd);
 
+    int32_t status = -1;
+    if (!read_exact_fd(stream_fd, &status, sizeof(status)) || status != 0) {
+        return false;
+    }
+
     for (const auto & t : data.tensors) {
-        if (t.shard < 0 || t.shard >= data.shard_count ||
-            !write_snapshot_tensor_header_fd(payload_fd, t)) {
+        if (!write_snapshot_tensor_header_fd(payload_fd, t)) {
             return false;
         }
     }
+    if (!read_exact_fd(stream_fd, &status, sizeof(status)) || status != 0) {
+        return false;
+    }
+
     for (const auto & t : data.tensors) {
         if (!t.data.empty() &&
             !write_exact_fd(payload_fd, t.data.data(), t.data.size())) {
@@ -555,7 +570,6 @@ bool Qwen35TargetShardIpcClient::snapshot_import(
                         sizeof(float) * data.logits.size())) {
         return false;
     }
-    int32_t status = -1;
     return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
 #endif
 }

--- a/server/src/qwen35/qwen35_target_shard_ipc.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc.cpp
@@ -41,6 +41,52 @@ BackendIpcPayloadTransport target_shard_ipc_transport_from_env() {
     return transport;
 }
 
+bool write_snapshot_tensor_header_fd(int fd,
+                                     const Qwen35TargetShardSnapshotTensor & t) {
+    if (fd < 0 || t.shard < 0 || t.name.empty() ||
+        t.name.size() >= (size_t)GGML_MAX_NAME ||
+        t.data.size() > (size_t)std::numeric_limits<uint64_t>::max()) {
+        return false;
+    }
+    const int32_t shard = (int32_t)t.shard;
+    const int32_t name_len = (int32_t)t.name.size();
+    const uint32_t type = t.type;
+    const uint64_t nbytes = (uint64_t)t.data.size();
+    return write_exact_fd(fd, &shard, sizeof(shard)) &&
+           write_exact_fd(fd, &name_len, sizeof(name_len)) &&
+           write_exact_fd(fd, t.name.data(), (size_t)name_len) &&
+           write_exact_fd(fd, &type, sizeof(type)) &&
+           write_exact_fd(fd, t.ne, sizeof(t.ne)) &&
+           write_exact_fd(fd, &nbytes, sizeof(nbytes));
+}
+
+bool read_snapshot_tensor_header_fd(int fd,
+                                    Qwen35TargetShardSnapshotTensor & t) {
+    int32_t shard = -1;
+    int32_t name_len = 0;
+    uint32_t type = 0;
+    uint64_t nbytes = 0;
+    if (!read_exact_fd(fd, &shard, sizeof(shard)) ||
+        !read_exact_fd(fd, &name_len, sizeof(name_len)) ||
+        shard < 0 || name_len <= 0 || name_len >= GGML_MAX_NAME) {
+        return false;
+    }
+    std::string name((size_t)name_len, '\0');
+    if (!read_exact_fd(fd, name.data(), (size_t)name_len) ||
+        !read_exact_fd(fd, &type, sizeof(type)) ||
+        !read_exact_fd(fd, t.ne, sizeof(t.ne)) ||
+        !read_exact_fd(fd, &nbytes, sizeof(nbytes)) ||
+        nbytes > (uint64_t)std::numeric_limits<size_t>::max()) {
+        return false;
+    }
+    t.shard = shard;
+    t.name = std::move(name);
+    t.type = type;
+    t.data.clear();
+    t.data.resize((size_t)nbytes);
+    return true;
+}
+
 size_t target_shard_required_shared_bytes(int hidden, int max_tokens) {
     if (hidden <= 0 || max_tokens <= 0) return 0;
     size_t elements = 0;
@@ -411,6 +457,104 @@ bool Qwen35TargetShardIpcClient::snapshot_restore(int slot) {
     if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
     std::fprintf(cmd, "prefix_snapshot_restore %d\n", slot);
     std::fflush(cmd);
+    int32_t status = -1;
+    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
+#endif
+}
+
+bool Qwen35TargetShardIpcClient::snapshot_export(
+        int slot,
+        Qwen35TargetShardSnapshotData & out) {
+#if defined(_WIN32)
+    (void)slot; (void)out;
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
+    out = Qwen35TargetShardSnapshotData{};
+    std::fprintf(cmd, "prefix_snapshot_export %d\n", slot);
+    std::fflush(cmd);
+
+    int32_t status = -1;
+    int32_t cur_pos = 0;
+    int32_t last_tok = -1;
+    int32_t shard_count = 0;
+    int32_t n_tensors = 0;
+    int32_t logits_count = 0;
+    if (!read_exact_fd(stream_fd, &status, sizeof(status)) || status != 0 ||
+        !read_exact_fd(stream_fd, &cur_pos, sizeof(cur_pos)) ||
+        !read_exact_fd(stream_fd, &last_tok, sizeof(last_tok)) ||
+        !read_exact_fd(stream_fd, &shard_count, sizeof(shard_count)) ||
+        !read_exact_fd(stream_fd, &n_tensors, sizeof(n_tensors)) ||
+        !read_exact_fd(stream_fd, &logits_count, sizeof(logits_count)) ||
+        cur_pos <= 0 || shard_count <= 0 || n_tensors <= 0 ||
+        logits_count <= 0) {
+        return false;
+    }
+
+    out.shard_count = shard_count;
+    out.cur_pos = cur_pos;
+    out.last_tok = last_tok;
+    out.tensors.resize((size_t)n_tensors);
+    for (int32_t i = 0; i < n_tensors; ++i) {
+        if (!read_snapshot_tensor_header_fd(stream_fd, out.tensors[(size_t)i]) ||
+            out.tensors[(size_t)i].shard >= shard_count) {
+            return false;
+        }
+    }
+    for (auto & t : out.tensors) {
+        if (!t.data.empty() &&
+            !read_exact_fd(stream_fd, t.data.data(), t.data.size())) {
+            return false;
+        }
+    }
+    out.logits.assign((size_t)logits_count, 0.0f);
+    return read_exact_fd(stream_fd, out.logits.data(),
+                         sizeof(float) * out.logits.size());
+#endif
+}
+
+bool Qwen35TargetShardIpcClient::snapshot_import(
+        int slot,
+        const Qwen35TargetShardSnapshotData & data) {
+#if defined(_WIN32)
+    (void)slot; (void)data;
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    const int payload_fd = process_.payload_fd();
+    if (!active_ || !cmd || stream_fd < 0 || payload_fd < 0 || slot < 0 ||
+        data.shard_count <= 0 || data.cur_pos <= 0 ||
+        data.tensors.empty() || data.logits.empty() ||
+        data.tensors.size() > (size_t)std::numeric_limits<int32_t>::max() ||
+        data.logits.size() > (size_t)std::numeric_limits<int32_t>::max()) {
+        return false;
+    }
+    const int32_t n_tensors = (int32_t)data.tensors.size();
+    const int32_t logits_count = (int32_t)data.logits.size();
+    std::fprintf(cmd, "prefix_snapshot_import %d %d %d %d %d %d\n",
+                 slot, data.cur_pos, data.last_tok, data.shard_count,
+                 n_tensors, logits_count);
+    std::fflush(cmd);
+
+    for (const auto & t : data.tensors) {
+        if (t.shard < 0 || t.shard >= data.shard_count ||
+            !write_snapshot_tensor_header_fd(payload_fd, t)) {
+            return false;
+        }
+    }
+    for (const auto & t : data.tensors) {
+        if (!t.data.empty() &&
+            !write_exact_fd(payload_fd, t.data.data(), t.data.size())) {
+            return false;
+        }
+    }
+    if (!write_exact_fd(payload_fd, data.logits.data(),
+                        sizeof(float) * data.logits.size())) {
+        return false;
+    }
     int32_t status = -1;
     return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
 #endif

--- a/server/src/qwen35/qwen35_target_shard_ipc.h
+++ b/server/src/qwen35/qwen35_target_shard_ipc.h
@@ -18,6 +18,22 @@ struct Qwen35TargetCaptureSlice {
     std::vector<float> data;
 };
 
+struct Qwen35TargetShardSnapshotTensor {
+    int shard = -1;
+    std::string name;
+    uint32_t type = 0;
+    int64_t ne[4] = {1, 1, 1, 1};
+    std::vector<uint8_t> data;
+};
+
+struct Qwen35TargetShardSnapshotData {
+    int shard_count = 0;
+    int cur_pos = 0;
+    int32_t last_tok = -1;
+    std::vector<Qwen35TargetShardSnapshotTensor> tensors;
+    std::vector<float> logits;
+};
+
 class Qwen35TargetShardIpcClient {
 public:
     Qwen35TargetShardIpcClient() = default;
@@ -59,6 +75,8 @@ public:
     bool snapshot_save(int slot);
     void snapshot_free(int slot);
     bool snapshot_restore(int slot);
+    bool snapshot_export(int slot, Qwen35TargetShardSnapshotData & out);
+    bool snapshot_import(int slot, const Qwen35TargetShardSnapshotData & data);
 
     bool active() const { return active_; }
     void close();

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -796,8 +796,9 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                         free_prefix_snapshot(snap);
                     }
                     if (consumed_payload_bytes < payload_bytes) {
-                        ok = drain_exact_fd(
+                        const bool drained = drain_exact_fd(
                             payload_fd, payload_bytes - consumed_payload_bytes);
+                        if (!drained) break;
                     }
                 }
                 stream_status(stream_fd, ok ? 0 : -1);

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -89,6 +89,21 @@ bool read_snapshot_tensor_header_fd(int fd, IpcSnapshotTensor & t) {
     return true;
 }
 
+bool drain_exact_fd(int fd, uint64_t bytes) {
+    if (fd < 0) return false;
+    std::vector<uint8_t> tmp(4 * 1024 * 1024);
+    uint64_t done = 0;
+    while (done < bytes) {
+        const size_t chunk = (size_t)std::min<uint64_t>(
+            (uint64_t)tmp.size(), bytes - done);
+        if (!read_exact_fd(fd, tmp.data(), chunk)) {
+            return false;
+        }
+        done += chunk;
+    }
+    return true;
+}
+
 bool bind_snapshot_tensor(PrefixSnapshot & snap,
                           const TargetCache & cache,
                           ggml_tensor * tensor) {
@@ -657,33 +672,45 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                           shard_count == (int)shards.size() &&
                           n_tensors > 0 &&
                           logits_count > 0;
+                if (!stream_status(stream_fd, ok ? 0 : -1)) break;
+                if (!ok) {
+                    continue;
+                }
+
                 std::vector<IpcSnapshotTensor> table;
-                if (ok) {
-                    table.resize((size_t)n_tensors);
-                    std::vector<int> tensor_counts(shards.size(), 0);
-                    for (int i = 0; ok && i < n_tensors; ++i) {
-                        ok = read_snapshot_tensor_header_fd(
-                            payload_fd, table[(size_t)i]) &&
-                            table[(size_t)i].shard >= 0 &&
-                            table[(size_t)i].shard < shard_count &&
-                            table[(size_t)i].nbytes <=
-                                (uint64_t)std::numeric_limits<size_t>::max();
-                        if (ok) {
-                            tensor_counts[(size_t)table[(size_t)i].shard]++;
-                        }
+                table.resize((size_t)n_tensors);
+                std::vector<int> tensor_counts(shards.size(), 0);
+                uint64_t payload_bytes = 0;
+                for (int i = 0; ok && i < n_tensors; ++i) {
+                    ok = read_snapshot_tensor_header_fd(
+                        payload_fd, table[(size_t)i]) &&
+                        table[(size_t)i].shard >= 0 &&
+                        table[(size_t)i].shard < shard_count &&
+                        table[(size_t)i].nbytes <=
+                            (uint64_t)std::numeric_limits<size_t>::max() &&
+                        payload_bytes <=
+                            std::numeric_limits<uint64_t>::max() -
+                            table[(size_t)i].nbytes;
+                    if (ok) {
+                        tensor_counts[(size_t)table[(size_t)i].shard]++;
+                        payload_bytes += table[(size_t)i].nbytes;
                     }
-                    for (int count : tensor_counts) {
-                        if (count <= 0) ok = false;
-                    }
+                }
+                ok = ok && payload_bytes <=
+                               std::numeric_limits<uint64_t>::max() -
+                                   (uint64_t)logits_count * sizeof(float);
+                payload_bytes += (uint64_t)logits_count * sizeof(float);
+                for (int count : tensor_counts) {
+                    if (count <= 0) ok = false;
+                }
+                if (!stream_status(stream_fd, ok ? 0 : -1)) break;
+                if (!ok) {
+                    continue;
                 }
 
                 std::vector<PrefixSnapshot> imported;
                 if (ok) {
                     imported.resize(shards.size());
-                    std::vector<int> tensor_counts(shards.size(), 0);
-                    for (const auto & entry : table) {
-                        tensor_counts[(size_t)entry.shard]++;
-                    }
                     for (size_t shard_idx = 0; ok && shard_idx < shards.size(); ++shard_idx) {
                         auto & snap = imported[shard_idx];
                         snap.attn_k_snap.assign(shards[shard_idx].cache.attn_k.size(), nullptr);
@@ -728,6 +755,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                 }
 
                 std::vector<uint8_t> tmp(4 * 1024 * 1024);
+                uint64_t consumed_payload_bytes = 0;
                 if (ok) {
                     for (auto & entry : table) {
                         size_t offset = 0;
@@ -740,6 +768,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                                     entry.tensor, tmp.data(), offset, chunk);
                             }
                             offset += chunk;
+                            consumed_payload_bytes += chunk;
                         }
                     }
                 }
@@ -749,6 +778,10 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                     imported_logits.assign((size_t)logits_count, 0.0f);
                     ok = read_exact_fd(payload_fd, imported_logits.data(),
                                        sizeof(float) * imported_logits.size());
+                    if (ok) {
+                        consumed_payload_bytes +=
+                            (uint64_t)sizeof(float) * imported_logits.size();
+                    }
                 }
                 for (size_t shard_idx = 0; ok && shard_idx < shards.size(); ++shard_idx) {
                     ok = validate_snapshot_tensors(
@@ -761,6 +794,10 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                 } else {
                     for (auto & snap : imported) {
                         free_prefix_snapshot(snap);
+                    }
+                    if (consumed_payload_bytes < payload_bytes) {
+                        ok = drain_exact_fd(
+                            payload_fd, payload_bytes - consumed_payload_bytes);
                     }
                 }
                 stream_status(stream_fd, ok ? 0 : -1);

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -681,21 +681,30 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                 table.resize((size_t)n_tensors);
                 std::vector<int> tensor_counts(shards.size(), 0);
                 uint64_t payload_bytes = 0;
-                for (int i = 0; ok && i < n_tensors; ++i) {
-                    ok = read_snapshot_tensor_header_fd(
-                        payload_fd, table[(size_t)i]) &&
-                        table[(size_t)i].shard >= 0 &&
-                        table[(size_t)i].shard < shard_count &&
-                        table[(size_t)i].nbytes <=
+                bool headers_read = true;
+                for (int i = 0; i < n_tensors; ++i) {
+                    auto & entry = table[(size_t)i];
+                    if (!read_snapshot_tensor_header_fd(payload_fd, entry)) {
+                        headers_read = false;
+                        ok = false;
+                        break;
+                    }
+                    const bool valid =
+                        entry.shard >= 0 &&
+                        entry.shard < shard_count &&
+                        entry.nbytes <=
                             (uint64_t)std::numeric_limits<size_t>::max() &&
                         payload_bytes <=
                             std::numeric_limits<uint64_t>::max() -
-                            table[(size_t)i].nbytes;
-                    if (ok) {
-                        tensor_counts[(size_t)table[(size_t)i].shard]++;
-                        payload_bytes += table[(size_t)i].nbytes;
+                                entry.nbytes;
+                    if (!valid) {
+                        ok = false;
+                        continue;
                     }
+                    tensor_counts[(size_t)entry.shard]++;
+                    payload_bytes += entry.nbytes;
                 }
+                if (!headers_read) break;
                 ok = ok && payload_bytes <=
                                std::numeric_limits<uint64_t>::max() -
                                    (uint64_t)logits_count * sizeof(float);
@@ -756,33 +765,41 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
 
                 std::vector<uint8_t> tmp(4 * 1024 * 1024);
                 uint64_t consumed_payload_bytes = 0;
+                bool payload_read = true;
                 if (ok) {
                     for (auto & entry : table) {
                         size_t offset = 0;
                         const size_t nbytes = (size_t)entry.nbytes;
                         while (ok && offset < nbytes) {
                             const size_t chunk = std::min(tmp.size(), nbytes - offset);
-                            ok = read_exact_fd(payload_fd, tmp.data(), chunk);
-                            if (ok) {
-                                ggml_backend_tensor_set(
-                                    entry.tensor, tmp.data(), offset, chunk);
+                            if (!read_exact_fd(payload_fd, tmp.data(), chunk)) {
+                                payload_read = false;
+                                ok = false;
+                                break;
                             }
+                            ggml_backend_tensor_set(
+                                entry.tensor, tmp.data(), offset, chunk);
                             offset += chunk;
                             consumed_payload_bytes += chunk;
                         }
                     }
                 }
+                if (!payload_read) break;
 
                 std::vector<float> imported_logits;
                 if (ok) {
                     imported_logits.assign((size_t)logits_count, 0.0f);
-                    ok = read_exact_fd(payload_fd, imported_logits.data(),
-                                       sizeof(float) * imported_logits.size());
-                    if (ok) {
-                        consumed_payload_bytes +=
-                            (uint64_t)sizeof(float) * imported_logits.size();
+                    const size_t logits_bytes =
+                        sizeof(float) * imported_logits.size();
+                    if (!read_exact_fd(payload_fd, imported_logits.data(),
+                                       logits_bytes)) {
+                        payload_read = false;
+                        ok = false;
+                    } else {
+                        consumed_payload_bytes += (uint64_t)logits_bytes;
                     }
                 }
+                if (!payload_read) break;
                 for (size_t shard_idx = 0; ok && shard_idx < shards.size(); ++shard_idx) {
                     ok = validate_snapshot_tensors(
                         imported[shard_idx], shards[shard_idx].cache);

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -34,6 +35,120 @@
 #endif
 
 namespace dflash::common {
+
+namespace {
+
+struct IpcSnapshotTensor {
+    int shard = -1;
+    std::string name;
+    uint32_t type = 0;
+    int64_t ne[4] = {1, 1, 1, 1};
+    uint64_t nbytes = 0;
+    ggml_tensor * tensor = nullptr;
+};
+
+bool write_snapshot_tensor_header_fd(int fd,
+                                     int shard,
+                                     const ggml_tensor * t) {
+    if (fd < 0 || shard < 0 || !t || !t->name[0]) return false;
+    const size_t name_len_size = std::strlen(t->name);
+    if (name_len_size == 0 || name_len_size >= GGML_MAX_NAME) return false;
+    const int32_t shard_i = (int32_t)shard;
+    const int32_t name_len = (int32_t)name_len_size;
+    const uint32_t type = (uint32_t)t->type;
+    const uint64_t nbytes = (uint64_t)ggml_nbytes(t);
+    return write_exact_fd(fd, &shard_i, sizeof(shard_i)) &&
+           write_exact_fd(fd, &name_len, sizeof(name_len)) &&
+           write_exact_fd(fd, t->name, (size_t)name_len) &&
+           write_exact_fd(fd, &type, sizeof(type)) &&
+           write_exact_fd(fd, t->ne, sizeof(t->ne)) &&
+           write_exact_fd(fd, &nbytes, sizeof(nbytes));
+}
+
+bool read_snapshot_tensor_header_fd(int fd, IpcSnapshotTensor & t) {
+    int32_t shard = -1;
+    int32_t name_len = 0;
+    uint32_t type = 0;
+    uint64_t nbytes = 0;
+    if (!read_exact_fd(fd, &shard, sizeof(shard)) ||
+        !read_exact_fd(fd, &name_len, sizeof(name_len)) ||
+        shard < 0 || name_len <= 0 || name_len >= GGML_MAX_NAME) {
+        return false;
+    }
+    std::string name((size_t)name_len, '\0');
+    if (!read_exact_fd(fd, name.data(), (size_t)name_len) ||
+        !read_exact_fd(fd, &type, sizeof(type)) ||
+        !read_exact_fd(fd, t.ne, sizeof(t.ne)) ||
+        !read_exact_fd(fd, &nbytes, sizeof(nbytes))) {
+        return false;
+    }
+    t.shard = shard;
+    t.name = std::move(name);
+    t.type = type;
+    t.nbytes = nbytes;
+    return true;
+}
+
+bool bind_snapshot_tensor(PrefixSnapshot & snap,
+                          const TargetCache & cache,
+                          ggml_tensor * tensor) {
+    if (!tensor || !tensor->name[0]) return false;
+    int idx = -1;
+    if (std::sscanf(tensor->name, "snap_cache_k_%d", &idx) == 1 &&
+        idx >= 0 && idx < (int)snap.attn_k_snap.size()) {
+        snap.attn_k_snap[(size_t)idx] = tensor;
+        return true;
+    }
+    if (std::sscanf(tensor->name, "snap_cache_v_%d", &idx) == 1 &&
+        idx >= 0 && idx < (int)snap.attn_v_snap.size()) {
+        snap.attn_v_snap[(size_t)idx] = tensor;
+        return true;
+    }
+    if (std::sscanf(tensor->name, "snap_ssm_state_%d", &idx) == 1 &&
+        idx >= 0 && idx < (int)snap.ssm_state_snap.size()) {
+        snap.ssm_state_snap[(size_t)idx] = tensor;
+        return true;
+    }
+    if (std::sscanf(tensor->name, "snap_conv_state_%d", &idx) == 1 &&
+        idx >= 0 && idx < (int)snap.conv_state_snap.size()) {
+        snap.conv_state_snap[(size_t)idx] = tensor;
+        return true;
+    }
+    if (std::strcmp(tensor->name, "snap_target_feat") == 0) {
+        snap.target_feat_snap = tensor;
+        return cache.target_feat != nullptr;
+    }
+    return false;
+}
+
+bool validate_snapshot_tensors(const PrefixSnapshot & snap,
+                               const TargetCache & cache) {
+    for (size_t i = 0; i < snap.attn_k_snap.size(); ++i) {
+        const bool cache_has_kv =
+            (i < cache.attn_k.size() && cache.attn_k[i]) ||
+            (i < cache.attn_v.size() && cache.attn_v[i]);
+        if (cache_has_kv) {
+            if (i >= snap.attn_v_snap.size() ||
+                !snap.attn_k_snap[i] || !snap.attn_v_snap[i]) {
+                return false;
+            }
+        }
+    }
+    for (size_t i = 0; i < snap.ssm_state_snap.size(); ++i) {
+        const bool cache_has_state =
+            (i < cache.ssm_state.size() && cache.ssm_state[i]) ||
+            (i < cache.conv_state.size() && cache.conv_state[i]);
+        if (cache_has_state) {
+            if (i >= snap.conv_state_snap.size() ||
+                !snap.ssm_state_snap[i] || !snap.conv_state_snap[i]) {
+                return false;
+            }
+        }
+    }
+    return !cache.target_feat || snap.target_feat_snap;
+}
+
+}  // namespace
 
 int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                                        const std::vector<int> & gpus,
@@ -461,6 +576,192 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                 }
                 if (ok) {
                     prefill_last_logits = snapshot_logits[(size_t)slot];
+                }
+                stream_status(stream_fd, ok ? 0 : -1);
+                continue;
+            }
+            if (cmd == "prefix_snapshot_export") {
+                int slot = -1;
+                iss >> slot;
+                bool ok = prefix_slot_used(slot);
+                std::vector<std::pair<int, ggml_tensor *>> tensors;
+                int32_t cur_pos = 0;
+                int32_t last_tok = -1;
+                if (ok) {
+                    const auto & snaps = prefix_snapshots[(size_t)slot];
+                    cur_pos = snaps.front().cur_pos;
+                    last_tok = snaps.front().last_tok;
+                    for (size_t shard_idx = 0; shard_idx < snaps.size(); ++shard_idx) {
+                        const auto & snap = snaps[shard_idx];
+                        for (ggml_tensor * t = ggml_get_first_tensor(snap.ctx); t;
+                             t = ggml_get_next_tensor(snap.ctx, t)) {
+                            tensors.push_back({(int)shard_idx, t});
+                        }
+                    }
+                    ok = !tensors.empty() &&
+                         !snapshot_logits[(size_t)slot].empty() &&
+                         tensors.size() <= (size_t)std::numeric_limits<int32_t>::max() &&
+                         snapshot_logits[(size_t)slot].size() <=
+                             (size_t)std::numeric_limits<int32_t>::max();
+                }
+                if (!ok) {
+                    stream_status(stream_fd, -1);
+                    continue;
+                }
+
+                const int32_t status = 0;
+                const int32_t shard_count = (int32_t)shards.size();
+                const int32_t n_tensors = (int32_t)tensors.size();
+                const int32_t logits_count =
+                    (int32_t)snapshot_logits[(size_t)slot].size();
+                ok = write_exact_fd(stream_fd, &status, sizeof(status)) &&
+                     write_exact_fd(stream_fd, &cur_pos, sizeof(cur_pos)) &&
+                     write_exact_fd(stream_fd, &last_tok, sizeof(last_tok)) &&
+                     write_exact_fd(stream_fd, &shard_count, sizeof(shard_count)) &&
+                     write_exact_fd(stream_fd, &n_tensors, sizeof(n_tensors)) &&
+                     write_exact_fd(stream_fd, &logits_count, sizeof(logits_count));
+                for (const auto & entry : tensors) {
+                    ok = ok && write_snapshot_tensor_header_fd(
+                        stream_fd, entry.first, entry.second);
+                }
+                std::vector<uint8_t> tmp(4 * 1024 * 1024);
+                for (const auto & entry : tensors) {
+                    ggml_tensor * t = entry.second;
+                    const size_t nbytes = ggml_nbytes(t);
+                    size_t offset = 0;
+                    while (ok && offset < nbytes) {
+                        const size_t chunk = std::min(tmp.size(), nbytes - offset);
+                        ggml_backend_tensor_get(t, tmp.data(), offset, chunk);
+                        ok = write_exact_fd(stream_fd, tmp.data(), chunk);
+                        offset += chunk;
+                    }
+                }
+                const auto & logits = snapshot_logits[(size_t)slot];
+                ok = ok && write_exact_fd(stream_fd, logits.data(),
+                                          sizeof(float) * logits.size());
+                if (!ok) break;
+                continue;
+            }
+            if (cmd == "prefix_snapshot_import") {
+                int slot = -1;
+                int cur_pos = 0;
+                int last_tok = -1;
+                int shard_count = 0;
+                int n_tensors = 0;
+                int logits_count = 0;
+                iss >> slot >> cur_pos >> last_tok >> shard_count >>
+                    n_tensors >> logits_count;
+                bool ok = payload_fd >= 0 &&
+                          slot >= 0 && slot < ModelBackend::kMaxSlots &&
+                          cur_pos > 0 &&
+                          shard_count == (int)shards.size() &&
+                          n_tensors > 0 &&
+                          logits_count > 0;
+                std::vector<IpcSnapshotTensor> table;
+                if (ok) {
+                    table.resize((size_t)n_tensors);
+                    std::vector<int> tensor_counts(shards.size(), 0);
+                    for (int i = 0; ok && i < n_tensors; ++i) {
+                        ok = read_snapshot_tensor_header_fd(
+                            payload_fd, table[(size_t)i]) &&
+                            table[(size_t)i].shard >= 0 &&
+                            table[(size_t)i].shard < shard_count &&
+                            table[(size_t)i].nbytes <=
+                                (uint64_t)std::numeric_limits<size_t>::max();
+                        if (ok) {
+                            tensor_counts[(size_t)table[(size_t)i].shard]++;
+                        }
+                    }
+                    for (int count : tensor_counts) {
+                        if (count <= 0) ok = false;
+                    }
+                }
+
+                std::vector<PrefixSnapshot> imported;
+                if (ok) {
+                    imported.resize(shards.size());
+                    std::vector<int> tensor_counts(shards.size(), 0);
+                    for (const auto & entry : table) {
+                        tensor_counts[(size_t)entry.shard]++;
+                    }
+                    for (size_t shard_idx = 0; ok && shard_idx < shards.size(); ++shard_idx) {
+                        auto & snap = imported[shard_idx];
+                        snap.attn_k_snap.assign(shards[shard_idx].cache.attn_k.size(), nullptr);
+                        snap.attn_v_snap.assign(shards[shard_idx].cache.attn_v.size(), nullptr);
+                        snap.ssm_state_snap.assign(shards[shard_idx].cache.ssm_state.size(), nullptr);
+                        snap.conv_state_snap.assign(shards[shard_idx].cache.conv_state.size(), nullptr);
+                        snap.target_feat_snap = nullptr;
+                        snap.cur_pos = cur_pos;
+                        snap.last_tok = last_tok;
+                        snap.kv_k_type = shards[shard_idx].cache.kv_k_type;
+                        snap.max_ctx = shards[shard_idx].cache.max_ctx;
+                        snap.target_feat_cap = shards[shard_idx].cache.target_feat_cap;
+
+                        ggml_init_params ip{};
+                        ip.mem_size =
+                            ggml_tensor_overhead() *
+                            (size_t)(tensor_counts[shard_idx] + 16);
+                        ip.no_alloc = true;
+                        snap.ctx = ggml_init(ip);
+                        ok = snap.ctx != nullptr;
+                    }
+                    for (auto & entry : table) {
+                        if (!ok) break;
+                        PrefixSnapshot & snap = imported[(size_t)entry.shard];
+                        ggml_tensor * t = ggml_new_tensor(
+                            snap.ctx, (ggml_type)entry.type, 4, entry.ne);
+                        if (!t || ggml_nbytes(t) != (size_t)entry.nbytes) {
+                            ok = false;
+                            break;
+                        }
+                        ggml_set_name(t, entry.name.c_str());
+                        entry.tensor = t;
+                        ok = bind_snapshot_tensor(
+                            snap, shards[(size_t)entry.shard].cache, t);
+                    }
+                    for (size_t shard_idx = 0; ok && shard_idx < shards.size(); ++shard_idx) {
+                        auto & snap = imported[shard_idx];
+                        snap.buf = ggml_backend_alloc_ctx_tensors(
+                            snap.ctx, snapshot_backends[shard_idx]);
+                        ok = snap.buf != nullptr;
+                    }
+                }
+
+                std::vector<uint8_t> tmp(4 * 1024 * 1024);
+                if (ok) {
+                    for (auto & entry : table) {
+                        size_t offset = 0;
+                        const size_t nbytes = (size_t)entry.nbytes;
+                        while (ok && offset < nbytes) {
+                            const size_t chunk = std::min(tmp.size(), nbytes - offset);
+                            ok = read_exact_fd(payload_fd, tmp.data(), chunk);
+                            if (ok) {
+                                ggml_backend_tensor_set(
+                                    entry.tensor, tmp.data(), offset, chunk);
+                            }
+                            offset += chunk;
+                        }
+                    }
+                }
+
+                std::vector<float> imported_logits;
+                if (ok) {
+                    imported_logits.assign((size_t)logits_count, 0.0f);
+                    ok = read_exact_fd(payload_fd, imported_logits.data(),
+                                       sizeof(float) * imported_logits.size());
+                }
+                for (size_t shard_idx = 0; ok && shard_idx < shards.size(); ++shard_idx) {
+                    ok = validate_snapshot_tensors(
+                        imported[shard_idx], shards[shard_idx].cache);
+                }
+                if (ok) {
+                    free_prefix_slot(slot);
+                    prefix_snapshots[(size_t)slot] = std::move(imported);
+                    snapshot_logits[(size_t)slot] = std::move(imported_logits);
+                } else {
+                    for (auto & snap : imported) {
+                        free_prefix_snapshot(snap);
+                    }
                 }
                 stream_status(stream_fd, ok ? 0 : -1);
                 continue;

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -140,13 +140,6 @@ static bool validate_server_placement(const BackendArgs & bargs,
     const bool mixed_target_split =
         bargs.device.is_layer_split() && bargs.device.is_mixed_layer_split();
     if (mixed_target_split) {
-        if (!sconfig.disk_cache_dir.empty()) {
-            std::fprintf(stderr,
-                "[server] --kv-cache-dir is not supported with mixed-backend "
-                "target layer split yet; remote shard disk snapshot/restore "
-                "needs IPC export/import support\n");
-            return false;
-        }
         if (!bargs.remote_target_shard.enabled()) {
             std::fprintf(stderr,
                 "[server] mixed-backend target layer split requires "


### PR DESCRIPTION
## Summary

This PR is the mixed-backend follow-up to #325. #325 restored disk prefix cache for same-backend target layer split; this PR adds the missing remote-shard snapshot export/import path for CUDA/HIP mixed-backend target split. With this change, placements such as `--target-devices cuda:0,hip:0,hip:1` can be used together with `--kv-cache-dir`, and a restarted server can restore the split target state from disk prefix cache.

Previously, mixed-backend target split could not safely enable disk cache because the target prefix state does not live only in the parent process. The parent can write its local shard into the disk snapshot, but the remote HIP/CUDA shards live inside the backend IPC daemon. Without remote shard snapshot IPC, disk restore could only recover the parent-local part and would leave the split target state incomplete.

This PR makes remote shard snapshots an explicit IPC operation. On save, the parent asks the remote target shard daemon to export its snapshot tensors, then writes them into the same disk snapshot as the local shard tensors, `snap_prefill_logits`, and the DFlash feature mirror. On load, the parent splits remote shard tensors back out of the disk snapshot and imports them into the remote daemon. DFlash target restore and feature-mirror restore stay in the same snapshot, so speculative decode can continue after disk restore.

## Changes

- Adds Qwen35 remote target shard snapshot IPC:
  - adds `prefix_snapshot_export` to export shard-local snapshot tensors and logits from the remote target shard daemon;
  - adds `prefix_snapshot_import` to rebuild disk-loaded remote tensors into a remote daemon prefix snapshot slot;
  - includes shard id, tensor name, dtype, shape, and payload size in each snapshot tensor header, with import-time validation that shape/type match the payload size.
- Extends the Qwen35 layer-split disk snapshot:
  - same-backend still stores local `ls<shard>_<tensor-name>` tensors;
  - mixed-backend additionally stores remote shard tensors after the local shard index range;
  - restore adopts local shards back into the parent adapter and imports remote shard tensors back into the backend IPC daemon;
  - keeps `snap_prefill_logits`, `dflash_feature_meta`, and `dflash_feature_data`, so DFlash disk restore does not degrade into a target-only partial state.
- Updates server placement validation to allow `--kv-cache-dir` with mixed-backend `--target-devices`; remote target shard IPC still has to be provided explicitly.

## Notes

- Local runtime validation passed on Tesla P4 CUDA + dual Pro VII HIP with Qwen3.6-27B Q4 target, the Qwen3.6 DFlash draft, and `--target-devices cuda:0,hip:0,hip:1 --target-layer-split 0.08,0.46,0.46`. The first server process saved disk prefix cache; after a cold restart, the second process hit disk cache and logged `[target-split] adopted disk snapshot slot=63 local_shards=1 remote_shards=2 pos=10`, `disk_hit=true`, `restore=true`, and DFlash speculative decode with accepted draft tokens.
- Remote runtime validation also passed on RTX 3090 CUDA + Radeon 8060S Strix Halo HIP/gfx1151 with Qwen3.6-27B Q4 target, the Qwen3.6 DFlash draft, and `--target-devices cuda:0,hip:0 --target-layer-split 0.5,0.5`. The second cold start scanned the disk cache and logged `[target-split] adopted disk snapshot slot=63 local_shards=1 remote_shards=1 pos=10`, `disk_hit=true`, `restore=true`; DFlash continued speculative decode with accepted draft tokens after restore.
