### PR TITLE
fix(build): make CURL optional so dflash_server links without libcurl

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -721,34 +721,34 @@ if(DFLASH27B_TESTS)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/server/server_main.cpp")
         find_package(CURL QUIET)
         if(NOT CURL_FOUND)
-            message(WARNING "CURL not found — skipping dflash_server (passthrough proxy disabled)")
+            message(WARNING "CURL not found — building dflash_server without passthrough proxy")
+        endif()
+        add_executable(dflash_server
+            src/server/server_main.cpp
+            src/server/http_server.cpp
+            src/server/model_card.cpp
+        )
+        target_include_directories(dflash_server PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+        if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+            target_compile_definitions(dflash_server PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
         else()
-            add_executable(dflash_server
-                src/server/server_main.cpp
-                src/server/http_server.cpp
-                src/server/model_card.cpp
-            )
-            target_include_directories(dflash_server PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
-            if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
-                target_compile_definitions(dflash_server PRIVATE DFLASH27B_BACKEND_HIP=1 GGML_USE_HIP)
-            else()
-                target_compile_definitions(dflash_server PRIVATE
-                    DFLASH27B_BACKEND_CUDA=1
-                    DFLASH27B_CUDA_MIN_SM=${_dflash_cuda_min_sm})
-            endif()
-            target_link_libraries(dflash_server PRIVATE dflash_common ggml ${DFLASH27B_GGML_BACKEND_TARGET} pthread CURL::libcurl)
-            if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
-                find_package(CUDAToolkit REQUIRED)
-                target_link_libraries(dflash_server PRIVATE CUDA::cudart)
-            else()
-                target_link_libraries(dflash_server PRIVATE hip::host)
-            endif()
+            target_compile_definitions(dflash_server PRIVATE
+                DFLASH27B_BACKEND_CUDA=1
+                DFLASH27B_CUDA_MIN_SM=${_dflash_cuda_min_sm})
+        endif()
+        target_link_libraries(dflash_server PRIVATE dflash_common ggml ${DFLASH27B_GGML_BACKEND_TARGET} pthread)
+        if(CURL_FOUND)
+            target_compile_definitions(dflash_server PRIVATE DFLASH_HAS_CURL=1)
+            target_link_libraries(dflash_server PRIVATE CURL::libcurl)
+        endif()
+        if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+            find_package(CUDAToolkit REQUIRED)
+            target_link_libraries(dflash_server PRIVATE CUDA::cudart)
+        else()
+            target_link_libraries(dflash_server PRIVATE hip::host)
         endif()
 
         # Copy share/status.html next to the binary so it can be found at runtime.
-        # Guard on the target: dflash_server is skipped when CURL is absent
-        # (e.g. CI without libcurl-dev), and referencing a missing target in
-        # add_custom_command/install is a hard CMake configure error.
         if(TARGET dflash_server)
             add_custom_command(TARGET dflash_server POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E make_directory

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -7,7 +7,9 @@
 #include "sse_emitter.h"
 #include "tool_hint.h"
 
+#ifdef DFLASH_HAS_CURL
 #include <curl/curl.h>
+#endif
 
 #include <algorithm>
 #include <cerrno>
@@ -49,6 +51,7 @@ static float pflash_keep_ratio(const ServerConfig & cfg, int n_tokens) {
 }
 
 // ─── curl helpers for upstream proxy ─────────────────────────────────────
+#ifdef DFLASH_HAS_CURL
 
 struct CurlWriteCtx {
     int client_fd;
@@ -242,6 +245,7 @@ static bool curl_forward(int client_fd, const std::string & url,
     curl_easy_cleanup(curl);
     return res == CURLE_OK;
 }
+#endif // DFLASH_HAS_CURL
 
 // ─── /props constants ───────────────────────────────────────────────────
 //
@@ -770,7 +774,9 @@ HttpServer::HttpServer(ModelBackend & backend,
                    config.disk_cache_continued_interval,
                    config.disk_cache_cold_max_tokens}, backend)
 {
+    #ifdef DFLASH_HAS_CURL
     curl_global_init(CURL_GLOBAL_DEFAULT);
+    #endif
     disk_cache_.init();
     status_html_path_ = resolve_status_html();
 }
@@ -906,7 +912,9 @@ void HttpServer::sse_heartbeat() {
 
 HttpServer::~HttpServer() {
     shutdown();
+    #ifdef DFLASH_HAS_CURL
     curl_global_cleanup();
+    #endif
 }
 
 void HttpServer::shutdown() {
@@ -1857,6 +1865,7 @@ void HttpServer::worker_loop() {
         }
 
         // ── Upstream proxy: forward to remote server if configured ────
+#ifdef DFLASH_HAS_CURL
         if (!config_.pflash_upstream_base.empty()) {
             const std::string & upstream = config_.pflash_upstream_base;
             const std::string & upstream_key = config_.pflash_upstream_key;
@@ -1905,6 +1914,7 @@ void HttpServer::worker_loop() {
             finish_job();
             continue;
         }
+#endif // DFLASH_HAS_CURL
 
         // Build generate request.
         //


### PR DESCRIPTION
Re-carved from #274 as a standalone change off current `main`.

Gates all libcurl usage in `http_server.cpp` behind `DFLASH_HAS_CURL`; CMake builds `dflash_server` unconditionally and only defines the macro + links `CURL::libcurl` when `find_package(CURL)` succeeds. Without libcurl the passthrough proxy compiles out and the server still builds.

Re-carved (not cherry-picked): #294's passthrough-proxy added two `curl_forward` call sites (`http_server.cpp:1888`, `:1909`) beyond the original commit; both are now gated.

Verified on a box without libcurl-dev: `cmake` configure succeeds and `http_server.cpp` compiles clean with `DFLASH_HAS_CURL` undefined. 2 files, +34/-24.