### PR TITLE
fix(ci): enable C++ server unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,13 @@ jobs:
             -DDFLASH27B_FA_ALL_QUANTS=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target \
-            test_dflash test_generate test_flash_attn_sparse \
+            test_dflash test_generate test_flash_attn_sparse test_server_unit \
             -j$(nproc)
 
-      # Server unit tests require libcurl-dev; skipped when CURL is absent.
-      # - name: Run C++ server unit tests
-      #   run: |
-      #     cd server/build
-      #     ctest --output-on-failure -R server_unit --no-tests=error
+      - name: Run C++ server unit tests
+        run: |
+          cd server/build
+          ctest --output-on-failure -R server_unit --no-tests=error
 
       - name: Populate venv with cu128 torch + setuptools
         # First pass: install the workspace's default deps. dflash declares


### PR DESCRIPTION
## Context

`test_server_unit` is defined in `server/CMakeLists.txt:874-902` and registered with ctest (line 901), but is never built or run in CI. The commented-out ctest block at `.github/workflows/ci.yml:63-67` claims:

> Server unit tests require libcurl-dev; skipped when CURL is absent.

This is incorrect. All curl usage in `http_server.cpp` is behind `#ifdef DFLASH_HAS_CURL` (lines 14, 60-254, 809, 954, 2187-2236). CMakeLists.txt conditionally defines `DFLASH_HAS_CURL` only when `CURL_FOUND` (lines 888-893). The test binary compiles and runs fine without curl — the proxy passthrough feature is simply disabled.

## Bug

204 CPU-only tests covering critical server components are untested in CI:

| Category | Tests | Critical path? |
|---|---|---|
| SSE emitter | 19 | Yes — every streaming response |
| Stop sequences | 10 | Yes — every request with stop tokens |
| Sampler | 18 | Yes — every non-greedy request |
| Prefix cache | 5 | Yes — prefix caching path |
| Jinja chat template | 7 | Yes — every chat request |
| Tool parser | 33 | Agent/tool-use flow |
| Reasoning parser | 7 | Reasoning mode |
| PFlash config | 18 | PFlash feature |
| Disk prefix cache | 18 | Disk-cache feature |
| Backend IPC | 5 | Remote-drafter IPC |
| + 8 more sections | 64 | Various |

## Fix

1. Add `test_server_unit` to the cmake build targets (line 60)
2. Uncomment the ctest step (lines 63-67)
3. Remove the incorrect comment about libcurl-dev

## Changes

- `.github/workflows/ci.yml` — added `test_server_unit` to build targets, uncommented ctest step

## Verification

- All curl code in `http_server.cpp` is `#ifdef DFLASH_HAS_CURL` guarded (5 occurrences)
- `CMakeLists.txt` conditionally defines and links curl only when `CURL_FOUND`
- CI already installs CUDA toolkit via `Jimver/cuda-toolkit@v0.2.35`
- Test binary tests pure CPU logic: parsers, emitters, sampler, templates, cache hashing

## Notes

- The test binary links against `dflash_common` which includes ggml-cuda, but CI has CUDA installed so this is fine
- No GPU or model files needed — tests exercise parser/emitter/sampler logic only


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

