### PR TITLE
feat(server): add scoped disk prefix cache policy

### DIFF
--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -956,6 +956,19 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
         start += n_tokens;
     }
 
+    // End-of-prefill snapshot: scoped disk-cache saves (auto/fixed policy)
+    // request snap_pos == prompt end, which never falls inside a chunk so the
+    // boundary branch above cannot fire. Taking the snapshot here changes
+    // nothing about the prefill computation; it only persists the final state
+    // (cache_.cur_pos == committed).
+    if (snap_slot >= 0 && snap_pos == committed) {
+        if (snapshot_save(snap_slot)) {
+            std::printf("[snap] end-of-prefill slot=%d cur_pos=%d\n",
+                        snap_slot, committed);
+            std::fflush(stdout);
+        }
+    }
+
     return committed;
 }
 

--- a/server/src/server/disk_prefix_cache.cpp
+++ b/server/src/server/disk_prefix_cache.cpp
@@ -8,8 +8,10 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <cctype>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <dirent.h>
@@ -100,6 +102,118 @@ static bool mkdir_p(const std::string & path) {
 
 static uint64_t now_unix() {
     return (uint64_t)std::time(nullptr);
+}
+
+const char * disk_prefix_cache_mode_name(DiskPrefixCacheMode mode) {
+    switch (mode) {
+        case DiskPrefixCacheMode::Off:   return "off";
+        case DiskPrefixCacheMode::Full:  return "full";
+        case DiskPrefixCacheMode::Auto:  return "auto";
+        case DiskPrefixCacheMode::Fixed: return "fixed";
+    }
+    return "full";
+}
+
+std::string disk_prefix_cache_policy_name(const DiskPrefixCachePolicy & policy) {
+    if (policy.mode == DiskPrefixCacheMode::Fixed) {
+        return "fixed:" + std::to_string(policy.fixed_tokens);
+    }
+    if (policy.mode == DiskPrefixCacheMode::Auto) {
+        return "auto:" + std::to_string(policy.auto_window);
+    }
+    return disk_prefix_cache_mode_name(policy.mode);
+}
+
+bool parse_disk_prefix_cache_policy(const std::string & value,
+                                    DiskPrefixCachePolicy & out) {
+    std::string v;
+    v.reserve(value.size());
+    for (char c : value) v.push_back((char)std::tolower((unsigned char)c));
+
+    if (v == "off" || v == "none" || v == "disabled") {
+        out = {};
+        out.mode = DiskPrefixCacheMode::Off;
+        return true;
+    }
+    if (v == "full" || v == "full-prefix") {
+        out = {};
+        out.mode = DiskPrefixCacheMode::Full;
+        return true;
+    }
+    if (v == "auto") {
+        out = {};
+        out.mode = DiskPrefixCacheMode::Auto;
+        return true;
+    }
+
+    const std::string auto_prefix = "auto:";
+    if (v.rfind(auto_prefix, 0) == 0) {
+        char * end = nullptr;
+        long n = std::strtol(v.c_str() + auto_prefix.size(), &end, 10);
+        if (!end || *end != '\0' || n <= 0 || n > 1000000) return false;
+        out = {};
+        out.mode = DiskPrefixCacheMode::Auto;
+        out.auto_window = (int)n;
+        return true;
+    }
+
+    char * end = nullptr;
+    long n = std::strtol(v.c_str(), &end, 10);
+    if (end && *end == '\0' && n > 0 && n <= 1000000) {
+        out = {};
+        out.mode = DiskPrefixCacheMode::Fixed;
+        out.fixed_tokens = (int)n;
+        return true;
+    }
+    return false;
+}
+
+static bool valid_boundary(int n, int full_len) {
+    return n > 0 && n <= full_len;
+}
+
+int disk_prefix_cache_fixed_boundary(const DiskPrefixCachePolicy & policy,
+                                     int full_len,
+                                     int min_tokens) {
+    if (policy.mode != DiskPrefixCacheMode::Fixed) return 0;
+    if (policy.fixed_tokens < min_tokens) return 0;
+    return valid_boundary(policy.fixed_tokens, full_len) ? policy.fixed_tokens : 0;
+}
+
+static int lcp_len(const std::vector<int32_t> & a,
+                   const std::vector<int32_t> & b) {
+    const int n = std::min((int)a.size(), (int)b.size());
+    int i = 0;
+    while (i < n && a[(size_t)i] == b[(size_t)i]) i++;
+    return i;
+}
+
+static int floor_to_safe_boundary(int n, const std::vector<int> & safe_boundaries) {
+    if (n <= 0) return 0;
+    if (safe_boundaries.empty()) return n;
+
+    int best = 0;
+    for (int b : safe_boundaries) {
+        if (b > 0 && b <= n) best = std::max(best, b);
+    }
+    return best;
+}
+
+int disk_prefix_cache_auto_boundary(
+    const std::vector<int32_t> & prompt_ids,
+    const std::vector<std::vector<int32_t>> & recent_prompts,
+    int window,
+    const std::vector<int> & safe_boundaries,
+    int min_tokens) {
+    if (prompt_ids.empty() || recent_prompts.empty() || window <= 0) return 0;
+
+    const int n_recent = std::min(window, (int)recent_prompts.size());
+    int common = 0;
+    for (int i = 0; i < n_recent; ++i) {
+        common = std::max(common, lcp_len(prompt_ids, recent_prompts[(size_t)i]));
+    }
+    common = floor_to_safe_boundary(common, safe_boundaries);
+    return common >= min_tokens ? common : 0;
 }
 
 // Little-endian I/O helpers.

--- a/server/src/server/disk_prefix_cache.h
+++ b/server/src/server/disk_prefix_cache.h
@@ -33,6 +33,33 @@ struct DiskCacheConfig {
     int         cold_max_tokens = 10240;    // create cold checkpoint for prompts longer than this
 };
 
+enum class DiskPrefixCacheMode {
+    Off,
+    Full,
+    Auto,
+    Fixed,
+};
+
+struct DiskPrefixCachePolicy {
+    DiskPrefixCacheMode mode = DiskPrefixCacheMode::Full;
+    int fixed_tokens = 0;
+    int auto_window = 30;
+};
+
+const char * disk_prefix_cache_mode_name(DiskPrefixCacheMode mode);
+std::string disk_prefix_cache_policy_name(const DiskPrefixCachePolicy & policy);
+bool parse_disk_prefix_cache_policy(const std::string & value,
+                                    DiskPrefixCachePolicy & out);
+int disk_prefix_cache_fixed_boundary(const DiskPrefixCachePolicy & policy,
+                                     int full_len,
+                                     int min_tokens = 1);
+int disk_prefix_cache_auto_boundary(
+    const std::vector<int32_t> & prompt_ids,
+    const std::vector<std::vector<int32_t>> & recent_prompts,
+    int window,
+    const std::vector<int> & safe_boundaries,
+    int min_tokens);
+
 // ─── File header (80 bytes, little-endian) ──────────────────────────────
 
 struct DiskCacheHeader {

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -578,6 +578,7 @@ json build_props_body(const ServerConfig & config,
             {"in_use",        pcfs.in_use},
             {"disk_bytes",    pcfs.disk_bytes},
             {"lifetime_hits", pcfs.lifetime_hits},
+            {"disk_policy",   disk_prefix_cache_policy_name(config.disk_cache_policy)},
         }},
         {"tool_replay", {
             {"max_entries",     tms.max_entries},
@@ -1275,6 +1276,7 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         // Common fields.
         req.stream = body.value("stream", false);
         req.model = body.value("model", config_.model_name);
+        req.disk_cache_policy = config_.disk_cache_policy;
         // Default when client omits all three: use --default-max-tokens
         // (16000, matches ds4_eval.c). Codex review flagged that
         // --default-max-tokens was previously a dead flag because the
@@ -1329,6 +1331,28 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         // Tool choice constraint for hint generation.
         if (body.contains("tool_choice")) {
             req.tool_choice = body["tool_choice"];
+        }
+
+        if (body.contains("prefix_cache") && body["prefix_cache"].is_object()) {
+            const auto & pc = body["prefix_cache"];
+            if (pc.contains("scope") && pc["scope"].is_string()) {
+                DiskPrefixCachePolicy parsed_policy;
+                if (!parse_disk_prefix_cache_policy(pc["scope"].get<std::string>(),
+                                                    parsed_policy)) {
+                    send_error(fd, 400,
+                        "prefix_cache.scope must be off, full, auto, auto:<window>, or a positive token count");
+                    return true;
+                }
+                req.disk_cache_policy = parsed_policy;
+            }
+            if (pc.contains("window") && pc["window"].is_number_integer()) {
+                const int window = pc["window"].get<int>();
+                if (window <= 0 || window > 1000000) {
+                    send_error(fd, 400, "prefix_cache.window must be a positive integer");
+                    return true;
+                }
+                req.disk_cache_policy.auto_window = window;
+            }
         }
 
         // Stop sequences — OpenAI uses "stop" (string or array), Anthropic uses "stop_sequences" (array).
@@ -2041,14 +2065,127 @@ void HttpServer::worker_loop() {
         // so slot 63 is safe as long as total cache slots < 63.
         static constexpr int DISK_STAGING_SLOT = ModelBackend::kMaxSlots - 1;
         bool disk_hit = false;
+        DiskPrefixCachePolicy disk_policy = req.disk_cache_policy;
+        if (pflash_compressed) {
+            // Auto/fixed boundaries are selected against the uncompressed
+            // request stream. Once PFlash rewrites effective_prompt, only
+            // exact full-cache restore remains well-defined.
+            if (disk_policy.mode != DiskPrefixCacheMode::Full) {
+                disk_policy.mode = DiskPrefixCacheMode::Off;
+            }
+        }
+        std::vector<int> safe_boundaries;
+        if (disk_policy.mode == DiskPrefixCacheMode::Auto) {
+            safe_boundaries =
+                find_all_boundaries(effective_prompt, prefix_cache_.chat_markers());
+        }
+        int selected_prefix_boundary = 0;
+        if (disk_policy.mode == DiskPrefixCacheMode::Fixed) {
+            selected_prefix_boundary =
+                disk_prefix_cache_fixed_boundary(
+                    disk_policy, (int)effective_prompt.size(),
+                    config_.disk_cache_min_tokens);
+        } else if (disk_policy.mode == DiskPrefixCacheMode::Auto) {
+            selected_prefix_boundary =
+                disk_prefix_cache_auto_boundary(
+                    effective_prompt, recent_disk_prompts_, disk_policy.auto_window,
+                    safe_boundaries, config_.disk_cache_min_tokens);
+            std::fprintf(stderr,
+                "[disk-cache] auto scope: window=%d recent=%zu safe=%zu selected=%d\n",
+                disk_policy.auto_window,
+                std::min(recent_disk_prompts_.size(), (size_t)disk_policy.auto_window),
+                safe_boundaries.size(), selected_prefix_boundary);
+        }
+        std::vector<int> disk_lookup_lengths;
+        if (disk_policy.mode == DiskPrefixCacheMode::Full &&
+            !effective_prompt.empty()) {
+            disk_lookup_lengths.push_back((int)effective_prompt.size());
+            if ((int)effective_prompt.size() > config_.disk_cache_cold_max_tokens) {
+                auto boundaries =
+                    find_all_boundaries(effective_prompt, prefix_cache_.chat_markers());
+                int cold_boundary = 0;
+                for (int b : boundaries) {
+                    if (b <= config_.disk_cache_cold_max_tokens &&
+                        b >= config_.disk_cache_min_tokens) {
+                        cold_boundary = b;
+                    }
+                }
+                if (cold_boundary > 0 &&
+                    cold_boundary != (int)effective_prompt.size()) {
+                    disk_lookup_lengths.push_back(cold_boundary);
+                }
+            }
+        } else if (selected_prefix_boundary > 0) {
+            disk_lookup_lengths.push_back(selected_prefix_boundary);
+        } else if (disk_policy.mode == DiskPrefixCacheMode::Auto) {
+            for (auto it = safe_boundaries.rbegin(); it != safe_boundaries.rend(); ++it) {
+                const int b = *it;
+                if (b >= config_.disk_cache_min_tokens &&
+                    b <= (int)effective_prompt.size()) {
+                    disk_lookup_lengths.push_back(b);
+                }
+            }
+        }
         if (!using_restore && !disk_cache_.disabled()) {
-            if (disk_cache_.lookup(effective_prompt, DISK_STAGING_SLOT)) {
-                cache_slot = DISK_STAGING_SLOT;
-                prefix_len = backend_.snapshot_cur_pos(DISK_STAGING_SLOT);
-                using_restore = true;
-                disk_hit = true;
-                std::fprintf(stderr, "[disk-cache] hit, loaded to slot=%d pos=%d\n",
-                             DISK_STAGING_SLOT, prefix_len);
+            for (int lookup_len : disk_lookup_lengths) {
+                std::vector<int32_t> prefix_tokens(
+                    effective_prompt.begin(), effective_prompt.begin() + lookup_len);
+                if (disk_cache_.lookup(prefix_tokens, DISK_STAGING_SLOT)) {
+                    cache_slot = DISK_STAGING_SLOT;
+                    prefix_len = backend_.snapshot_cur_pos(DISK_STAGING_SLOT);
+                    if (prefix_len <= 0 || prefix_len > (int)effective_prompt.size()) {
+                        std::fprintf(stderr,
+                            "[disk-cache] ignoring invalid hit pos=%d prompt=%zu\n",
+                            prefix_len, effective_prompt.size());
+                        backend_.snapshot_free(DISK_STAGING_SLOT);
+                        continue;
+                    }
+                    using_restore = true;
+                    disk_hit = true;
+                    std::fprintf(stderr,
+                        "[disk-cache] hit policy=%s len=%d slot=%d pos=%d\n",
+                        disk_prefix_cache_policy_name(disk_policy).c_str(), lookup_len,
+                        DISK_STAGING_SLOT, prefix_len);
+                    break;
+                }
+            }
+        }
+
+        // Scoped prefix save: auto/fixed modes prefill exactly to the
+        // selected token boundary and save that snapshot.
+        // This keeps the disk key and snapshot position aligned; unlike the
+        // legacy full-prompt key path, scoped entries must not point at a
+        // longer snapshot than their token hash covers.
+        if (!using_restore && !disk_cache_.disabled() &&
+            selected_prefix_boundary > 0) {
+            const int scoped_boundary = selected_prefix_boundary;
+            if (scoped_boundary > 0) {
+                std::fprintf(stderr,
+                    "[disk-cache] scoped prefix: policy=%s boundary=%d\n",
+                    disk_prefix_cache_policy_name(disk_policy).c_str(), scoped_boundary);
+                GenerateRequest scoped_req;
+                scoped_req.prompt = std::vector<int32_t>(
+                    effective_prompt.begin(), effective_prompt.begin() + scoped_boundary);
+                scoped_req.n_gen = 0;
+                scoped_req.snap_slot = DISK_STAGING_SLOT;
+                scoped_req.snap_pos = scoped_boundary;
+                DaemonIO scoped_io;
+                scoped_io.stream_fd = -1;
+                auto scoped_result = backend_.generate(scoped_req, scoped_io);
+                if (scoped_result.ok && backend_.snapshot_used(DISK_STAGING_SLOT)) {
+                    disk_cache_.learn_layout(DISK_STAGING_SLOT);
+                    const bool saved =
+                        disk_cache_.save(DISK_STAGING_SLOT, scoped_req.prompt);
+                    cache_slot = DISK_STAGING_SLOT;
+                    prefix_len = scoped_boundary;
+                    using_restore = true;
+                    disk_hit = true;
+                    std::fprintf(stderr,
+                        "[disk-cache] scoped prefix %s, restoring from %d\n",
+                        saved ? "saved" : "staged", scoped_boundary);
+                } else {
+                    backend_.snapshot_free(DISK_STAGING_SLOT);
+                }
             }
         }
 
@@ -2056,7 +2193,8 @@ void HttpServer::worker_loop() {
         // turn boundary and save a cold checkpoint before the full generation.
         // This makes subsequent requests to similar (but not identical) prompts
         // much faster by reusing the cold prefix.
-        if (!using_restore && !disk_cache_.disabled()) {
+        if (!using_restore && !disk_cache_.disabled() &&
+            disk_policy.mode == DiskPrefixCacheMode::Full) {
             auto boundaries = find_all_boundaries(effective_prompt, prefix_cache_.chat_markers());
             int cold_boundary = disk_cache_.cold_prefix_boundary(effective_prompt, boundaries);
             if (cold_boundary > 0) {
@@ -2100,13 +2238,15 @@ void HttpServer::worker_loop() {
 
         std::fprintf(stderr,
             "[server] chat CACHE %s restore=%s slot=%d prefix_len=%d "
-            "effective_prompt=%zu pflash=%s disk_hit=%s snap_slot=%d snap_pos=%d\n",
+            "effective_prompt=%zu pflash=%s disk_policy=%s disk_hit=%s "
+            "snap_slot=%d snap_pos=%d\n",
             req.response_id.c_str(),
             using_restore ? "true" : "false",
             cache_slot,
             prefix_len,
             effective_prompt.size(),
             pflash_compressed ? "true" : "false",
+            disk_prefix_cache_policy_name(disk_policy).c_str(),
             disk_hit ? "true" : "false",
             snap_slot,
             snap_cut);
@@ -2285,7 +2425,9 @@ void HttpServer::worker_loop() {
                 // Save to disk cache if threshold met.
                 if (!disk_cache_.disabled()) {
                     disk_cache_.learn_layout(snap_slot);
-                    disk_cache_.save(snap_slot, effective_prompt);
+                    if (disk_policy.mode == DiskPrefixCacheMode::Full) {
+                        disk_cache_.save(snap_slot, effective_prompt);
+                    }
                 }
             } else {
                 prefix_cache_.abort_inline_snap(snap_slot);
@@ -2299,7 +2441,8 @@ void HttpServer::worker_loop() {
 
         // Continued checkpoint: save if total tokens crossed an interval boundary.
         // This captures prompt + all generated tokens for long conversation reuse.
-        if (!disk_cache_.disabled() && result.ok && completion_tokens > 0 &&
+        if (!disk_cache_.disabled() && disk_policy.mode == DiskPrefixCacheMode::Full &&
+            result.ok && completion_tokens > 0 &&
             visible_output_seen && !client_disconnected) {
             int final_pos = (int)effective_prompt.size() + (int)result.tokens.size();
             if (final_pos >= disk_cache_.continued_interval()) {
@@ -2312,6 +2455,14 @@ void HttpServer::worker_loop() {
                     disk_cache_.maybe_store_continued(DISK_STAGING_SLOT, all_tokens, final_pos);
                     backend_.snapshot_free(DISK_STAGING_SLOT);
                 }
+            }
+        }
+
+        if (!disk_cache_.disabled() && !pflash_compressed) {
+            recent_disk_prompts_.insert(recent_disk_prompts_.begin(), effective_prompt);
+            static constexpr size_t kMaxRecentDiskPrompts = 256;
+            if (recent_disk_prompts_.size() > kMaxRecentDiskPrompts) {
+                recent_disk_prompts_.resize(kMaxRecentDiskPrompts);
             }
         }
 

--- a/server/src/server/http_server.h
+++ b/server/src/server/http_server.h
@@ -167,6 +167,7 @@ struct ServerConfig {
     int         disk_cache_min_tokens = 512; // only persist >= this many tokens
     int         disk_cache_continued_interval = 10240; // continued checkpoint every N tokens
     int         disk_cache_cold_max_tokens = 10240;    // cold prefix for prompts longer than this
+    DiskPrefixCachePolicy disk_cache_policy;
 
     // Optional Jinja chat template (overrides the hardcoded ChatFormat::QWEN3
     // / LAGUNA renderer when non-empty). Used for tool-using agents that need
@@ -212,6 +213,7 @@ struct ParsedRequest {
     std::vector<std::string>  stop_sequences;
     // Bandit: per-session adaptive keep_ratio opt-in
     std::string               session_id;
+    DiskPrefixCachePolicy     disk_cache_policy;
 };
 
 // Build the /props response body. Exposed (non-static) so unit tests
@@ -321,6 +323,7 @@ private:
 
     // Track prompt tokens for each snapshot slot (for shutdown save).
     std::unordered_map<int, std::vector<int32_t>> slot_tokens_;
+    std::vector<std::vector<int32_t>> recent_disk_prompts_;
 
     // Worker thread.
     std::thread                     worker_thread_;

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -273,6 +273,11 @@ static void print_usage(const char * prog) {
         "  --kv-cache-min-tokens <N>   Min tokens to persist (default: 512)\n"
         "  --kv-cache-interval <N>     Continued checkpoint every N tokens (default: 10240)\n"
         "  --kv-cache-cold-max <N>     Cold prefix for prompts longer than N tokens (default: 10240)\n"
+        "  --disk-prefix-cache off|full|auto|auto:N|N\n"
+        "                              Default disk prefix-cache policy (default: full).\n"
+        "                              auto compares recent requests to select a stable\n"
+        "                              prefix; auto:N uses the last N requests.\n"
+        "                              A plain N caches the first N prompt tokens.\n"
         "\n"
         "Chat template (optional, e.g. froggeric Qwen3.6 template for tool-using\n"
         "agents that need the Anthropic tool_use envelope):\n"
@@ -533,6 +538,14 @@ int main(int argc, char ** argv) {
             sconfig.disk_cache_continued_interval = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--kv-cache-cold-max") == 0 && i + 1 < argc) {
             sconfig.disk_cache_cold_max_tokens = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--disk-prefix-cache") == 0 && i + 1 < argc) {
+            DiskPrefixCachePolicy policy;
+            if (!parse_disk_prefix_cache_policy(argv[++i], policy)) {
+                std::fprintf(stderr,
+                    "[server] --disk-prefix-cache must be off, full, auto, auto:<window>, or a positive token count\n");
+                return 2;
+            }
+            sconfig.disk_cache_policy = policy;
         } else if (std::strcmp(argv[i], "--cache-type-k") == 0 && i + 1 < argc) {
             cache_type_k = argv[++i];
         } else if (std::strcmp(argv[i], "--cache-type-v") == 0 && i + 1 < argc) {

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -2075,6 +2075,70 @@ static void test_disk_cache_config_defaults() {
     TEST_ASSERT(cfg.cold_max_tokens == 10240);
 }
 
+static void test_disk_cache_policy_parse() {
+    DiskPrefixCachePolicy policy;
+    TEST_ASSERT(parse_disk_prefix_cache_policy("off", policy));
+    TEST_ASSERT(policy.mode == DiskPrefixCacheMode::Off);
+    TEST_ASSERT(parse_disk_prefix_cache_policy("full", policy));
+    TEST_ASSERT(policy.mode == DiskPrefixCacheMode::Full);
+    TEST_ASSERT(parse_disk_prefix_cache_policy("auto", policy));
+    TEST_ASSERT(policy.mode == DiskPrefixCacheMode::Auto);
+    TEST_ASSERT(policy.auto_window == 30);
+    TEST_ASSERT(parse_disk_prefix_cache_policy("auto:30", policy));
+    TEST_ASSERT(policy.mode == DiskPrefixCacheMode::Auto);
+    TEST_ASSERT(policy.auto_window == 30);
+    TEST_ASSERT(parse_disk_prefix_cache_policy("1000", policy));
+    TEST_ASSERT(policy.mode == DiskPrefixCacheMode::Fixed);
+    TEST_ASSERT(policy.fixed_tokens == 1000);
+    TEST_ASSERT(!parse_disk_prefix_cache_policy("core", policy));
+    TEST_ASSERT(!parse_disk_prefix_cache_policy("task", policy));
+    TEST_ASSERT(!parse_disk_prefix_cache_policy("auto:0", policy));
+}
+
+static void test_disk_cache_fixed_boundary() {
+    DiskPrefixCachePolicy policy;
+    TEST_ASSERT(parse_disk_prefix_cache_policy("1000", policy));
+    TEST_ASSERT(disk_prefix_cache_fixed_boundary(policy, 2000) == 1000);
+    TEST_ASSERT(disk_prefix_cache_fixed_boundary(policy, 500) == 0);
+    TEST_ASSERT(disk_prefix_cache_fixed_boundary(policy, 2000, 1001) == 0);
+    TEST_ASSERT(disk_prefix_cache_fixed_boundary(policy, 2000, 1000) == 1000);
+}
+
+static void test_disk_cache_auto_boundary_lcp() {
+    std::vector<int32_t> current{1, 2, 3, 4, 5, 9};
+    std::vector<std::vector<int32_t>> recent{
+        {1, 2, 3, 4, 8},
+        {1, 2, 3, 4, 7},
+        {7, 8},
+    };
+    std::vector<int> safe_boundaries{2, 4};
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 2, safe_boundaries, 2) == 4);
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 2, {}, 2) == 4);
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 3, {}, 2) == 4);
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 2, safe_boundaries, 5) == 0);
+}
+
+static void test_disk_cache_auto_window_limits_history() {
+    std::vector<int32_t> current{1, 2, 3, 4, 5};
+    std::vector<std::vector<int32_t>> recent{
+        {9},
+        {1, 2, 3, 4, 0},
+        {1, 2, 3, 4, 9},
+    };
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 1, {}, 2) == 0);
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 2, {}, 2) == 4);
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 3, {}, 2) == 4);
+    TEST_ASSERT(disk_prefix_cache_auto_boundary(
+        current, recent, 0, {}, 2) == 0);
+}
+
 static void test_disk_cache_disabled_when_no_dir() {
     MockBackend backend;
     DiskCacheConfig cfg;
@@ -3422,6 +3486,10 @@ int main() {
 
     std::fprintf(stderr, "\n── Disk prefix cache ──\n");
     RUN_TEST(test_disk_cache_config_defaults);
+    RUN_TEST(test_disk_cache_policy_parse);
+    RUN_TEST(test_disk_cache_fixed_boundary);
+    RUN_TEST(test_disk_cache_auto_boundary_lcp);
+    RUN_TEST(test_disk_cache_auto_window_limits_history);
     RUN_TEST(test_disk_cache_disabled_when_no_dir);
     RUN_TEST(test_disk_cache_init_creates_directory);
     RUN_TEST(test_disk_cache_header_size);


### PR DESCRIPTION
## Summary

This PR adds a configurable prefix-selection policy for disk prefix cache to improve hit rate on real agent-style workloads.

The existing disk prefix restore behavior, introduced by [PR #227](https://github.com/Luce-Org/lucebox-hub/pull/227) and extended for target split / mixed-backend restore by [PR #325](https://github.com/Luce-Org/lucebox-hub/pull/325) and [PR #352](https://github.com/Luce-Org/lucebox-hub/pull/352), was oriented around saving/restoring the full prompt. That works for repeated identical requests, but agent workloads usually have a large stable context followed by a dynamic tail: tool results, recent turns, and task state can change between requests. When the full prompt is used as the cache scope, small tail changes can prevent reuse of an otherwise valuable cached prefix.

This PR adds a controllable prefix scope for disk cache. By caching a slightly shorter but more stable prefix, the server can trade a small number of cached tokens for a higher cross-request hit rate. The scope can be a fixed token count provided by the user, or `auto` can infer a stable boundary from recent similar requests.

CLI:

```bash
--disk-prefix-cache off
--disk-prefix-cache full
--disk-prefix-cache auto
--disk-prefix-cache auto:30
--disk-prefix-cache 1000
```

Requests can also override the policy through `prefix_cache.scope`:

```json
{
  "prefix_cache": {
    "scope": "auto:30"
  }
}
```

Semantics:

- `off`: disables disk prefix cache restore/save.
- `full`: keeps the existing full-prompt disk cache behavior, including cold-prefix and continued checkpoints.
- `auto`: defaults to `auto:30`; searches the most similar token prefix in the most recent 30 requests, then aligns down to a safe chat boundary.
- `auto:N`: sets the lookback window to N requests. N is the candidate window size; it does not require all N requests to share the same prefix.
- `N`: caches/restores the first N prompt tokens, for example `1000`.

The server only compares token prefixes. It does not make semantic decisions about system prompts, tools, AGENTS.md, RAG, or dynamic tails. Disk keys remain token-prefix hashes, so semantically similar but token-different prompts do not collide.

## Window / Hit-rate Tradeoff

`auto:N` uses N as the recent-request lookback window. Smaller windows usually cache more recent-context tokens, but the key is more likely to drift with the dynamic tail; larger windows usually cache fewer tokens but produce a more stable hit rate.

Tokenizer-level simulation results:

| workload | `auto:2` | `auto:8` | `auto:30` |
|---|---:|---:|---:|
| independent agent tasks | avg `1432` tokens, `28/30` hits (`93%`) | avg `1432` tokens, `28/30` hits (`93%`) | avg `1432` tokens, `28/30` hits (`93%`) |
| synthetic rolling chat | avg `1988` tokens, `1/30` hits (`3%`) | avg `1783` tokens, `7/30` hits (`23%`) | avg `1452` tokens, `28/30` hits (`93%`) |
| real rolling trace A | avg `1776` tokens, `8/20` hits (`40%`) | avg `1389` tokens, `10/20` hits (`50%`) | avg `1049` tokens, `18/20` hits (`90%`) |
| real rolling trace B | avg `2204` tokens, `7/20` hits (`35%`) | avg `1489` tokens, `10/20` hits (`50%`) | avg `869` tokens, `18/20` hits (`90%`) |

The default `auto:30` is therefore intentionally conservative: it caches fewer high-variance tail tokens to get a higher disk prefix hit rate. Users that want a longer recent-context cache can still use `auto:2`, `auto:8`, or a fixed token count.

## Changes

- Adds `DiskPrefixCachePolicy` with `off`, `full`, `auto[:window]`, and fixed-token modes.
- Adds `--disk-prefix-cache off|full|auto|auto:N|N`.
- Adds request-level support for the same values through `prefix_cache.scope`; `prefix_cache.window` can override the auto window.
- Makes `auto` use the best-match longest common token prefix from the recent request window, aligned down to a safe chat boundary.
- Sets the default auto window to 30.
- Makes `fixed` / `auto` prefill exactly to the selected token boundary before saving the KV snapshot, keeping the disk key and snapshot position aligned.
- Keeps `full` on the existing full-prompt, cold-prefix, and continued-checkpoint behavior.
- Keeps `--kv-cache-min-tokens` as the global minimum save threshold.
- Limits `--kv-cache-cold-max` to `full` mode cold-prefix selection; it does not cap `auto` or fixed-number boundaries.
- Disables `auto` / `fixed` when PFlash rewrites the effective prompt; full-prompt restore keeps the existing behavior.
- Exposes the active disk policy in `/props.full_cache.disk_policy`.
- Adds `[disk-cache] auto scope: ... selected=...` diagnostics for boundary selection.

## End-to-end Restore Checks

End-to-end restore closure was validated on both a 27B dense backend and an OpenClaw-style MoE request. The dense backend check showed that a scoped prefix selected by `auto:30` can be persisted, found again after server restart as a cold-start disk hit, and reduce prefill from a `77.6s` cold run to `1.6s` after restore. The MoE check showed that auto boundary selection maps to a stable scoped prefix on a real agent prompt shape. qwen35moe hybrid restore itself is covered by companion bugfix PR #362: https://github.com/Luce-Org/lucebox-hub/pull/362. This PR only covers disk prefix policy and boundary selection; the hit-rate behavior is covered by the window tradeoff simulation above.
