### PR TITLE
server: fall back to fresh prefill when a cached snapshot is longer than the prompt

### DIFF
--- a/server/src/common/layer_split_backend.cpp
+++ b/server/src/common/layer_split_backend.cpp
@@ -172,9 +172,12 @@ GenerateResult LayerSplitBackend::restore_and_generate_impl(
     }
     const int snap_pos = adapter_->snapshot_cur_pos(slot);
     if ((int)req.prompt.size() < snap_pos) {
-        result.error = "snapshot_longer_than_prompt";
-        io.emit(-1);
-        return result;
+        // Snapshot covers more KV than the new prompt (client edited or
+        // summarized its history). Fall back to a fresh full prefill.
+        std::fprintf(stderr,
+            "[pc] snapshot longer than prompt (snap=%d > prompt=%zu) — "
+            "fresh prefill fallback\n", snap_pos, req.prompt.size());
+        return run_from_state(req, io, /*base_pos=*/0, /*reset_state=*/true);
     }
     GenerateRequest delta_req = req;
     delta_req.prompt = std::vector<int32_t>(

--- a/server/src/gemma4/gemma4_backend.cpp
+++ b/server/src/gemma4/gemma4_backend.cpp
@@ -748,9 +748,17 @@ GenerateResult Gemma4Backend::restore_and_generate_impl(int slot,
             return result;
         }
     } else if (prompt_len > 0 && prompt_len < snap_pos) {
-        result.error = "snapshot_longer_than_prompt";
-        out_io.emit(-1);
-        return result;
+        // Snapshot covers more KV than the new prompt (client edited or
+        // summarized its history). Fall back to a fresh full prefill.
+        std::fprintf(stderr,
+            "[pc] snapshot longer than prompt (snap=%d > prompt=%d) — "
+            "fresh prefill fallback\n", snap_pos, prompt_len);
+        cache_.cur_pos = 0;
+        committed = do_prefill(req.prompt, out_io, /*kv_offset=*/0);
+        if (committed < 0) {
+            result.error = "prefill";
+            return result;
+        }
     }
     // else: prompt_len == snap_pos → no delta, committed stays at snap_pos
     result.prefill_s = std::chrono::duration<double>(

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -773,10 +773,23 @@ GenerateResult Qwen35Backend::restore_and_generate_impl(int slot,
         result.prefill_s = std::chrono::duration<double>(
             std::chrono::steady_clock::now() - t_prefill_start).count();
     } else if (prompt_len > 0 && prompt_len < snap_pos) {
-        // Cached more than the request — should never happen in practice.
-        result.error = "snapshot_longer_than_prompt";
-        out_io.emit(-1);
-        return result;
+        // The slot's snapshot covers more KV than the new prompt. This is
+        // routine with agent clients (Letta, Hermes, ...) that edit or
+        // summarize their history between turns. Fall back to a fresh full
+        // prefill instead of failing the request with zero tokens.
+        std::fprintf(stderr,
+            "[pc] snapshot longer than prompt (snap=%d > prompt=%d) — "
+            "fresh prefill fallback\n", snap_pos, prompt_len);
+        reset_recurrent_state(cache_);
+        cache_.cur_pos = 0;
+        auto t_prefill_start = std::chrono::steady_clock::now();
+        committed = do_prefill(req.prompt, out_io, req.snap_pos, req.snap_slot);
+        if (committed < 0) {
+            result.error = "prefill";
+            return result;
+        }
+        result.prefill_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t_prefill_start).count();
     }
 
     // Decode

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -2235,6 +2235,24 @@ void HttpServer::worker_loop() {
             }
         }
 
+        // A slot whose snapshot covers more KV than this prompt cannot be
+        // diff-prefilled (the client edited/summarized its history since the
+        // snapshot was saved). Treat as a cache miss; the backend-side
+        // fallback also guards this, but skipping restore here avoids a
+        // pointless snapshot copy-in.
+        if (using_restore) {
+            const int snap_len = backend_.snapshot_cur_pos(cache_slot);
+            if (snap_len > (int)effective_prompt.size()) {
+                std::fprintf(stderr,
+                    "[pc] slot=%d snapshot pos=%d > prompt=%zu — treating as miss\n",
+                    cache_slot, snap_len, effective_prompt.size());
+                cache_slot = -1;
+                prefix_len = 0;
+                using_restore = false;
+                disk_hit = false;
+            }
+        }
+
         // Cold prefix save: for long prompts with no cache hit, prefill to a
         // turn boundary and save a cold checkpoint before the full generation.
         // This makes subsequent requests to similar (but not identical) prompts


### PR DESCRIPTION
## Problem

The prefix-cache restore path treats `prompt_len < snap_pos` as impossible and fails the request:

```cpp
} else if (prompt_len > 0 && prompt_len < snap_pos) {
    // Cached more than the request — should never happen in practice.
    result.error = "snapshot_longer_than_prompt";
    out_io.emit(-1);
    return result;
}
```

With agent clients (Letta, Hermes, OpenClaw, ...) this happens routinely: they summarize/edit their message history between turns, so a follow-up prompt is often *shorter* than the KV snapshot cached on the slot. In production this surfaces as agents silently hanging mid-conversation — the server returns an empty completion:

```
chat DONE ... ok=false in=42491 effective_in=42491 out=0 restore=true slot=14 prefix_len=38663 error=snapshot_longer_than_prompt
chat DONE ... ok=false in=37831 effective_in=37831 out=0 restore=true slot=25 prefix_len=37530 error=snapshot_longer_than_prompt
```

Note `prefix_len` (the matched boundary) is *smaller* than the prompt in these logs — the slot's actual snapshot `cur_pos` was larger, i.e. the entry table and the slot contents had diverged after history edits.

## Fix (two layers)

1. **Routing** (`http_server.cpp`): when the selected slot's snapshot covers more KV than the incoming prompt, treat the lookup as a cache miss instead of restoring a state that cannot be diff-prefilled. Applies to the inline, full-compress and disk hit paths.
2. **Backends** (`qwen35`, `gemma4`, `layer_split`): if such a request still reaches `restore_and_generate`, fall back to a fresh full prefill (mirroring the `generate()` path) instead of emitting `-1`.

## Validation

On an RTX 3090 (Qwen3.6-27B Q4_K_M + DFlash + PFlash): cold request, cache-hit continuation (diff prefill 1.0s vs 8.0s cold), and a shortened-history follow-up all return tokens; greedy outputs on normal cache hits are unchanged. Running in production since 2026-06-11 with the failures gone.

@Luce-Org/maintainers