### PR TITLE
ci: run self-hosted GPU tests on fork PRs (behind run approval)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,14 +115,12 @@ jobs:
     # kernels for sm_86 but execute on GPU-less VMs, so the kernel never runs.
     # This job lands on lucebox3 (RTX 3090) and actually executes it.
     #
-    # SECURITY: a self-hosted runner must never execute untrusted fork code.
-    # This guard restricts the job to same-repo PRs (head repo == this repo)
-    # and manual dispatch, so fork PRs against this public repo skip it
-    # entirely and never run on the box. The ubuntu-latest jobs above still
-    # run for forks (safe, ephemeral GitHub VMs).
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    # SECURITY: fork PRs DO run here, but only after a maintainer approves the
+    # workflow run. The repo enforces approval_policy=all_external_contributors,
+    # so every push from an outside collaborator parks the run as
+    # action_required until a maintainer reviews the diff and approves it.
+    # That human checkpoint is the line of defense for the self-hosted box;
+    # do not weaken the approval policy while this job runs fork code.
     # Gate only on the 1-minute workspace check, NOT the ~18-minute hosted
     # CPU build: the GPU job compiles the same tree itself in ~2 minutes on
     # real hardware, so serializing it behind the cloud build only delayed
@@ -190,11 +188,8 @@ jobs:
     # faults on gfx1151); hipcc is not on the runner's minimal PATH, so it is
     # invoked by absolute path.
     #
-    # SECURITY: same fork guard as gpu-tests - never execute untrusted fork
-    # code on the self-hosted box. Fork PRs skip this job.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    # SECURITY: same model as gpu-tests - fork PRs run only after a maintainer
+    # approves the workflow run (approval_policy=all_external_contributors).
     # Gate only on the 1-minute workspace check, NOT the ~18-minute hosted
     # CPU build: the GPU job compiles the same tree itself in ~2 minutes on
     # real hardware, so serializing it behind the cloud build only delayed


### PR DESCRIPTION
The `gpu-tests` (RTX 3090, sm_86) and `gpu-tests-amd` (Radeon 8060S, gfx1151) jobs were guarded to same-repo PRs, so fork PRs (e.g. #349) skipped both — losing the only real-hardware signal exactly where it matters most.

This removes the same-repo guard and relies on the repo's existing `approval_policy=all_external_contributors`: every fork push parks as `action_required` until a maintainer reviews and approves the run, for hosted and self-hosted jobs alike. Nothing runs on lucebox3 without a human green-light.

- Fork PR flow: push → maintainer approves run → GPU jobs execute on lucebox3
- `workflow_dispatch` no longer needed as an escape hatch (jobs run on the PR event itself)
- Both jobs keep the `lucebox3-gpu-runner` concurrency group (serialized on the single box)

🧙 Built with [WOZCODE](https://wozcode.com)