### PR TITLE
fix(server): warn when --fa-window > 0 breaks tool calls

### DIFF
--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -209,7 +209,9 @@ static void print_usage(const char * prog) {
         "  --target-layer-split <weights>  Reserved layer-split weights\n"
         "  --peer-access        Enable peer access for multi-GPU placement\n"
         "  --chunk <N>          Chunked-prefill chunk size (default: 512)\n"
-        "  --fa-window <N>     Flash-attention sliding window (default: 0=full)\n"
+        "  --fa-window <N>     Flash-attention sliding window (default: 0=full).\n"
+        "                       WARNING: >0 drops system prompt / tool definitions\n"
+        "                       from attention at long contexts. Use 0 for tools.\n"
         "  --model-name <name>  Model name for /v1/models (default: dflash)\n"
         "  --prefix-cache-slots <N>  Prefix cache slots (default: 32, 0 disables)\n"
         "  --ddtree             Enable DDTree speculative decode\n"
@@ -979,6 +981,11 @@ int main(int argc, char ** argv) {
                  bargs.device.peer_access ? "ON" : "off");
     std::fprintf(stderr, "[server] │  chunk           = %d\n", bargs.chunk);
     std::fprintf(stderr, "[server] │  fa_window       = %d\n", bargs.fa_window);
+    if (bargs.fa_window > 0) {
+        std::fprintf(stderr, "[server] │  ⚠  fa_window > 0 drops system prompt / "
+                             "tool definitions from attention at long contexts.\n"
+                             "[server] │     Use --fa-window 0 for tool-call workloads.\n");
+    }
     std::fprintf(stderr, "[server] │  ddtree          = %s\n", bargs.ddtree_mode ? "ON" : "off");
     std::fprintf(stderr, "[server] │  ddtree_budget   = %d\n", bargs.ddtree_budget);
     std::fprintf(stderr, "[server] │  prefix_cache    = %d slots\n", sconfig.prefix_cache_cap);


### PR DESCRIPTION
## Problem

`--fa-window > 0` applies a sliding window to **all** attention layers, including full-attn layers that must see the whole context. Once context exceeds the window size, the system prompt (containing tool definitions) is masked out of the attention window, producing garbled `tool_call` output or blank responses ([bug #327](https://github.com/Luce-Org/lucebox-hub/issues/327)).

The codebase documents this in 5 config struct comments but emits **no runtime diagnostic**. Operators have no way to know their tool calls are broken until they see corrupted output.

## Fix

- Add a startup `fprintf(stderr)` warning when `fa_window > 0`.
- Clarify the `--fa-window` help text to mention the tool-call side effect.

## Changes

- `server/src/server/server_main.cpp`: +8 lines (warning + help text)

## Verification

- `--fa-window 0` → no warning (default, safe for tools)
- `--fa-window 2048` → warning printed at startup
- `--fa-window 2048 --ddtree` → warning printed at startup
- Server binary compiles cleanly; no behavioral change

## Notes

This is a documentation-level fix. A proper fix (smart masking that preserves tool-definition tokens while windowing the rest) would require changes to `layer_split_forward.cpp` and is tracked separately.

Closes #327
