### PR TITLE
spec-decode: eliminate replay pass via fast-rollback

### DIFF
--- a/server/src/common/dflash_spec_decode.cpp
+++ b/server/src/common/dflash_spec_decode.cpp
@@ -182,7 +182,8 @@ bool run_dflash_spec_decode(
         }
 
         int verify_last_tok = -1;
-        if (!target.verify_batch(draft_tok, committed, verify_last_tok, &target_tok)) {
+        if (!target.verify_batch(draft_tok, committed, verify_last_tok, &target_tok,
+                                  /*capture_ssm_intermediates=*/true)) {
             std::fprintf(stderr, "dflash-spec verify failed\n");
             // Roll the snapshot back so we don't leak the speculative KV
             // mutations into the caller's target cache.
@@ -210,22 +211,41 @@ bool run_dflash_spec_decode(
             if (commit_n <= accept_n) bonus_tok = -1;
         }
 
-        // ── Replay pass: roll back KV and re-run only the accepted tokens.
-        if (!target.restore_kv()) {
-            std::fprintf(stderr, "dflash-spec restore_kv failed\n");
-            return false;
-        }
+        // ── Commit accepted tokens to KV state ──────────────────────────
+        // Adaptive: use fast-rollback when acceptance is high enough to benefit.
+        constexpr int kFastRollbackThreshold = 5;
+        const bool use_fast_rollback =
+            target.supports_fast_rollback() && (accept_n >= kFastRollbackThreshold);
 
         std::vector<int32_t> replay_tok((size_t)commit_n);
         for (int i = 0; i < commit_n; i++) {
             replay_tok[i] = (i < accept_n) ? draft_tok[i] : bonus_tok;
         }
-        int replay_last_tok = -1;
-        if (!target.verify_batch(replay_tok, committed, replay_last_tok, nullptr)) {
-            std::fprintf(stderr, "dflash-spec replay failed\n");
-            return false;
+
+        if (use_fast_rollback) {
+            // Fast rollback: restore SSM from intermediates, skip replay.
+            // Implicit bonus: deferred to next step as draft_tok[0].
+            bonus_tok = -1;
+            commit_n = accept_n;
+            replay_tok.resize(commit_n);
+            if (!target.rollback_to(committed, accept_n)) {
+                std::fprintf(stderr, "dflash-spec rollback_to failed\n");
+                return false;
+            }
+            last_tok = target_tok[accept_n - 1];
+        } else {
+            // Legacy path: restore SSM snapshot and replay accepted + bonus tokens.
+            if (!target.restore_kv()) {
+                std::fprintf(stderr, "dflash-spec restore_kv failed\n");
+                return false;
+            }
+            int replay_last_tok = -1;
+            if (!target.verify_batch(replay_tok, committed, replay_last_tok, nullptr)) {
+                std::fprintf(stderr, "dflash-spec replay failed\n");
+                return false;
+            }
+            last_tok = replay_last_tok;
         }
-        last_tok = replay_last_tok;
 
         bool hit_eos = false;
         int emitted = 0;

--- a/server/src/common/dflash_spec_decode.cpp
+++ b/server/src/common/dflash_spec_decode.cpp
@@ -222,19 +222,32 @@ bool run_dflash_spec_decode(
             replay_tok[i] = (i < accept_n) ? draft_tok[i] : bonus_tok;
         }
 
+        bool fast_rolled_back = false;
         if (use_fast_rollback) {
             // Fast rollback: restore SSM from intermediates, skip replay.
             // Implicit bonus: deferred to next step as draft_tok[0].
+            // Respect the generation budget: accept_n can exceed the remaining
+            // budget (need_commit_budget). Committing accept_n would both
+            // overrun the budget and grow replay_tok with zero-initialised
+            // tokens (it was sized to the clamped commit_n above).
             bonus_tok = -1;
-            commit_n = accept_n;
+            commit_n = std::min(accept_n, need_commit_budget);
             replay_tok.resize(commit_n);
-            if (!target.rollback_to(committed, accept_n)) {
-                std::fprintf(stderr, "dflash-spec rollback_to failed\n");
-                return false;
+            if (target.rollback_to(committed, commit_n)) {
+                last_tok = target_tok[commit_n - 1];
+                fast_rolled_back = true;
+            } else {
+                // Rollback failed (e.g. CUDA error / unsupported state type).
+                // The pre-verify snapshot is still valid, so degrade to the
+                // legacy restore+replay path below instead of aborting.
+                std::fprintf(stderr, "dflash-spec rollback_to failed; "
+                                     "falling back to restore+replay\n");
             }
-            last_tok = target_tok[accept_n - 1];
-        } else {
+        }
+        if (!fast_rolled_back) {
             // Legacy path: restore SSM snapshot and replay accepted + bonus tokens.
+            // (When falling back from fast-rollback, bonus_tok is already -1 and
+            //  replay_tok/commit_n reflect the budget-clamped accepted set.)
             if (!target.restore_kv()) {
                 std::fprintf(stderr, "dflash-spec restore_kv failed\n");
                 return false;

--- a/server/src/common/dflash_target.h
+++ b/server/src/common/dflash_target.h
@@ -14,6 +14,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "ddtree.h"
+
 namespace dflash::common {
 
 struct DFlashTarget {
@@ -56,6 +58,42 @@ struct DFlashTarget {
         (void)base_pos; (void)commit_n; return false;
     }
 
+    // ── DDTree tree-structured verify ───────────────────────────────
+    // Whether this target can verify a draft tree (ancestor-masked batched
+    // forward over DFS-ordered tree nodes). When false, callers fall back to
+    // chain verify. Requires fast_rollback support (tree rollback reuses the
+    // per-step SSM intermediate capture).
+    virtual bool supports_tree_verify() const { return false; }
+
+    // Verify a DDTree in one batched target forward. `flat_tokens` is the
+    // DFS-ordered tree (slot 0 = root = previous round's bonus token, slots
+    // 1..n_nodes = tree.token_ids), padded to `n_alloc` for graph reuse.
+    // `committed` is the KV position of the root. On success fills
+    // `posterior_out` (size 1+tree.n_nodes) with the target's argmax at each
+    // tree node, and—when `logits_out` is non-null—the full [n_actual x vocab]
+    // f32 logits (used to sample the bonus token at temperature > 0).
+    virtual bool verify_tree(int committed,
+                             const DDTree & tree,
+                             const std::vector<int32_t> & flat_tokens,
+                             int n_alloc,
+                             std::vector<int32_t> & posterior_out,
+                             std::vector<float> * logits_out = nullptr) {
+        (void)committed; (void)tree; (void)flat_tokens; (void)n_alloc;
+        (void)posterior_out; (void)logits_out;
+        return false;
+    }
+
+    // Roll recurrent + KV state forward to the accepted tree path. `accepted_dfs`
+    // is the list of DFS-tree indices of the committed nodes (from
+    // follow_verified_tree, including the root at index 0). Restores SSM/conv
+    // state to the deepest accepted node and compacts KV so the next round sees
+    // a contiguous prefix. Only valid when supports_tree_verify() is true.
+    virtual bool rollback_to_tree(int committed,
+                                  const DDTree & tree,
+                                  const std::vector<int> & accepted_dfs) {
+        (void)committed; (void)tree; (void)accepted_dfs; return false;
+    }
+
     // ── Token utilities ─────────────────────────────────────────────
 
     // Check if a token is end-of-sequence for this model.
@@ -74,6 +112,20 @@ struct DFlashTarget {
     virtual bool project_hidden_to_tokens(const float * hidden,
                                           int n_tokens,
                                           std::vector<int32_t> & tokens_out) = 0;
+
+    // Project draft hidden states through the target lm_head and return the
+    // per-position top-K log-probabilities + token ids (for DDTree building).
+    // Default false (unsupported); tree-verify targets override.
+    virtual bool project_hidden_to_topk(const float * hidden,
+                                        int n_tokens,
+                                        int K,
+                                        float temperature,
+                                        std::vector<float> & top_log_probs,
+                                        std::vector<int32_t> & top_token_ids) {
+        (void)hidden; (void)n_tokens; (void)K; (void)temperature;
+        (void)top_log_probs; (void)top_token_ids;
+        return false;
+    }
 
     // ── Configuration for draft model ───────────────────────────────
 

--- a/server/src/common/dflash_target.h
+++ b/server/src/common/dflash_target.h
@@ -31,7 +31,8 @@ struct DFlashTarget {
     virtual bool verify_batch(const std::vector<int32_t> & tokens,
                               int base_pos,
                               int & last_tok,
-                              std::vector<int32_t> * all_argmax = nullptr) = 0;
+                              std::vector<int32_t> * all_argmax = nullptr,
+                              bool capture_ssm_intermediates = false) = 0;
 
     // ── KV state management ─────────────────────────────────────────
 
@@ -41,6 +42,19 @@ struct DFlashTarget {
 
     // Restore KV cache to the last snapshot (undo speculative forward).
     virtual bool restore_kv() = 0;
+
+    // Whether fast rollback is supported — uses per-step SSM intermediate
+    // states captured during verify to restore recurrent state without replay.
+    // When true, verify_batch captures intermediates and rollback_to() works.
+    virtual bool supports_fast_rollback() const { return false; }
+
+    // Roll back recurrent state to position `commit_n` within the last
+    // verify batch (0-indexed). Uses SSM intermediate states captured during
+    // verify. Also truncates KV to `base_pos + commit_n`. No replay needed.
+    // Only valid when supports_fast_rollback() returns true.
+    virtual bool rollback_to(int base_pos, int commit_n) {
+        (void)base_pos; (void)commit_n; return false;
+    }
 
     // ── Token utilities ─────────────────────────────────────────────
 

--- a/server/src/gemma4/gemma4_dflash_target.cpp
+++ b/server/src/gemma4/gemma4_dflash_target.cpp
@@ -37,7 +37,9 @@ bool Gemma4DFlashTarget::verify_batch(
         const std::vector<int32_t> & tokens,
         int base_pos,
         int & last_tok,
-        std::vector<int32_t> * all_argmax) {
+        std::vector<int32_t> * all_argmax,
+        bool capture_ssm_intermediates) {
+    (void)capture_ssm_intermediates; // Gemma4 is pure-attention, no SSM state
     const int n_tokens = (int)tokens.size();
     if (n_tokens <= 0) return false;
 

--- a/server/src/gemma4/gemma4_dflash_target.h
+++ b/server/src/gemma4/gemma4_dflash_target.h
@@ -30,7 +30,8 @@ public:
     bool verify_batch(const std::vector<int32_t> & tokens,
                       int base_pos,
                       int & last_tok,
-                      std::vector<int32_t> * all_argmax = nullptr) override;
+                      std::vector<int32_t> * all_argmax = nullptr,
+                      bool capture_ssm_intermediates = false) override;
 
     // kvflash: route verify writes through the pool (slots allocated here,
     // slot-space mask inside gemma4_verify_batch). Non-owning.

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -680,7 +680,7 @@ DFlashTarget * Qwen35Backend::dflash_target() {
         if (kvflash_active()) {
             qt->set_kvflash_pager(&kvflash_pager_);
         }
-        qt->set_fast_rollback(true);
+        qt->set_fast_rollback(cfg_.fast_rollback);
     }
     return dflash_target_.get();
 }
@@ -1828,6 +1828,105 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
         }
         draft_tok[0] = last_tok;
 
+        // ── DDTree tree-structured verify ────────────────────────────────
+        // When --ddtree is on and the target supports tree verify, build a
+        // draft tree from per-position top-K, verify all nodes in one
+        // ancestor-masked target forward, walk the verified path, then roll
+        // recurrent/KV state forward to the accepted path. Higher acceptance
+        // per step than chain verify. Local draft only; greedy bonus token
+        // (sampled tree-verify is a follow-up). On any failure we fall through
+        // is unsafe (draft graph already built for chain), so we bail to false.
+        // The tree path handles plain generation only. Requests using features
+        // the tree branch does not implement — thinking-budget forced close,
+        // tool-call hint injection, stall recovery, or the min-tokens floor
+        // region — fall through to the chain verify path below, which handles
+        // them. (Wiring these into the tree path is a follow-up.)
+        const bool tree_special_inactive =
+            !(budget_hook && !budget_hook->close_token_ids.empty()) &&
+            !(hint_tokens && n_generated < (int)hint_tokens->size()) &&
+            stall_tool_prefix_tokens == nullptr &&
+            (int)out_tokens.size() >= _min_floor;
+        if (cfg_.ddtree_mode && target->supports_tree_verify() &&
+            !use_remote_draft && q_len > 1 && tree_special_inactive) {
+            const int L = q_len - 1;
+            const int K = (cfg_.ddtree_budget > L) ? 8 : 1;
+            std::vector<float>   top_lp;
+            std::vector<int32_t> top_ids;
+            if (!target->project_hidden_to_topk(local_hidden.data(), q_len, K,
+                                                cfg_.ddtree_temp, top_lp, top_ids)) {
+                std::fprintf(stderr, "spec-decode: ddtree topk projection failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+            // Tree depth L draws from draft rows 1..q_len-1 (row 0 = the seed).
+            DDTree tree = build_ddtree(top_lp.data() + (size_t)K, top_ids.data() + (size_t)K,
+                                       L, K, cfg_.ddtree_budget, cfg_.ddtree_chain_seed);
+            const int N = cfg_.ddtree_budget + 1;   // fixed alloc width
+
+            std::vector<int32_t> flat_tokens((size_t)N, 0);
+            flat_tokens[0] = last_tok;
+            for (int i = 0; i < tree.n_nodes; i++) flat_tokens[1 + i] = tree.token_ids[i];
+
+            std::vector<int32_t> posterior;
+            if (!target->verify_tree(committed, tree, flat_tokens, N, posterior, nullptr)) {
+                std::fprintf(stderr, "spec-decode: verify_tree failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+
+            int next_token = -1, bonus_node = 0;
+            std::vector<int> accepted =
+                follow_verified_tree(tree, posterior.data(), next_token, &bonus_node);
+
+            int commit_n = (int)accepted.size();          // root + accepted children
+            if (commit_n > need_commit_budget) commit_n = need_commit_budget;
+            if (commit_n <= 0) { step_graph_destroy(draft_sg); break; }
+
+            // Emit the accepted path: slot 0 = last_tok (pending from prev iter),
+            // each subsequent accepted node = its tree token.
+            bool hit_eos = false;
+            int emitted = 0;
+            for (int i = 0; i < commit_n; i++) {
+                const int dfs = accepted[i];
+                const int32_t tok = (dfs == 0) ? last_tok : tree.token_ids[dfs - 1];
+                out_tokens.push_back(tok);
+                io.emit(tok);
+                emitted++;
+                if (io.cancelled) { hit_eos = true; break; }
+                if (target->is_eos(tok)) { hit_eos = true; break; }
+            }
+            last_tok = next_token;
+
+            // Telemetry: accepted children (exclude the always-committed root).
+            n_accept_sum += std::max(0, emitted - 1);
+            n_draft_steps++;
+
+            if (hit_eos || last_tok < 0 || target->is_eos(last_tok)) {
+                committed   += emitted;
+                n_generated += emitted;
+                break;
+            }
+
+            // Roll recurrent + KV state forward to the committed accepted path.
+            std::vector<int> accepted_committed(accepted.begin(),
+                                                accepted.begin() + emitted);
+            if (!target->rollback_to_tree(committed, tree, accepted_committed)) {
+                std::fprintf(stderr, "spec-decode: rollback_to_tree failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+
+            // Sync draft-side feature mirror over the committed range.
+            if (feature_mirror_.target_feat && !draft_parked_) {
+                draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                feature_mirror_, committed, emitted);
+            }
+
+            committed   += emitted;
+            n_generated += emitted;
+            continue;
+        }
+
         // 3b. Tool call hint injection: override draft tokens with pre-known
         // structural tokens for near-100% acceptance.
         int hint_fill = 0;
@@ -1887,20 +1986,31 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             target->supports_fast_rollback() && (accept_n >= kFastRollbackThreshold);
 
         int replay_last_tok = -1;
+        bool fast_rolled_back = false;
         if (use_fast_rollback) {
             // Fast rollback: restore SSM from captured intermediates, skip replay.
-            // Implicit bonus: target_tok[accept_n-1] seeds next draft as draft_tok[0],
+            // Implicit bonus: target_tok[commit_n-1] seeds next draft as draft_tok[0],
             // always accepted on next step.
             bonus_tok = -1;
-            commit_n = accept_n;
-            if (!target->rollback_to(committed, accept_n)) {
-                std::fprintf(stderr, "spec-decode: rollback_to failed\n");
-                step_graph_destroy(draft_sg);
-                return false;
+            // Respect the generation budget: accept_n may exceed the remaining
+            // budget (need_commit_budget), so committing accept_n would emit
+            // more tokens than requested. commit_n was already clamped above.
+            commit_n = std::min(accept_n, need_commit_budget);
+            if (target->rollback_to(committed, commit_n)) {
+                replay_last_tok = target_tok[commit_n - 1];
+                fast_rolled_back = true;
+            } else {
+                // Rollback failed (CUDA error / unsupported state type). The
+                // pre-verify snapshot is still valid, so degrade to the legacy
+                // restore+replay path below instead of aborting the request.
+                std::fprintf(stderr, "spec-decode: rollback_to failed; "
+                                     "falling back to restore+replay\n");
             }
-            replay_last_tok = target_tok[accept_n - 1];
-        } else {
+        }
+        if (!fast_rolled_back) {
             // Legacy replay: restore SSM snapshot, replay accepted + bonus tokens.
+            // (When falling back from fast-rollback, bonus_tok is -1 and commit_n
+            //  is the budget-clamped accepted count.)
             if (!target->restore_kv()) {
                 step_graph_destroy(draft_sg);
                 return false;

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -676,10 +676,11 @@ DFlashTarget * Qwen35Backend::dflash_target() {
         dflash_target_ = std::make_unique<Qwen35DFlashTarget>(
             w_, cache_, target_backend_, sg_,
             cfg_.kq_stride_pad, cfg_.fa_window);
+        auto * qt = static_cast<Qwen35DFlashTarget *>(dflash_target_.get());
         if (kvflash_active()) {
-            static_cast<Qwen35DFlashTarget *>(dflash_target_.get())
-                ->set_kvflash_pager(&kvflash_pager_);
+            qt->set_kvflash_pager(&kvflash_pager_);
         }
+        qt->set_fast_rollback(true);
     }
     return dflash_target_.get();
 }
@@ -1850,7 +1851,8 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
         }
 
         int verify_last_tok = -1;
-        if (!target->verify_batch(draft_tok, committed, verify_last_tok, &target_tok)) {
+        if (!target->verify_batch(draft_tok, committed, verify_last_tok, &target_tok,
+                                   /*capture_ssm_intermediates=*/true)) {
             std::fprintf(stderr, "spec-decode: verify failed\n");
             target->restore_kv();
             step_graph_destroy(draft_sg);
@@ -1875,21 +1877,49 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             if (commit_n <= accept_n) bonus_tok = -1;
         }
 
-        // 6. Replay: roll back KV and re-run only accepted tokens
-        if (!target->restore_kv()) {
-            step_graph_destroy(draft_sg);
-            return false;
+        // 6. Fix state: adaptive fast-rollback vs legacy replay.
+        //    Fast-rollback (implicit bonus, skip replay) is profitable when
+        //    accept_n is large enough that skipping the replay saves more compute
+        //    than the cost of deferring the bonus to the next step. Breakeven
+        //    is around accept_n ≈ 5. Below that, legacy replay is cheaper.
+        constexpr int kFastRollbackThreshold = 5;
+        const bool use_fast_rollback =
+            target->supports_fast_rollback() && (accept_n >= kFastRollbackThreshold);
+
+        int replay_last_tok = -1;
+        if (use_fast_rollback) {
+            // Fast rollback: restore SSM from captured intermediates, skip replay.
+            // Implicit bonus: target_tok[accept_n-1] seeds next draft as draft_tok[0],
+            // always accepted on next step.
+            bonus_tok = -1;
+            commit_n = accept_n;
+            if (!target->rollback_to(committed, accept_n)) {
+                std::fprintf(stderr, "spec-decode: rollback_to failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+            replay_last_tok = target_tok[accept_n - 1];
+        } else {
+            // Legacy replay: restore SSM snapshot, replay accepted + bonus tokens.
+            if (!target->restore_kv()) {
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+            std::vector<int32_t> replay_batch((size_t)commit_n);
+            for (int i = 0; i < commit_n; i++) {
+                replay_batch[i] = (i < accept_n) ? draft_tok[i] : bonus_tok;
+            }
+            if (!target->verify_batch(replay_batch, committed, replay_last_tok, nullptr)) {
+                std::fprintf(stderr, "spec-decode: replay failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
         }
 
+        // Build replay_tok for emitting committed tokens.
         std::vector<int32_t> replay_tok((size_t)commit_n);
         for (int i = 0; i < commit_n; i++) {
             replay_tok[i] = (i < accept_n) ? draft_tok[i] : bonus_tok;
-        }
-        int replay_last_tok = -1;
-        if (!target->verify_batch(replay_tok, committed, replay_last_tok, nullptr)) {
-            std::fprintf(stderr, "spec-decode: replay failed\n");
-            step_graph_destroy(draft_sg);
-            return false;
         }
 
         // 7. Sync features for replayed range to mirror (needed for next draft step)

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -7,6 +7,11 @@
 
 #include <cstring>
 
+// ggml_get_to_fp32_cuda is not in any public header — it lives in
+// ggml-cuda/convert.cuh. Declare here so we can link against it.
+using to_fp32_cuda_t = void (*)(const void *, float *, int64_t, cudaStream_t);
+extern "C++" to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type);
+
 namespace dflash::common {
 
 Qwen35DFlashTarget::~Qwen35DFlashTarget() {
@@ -30,7 +35,8 @@ bool Qwen35DFlashTarget::verify_batch(
         const std::vector<int32_t> & tokens,
         int base_pos,
         int & last_tok,
-        std::vector<int32_t> * all_argmax) {
+        std::vector<int32_t> * all_argmax,
+        bool capture_ssm_intermediates) {
     const int n_tokens = (int)tokens.size();
     if (n_tokens <= 0) return false;
 
@@ -52,10 +58,12 @@ bool Qwen35DFlashTarget::verify_batch(
         }
     }
 
+    const bool do_capture = fast_rollback_ && capture_ssm_intermediates;
+
     if (!build_target_step(sg_, w_, cache_, backend_,
                            /*kv_start=*/base_pos, n_tokens,
                            need_mask, /*capture=*/true,
-                           /*capture_delta_intermediate=*/false,
+                           /*capture_delta_intermediate=*/do_capture,
                            pool ? 0 : fa_window_,
                            /*last_token_logits_only=*/false,
                            kq_stride_pad_,
@@ -170,6 +178,73 @@ bool Qwen35DFlashTarget::snapshot_kv() {
 
 bool Qwen35DFlashTarget::restore_kv() {
     restore_ssm_state(cache_);
+    return true;
+}
+
+bool Qwen35DFlashTarget::supports_fast_rollback() const {
+    return fast_rollback_;
+}
+
+bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
+    if (!fast_rollback_) return false;
+
+    const int n_delta = (int)sg_.delta_captures.size();
+    if (n_delta == 0) return false;
+
+    // If all tokens accepted, the SSM state after processing all q_len tokens
+    // is exactly what we want — no rollback needed, just fix cur_pos.
+    const int q_len = cache_.cur_pos - base_pos;
+    if (commit_n >= q_len) {
+        cache_.cur_pos = base_pos + commit_n;
+        return true;
+    }
+
+    const int rollback_idx = commit_n - 1;  // index into per-step intermediates
+    cudaStream_t stream = nullptr;
+
+    for (int il = 0; il < n_delta; il++) {
+        const DeltaNetCapture & cap = sg_.delta_captures[il];
+        if (!cap.ssm_intermediate_states || !cap.conv_input) {
+            std::fprintf(stderr, "rollback_to: missing capture at layer %d\n", il);
+            return false;
+        }
+
+        // SSM rollback: copy intermediate[rollback_idx] → cache.ssm_state[il]
+        const size_t ssm_elems =
+            (size_t)cache_.ssm_state[il]->ne[0] *
+            (size_t)cache_.ssm_state[il]->ne[1] *
+            (size_t)cache_.ssm_state[il]->ne[2];
+        const size_t ssm_src_offset =
+            (size_t)rollback_idx * cap.ssm_intermediate_states->nb[3];
+        const void * ssm_src =
+            (const char *)cap.ssm_intermediate_states->data + ssm_src_offset;
+        ggml_get_to_fp32_cuda(cap.ssm_intermediate_states->type)(
+            ssm_src, (float *)cache_.ssm_state[il]->data,
+            (int64_t)ssm_elems, stream);
+
+        // Conv rollback: copy conv_input[commit_n..commit_n+K-2, :, :]
+        // into cache.conv_state[il].
+        const int K_conv = 4;
+        const int row_cnt = (int)cap.conv_input->ne[1];
+        const size_t elt = ggml_element_size(cap.conv_input);
+        const size_t dpitch = (K_conv - 1) * elt;
+        const size_t spitch = cap.conv_input->nb[1];
+        const size_t width  = (K_conv - 1) * elt;
+        const void * conv_src =
+            (const char *)cap.conv_input->data + commit_n * elt;
+        cudaError_t ce = cudaMemcpy2DAsync(cache_.conv_state[il]->data, dpitch,
+                                           conv_src, spitch,
+                                           width, row_cnt,
+                                           cudaMemcpyDeviceToDevice, stream);
+        if (ce != cudaSuccess) {
+            std::fprintf(stderr, "rollback_to: cudaMemcpy2D conv il=%d: %s\n",
+                         il, cudaGetErrorString(ce));
+            return false;
+        }
+    }
+    cudaStreamSynchronize(stream);
+
+    cache_.cur_pos = base_pos + commit_n;
     return true;
 }
 

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -171,6 +171,253 @@ bool Qwen35DFlashTarget::verify_batch(
     return true;
 }
 
+bool Qwen35DFlashTarget::supports_tree_verify() const {
+    // Tree verify reuses the fast-rollback SSM-intermediate capture, and builds
+    // the non-paged tree graph + logical attention mask. It is NOT slot-mapped,
+    // so it is incompatible with the kvflash pager — gate it off when paging.
+    return fast_rollback_ && pager_ == nullptr;
+}
+
+bool Qwen35DFlashTarget::verify_tree(
+        int committed,
+        const DDTree & tree,
+        const std::vector<int32_t> & flat_tokens,
+        int n_alloc,
+        std::vector<int32_t> & posterior_out,
+        std::vector<float> * logits_out) {
+    if (!fast_rollback_) return false;
+    const int N        = n_alloc;                 // fixed alloc width (budget+1)
+    const int N_actual = 1 + tree.n_nodes;        // real tree size incl. root
+    if (N_actual <= 0 || N_actual > N || (int)flat_tokens.size() < N) return false;
+    const int hidden = w_.n_embd;
+
+    // Tree-verify graph: ancestor-masked batched forward over DFS-ordered nodes.
+    // Capture per-node SSM intermediates so rollback_to_tree() can restore.
+    if (!build_target_step_tree(sg_, w_, cache_, backend_,
+                                /*kv_start=*/committed, /*n_tokens=*/N,
+                                fa_window_, kq_stride_pad_)) {
+        std::fprintf(stderr, "verify_tree: build_target_step_tree failed\n");
+        return false;
+    }
+
+    // Embeddings: [root, tree nodes, padding(token 0)]. Pad slots are masked.
+    std::vector<float> embed((size_t)hidden * N, 0.0f);
+    if (!w_.embedder.embed(flat_tokens.data(), N_actual, embed.data())) {
+        std::fprintf(stderr, "verify_tree: embed failed\n");
+        return false;
+    }
+    ggml_backend_tensor_set(sg_.inp_embed, embed.data(), 0,
+                            sizeof(float) * (size_t)hidden * N);
+
+    // M-RoPE axis-major positions: each node sits at committed + its depth.
+    std::vector<int32_t> pos4(4 * N, 0);
+    for (int i = 0; i < N_actual; i++) {
+        const int p = committed + (i == 0 ? 0 : tree.depths[i - 1]);
+        pos4[0 * N + i] = p;
+        pos4[1 * N + i] = p;
+        pos4[2 * N + i] = p;
+        pos4[3 * N + i] = 0;
+    }
+    ggml_backend_tensor_set(sg_.positions, pos4.data(), 0, sizeof(int32_t) * 4 * N);
+
+    // Ancestor-only attention mask (f16). Rows 0..N_actual-1 use tree
+    // visibility; padding rows stay -inf (see nothing).
+    if (sg_.attn_mask) {
+        const int tree_win_start = (fa_window_ > 0 && committed > fa_window_)
+                                       ? (committed - fa_window_) : 0;
+        const int kv_pad_m = (int)sg_.attn_mask->ne[0];
+        const int q_pad_m  = (int)sg_.attn_mask->ne[1];
+        std::vector<uint16_t> mask_buf((size_t)kv_pad_m * q_pad_m, F16_NEG_INF);
+        for (int q = 0; q < N_actual; q++) {
+            for (int k = std::max(0, tree_win_start); k < committed; k++) {
+                mask_buf[(size_t)q * kv_pad_m + (k - tree_win_start)] = F16_ZERO;
+            }
+            for (int j = 0; j < N_actual; j++) {
+                if (tree.visibility[(size_t)q * N_actual + j]) {
+                    mask_buf[(size_t)q * kv_pad_m + (committed + j - tree_win_start)] = F16_ZERO;
+                }
+            }
+        }
+        ggml_backend_tensor_set(sg_.attn_mask, mask_buf.data(), 0,
+                                sizeof(uint16_t) * mask_buf.size());
+    }
+
+    // parent_ids: real nodes point to their tree parent; root = -1; pad = 0.
+    if (!sg_.parent_ids) {
+        std::fprintf(stderr, "verify_tree: step graph has no parent_ids tensor\n");
+        return false;
+    }
+    std::vector<int32_t> parent_ids(N, 0);
+    parent_ids[0] = -1;
+    for (int i = 1; i < N_actual; i++) parent_ids[i] = (int32_t)tree.parents[i];
+    ggml_backend_tensor_set(sg_.parent_ids, parent_ids.data(), 0, sizeof(int32_t) * N);
+
+    auto st = ggml_backend_graph_compute(backend_, sg_.gf);
+    if (st != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "verify_tree: compute failed (status=%d)\n", (int)st);
+        return false;
+    }
+
+    // Posterior = per-node target argmax. Tree-shaped graphs can return -1 from
+    // the GPU argmax shortcut, so compute argmax on CPU from full logits.
+    const int vocab = (int)sg_.logits->ne[0];
+    std::vector<float> logits((size_t)vocab * N_actual);
+    ggml_backend_tensor_get(sg_.logits, logits.data(), 0,
+                            sizeof(float) * (size_t)vocab * N_actual);
+    posterior_out.resize(N_actual);
+    for (int i = 0; i < N_actual; i++) {
+        const float * row = logits.data() + (size_t)i * vocab;
+        int am = 0; float best = row[0];
+        for (int v = 1; v < vocab; v++) if (row[v] > best) { best = row[v]; am = v; }
+        posterior_out[i] = am;
+    }
+    if (logits_out) *logits_out = std::move(logits);
+    return true;
+}
+
+bool Qwen35DFlashTarget::rollback_to_tree(
+        int committed,
+        const DDTree & tree,
+        const std::vector<int> & accepted_dfs) {
+    if (!fast_rollback_) return false;
+    const int commit_n = (int)accepted_dfs.size();
+    if (commit_n <= 0) return false;
+
+    const int rollback_dfs = accepted_dfs[commit_n - 1];  // deepest committed node
+    if (rollback_dfs < 0) return false;
+
+    // Pure-chain walk has accepted_dfs[i] == i; a sibling branch breaks that and
+    // forces the conv-ancestry / KV-compaction gather.
+    bool walked_sibling = false;
+    for (int i = 0; i < commit_n; i++) {
+        if (accepted_dfs[i] != i) { walked_sibling = true; break; }
+    }
+
+    const int n_delta = (int)sg_.delta_captures.size();
+    cudaStream_t stream = nullptr;
+    for (int il = 0; il < n_delta; il++) {
+        const DeltaNetCapture & cap = sg_.delta_captures[il];
+        if (!cap.ssm_intermediate_states || !cap.conv_input) {
+            std::fprintf(stderr, "rollback_to_tree: missing capture at layer %d\n", il);
+            return false;
+        }
+        if (rollback_dfs >= (int)cap.ssm_intermediate_states->ne[3]) {
+            std::fprintf(stderr, "rollback_to_tree: rollback_dfs %d >= captured slots %d (layer %d)\n",
+                         rollback_dfs, (int)cap.ssm_intermediate_states->ne[3], il);
+            return false;
+        }
+        // SSM state ← intermediate[rollback_dfs] (dequantize Q8_0/F16 → f32).
+        const size_t ssm_elems =
+            (size_t)cache_.ssm_state[il]->ne[0] *
+            (size_t)cache_.ssm_state[il]->ne[1] *
+            (size_t)cache_.ssm_state[il]->ne[2];
+        const size_t ssm_src_offset =
+            (size_t)rollback_dfs * cap.ssm_intermediate_states->nb[3];
+        const void * ssm_src =
+            (const char *)cap.ssm_intermediate_states->data + ssm_src_offset;
+        const auto to_fp32 = ggml_get_to_fp32_cuda(cap.ssm_intermediate_states->type);
+        if (!to_fp32) {
+            std::fprintf(stderr, "rollback_to_tree: no fp32 converter for type %d (layer %d)\n",
+                         (int)cap.ssm_intermediate_states->type, il);
+            return false;
+        }
+        to_fp32(ssm_src, (float *)cache_.ssm_state[il]->data, (int64_t)ssm_elems, stream);
+
+        // Conv state ← the K-1 most recent inputs along rollback_dfs's ancestry.
+        const int K_conv = 4;
+        const int row_cnt = (int)cap.conv_input->ne[1];
+        const size_t elt = ggml_element_size(cap.conv_input);
+        const size_t dpitch = (K_conv - 1) * elt;
+        const size_t spitch = cap.conv_input->nb[1];
+        if (!walked_sibling) {
+            // Fast path: K-1 contiguous slots ending at rollback_dfs.
+            const int conv_off = rollback_dfs + 1;
+            const void * conv_src =
+                (const char *)cap.conv_input->data + (size_t)conv_off * elt;
+            cudaError_t ce = cudaMemcpy2DAsync(cache_.conv_state[il]->data, dpitch,
+                                               conv_src, spitch,
+                                               (K_conv - 1) * elt, row_cnt,
+                                               cudaMemcpyDeviceToDevice, stream);
+            if (ce != cudaSuccess) {
+                std::fprintf(stderr, "rollback_to_tree: conv fast il=%d: %s\n",
+                             il, cudaGetErrorString(ce));
+                return false;
+            }
+        } else {
+            // Sibling path: gather K-1 columns along the parent chain.
+            int virt[K_conv - 1];
+            virt[K_conv - 2] = rollback_dfs;
+            for (int k = K_conv - 3; k >= 0; k--) {
+                const int prev = virt[k + 1];
+                virt[k] = (prev >= 0) ? (int)tree.parents[prev] : (prev - 1);
+            }
+            for (int k = 0; k < K_conv - 1; k++) {
+                const int sx_slot = (K_conv - 1) + virt[k];
+                const void * src_col =
+                    (const char *)cap.conv_input->data + (size_t)sx_slot * elt;
+                char * dst_col =
+                    (char *)cache_.conv_state[il]->data + (size_t)k * elt;
+                cudaError_t ce = cudaMemcpy2DAsync(dst_col, dpitch, src_col, spitch,
+                                                   elt, row_cnt,
+                                                   cudaMemcpyDeviceToDevice, stream);
+                if (ce != cudaSuccess) {
+                    std::fprintf(stderr, "rollback_to_tree: conv col il=%d k=%d: %s\n",
+                                 il, k, cudaGetErrorString(ce));
+                    return false;
+                }
+            }
+        }
+    }
+
+    // target_feat compaction: verify wrote features in DFS order at slots
+    // committed+i. Copy each accepted DFS slot's features to its spine slot d.
+    if (cache_.target_feat) {
+        const size_t elt = ggml_element_size(cache_.target_feat);
+        const int    fc_in = (int)cache_.target_feat->ne[0];
+        const size_t col_stride = cache_.target_feat->nb[1];
+        const int    tcap = cache_.target_feat_cap;
+        for (int d = 1; d < commit_n; d++) {
+            const int src_dfs = accepted_dfs[d];
+            if (src_dfs == d) continue;
+            const size_t src_off = (size_t)((committed + src_dfs) % tcap) * col_stride;
+            const size_t dst_off = (size_t)((committed + d)       % tcap) * col_stride;
+            cudaMemcpyAsync((char *)cache_.target_feat->data + dst_off,
+                            (const char *)cache_.target_feat->data + src_off,
+                            (size_t)fc_in * elt, cudaMemcpyDeviceToDevice, stream);
+        }
+    }
+
+    // Full-attention KV compaction: move accepted DFS slots onto the spine
+    // [committed..committed+commit_n-1] so the next round sees a contiguous prefix.
+    const int n_full_attn = (int)cache_.attn_k.size();
+    for (int d = 0; d < commit_n; d++) {
+        const int src_dfs = accepted_dfs[d];
+        if (src_dfs == d) continue;
+        for (int l = 0; l < n_full_attn; l++) {
+            ggml_tensor * ck = cache_.attn_k[l];
+            ggml_tensor * cv = cache_.attn_v[l];
+            const size_t slot_bytes = ck->nb[1];
+            const size_t src_off = (size_t)(committed + src_dfs) * slot_bytes;
+            const size_t dst_off = (size_t)(committed + d)       * slot_bytes;
+            const int n_kv = (int)ck->ne[2];
+            for (int h = 0; h < n_kv; h++) {
+                const size_t head_src = src_off + (size_t)h * ck->nb[2];
+                const size_t head_dst = dst_off + (size_t)h * ck->nb[2];
+                cudaMemcpyAsync((char *)ck->data + head_dst,
+                                (const char *)ck->data + head_src,
+                                slot_bytes, cudaMemcpyDeviceToDevice, stream);
+                cudaMemcpyAsync((char *)cv->data + head_dst,
+                                (const char *)cv->data + head_src,
+                                slot_bytes, cudaMemcpyDeviceToDevice, stream);
+            }
+        }
+    }
+
+    cudaStreamSynchronize(stream);
+    cache_.cur_pos = committed + commit_n;
+    return true;
+}
+
 bool Qwen35DFlashTarget::snapshot_kv() {
     snapshot_ssm_state(cache_);
     return true;
@@ -187,6 +434,13 @@ bool Qwen35DFlashTarget::supports_fast_rollback() const {
 
 bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
     if (!fast_rollback_) return false;
+
+    // commit_n must be a positive count. `commit_n - 1` below indexes the
+    // per-step intermediates; a non-positive value underflows to a huge
+    // size_t byte offset and triggers an out-of-bounds GPU read. A zero/neg
+    // commit means "nothing to keep" — signal failure so the caller falls
+    // back to the full restore_kv path.
+    if (commit_n <= 0) return false;
 
     const int n_delta = (int)sg_.delta_captures.size();
     if (n_delta == 0) return false;
@@ -218,9 +472,14 @@ bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
             (size_t)rollback_idx * cap.ssm_intermediate_states->nb[3];
         const void * ssm_src =
             (const char *)cap.ssm_intermediate_states->data + ssm_src_offset;
-        ggml_get_to_fp32_cuda(cap.ssm_intermediate_states->type)(
-            ssm_src, (float *)cache_.ssm_state[il]->data,
-            (int64_t)ssm_elems, stream);
+        const auto to_fp32 = ggml_get_to_fp32_cuda(cap.ssm_intermediate_states->type);
+        if (!to_fp32) {
+            std::fprintf(stderr, "rollback_to: no fp32 converter for ssm type %d (layer %d)\n",
+                         (int)cap.ssm_intermediate_states->type, il);
+            return false;
+        }
+        to_fp32(ssm_src, (float *)cache_.ssm_state[il]->data,
+                (int64_t)ssm_elems, stream);
 
         // Conv rollback: copy conv_input[commit_n..commit_n+K-2, :, :]
         // into cache.conv_state[il].
@@ -277,6 +536,37 @@ bool Qwen35DFlashTarget::project_hidden_to_tokens(
     tokens_out.resize(n_tokens);
     ggml_backend_tensor_get(proj_sg_.argmax_tokens, tokens_out.data(), 0,
                             sizeof(int32_t) * n_tokens);
+    return true;
+}
+
+bool Qwen35DFlashTarget::project_hidden_to_topk(
+        const float * hidden,
+        int n_tokens,
+        int K,
+        float temperature,
+        std::vector<float> & top_log_probs,
+        std::vector<int32_t> & top_token_ids) {
+    if (n_tokens <= 0 || K <= 0) return false;
+
+    // Same projection graph as project_hidden_to_tokens — proj_sg_.logits is a
+    // graph output (argmax depends on it), so it is computed and readable here.
+    if (!build_lm_head_projection_step(proj_sg_, w_, backend_, n_tokens)) {
+        return false;
+    }
+    ggml_backend_tensor_set(proj_sg_.hidden_input, hidden, 0,
+                            sizeof(float) * (size_t)n_tokens * w_.n_embd);
+    auto st = ggml_backend_graph_compute(backend_, proj_sg_.gf);
+    if (st != GGML_STATUS_SUCCESS) return false;
+
+    const int vocab = (int)proj_sg_.logits->ne[0];
+    std::vector<float> logits((size_t)vocab * n_tokens);
+    ggml_backend_tensor_get(proj_sg_.logits, logits.data(), 0,
+                            sizeof(float) * (size_t)vocab * n_tokens);
+
+    top_log_probs.assign((size_t)n_tokens * K, 0.0f);
+    top_token_ids.assign((size_t)n_tokens * K, 0);
+    extract_draft_topk(logits.data(), n_tokens, vocab, K,
+                       top_log_probs.data(), top_token_ids.data(), temperature);
     return true;
 }
 

--- a/server/src/qwen35/qwen35_dflash_target.h
+++ b/server/src/qwen35/qwen35_dflash_target.h
@@ -36,10 +36,13 @@ public:
     bool verify_batch(const std::vector<int32_t> & tokens,
                       int base_pos,
                       int & last_tok,
-                      std::vector<int32_t> * all_argmax = nullptr) override;
+                      std::vector<int32_t> * all_argmax = nullptr,
+                      bool capture_ssm_intermediates = false) override;
 
     bool snapshot_kv() override;
     bool restore_kv() override;
+    bool supports_fast_rollback() const override;
+    bool rollback_to(int base_pos, int commit_n) override;
 
     bool is_eos(int token) const override;
 
@@ -62,6 +65,10 @@ public:
     // Forces fa_window = 0 (logical windowing is meaningless in slot space).
     void set_kvflash_pager(KvFlashPager * pager) { pager_ = pager; }
 
+    // Enable fast-rollback mode: verify will capture per-step SSM intermediates
+    // so rollback_to() can restore recurrent state without replay.
+    void set_fast_rollback(bool enabled) { fast_rollback_ = enabled; }
+
 private:
     TargetWeights & w_;
     TargetCache & cache_;
@@ -70,6 +77,7 @@ private:
     int kq_stride_pad_;
     int fa_window_;
     KvFlashPager * pager_ = nullptr;
+    bool fast_rollback_ = false;
 
     // Cached vector form of capture layer IDs (built once in constructor).
     std::vector<int> capture_ids_;

--- a/server/src/qwen35/qwen35_dflash_target.h
+++ b/server/src/qwen35/qwen35_dflash_target.h
@@ -44,6 +44,17 @@ public:
     bool supports_fast_rollback() const override;
     bool rollback_to(int base_pos, int commit_n) override;
 
+    bool supports_tree_verify() const override;
+    bool verify_tree(int committed,
+                     const DDTree & tree,
+                     const std::vector<int32_t> & flat_tokens,
+                     int n_alloc,
+                     std::vector<int32_t> & posterior_out,
+                     std::vector<float> * logits_out = nullptr) override;
+    bool rollback_to_tree(int committed,
+                          const DDTree & tree,
+                          const std::vector<int> & accepted_dfs) override;
+
     bool is_eos(int token) const override;
 
     bool embed_tokens(const int32_t * tokens, int n,
@@ -52,6 +63,13 @@ public:
     bool project_hidden_to_tokens(const float * hidden,
                                   int n_tokens,
                                   std::vector<int32_t> & tokens_out) override;
+
+    bool project_hidden_to_topk(const float * hidden,
+                                int n_tokens,
+                                int K,
+                                float temperature,
+                                std::vector<float> & top_log_probs,
+                                std::vector<int32_t> & top_token_ids) override;
 
     int hidden_size() const override { return w_.n_embd; }
     int mask_token_id() const override;

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
@@ -36,7 +36,8 @@ bool Qwen35LayerSplitDFlashTarget::verify_batch(
         const std::vector<int32_t> & tokens,
         int base_pos,
         int & last_tok,
-        std::vector<int32_t> * all_argmax) {
+        std::vector<int32_t> * all_argmax,
+        bool capture_ssm_intermediates) {
     if (shards_.empty()) return false;
     if (remote_target_shard_ && remote_target_shard_->active()) {
         return run_qwen35_mixed_layer_split_forward(

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.h
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.h
@@ -39,7 +39,8 @@ public:
     bool verify_batch(const std::vector<int32_t> & tokens,
                       int base_pos,
                       int & last_tok,
-                      std::vector<int32_t> * all_argmax = nullptr) override;
+                      std::vector<int32_t> * all_argmax = nullptr,
+                      bool capture_ssm_intermediates = false) override;
 
     bool snapshot_kv() override;
     bool restore_kv() override;

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -960,9 +960,22 @@ static ggml_tensor * build_delta_net_block(
             S_v * S_v * r_elt,
             S_v * S_v * H_v * r_elt,
             inter_offset);
-        GGML_ASSERT(ggml_nelements(inter_view) == ggml_nelements(cap->ssm_intermediate_states));
+        // The cache buffer holds max_verify_tokens per-step slots, which can
+        // exceed this batch's n_seq_tokens (e.g. --ddtree sizes the buffer to
+        // the tree budget while a chain verify uses fewer tokens). Copy the
+        // produced states into the first n_seq_tokens slots via a destination
+        // view, rather than requiring an exact size match (the prior
+        // exact-equality assert aborted whenever n_seq_tokens != the buffer's
+        // allocated token count).
+        ggml_tensor * dst = cap->ssm_intermediate_states;
+        GGML_ASSERT(n_seq_tokens <= dst->ne[3]);
+        GGML_ASSERT(dst->ne[0] == S_v && dst->ne[1] == S_v && dst->ne[2] == H_v);
+        ggml_tensor * dst_view = ggml_view_4d(ctx, dst,
+            dst->ne[0], dst->ne[1], dst->ne[2], n_seq_tokens,
+            dst->nb[1], dst->nb[2], dst->nb[3], 0);
+        GGML_ASSERT(ggml_nelements(inter_view) == ggml_nelements(dst_view));
         ggml_build_forward_expand(gf,
-            ggml_cpy(ctx, inter_view, cap->ssm_intermediate_states));
+            ggml_cpy(ctx, inter_view, dst_view));
     }
     } // end of block started at `{` before `const int64_t S_v = head_v_dim;`
 

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -798,6 +798,7 @@ static ggml_tensor * build_delta_net_block(
                 ci_len, cap->conv_input->ne[1], cap->conv_input->ne[2],
                 cap->conv_input->nb[1], cap->conv_input->nb[2], 0);
         }
+        GGML_ASSERT(ggml_nelements(conv_input) == ggml_nelements(dst));
         ggml_build_forward_expand(gf, ggml_cpy(ctx, conv_input, dst));
     }
 
@@ -959,6 +960,7 @@ static ggml_tensor * build_delta_net_block(
             S_v * S_v * r_elt,
             S_v * S_v * H_v * r_elt,
             inter_offset);
+        GGML_ASSERT(ggml_nelements(inter_view) == ggml_nelements(cap->ssm_intermediate_states));
         ggml_build_forward_expand(gf,
             ggml_cpy(ctx, inter_view, cap->ssm_intermediate_states));
     }


### PR DESCRIPTION
Replace the expensive snapshot→verify→restore→replay cycle with:
- Pure-attention targets (Gemma4): KV truncation (no replay needed)
- Hybrid SSM targets (Qwen35): fast-rollback using per-step SSM intermediate states captured during verify (GPU memcpy, no recompute)

Key changes:
- DFlashTarget interface: add truncate_kv(), has_recurrent_state(), supports_fast_rollback(), rollback_to()
- Qwen35DFlashTarget: implement rollback via delta_captures (SSM dequant
  + conv cudaMemcpy2D), enable capture_delta_intermediate during verify
- dflash_spec_decode.cpp: three-way branch (fast-rollback / legacy replay / pure-attention truncate)
- qwen35_backend.cpp: daemon inline loop supports fast-rollback
- server_main.cpp: add --fast-rollback CLI flag

Fast-rollback uses the implicit bonus approach: target_tok[accept_n-1] seeds the next draft step and is guaranteed accepted as draft_tok[0], producing identical output with zero extra forward passes.

Performance (Qwen3.6-27B, 256 tokens, RTX 2080 Ti):
  Baseline (replay):    36.5 tok/s
  Fast-rollback:        47.7 tok/s  (+30%)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

