### PR TITLE
fix(cmake): missing endif() in test_anchor_params block breaks configure

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -593,7 +593,9 @@ if(DFLASH27B_TESTS)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_anchor_params.cpp")
         add_executable(test_anchor_params test/test_anchor_params.cpp)
         target_include_directories(test_anchor_params PRIVATE ${DFLASH27B_SRC_INCLUDE_DIRS})
+        target_link_libraries(test_anchor_params PRIVATE dflash_common)
         add_test(NAME anchor_params COMMAND test_anchor_params)
+    endif()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/test_drafter_tail_capture_guard.cpp")
         # GREEN phase: built with TAIL_GUARD_USE_NEW_FORMULA — must pass after Bug #42 fix.
         add_executable(test_drafter_tail_capture_guard


### PR DESCRIPTION
## Problem

CI run [27283798581](https://github.com/Luce-Org/lucebox-hub/actions/runs/27283798581) failed on both the **cmake build** and **sm_86 GPU tests** jobs at the configure step:

```
CMake Error at CMakeLists.txt:564 (if):
  Flow control statements are not properly nested.
```

The `test_anchor_params` block in `server/CMakeLists.txt` (line 593) was never closed with `endif()`, leaving the file with 103 `if(` vs 102 `endif(`. CMake reports the mismatch at the enclosing `if(DFLASH27B_TESTS)` on line 564. The bug is on `main`, so every PR branched from it fails configure.

## Fix

- Add the missing `endif()` after the `anchor_params` `add_test` line.
- Add `target_link_libraries(test_anchor_params PRIVATE dflash_common)`, matching every sibling test block; without it the target would fail at link time once configure succeeds.

## Verification

- `if`/`endif` balance is now 103/103.
- `cmake -B` configure proceeds past the syntax error (locally it now stops only at CUDA toolkit detection, which is expected on a non-CUDA machine; CI runners have CUDA).

🧙 Built with [WOZCODE](https://wozcode.com)