### PR TITLE
fix(server): drop stale prefix-cache entries when a snapshot slot is reused

### DIFF
--- a/server/src/server/prefix_cache.cpp
+++ b/server/src/server/prefix_cache.cpp
@@ -261,6 +261,21 @@ void PrefixCache::confirm_inline_snap(int slot, int target_cut,
         has_pending_evict_ = false;
     }
 
+    // The new snapshot replaces whatever this slot previously held. Drop any
+    // other entries still pointing at the slot: their hashes describe a
+    // different (or shorter) token stream than the new snapshot, and a later
+    // restore through them would attach mismatched KV. Stale entries arise
+    // when an aborted snap burns a round-robin next_slot_ step and a later
+    // confirm wraps onto a slot with a live entry (PR #370 repro).
+    for (int i = (int)entries_.size() - 1; i >= 0; --i) {
+        if (entries_[(size_t)i].slot == slot) {
+            std::fprintf(stderr,
+                "[pc] dropping stale entry for reused slot=%d\n", slot);
+            entries_.erase(entries_.begin() + i);
+            entries_size_count_.fetch_sub(1, std::memory_order_relaxed);
+        }
+    }
+
     auto key = hash_prefix(prompt_ids.data(), target_cut);
     entries_.push_back({key, slot});
     entries_size_count_.fetch_add(1, std::memory_order_relaxed);
@@ -366,6 +381,15 @@ void PrefixCache::confirm_full_snap(int slot,
             full_entries_size_count_.fetch_sub(1, std::memory_order_relaxed);
         }
         full_has_pending_evict_ = false;
+    }
+
+    for (int i = (int)full_entries_.size() - 1; i >= 0; --i) {
+        if (full_entries_[(size_t)i].entry.slot == slot) {
+            std::fprintf(stderr,
+                "[pc] dropping stale full-cache entry for reused slot=%d\n", slot);
+            full_entries_.erase(full_entries_.begin() + i);
+            full_entries_size_count_.fetch_sub(1, std::memory_order_relaxed);
+        }
     }
 
     auto key = hash_prefix(prompt_ids.data(), (int)prompt_ids.size());


### PR DESCRIPTION
## Problem

Follow-up to #370, fixing the root cause behind its symptom.

The inline and full-compress prefix caches hand out snapshot slots round-robin (`next_slot_`), and the counter advances in `prepare_*_snap` even when the snapshot later **aborts** (degenerate boundary < 512 tokens, failed generation, client disconnect). One burned step is enough: a later confirm wraps onto a slot that a **live entry still references**. From then on the entry table and the slot contents disagree — the entry's hash describes one token stream, the slot holds a snapshot of another.

A stale entry then misbehaves in two ways:

- **follow-up prompt shorter than the slot's snapshot** → `snapshot_longer_than_prompt`, a failed request with an empty completion (the silent agent hang #370 reported; #370 downgrades it to a conservative cache miss);
- **follow-up prompt longer than the slot's snapshot** → the restore path attaches KV from the wrong token stream with no validation: **silent context corruption**, which #370 does not cover.

## Fix

When `confirm_inline_snap` / `confirm_full_snap` commit a snapshot into a slot, erase every other entry still pointing at that slot. A slot holds exactly one snapshot, so at most one entry may describe it. 24 lines, no API change.

## Validation (RTX 3090, Qwen3.6-27B Q4_K_M, `--prefix-cache-slots 2`)

Deterministic repro: short conv (snap@3801 → slot 0) → tiny conv whose snap aborts (burns a slot step) → big distinct conv (8.2K tokens, wraps onto slot 0) → shortened follow-up of the first conv.

- on main pre-#370 this sequence ends in `ok=false out=0 error=snapshot_longer_than_prompt`;
- with this fix the wrap logs `[pc] dropping stale entry for reused slot=0`, the follow-up is a clean miss with correct output, and a longer same-conversation follow-up restores a **valid** snapshot (correct KV, correct answer) — the corruption window is closed, cache effectiveness preserved.

Greedy outputs across the whole sequence match the no-cache baseline. All 1905 server unit assertions pass.

🧙 Built with [WOZCODE](https://wozcode.com)