### PR TITLE
feat(server): support KV Flash with same-backend target layer split

### DIFF
--- a/server/src/common/kvflash_pager.h
+++ b/server/src/common/kvflash_pager.h
@@ -88,20 +88,28 @@ public:
                 cfg.sink_chunks, cfg.tail_window_chunks);
             return false;
         }
-        if (attn_k.empty() || attn_k.size() != attn_v.size()) return false;
+        if (attn_k.size() != attn_v.size()) return false;
         cfg_ = cfg;
         attn_k_ = attn_k;
         attn_v_ = attn_v;
         n_blocks_ = cfg.pool_tokens / cfg.chunk_tokens;
-        const ggml_tensor * K0 = attn_k[0];
-        if ((int)K0->ne[1] < cfg.pool_tokens) return false;
-        n_head_kv_ = (int)K0->ne[2];
+        if (!attn_k.empty()) {
+            const ggml_tensor * K0 = attn_k[0];
+            if ((int)K0->ne[1] < cfg.pool_tokens) return false;
+            n_head_kv_ = (int)K0->ne[2];
 
-        // Per-(tensor, head) contiguous segment of chunk_tokens rows.
-        k_seg_bytes_ = (size_t)cfg.chunk_tokens * K0->nb[1];
-        v_seg_bytes_ = (size_t)cfg.chunk_tokens * attn_v[0]->nb[1];
-        chunk_bytes_ = (k_seg_bytes_ + v_seg_bytes_) * (size_t)n_head_kv_ * attn_k.size();
-        zero_buf_.assign(std::max(k_seg_bytes_, v_seg_bytes_), 0);
+            // Per-(tensor, head) contiguous segment of chunk_tokens rows.
+            k_seg_bytes_ = (size_t)cfg.chunk_tokens * K0->nb[1];
+            v_seg_bytes_ = (size_t)cfg.chunk_tokens * attn_v[0]->nb[1];
+            chunk_bytes_ = (k_seg_bytes_ + v_seg_bytes_) * (size_t)n_head_kv_ * attn_k.size();
+            zero_buf_.assign(std::max(k_seg_bytes_, v_seg_bytes_), 0);
+        } else {
+            n_head_kv_ = 0;
+            k_seg_bytes_ = 0;
+            v_seg_bytes_ = 0;
+            chunk_bytes_ = 0;
+            zero_buf_.clear();
+        }
 
         free_blocks_.clear();
         for (int b = n_blocks_ - 1; b >= 0; b--) free_blocks_.push_back(b);
@@ -195,7 +203,7 @@ public:
     bool page_out(int c) {
         if (c >= (int)chunks_.size() || chunks_[c].block < 0) return false;
         ChunkState & st = chunks_[c];
-        if (!st.on_host) {
+        if (has_tensor_storage() && !st.on_host) {
             st.host_data.resize(chunk_bytes_);
             stats_.host_bytes += (int64_t)chunk_bytes_;
         }
@@ -343,6 +351,7 @@ private:
     // Move one chunk between pool slots and host backing. Segment order is
     // fixed (layer-major, K then V, head-minor) so offsets are stable.
     void copy_chunk(int c, int block, bool to_host) {
+        if (!has_tensor_storage()) return;
         ChunkState & st = chunks_[c];
         uint8_t * p = st.host_data.data();
         for (size_t l = 0; l < attn_k_.size(); l++) {
@@ -360,6 +369,7 @@ private:
     }
 
     void zero_block(int block) {
+        if (!has_tensor_storage()) return;
         for (size_t l = 0; l < attn_k_.size(); l++) {
             for (int kv = 0; kv < 2; kv++) {
                 ggml_tensor * t = kv == 0 ? attn_k_[l] : attn_v_[l];
@@ -370,6 +380,10 @@ private:
                 }
             }
         }
+    }
+
+    bool has_tensor_storage() const {
+        return !attn_k_.empty() && chunk_bytes_ > 0;
     }
 
     KvFlashConfig cfg_;

--- a/server/src/gemma4/gemma4_graph.cpp
+++ b/server/src/gemma4/gemma4_graph.cpp
@@ -460,6 +460,8 @@ void gemma4_layer_step_graph_free(Gemma4LayerStepGraph & sg) {
     sg.token_ids = nullptr;
     sg.attn_mask_full = nullptr;
     sg.attn_mask_swa = nullptr;
+    sg.kv_idx_full = nullptr;
+    sg.kv_idx_swa = nullptr;
 }
 
 void gemma4_layer_step_graph_destroy(Gemma4LayerStepGraph & sg) {
@@ -481,9 +483,11 @@ bool build_gemma4_layer_step(
     ggml_tensor *          act_out,
     int                    chunk_start,
     int                    n_tokens,
-    int                    kv_start) {
+    int                    kv_start,
+    const KvFlashPager *   kvflash) {
     gemma4_layer_step_graph_free(sg);
     if (layer_idx < 0 || layer_idx >= w.n_layer) return false;
+    if (kvflash && cache.fa_window > 0) return false;
 
     ggml_init_params ip{};
     ip.mem_size = ggml_tensor_overhead() * 16384 + ggml_graph_overhead() + 16 * 1024 * 1024;
@@ -508,8 +512,15 @@ bool build_gemma4_layer_step(
     sg.token_ids = ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
     ggml_set_input(sg.token_ids);
 
+    int full_cap = cache.max_ctx;
+    for (int il = 0; il < (int)cache.k.size(); ++il) {
+        if (cache.k[(size_t)il] && !gemma4_is_swa_layer(w, il)) {
+            full_cap = (int)cache.k[(size_t)il]->ne[1];
+            break;
+        }
+    }
     const int kv_len_raw = kv_start + n_tokens;
-    const int kv_len_padded = (kv_len_raw + 255) & ~255;
+    const int kv_len_padded = std::min((kv_len_raw + 255) & ~255, full_cap);
     sg.attn_mask_full = ggml_new_tensor_4d(
         sg.ctx, GGML_TYPE_F32, kv_len_padded, n_tokens, 1, 1);
     ggml_set_input(sg.attn_mask_full);
@@ -524,11 +535,17 @@ bool build_gemma4_layer_step(
     ggml_set_input(sg.attn_mask_swa);
     ggml_tensor * mask_swa_f16 = ggml_cast(sg.ctx, sg.attn_mask_swa, GGML_TYPE_F16);
 
+    sg.kv_idx_full = ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
+    ggml_set_input(sg.kv_idx_full);
+    sg.kv_idx_swa = ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
+    ggml_set_input(sg.kv_idx_swa);
+
     ggml_tensor * pl_input = build_gemma4_per_layer_input(
         sg.ctx, w, embed, sg.token_ids, n_tokens, layer_idx);
     ggml_tensor * layer_out = build_gemma4_layer(
         sg.ctx, sg.gf, w, cache, layer_idx, inp, sg.positions,
-        mask_full_f16, mask_swa_f16, pl_input, kv_start, n_tokens);
+        mask_full_f16, mask_swa_f16, pl_input, kv_start, n_tokens,
+        /*capture_idx=*/-1, sg.kv_idx_full, sg.kv_idx_swa);
     if (!layer_out) return false;
 
     ggml_tensor * out_view = ggml_view_2d(

--- a/server/src/gemma4/gemma4_internal.h
+++ b/server/src/gemma4/gemma4_internal.h
@@ -280,6 +280,8 @@ struct Gemma4LayerStepGraph {
     ggml_tensor * token_ids = nullptr;
     ggml_tensor * attn_mask_full = nullptr;
     ggml_tensor * attn_mask_swa = nullptr;
+    ggml_tensor * kv_idx_full = nullptr;
+    ggml_tensor * kv_idx_swa = nullptr;
 };
 
 void gemma4_layer_step_graph_free(Gemma4LayerStepGraph & sg);
@@ -296,7 +298,8 @@ bool build_gemma4_layer_step(
     ggml_tensor *          act_out,
     int                    chunk_start,
     int                    n_tokens,
-    int                    kv_start);
+    int                    kv_start,
+    const class KvFlashPager * kvflash = nullptr);
 
 bool compute_gemma4_split_argmax(
     ggml_backend_t          backend,

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -65,9 +65,11 @@ static bool gemma4_align_split_for_kv_sharing(
     const int kv_source_layer = kv_sharing_start - 1;
     if (kv_source_layer <= 0) return true;
     for (size_t i = 0; i + 1 < shards.size(); ++i) {
-        if (shards[i].layer_end > kv_source_layer) {
+        if (shards[i].layer_begin < kv_source_layer &&
+            shards[i].layer_end > kv_source_layer) {
             shards[i].layer_end = kv_source_layer;
             shards[i + 1].layer_begin = kv_source_layer;
+            break;
         }
     }
     for (const auto & shard : shards) {
@@ -260,7 +262,7 @@ bool Gemma4LayerSplitAdapter::kvflash_attach() {
 
 bool Gemma4LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+    if (committed > kvflash_tokens_) {
         std::fprintf(stderr,
             "[gemma4-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -8,6 +8,7 @@
 #include "common/layer_split_utils.h"
 #include "common/layer_split_runtime.h"
 #include "dflash27b.h"
+#include "qwen3/qwen3_kvflash_scorer.h"
 
 #include "ggml-cuda.h"
 
@@ -15,6 +16,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 
 namespace dflash::common {
 
@@ -22,6 +24,62 @@ namespace {
 
 static bool tensor_ready(const ggml_tensor * t) {
     return t && t->buffer;
+}
+
+static bool gemma4_align_split_for_kv_sharing(
+        const char * target_path,
+        std::vector<Gemma4LayerSplitShard> & shards) {
+    if (shards.size() <= 1 || !target_path) return true;
+
+    ggml_context * meta_ctx = nullptr;
+    gguf_init_params gip{};
+    gip.no_alloc = true;
+    gip.ctx      = &meta_ctx;
+    gguf_context * gctx = gguf_init_from_file(target_path, gip);
+    if (!gctx) return true;
+
+    int64_t arch_id = gguf_find_key(gctx, "general.architecture");
+    if (arch_id < 0 || std::string(gguf_get_val_str(gctx, arch_id)) != "gemma4") {
+        gguf_free(gctx);
+        if (meta_ctx) ggml_free(meta_ctx);
+        return true;
+    }
+
+    auto get_u32 = [&](const char * key, uint32_t def) {
+        int64_t id = gguf_find_key(gctx, key);
+        if (id < 0) return def;
+        if (gguf_get_kv_type(gctx, id) == GGUF_TYPE_ARRAY) {
+            if (gguf_get_arr_n(gctx, id) == 0) return def;
+            return ((const uint32_t *)gguf_get_arr_data(gctx, id))[0];
+        }
+        return gguf_get_val_u32(gctx, id);
+    };
+
+    const int n_layer = (int)get_u32("gemma4.block_count", 0);
+    const int shared_kv = (int)get_u32("gemma4.attention.shared_kv_layers", 0);
+    gguf_free(gctx);
+    if (meta_ctx) ggml_free(meta_ctx);
+    if (n_layer <= 0 || shared_kv <= 0 || shared_kv >= n_layer) return true;
+
+    const int kv_sharing_start = n_layer - shared_kv;
+    const int kv_source_layer = kv_sharing_start - 1;
+    if (kv_source_layer <= 0) return true;
+    for (size_t i = 0; i + 1 < shards.size(); ++i) {
+        if (shards[i].layer_end > kv_source_layer) {
+            shards[i].layer_end = kv_source_layer;
+            shards[i + 1].layer_begin = kv_source_layer;
+        }
+    }
+    for (const auto & shard : shards) {
+        if (shard.layer_begin >= shard.layer_end) {
+            std::fprintf(stderr,
+                "[gemma4-target-split] KV-sharing boundary alignment produced "
+                "empty shard [%d,%d); adjust --target-layer-split\n",
+                shard.layer_begin, shard.layer_end);
+            return false;
+        }
+    }
+    return true;
 }
 
 }  // namespace
@@ -45,6 +103,9 @@ bool Gemma4LayerSplitAdapter::init() {
         "gemma4-target-split",
     };
     if (!init_layer_split_runtime(runtime_cfg, shards_, snapshot_backends_)) {
+        return false;
+    }
+    if (!gemma4_align_split_for_kv_sharing(cfg_.target_path, shards_)) {
         return false;
     }
 
@@ -72,13 +133,29 @@ bool Gemma4LayerSplitAdapter::init() {
             make_layer_split_load_plan<TargetLoadPlan>(
                 shard, i + 1 == shards_.size());
         if (!load_gemma4_gguf_partial(cfg_.target_path, shard.backend,
-                                      plan, shard.weights) ||
-            !create_gemma4_cache_partial(shard.backend, shard.weights,
+                                      plan, shard.weights)) {
+            std::fprintf(stderr,
+                "[gemma4-target-split] load gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+
+    kvflash_read_config();
+    if (kvflash_active() && cfg_.fa_window > 0) {
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] fa_window is incompatible with "
+            "pooled full-attention slots\n");
+        return false;
+    }
+
+    for (auto & shard : shards_) {
+        if (!create_gemma4_cache_partial(shard.backend, shard.weights,
                                          cfg_.device.max_ctx,
                                          shard.layer_begin, shard.layer_end,
-                                         shard.cache)) {
+                                         shard.cache, kvflash_tokens_)) {
             std::fprintf(stderr,
-                "[gemma4-target-split] load/cache gpu=%d: %s\n",
+                "[gemma4-target-split] cache gpu=%d: %s\n",
                 shard.gpu, dflash27b_last_error());
             return false;
         }
@@ -86,12 +163,172 @@ bool Gemma4LayerSplitAdapter::init() {
         std::fprintf(stderr, "[gemma4-target-split] gpu=%d layers=[%d,%d)\n",
                      shard.gpu, shard.layer_begin, shard.layer_end);
     }
+    if (!kvflash_attach()) return false;
+
     snapshots_.resize(PREFIX_SLOTS);
     for (auto & slot : snapshots_) {
         slot.shards.resize(shards_.size());
     }
+    kvflash_history_snapshots_.resize(PREFIX_SLOTS);
 
     return true;
+}
+
+void Gemma4LayerSplitAdapter::kvflash_read_config() {
+    if (!std::getenv("DFLASH_KVFLASH") || shards_.empty()) return;
+    kvflash_drafter_path_ = kvflash_find_drafter(cfg_.target_path);
+
+    int64_t min_free = std::numeric_limits<int64_t>::max();
+    int64_t max_bytes_per_token = 0;
+    for (const auto & shard : shards_) {
+        size_t gpu_free = 0, gpu_total = 0;
+        if (ggml_backend_dev_t dev = ggml_backend_get_device(shard.backend)) {
+            ggml_backend_dev_memory(dev, &gpu_free, &gpu_total);
+        }
+        min_free = std::min<int64_t>(min_free, (int64_t)gpu_free);
+
+        int64_t bpt = 0;
+        for (int il = shard.layer_begin; il < shard.layer_end; ++il) {
+            if (!gemma4_has_kv(shard.weights, il) ||
+                gemma4_is_swa_layer(shard.weights, il)) {
+                continue;
+            }
+            bpt += (int64_t)gemma4_n_head_kv(shard.weights, il) * 2 *
+                   (int64_t)ggml_row_size(GGML_TYPE_F16,
+                                          gemma4_head_dim(shard.weights, il));
+        }
+        max_bytes_per_token = std::max<int64_t>(max_bytes_per_token, bpt);
+    }
+    if (min_free == std::numeric_limits<int64_t>::max()) min_free = 0;
+
+    KvFlashAutoBudget budget;
+    budget.free_bytes = min_free;
+    budget.bytes_per_token = max_bytes_per_token;
+    budget.reserve_bytes = (int64_t)(1.5 * 1073741824.0) +
+        (kvflash_drafter_path_.empty() ? 0 : (int64_t)(1.7 * 1073741824.0));
+    kvflash_tokens_ = kvflash_pool_from_env(
+        cfg_.device.max_ctx, KvFlashConfig{},
+        !kvflash_drafter_path_.empty(), budget);
+    if (kvflash_tokens_ > 0) {
+        const char * tau = std::getenv("DFLASH_KVFLASH_TAU");
+        kvflash_tau_ = std::max(1, tau ? std::atoi(tau) : 64);
+    }
+}
+
+bool Gemma4LayerSplitAdapter::kvflash_attach() {
+    if (!kvflash_active()) return true;
+    std::vector<ggml_tensor *> full_k;
+    std::vector<ggml_tensor *> full_v;
+    const int n_layer = shards_.empty() ? 0 : shards_.front().weights.n_layer;
+    for (int il = 0; il < n_layer; ++il) {
+        if (!gemma4_has_kv(shards_.front().weights, il) ||
+            gemma4_is_swa_layer(shards_.front().weights, il)) {
+            continue;
+        }
+        ggml_tensor * k = nullptr;
+        ggml_tensor * v = nullptr;
+        for (auto & shard : shards_) {
+            if (il < (int)shard.cache.k.size() && shard.cache.k[(size_t)il]) {
+                k = shard.cache.k[(size_t)il];
+                v = shard.cache.v[(size_t)il];
+                break;
+            }
+        }
+        if (k && v) {
+            full_k.push_back(k);
+            full_v.push_back(v);
+        }
+    }
+    KvFlashConfig pc;
+    pc.pool_tokens = kvflash_tokens_;
+    if (!kvflash_pager_.attach(pc, full_k, full_v)) {
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] pager attach failed pool=%d layers=%zu\n",
+            kvflash_tokens_, full_k.size());
+        return false;
+    }
+    std::printf("[gemma4-target-split][kvflash] resident pool %d tokens over "
+                "%zu full-attn layers (logical max_ctx %d), tau=%d, policy=%s\n",
+                kvflash_tokens_, full_k.size(), cfg_.device.max_ctx,
+                kvflash_tau_,
+                !kvflash_drafter_path_.empty()
+                    ? "drafter/cross-tok (attaches on first reselect)"
+                    : "lru (recency-only: no Qwen3-0.6B drafter found)");
+    std::fflush(stdout);
+    return true;
+}
+
+bool Gemma4LayerSplitAdapter::kvflash_sync_identity(int committed) {
+    if (!kvflash_active()) return true;
+    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
+            committed, kvflash_tokens_);
+        return false;
+    }
+    kvflash_pager_.reset();
+    if (!kvflash_pager_.alloc_span(0, committed)) return false;
+    kvflash_pager_.zero_free_blocks();
+    return true;
+}
+
+void Gemma4LayerSplitAdapter::kvflash_sync_history(
+        const std::vector<int32_t> & tokens, int base_pos) {
+    if (!kvflash_active()) return;
+    if (base_pos == 0) {
+        kvflash_history_.assign(tokens.begin(), tokens.end());
+        return;
+    }
+    if ((int)kvflash_history_.size() > base_pos) {
+        kvflash_history_.resize((size_t)base_pos);
+    } else if ((int)kvflash_history_.size() < base_pos) {
+        kvflash_history_.resize((size_t)base_pos, 0);
+    }
+    kvflash_history_.insert(kvflash_history_.end(), tokens.begin(), tokens.end());
+}
+
+void Gemma4LayerSplitAdapter::kvflash_maybe_reselect(int generated) {
+    if (!kvflash_active() || kvflash_tau_ <= 0) return;
+    const int tau = std::max<int>(kvflash_tau_, (int)(kvflash_history_.size() / 45));
+    if (generated % tau != 0) return;
+    if (!kvflash_scorer_) {
+        if (kvflash_drafter_path_.empty() || kvflash_drafter_failed_) return;
+        if (!kvflash_drafter_loaded_) {
+            for (auto & shard : shards_) ggml_backend_synchronize(shard.backend);
+            std::fprintf(stderr,
+                "[gemma4-target-split][kvflash] loading residency drafter: %s\n",
+                kvflash_drafter_path_.c_str());
+            if (!load_drafter(kvflash_drafter_path_, /*gpu_layers=*/999,
+                              shards_.front().gpu, kvflash_drafter_)) {
+                std::fprintf(stderr,
+                    "[gemma4-target-split][kvflash] drafter load failed (%s); "
+                    "staying on LRU residency\n",
+                    dflash27b_last_error());
+                kvflash_drafter_failed_ = true;
+                return;
+            }
+            kvflash_drafter_loaded_ = true;
+        }
+        kvflash_scorer_ = std::make_unique<KvFlashCrossTokScorer>(
+            &kvflash_drafter_, cfg_.target_path, kvflash_drafter_path_);
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] cross-tokenizer drafter scorer "
+            "attached (tau=%d)\n", kvflash_tau_);
+    }
+    if (!kvflash_scorer_->score_chunks(
+            kvflash_history_, kvflash_pager_.chunk_tokens(), kvflash_scores_)) {
+        return;
+    }
+    kvflash_pager_.score_hook = [this](int c) {
+        return c < (int)kvflash_scores_.size() ? kvflash_scores_[(size_t)c] : 1e30f;
+    };
+    const int events = kvflash_pager_.reselect();
+    kvflash_pager_.score_hook = nullptr;
+    if (events > 0) {
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] reselect @gen=%d: %d page events\n",
+            generated, events);
+    }
 }
 
 void Gemma4LayerSplitAdapter::begin_request(const GenerateRequest & req) {
@@ -105,6 +342,12 @@ void Gemma4LayerSplitAdapter::reset_request_state() {
     for (auto & shard : shards_) {
         shard.cache.cur_pos = 0;
         shard.cache.last_tok = -1;
+    }
+    if (kvflash_active()) {
+        kvflash_pager_.reset();
+        kvflash_history_.clear();
+        kvflash_scores_.clear();
+        kvflash_pager_.score_hook = nullptr;
     }
     prefill_last_logits_.clear();
 }
@@ -223,10 +466,18 @@ bool Gemma4LayerSplitAdapter::run_forward(
                     shard->cache.swa_size - (kv_start % shard->cache.swa_size);
                 n = std::min(n, swa_remaining);
             }
+            const bool use_kvflash =
+                kvflash_active() && !gemma4_is_swa_layer(ref, il);
+            if (use_kvflash && !kvflash_pager_.alloc_span(kv_start, n)) {
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
             if (!build_gemma4_layer_step(
                     shard->layer_graph, shard->weights, shard->cache,
                     shard->backend, il, act_in, orig.tensor, act_out,
-                    start, n, kv_start)) {
+                    start, n, kv_start,
+                    use_kvflash ? &kvflash_pager_ : nullptr)) {
                 std::fprintf(stderr,
                     "[gemma4-target-split] build layer=%d @%d gpu=%d\n",
                     il, start, shard->gpu);
@@ -253,16 +504,40 @@ bool Gemma4LayerSplitAdapter::run_forward(
                                         sizeof(int32_t) * (size_t)n);
             }
 
-            const int kv_len_raw = kv_start + n;
-            const int kv_len_padded = (kv_len_raw + 255) & ~255;
-            std::vector<float> mfull((size_t)kv_len_padded * n, -INFINITY);
-            for (int q = 0; q < n; ++q) {
-                const int abs_q = kv_start + q;
-                for (int k = 0; k <= abs_q && k < kv_len_raw; ++k) {
-                    mfull[(size_t)q * kv_len_padded + k] = 0.0f;
+            if (tensor_ready(shard->layer_graph.kv_idx_full)) {
+                if (use_kvflash) {
+                    std::vector<int32_t> rows;
+                    std::vector<float> mfull;
+                    if (!kvflash_fill_rows_and_masks(
+                            kvflash_pager_, kv_start, n,
+                            (int)shard->layer_graph.attn_mask_full->ne[0],
+                            /*swa_window=*/0, rows, &mfull, nullptr)) {
+                        activation_buffer_free(orig);
+                        activation_pair_free(acts);
+                        return false;
+                    }
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx_full,
+                                            rows.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx_full));
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask_full,
+                                            mfull.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask_full));
+                } else {
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx_full,
+                                            pos.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx_full));
                 }
             }
-            if (tensor_ready(shard->layer_graph.attn_mask_full)) {
+            if (!use_kvflash && tensor_ready(shard->layer_graph.attn_mask_full)) {
+                const int kv_len_raw = kv_start + n;
+                const int kv_len_padded = (int)shard->layer_graph.attn_mask_full->ne[0];
+                std::vector<float> mfull((size_t)kv_len_padded * n, -INFINITY);
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    for (int k = 0; k <= abs_q && k < kv_len_raw && k < kv_len_padded; ++k) {
+                        mfull[(size_t)q * kv_len_padded + k] = 0.0f;
+                    }
+                }
                 ggml_backend_tensor_set(shard->layer_graph.attn_mask_full,
                                         mfull.data(), 0,
                                         ggml_nbytes(shard->layer_graph.attn_mask_full));
@@ -270,7 +545,16 @@ bool Gemma4LayerSplitAdapter::run_forward(
 
             const int swa_size = shard->cache.swa_size;
             const int swa_len_raw = std::min(kv_start + n, swa_size);
-            const int swa_len_padded = (swa_len_raw + 255) & ~255;
+            const int swa_len_padded = tensor_ready(shard->layer_graph.attn_mask_swa)
+                ? (int)shard->layer_graph.attn_mask_swa->ne[0]
+                : ((swa_len_raw + 255) & ~255);
+            if (tensor_ready(shard->layer_graph.kv_idx_swa)) {
+                std::vector<int32_t> ring((size_t)n);
+                for (int i = 0; i < n; ++i) ring[(size_t)i] = (kv_start + i) % swa_size;
+                ggml_backend_tensor_set(shard->layer_graph.kv_idx_swa,
+                                        ring.data(), 0,
+                                        ggml_nbytes(shard->layer_graph.kv_idx_swa));
+            }
             std::vector<float> mswa((size_t)swa_len_padded * n, -INFINITY);
             for (int q = 0; q < n; ++q) {
                 const int abs_q = kv_start + q;
@@ -322,7 +606,12 @@ bool Gemma4LayerSplitAdapter::run_forward(
 bool Gemma4LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
                                       int base_pos,
                                       int & last_tok) {
-    return run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
+    const bool ok = run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
+    if (ok && kvflash_active()) {
+        kvflash_sync_history(prompt, base_pos);
+        kvflash_pager_.zero_free_blocks();
+    }
+    return ok;
 }
 
 bool Gemma4LayerSplitAdapter::decode_ar(
@@ -336,7 +625,7 @@ bool Gemma4LayerSplitAdapter::decode_ar(
 
     const auto & w = shards_.front().weights;
     const int vocab = w.n_vocab;
-    return run_layer_split_ar_decode(
+    const bool ok = run_layer_split_ar_decode(
         last_tok, committed, n_gen, vocab, prefill_last_logits_, sampler_,
         sampler_rng_,
         [&](const std::vector<int32_t> & one, int pos, int & next_tok,
@@ -345,6 +634,11 @@ bool Gemma4LayerSplitAdapter::decode_ar(
         },
         [&](int tok) { return tok == w.eos_id || tok == w.eos_chat_id; },
         out_tokens, io);
+    if (ok && kvflash_active()) {
+        kvflash_sync_history(out_tokens, committed);
+        kvflash_maybe_reselect((int)out_tokens.size());
+    }
+    return ok;
 }
 
 bool Gemma4LayerSplitAdapter::snapshot_save(int slot) {
@@ -353,6 +647,17 @@ bool Gemma4LayerSplitAdapter::snapshot_save(int slot) {
     auto & snap = snapshots_[(size_t)slot];
     const int snap_pos = shards_.front().cache.cur_pos;
     if (snap_pos <= 0) return false;
+    if (kvflash_active() &&
+        (snap_pos > kvflash_tokens_ || !kvflash_pager_.is_identity())) {
+        static bool warned = false;
+        if (!warned) {
+            std::fprintf(stderr,
+                "[gemma4-target-split][kvflash] snapshot skipped: pooled "
+                "layout needs page-table serialization\n");
+            warned = true;
+        }
+        return false;
+    }
 
     snapshot_free(slot);
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
@@ -410,6 +715,16 @@ bool Gemma4LayerSplitAdapter::snapshot_save(int slot) {
     snap.cur_pos = snap_pos;
     snap.last_tok = shards_.front().cache.last_tok;
     snap.prefill_last_logits = prefill_last_logits_;
+    if (kvflash_active() &&
+        kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        auto & history_snap = kvflash_history_snapshots_[(size_t)slot];
+        history_snap.clear();
+        const size_t keep = (size_t)std::min(snap_pos, (int)kvflash_history_.size());
+        history_snap.assign(kvflash_history_.begin(), kvflash_history_.begin() + keep);
+        if ((int)history_snap.size() < snap_pos) {
+            history_snap.resize((size_t)snap_pos, 0);
+        }
+    }
     return true;
 }
 
@@ -422,6 +737,9 @@ void Gemma4LayerSplitAdapter::snapshot_free(int slot) {
     snap.cur_pos = 0;
     snap.last_tok = -1;
     snap.prefill_last_logits.clear();
+    if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        kvflash_history_snapshots_[(size_t)slot].clear();
+    }
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
 }
 
@@ -473,6 +791,20 @@ bool Gemma4LayerSplitAdapter::snapshot_restore(int slot) {
         shards_[i].cache.last_tok = snap.last_tok;
     }
     prefill_last_logits_ = snap.prefill_last_logits;
+    if (kvflash_active()) {
+        if (!kvflash_sync_identity(snap.cur_pos)) return false;
+        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS &&
+            !kvflash_history_snapshots_[(size_t)slot].empty()) {
+            kvflash_history_ = kvflash_history_snapshots_[(size_t)slot];
+        } else {
+            kvflash_history_.clear();
+        }
+        if ((int)kvflash_history_.size() > snap.cur_pos) {
+            kvflash_history_.resize((size_t)snap.cur_pos);
+        } else if ((int)kvflash_history_.size() < snap.cur_pos) {
+            kvflash_history_.resize((size_t)snap.cur_pos, 0);
+        }
+    }
     return true;
 }
 
@@ -482,7 +814,13 @@ int Gemma4LayerSplitAdapter::current_last_token() const {
 }
 
 void Gemma4LayerSplitAdapter::shutdown() {
+    kvflash_scorer_.reset();
+    if (kvflash_drafter_loaded_) {
+        dflash::common::free_drafter(kvflash_drafter_);
+        kvflash_drafter_loaded_ = false;
+    }
     for (int i = 0; i < PREFIX_SLOTS; ++i) snapshot_free(i);
+    kvflash_history_snapshots_.clear();
     auto shard_metas = layer_split_shard_metas(shards_);
     free_layer_split_snapshot_backends(shard_metas, snapshot_backends_);
     free_gemma4_layer_split_shards(shards_);

--- a/server/src/gemma4/gemma4_layer_split_adapter.h
+++ b/server/src/gemma4/gemma4_layer_split_adapter.h
@@ -4,11 +4,16 @@
 
 #include "common/layer_split_backend.h"
 #include "common/layer_split_utils.h"
+#include "common/kvflash_pager.h"
+#include "common/kvflash_scorer.h"
 #include "gemma4_internal.h"
 #include "placement/placement_config.h"
+#include "qwen3/qwen3_drafter.h"
 
 #include "ggml-backend.h"
 
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace dflash::common {
@@ -70,12 +75,29 @@ private:
                      int base_pos,
                      int & last_tok,
                      std::vector<float> * logits_out = nullptr);
+    void kvflash_read_config();
+    bool kvflash_attach();
+    bool kvflash_active() const { return kvflash_tokens_ > 0; }
+    bool kvflash_sync_identity(int committed);
+    void kvflash_sync_history(const std::vector<int32_t> & tokens, int base_pos);
+    void kvflash_maybe_reselect(int generated);
 
     Gemma4LayerSplitAdapterConfig cfg_;
     std::vector<Gemma4LayerSplitShard> shards_;
     std::vector<ggml_backend_t> snapshot_backends_;
     std::vector<Gemma4LayerSplitSnapshot> snapshots_;
     ggml_type activation_type_ = GGML_TYPE_F32;
+    KvFlashPager kvflash_pager_;
+    std::unique_ptr<KvFlashScorer> kvflash_scorer_;
+    DrafterContext kvflash_drafter_;
+    std::vector<int32_t> kvflash_history_;
+    std::vector<std::vector<int32_t>> kvflash_history_snapshots_;
+    std::vector<float> kvflash_scores_;
+    std::string kvflash_drafter_path_;
+    int kvflash_tokens_ = 0;
+    int kvflash_tau_ = 64;
+    bool kvflash_drafter_loaded_ = false;
+    bool kvflash_drafter_failed_ = false;
     static constexpr int PREFIX_SLOTS = ModelBackend::kMaxSlots;
     SamplerCfg sampler_;
     std::mt19937_64 sampler_rng_{std::random_device{}()};

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -599,7 +599,8 @@ ggml_tensor * build_qwen35_layer(
     bool                  capture,
     int                   fa_window = 0,
     ggml_tensor *         q_tail_capture = nullptr,
-    int                   q_tail_start = 0);
+    int                   q_tail_start = 0,
+    ggml_tensor *         kv_write_rows = nullptr);
 
 // Overload that also exposes the MoE router selection tensor (if MoE layer).
 ggml_tensor * build_qwen35_layer(
@@ -617,7 +618,8 @@ ggml_tensor * build_qwen35_layer(
     int                   fa_window,
     ggml_tensor *         q_tail_capture,
     int                   q_tail_start,
-    ggml_tensor **        moe_selected_out);
+    ggml_tensor **        moe_selected_out,
+    ggml_tensor *         kv_write_rows = nullptr);
 
 QwenLayerPrefnOutputs build_qwen35_layer_prefn(
     ggml_context *        ctx,

--- a/server/src/laguna/laguna_internal.h
+++ b/server/src/laguna/laguna_internal.h
@@ -328,6 +328,7 @@ struct LagunaLayerStepGraph {
     ggml_tensor * positions = nullptr;
     ggml_tensor * attn_mask = nullptr;
     ggml_tensor * attn_mask_swa = nullptr;
+    ggml_tensor * kv_idx = nullptr;
 };
 
 void laguna_layer_step_graph_free(LagunaLayerStepGraph & sg);
@@ -343,7 +344,8 @@ bool build_laguna_layer_step(
     ggml_tensor * act_out,
     int chunk_start,
     int n_tokens,
-    int kv_start);
+    int kv_start,
+    const class KvFlashPager * kvflash = nullptr);
 
 bool compute_laguna_split_argmax(
     ggml_backend_t backend,

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -9,6 +9,7 @@
 #include "common/sampler.h"
 #include "common/layer_split_runtime.h"
 #include "dflash27b.h"
+#include "qwen3/qwen3_kvflash_scorer.h"
 
 #include "ggml-cuda.h"
 #include "ggml-cpu.h"
@@ -18,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <random>
 #include <string>
 #include <vector>
@@ -71,18 +73,31 @@ bool LagunaLayerSplitAdapter::init() {
         const TargetLoadPlan plan =
             make_layer_split_load_plan<TargetLoadPlan>(shard, i + 1 == shards_.size());
         if (!load_target_gguf_laguna_partial(
-                cfg_.target_path, shard.backend, plan, shard.weights) ||
-            !create_laguna_target_cache_partial(
-                shard.weights, cfg_.device.max_ctx, shard.backend,
-                shard.layer_begin, shard.layer_end, shard.cache)) {
+                cfg_.target_path, shard.backend, plan, shard.weights)) {
             std::fprintf(stderr,
-                "[laguna-target-split] load/cache gpu=%d: %s\n",
+                "[laguna-target-split] load gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+
+    kvflash_read_config();
+
+    for (size_t i = 0; i < shards_.size(); ++i) {
+        auto & shard = shards_[i];
+        if (!create_laguna_target_cache_partial(
+                shard.weights, cfg_.device.max_ctx, shard.backend,
+                shard.layer_begin, shard.layer_end, shard.cache,
+                kvflash_tokens_)) {
+            std::fprintf(stderr,
+                "[laguna-target-split] cache gpu=%d: %s\n",
                 shard.gpu, dflash27b_last_error());
             return false;
         }
         std::fprintf(stderr, "[laguna-target-split] gpu=%d layers=[%d,%d)\n",
                      shard.gpu, shard.layer_begin, shard.layer_end);
     }
+    if (!kvflash_attach()) return false;
 
     snapshots_.resize(PREFIX_SLOTS);
     for (auto & slot : snapshots_) {
@@ -92,7 +107,169 @@ bool LagunaLayerSplitAdapter::init() {
     disk_snapshot_contexts_.assign(PREFIX_SLOTS, nullptr);
     disk_snapshot_buffers_.assign(PREFIX_SLOTS, nullptr);
     disk_snapshot_backends_.assign(PREFIX_SLOTS, nullptr);
+    kvflash_history_snapshots_.resize(PREFIX_SLOTS);
     return true;
+}
+
+KvFlashConfig LagunaLayerSplitAdapter::kvflash_config() const {
+    KvFlashConfig pc;
+    if (!shards_.empty() && shards_.front().weights.sliding_window > 0) {
+        pc.tail_window_chunks =
+            std::max(4, (shards_.front().weights.sliding_window +
+                         pc.chunk_tokens - 1) / pc.chunk_tokens + 1);
+    }
+    return pc;
+}
+
+void LagunaLayerSplitAdapter::kvflash_read_config() {
+    if (!std::getenv("DFLASH_KVFLASH") || shards_.empty()) return;
+    kvflash_drafter_path_ = kvflash_find_drafter(cfg_.target_path);
+
+    int64_t min_free = std::numeric_limits<int64_t>::max();
+    int64_t max_bytes_per_token = 0;
+    const LagunaTargetWeights & ref = shards_.front().weights;
+    for (const auto & shard : shards_) {
+        size_t gpu_free = 0, gpu_total = 0;
+        if (ggml_backend_dev_t dev = ggml_backend_get_device(shard.backend)) {
+            ggml_backend_dev_memory(dev, &gpu_free, &gpu_total);
+        }
+        min_free = std::min<int64_t>(min_free, (int64_t)gpu_free);
+
+        const int owned_layers =
+            std::max(0, shard.layer_end - shard.layer_begin);
+        const int64_t bpt = (int64_t)owned_layers * ref.n_head_kv * 2 *
+            (int64_t)ggml_row_size(GGML_TYPE_Q8_0, ref.head_dim);
+        max_bytes_per_token = std::max<int64_t>(max_bytes_per_token, bpt);
+    }
+    if (min_free == std::numeric_limits<int64_t>::max()) min_free = 0;
+
+    KvFlashAutoBudget budget;
+    budget.free_bytes = min_free;
+    budget.bytes_per_token = max_bytes_per_token;
+    budget.reserve_bytes = (int64_t)(1.5 * 1073741824.0) +
+        (kvflash_drafter_path_.empty() ? 0 : (int64_t)(1.7 * 1073741824.0));
+    kvflash_tokens_ = kvflash_pool_from_env(
+        cfg_.device.max_ctx, kvflash_config(),
+        !kvflash_drafter_path_.empty(), budget);
+    if (kvflash_tokens_ > 0) {
+        const char * tau = std::getenv("DFLASH_KVFLASH_TAU");
+        kvflash_tau_ = std::max(1, tau ? std::atoi(tau) : 64);
+    }
+}
+
+bool LagunaLayerSplitAdapter::kvflash_attach() {
+    if (!kvflash_active()) return true;
+    std::vector<ggml_tensor *> all_k;
+    std::vector<ggml_tensor *> all_v;
+    const int n_layer = shards_.empty() ? 0 : shards_.front().weights.n_layer;
+    for (int il = 0; il < n_layer; ++il) {
+        ggml_tensor * k = nullptr;
+        ggml_tensor * v = nullptr;
+        for (auto & shard : shards_) {
+            if (il < (int)shard.cache.attn_k.size() &&
+                shard.cache.attn_k[(size_t)il]) {
+                k = shard.cache.attn_k[(size_t)il];
+                v = shard.cache.attn_v[(size_t)il];
+                break;
+            }
+        }
+        if (k && v) {
+            all_k.push_back(k);
+            all_v.push_back(v);
+        }
+    }
+    KvFlashConfig pc = kvflash_config();
+    pc.pool_tokens = kvflash_tokens_;
+    if (!kvflash_pager_.attach(pc, all_k, all_v)) {
+        std::fprintf(stderr,
+            "[laguna-target-split][kvflash] pager attach failed pool=%d layers=%zu\n",
+            kvflash_tokens_, all_k.size());
+        return false;
+    }
+    std::printf("[laguna-target-split][kvflash] resident pool %d tokens over "
+                "%zu layers (logical max_ctx %d), tau=%d, policy=%s, "
+                "swa_tail=%d chunks\n",
+                kvflash_tokens_, all_k.size(), cfg_.device.max_ctx,
+                kvflash_tau_,
+                !kvflash_drafter_path_.empty()
+                    ? "drafter/cross-tok (attaches on first reselect)"
+                    : "lru (recency-only: no Qwen3-0.6B drafter found)",
+                pc.tail_window_chunks);
+    std::fflush(stdout);
+    return true;
+}
+
+bool LagunaLayerSplitAdapter::kvflash_sync_identity(int committed) {
+    if (!kvflash_active()) return true;
+    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+        std::fprintf(stderr,
+            "[laguna-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
+            committed, kvflash_tokens_);
+        return false;
+    }
+    kvflash_pager_.reset();
+    if (!kvflash_pager_.alloc_span(0, committed)) return false;
+    kvflash_pager_.zero_free_blocks();
+    return true;
+}
+
+void LagunaLayerSplitAdapter::kvflash_sync_history(
+        const std::vector<int32_t> & tokens, int base_pos) {
+    if (!kvflash_active()) return;
+    if (base_pos == 0) {
+        kvflash_history_.assign(tokens.begin(), tokens.end());
+        return;
+    }
+    if ((int)kvflash_history_.size() > base_pos) {
+        kvflash_history_.resize((size_t)base_pos);
+    } else if ((int)kvflash_history_.size() < base_pos) {
+        kvflash_history_.resize((size_t)base_pos, 0);
+    }
+    kvflash_history_.insert(kvflash_history_.end(), tokens.begin(), tokens.end());
+}
+
+void LagunaLayerSplitAdapter::kvflash_maybe_reselect(int generated) {
+    if (!kvflash_active() || kvflash_tau_ <= 0) return;
+    const int tau = std::max<int>(kvflash_tau_, (int)(kvflash_history_.size() / 45));
+    if (generated % tau != 0) return;
+    if (!kvflash_scorer_) {
+        if (kvflash_drafter_path_.empty() || kvflash_drafter_failed_) return;
+        if (!kvflash_drafter_loaded_) {
+            for (auto & shard : shards_) ggml_backend_synchronize(shard.backend);
+            std::fprintf(stderr,
+                "[laguna-target-split][kvflash] loading residency drafter: %s\n",
+                kvflash_drafter_path_.c_str());
+            if (!load_drafter(kvflash_drafter_path_, /*gpu_layers=*/999,
+                              shards_.front().gpu, kvflash_drafter_)) {
+                std::fprintf(stderr,
+                    "[laguna-target-split][kvflash] drafter load failed (%s); "
+                    "staying on LRU residency\n",
+                    dflash27b_last_error());
+                kvflash_drafter_failed_ = true;
+                return;
+            }
+            kvflash_drafter_loaded_ = true;
+        }
+        kvflash_scorer_ = std::make_unique<KvFlashCrossTokScorer>(
+            &kvflash_drafter_, cfg_.target_path, kvflash_drafter_path_);
+        std::fprintf(stderr,
+            "[laguna-target-split][kvflash] cross-tokenizer drafter scorer "
+            "attached (tau=%d)\n", kvflash_tau_);
+    }
+    if (!kvflash_scorer_->score_chunks(
+            kvflash_history_, kvflash_pager_.chunk_tokens(), kvflash_scores_)) {
+        return;
+    }
+    kvflash_pager_.score_hook = [this](int c) {
+        return c < (int)kvflash_scores_.size() ? kvflash_scores_[(size_t)c] : 1e30f;
+    };
+    const int events = kvflash_pager_.reselect();
+    kvflash_pager_.score_hook = nullptr;
+    if (events > 0) {
+        std::fprintf(stderr,
+            "[laguna-target-split][kvflash] reselect @gen=%d: %d page events\n",
+            generated, events);
+    }
 }
 
 void LagunaLayerSplitAdapter::begin_request(const GenerateRequest & req) {
@@ -105,6 +282,12 @@ void LagunaLayerSplitAdapter::begin_request(const GenerateRequest & req) {
 void LagunaLayerSplitAdapter::reset_request_state() {
     for (auto & shard : shards_) {
         reset_laguna_target_cache(shard.cache);
+    }
+    if (kvflash_active()) {
+        kvflash_pager_.reset();
+        kvflash_history_.clear();
+        kvflash_scores_.clear();
+        kvflash_pager_.score_hook = nullptr;
     }
     prefill_last_logits_.clear();
 }
@@ -191,9 +374,14 @@ bool LagunaLayerSplitAdapter::run_forward(
         for (int start = 0; start < n_tokens_total;) {
             const int n = std::min(ubatch, n_tokens_total - start);
             const int kv_start = base_pos + start;
+            if (kvflash_active() && !kvflash_pager_.alloc_span(kv_start, n)) {
+                activation_pair_free(acts);
+                return false;
+            }
             if (!build_laguna_layer_step(
                     shard->layer_graph, shard->weights, shard->cache,
-                    shard->backend, il, act_in, act_out, start, n, kv_start)) {
+                    shard->backend, il, act_in, act_out, start, n, kv_start,
+                    kvflash_active() ? &kvflash_pager_ : nullptr)) {
                 std::fprintf(stderr,
                     "[laguna-target-split] build layer=%d @%d gpu=%d\n",
                     il, start, shard->gpu);
@@ -210,33 +398,73 @@ bool LagunaLayerSplitAdapter::run_forward(
             ggml_backend_tensor_set(shard->layer_graph.positions, pos.data(), 0,
                                     sizeof(int32_t) * pos.size());
 
-            const int kv_len = kv_start + n;
-            std::vector<float> mfull((size_t)kv_len * n, -INFINITY);
-            for (int q = 0; q < n; ++q) {
-                const int abs_q = kv_start + q;
-                for (int k = 0; k <= abs_q && k < kv_len; ++k) {
-                    mfull[(size_t)q * kv_len + k] = 0.0f;
+            if (kvflash_active()) {
+                std::vector<int32_t> rows;
+                std::vector<float> mfull;
+                std::vector<float> mswa;
+                const ggml_tensor * mask_ref =
+                    shard->layer_graph.attn_mask ? shard->layer_graph.attn_mask
+                                                 : shard->layer_graph.attn_mask_swa;
+                if (!mask_ref) {
+                    activation_pair_free(acts);
+                    return false;
                 }
-            }
-            if (tensor_ready(shard->layer_graph.attn_mask)) {
-                ggml_backend_tensor_set(shard->layer_graph.attn_mask,
-                                        mfull.data(), 0,
-                                        ggml_nbytes(shard->layer_graph.attn_mask));
-            }
+                if (!kvflash_fill_rows_and_masks(
+                        kvflash_pager_, kv_start, n,
+                        (int)mask_ref->ne[0],
+                        ref.sliding_window, rows, &mfull, &mswa)) {
+                    activation_pair_free(acts);
+                    return false;
+                }
+                if (tensor_ready(shard->layer_graph.kv_idx)) {
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx,
+                                            rows.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx));
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask,
+                                            mfull.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask));
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask_swa,
+                                            mswa.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                }
+            } else {
+                const int kv_len = kv_start + n;
+                std::vector<float> mfull((size_t)kv_len * n, -INFINITY);
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    for (int k = 0; k <= abs_q && k < kv_len; ++k) {
+                        mfull[(size_t)q * kv_len + k] = 0.0f;
+                    }
+                }
+                if (tensor_ready(shard->layer_graph.kv_idx)) {
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx,
+                                            pos.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx));
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask,
+                                            mfull.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask));
+                }
 
-            std::vector<float> mswa((size_t)kv_len * n, -INFINITY);
-            const int W = ref.sliding_window;
-            for (int q = 0; q < n; ++q) {
-                const int abs_q = kv_start + q;
-                const int win_lo = std::max(0, abs_q - W + 1);
-                for (int k = win_lo; k <= abs_q && k < kv_len; ++k) {
-                    mswa[(size_t)q * kv_len + k] = 0.0f;
+                std::vector<float> mswa((size_t)kv_len * n, -INFINITY);
+                const int W = ref.sliding_window;
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    const int win_lo = std::max(0, abs_q - W + 1);
+                    for (int k = win_lo; k <= abs_q && k < kv_len; ++k) {
+                        mswa[(size_t)q * kv_len + k] = 0.0f;
+                    }
                 }
-            }
-            if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
-                ggml_backend_tensor_set(shard->layer_graph.attn_mask_swa,
-                                        mswa.data(), 0,
-                                        ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask_swa,
+                                            mswa.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                }
             }
 
             auto st = ggml_backend_graph_compute(shard->backend,
@@ -271,7 +499,12 @@ bool LagunaLayerSplitAdapter::run_forward(
 bool LagunaLayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
                                       int base_pos,
                                       int & last_tok) {
-    return run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
+    const bool ok = run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
+    if (ok && kvflash_active()) {
+        kvflash_sync_history(prompt, base_pos);
+        kvflash_pager_.zero_free_blocks();
+    }
+    return ok;
 }
 
 bool LagunaLayerSplitAdapter::decode_ar(
@@ -285,7 +518,7 @@ bool LagunaLayerSplitAdapter::decode_ar(
 
     const auto & w = shards_.front().weights;
     const int vocab = (int)w.embedder.n_vocab;
-    return run_layer_split_ar_decode(
+    const bool ok = run_layer_split_ar_decode(
         last_tok, committed, n_gen, vocab, prefill_last_logits_, sampler_,
         sampler_rng_,
         [&](const std::vector<int32_t> & one, int pos, int & next_tok,
@@ -294,6 +527,11 @@ bool LagunaLayerSplitAdapter::decode_ar(
         },
         [&](int tok) { return tok == w.eos_id || tok == w.eos_chat_id; },
         out_tokens, io);
+    if (ok && kvflash_active()) {
+        kvflash_sync_history(out_tokens, committed);
+        kvflash_maybe_reselect((int)out_tokens.size());
+    }
+    return ok;
 }
 
 bool LagunaLayerSplitAdapter::snapshot_save(int slot) {
@@ -302,6 +540,17 @@ bool LagunaLayerSplitAdapter::snapshot_save(int slot) {
     auto & snap = snapshots_[(size_t)slot];
     const int snap_pos = shards_.front().cache.cur_pos;
     if (snap_pos <= 0) return false;
+    if (kvflash_active() &&
+        (snap_pos > kvflash_tokens_ || !kvflash_pager_.is_identity())) {
+        static bool warned = false;
+        if (!warned) {
+            std::fprintf(stderr,
+                "[laguna-target-split][kvflash] snapshot skipped: pooled "
+                "layout needs page-table serialization\n");
+            warned = true;
+        }
+        return false;
+    }
 
     snapshot_free(slot);
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
@@ -318,6 +567,16 @@ bool LagunaLayerSplitAdapter::snapshot_save(int slot) {
     snap.cur_pos = snap_pos;
     snap.last_tok = shards_.front().cache.last_tok;
     snap.prefill_last_logits = prefill_last_logits_;
+    if (kvflash_active() &&
+        kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        auto & history_snap = kvflash_history_snapshots_[(size_t)slot];
+        history_snap.clear();
+        const size_t keep = (size_t)std::min(snap_pos, (int)kvflash_history_.size());
+        history_snap.assign(kvflash_history_.begin(), kvflash_history_.begin() + keep);
+        if ((int)history_snap.size() < snap_pos) {
+            history_snap.resize((size_t)snap_pos, 0);
+        }
+    }
     if (!rebuild_disk_snapshot(slot)) {
         snapshot_free(slot);
         return false;
@@ -357,6 +616,9 @@ void LagunaLayerSplitAdapter::snapshot_free(int slot) {
     if (snapshot_prefill_logit_tensors_.size() == (size_t)PREFIX_SLOTS) {
         snapshot_prefill_logit_tensors_[(size_t)slot].clear();
     }
+    if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        kvflash_history_snapshots_[(size_t)slot].clear();
+    }
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
 }
 
@@ -389,6 +651,20 @@ bool LagunaLayerSplitAdapter::snapshot_restore(int slot) {
         shards_[i].cache.last_tok = snap.last_tok;
     }
     prefill_last_logits_ = snap.prefill_last_logits;
+    if (kvflash_active()) {
+        if (!kvflash_sync_identity(snap.cur_pos)) return false;
+        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS &&
+            !kvflash_history_snapshots_[(size_t)slot].empty()) {
+            kvflash_history_ = kvflash_history_snapshots_[(size_t)slot];
+        } else {
+            kvflash_history_.clear();
+        }
+        if ((int)kvflash_history_.size() > snap.cur_pos) {
+            kvflash_history_.resize((size_t)snap.cur_pos);
+        } else if ((int)kvflash_history_.size() < snap.cur_pos) {
+            kvflash_history_.resize((size_t)snap.cur_pos, 0);
+        }
+    }
     return true;
 }
 
@@ -595,7 +871,13 @@ int LagunaLayerSplitAdapter::current_last_token() const {
 }
 
 void LagunaLayerSplitAdapter::shutdown() {
+    kvflash_scorer_.reset();
+    if (kvflash_drafter_loaded_) {
+        dflash::common::free_drafter(kvflash_drafter_);
+        kvflash_drafter_loaded_ = false;
+    }
     for (int i = 0; i < PREFIX_SLOTS; ++i) snapshot_free(i);
+    kvflash_history_snapshots_.clear();
     auto shard_metas = layer_split_shard_metas(shards_);
     free_layer_split_snapshot_backends(shard_metas, snapshot_backends_);
     free_laguna_layer_split_shards(shards_);

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -201,7 +201,7 @@ bool LagunaLayerSplitAdapter::kvflash_attach() {
 
 bool LagunaLayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+    if (committed > kvflash_tokens_) {
         std::fprintf(stderr,
             "[laguna-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/laguna/laguna_layer_split_adapter.h
+++ b/server/src/laguna/laguna_layer_split_adapter.h
@@ -4,12 +4,17 @@
 
 #include "common/layer_split_backend.h"
 #include "common/layer_split_utils.h"
+#include "common/kvflash_pager.h"
+#include "common/kvflash_scorer.h"
 #include "laguna_internal.h"
 #include "placement/placement_config.h"
+#include "qwen3/qwen3_drafter.h"
 
 #include "ggml-backend.h"
 
+#include <memory>
 #include <random>
+#include <string>
 #include <vector>
 
 namespace dflash::common {
@@ -74,6 +79,13 @@ private:
                      int & last_tok,
                      std::vector<float> * logits_out = nullptr);
     bool rebuild_disk_snapshot(int slot);
+    KvFlashConfig kvflash_config() const;
+    void kvflash_read_config();
+    bool kvflash_attach();
+    bool kvflash_active() const { return kvflash_tokens_ > 0; }
+    bool kvflash_sync_identity(int committed);
+    void kvflash_sync_history(const std::vector<int32_t> & tokens, int base_pos);
+    void kvflash_maybe_reselect(int generated);
 
     LagunaLayerSplitAdapterConfig cfg_;
     std::vector<LagunaLayerSplitShard> shards_;
@@ -84,6 +96,17 @@ private:
     std::vector<ggml_backend_buffer_t> disk_snapshot_buffers_;
     std::vector<ggml_backend_t> disk_snapshot_backends_;
     ggml_type activation_type_ = GGML_TYPE_F32;
+    KvFlashPager kvflash_pager_;
+    std::unique_ptr<KvFlashScorer> kvflash_scorer_;
+    DrafterContext kvflash_drafter_;
+    std::vector<int32_t> kvflash_history_;
+    std::vector<std::vector<int32_t>> kvflash_history_snapshots_;
+    std::vector<float> kvflash_scores_;
+    std::string kvflash_drafter_path_;
+    int kvflash_tokens_ = 0;
+    int kvflash_tau_ = 64;
+    bool kvflash_drafter_loaded_ = false;
+    bool kvflash_drafter_failed_ = false;
     static constexpr int PREFIX_SLOTS = ModelBackend::kMaxSlots;
     SamplerCfg sampler_;
     std::mt19937_64 sampler_rng_{std::random_device{}()};

--- a/server/src/laguna/laguna_target_graph.cpp
+++ b/server/src/laguna/laguna_target_graph.cpp
@@ -790,6 +790,7 @@ void laguna_layer_step_graph_free(LagunaLayerStepGraph & sg) {
     sg.positions = nullptr;
     sg.attn_mask = nullptr;
     sg.attn_mask_swa = nullptr;
+    sg.kv_idx = nullptr;
 }
 
 void laguna_layer_step_graph_destroy(LagunaLayerStepGraph & sg) {
@@ -810,10 +811,12 @@ bool build_laguna_layer_step(
     ggml_tensor * act_out,
     int chunk_start,
     int n_tokens,
-    int kv_start) {
+    int kv_start,
+    const KvFlashPager * kvflash) {
     laguna_layer_step_graph_free(sg);
     if (layer_idx < 0 || layer_idx >= w.n_layer) return false;
     if (!cache.attn_k[layer_idx] || !cache.attn_v[layer_idx]) return false;
+    if (kvflash && std::getenv("DFLASH_LAGUNA_NO_KVPAD")) return false;
 
     ggml_init_params ip{};
     ip.mem_size = ggml_tensor_overhead() * 16384 + ggml_graph_overhead() + 16 * 1024 * 1024;
@@ -831,17 +834,25 @@ bool build_laguna_layer_step(
     ggml_set_input(sg.positions);
 
     const int kv_len = kv_start + n_tokens;
-    sg.attn_mask = ggml_new_tensor_4d(sg.ctx, GGML_TYPE_F32, kv_len, n_tokens, 1, 1);
+    const int kv_cap = cache.attn_k[(size_t)layer_idx]
+        ? (int)cache.attn_k[(size_t)layer_idx]->ne[1] : cache.max_ctx;
+    const int kv_pad = std::min((kv_len + 255) & ~255, kv_cap);
+    const int mk_w = kvflash ? kv_pad : kv_len;
+    sg.attn_mask = ggml_new_tensor_4d(sg.ctx, GGML_TYPE_F32, mk_w, n_tokens, 1, 1);
     ggml_set_input(sg.attn_mask);
     ggml_tensor * mask_full_f16 = ggml_cast(sg.ctx, sg.attn_mask, GGML_TYPE_F16);
 
-    sg.attn_mask_swa = ggml_new_tensor_4d(sg.ctx, GGML_TYPE_F32, kv_len, n_tokens, 1, 1);
+    sg.attn_mask_swa = ggml_new_tensor_4d(sg.ctx, GGML_TYPE_F32, mk_w, n_tokens, 1, 1);
     ggml_set_input(sg.attn_mask_swa);
     ggml_tensor * mask_swa_f16 = ggml_cast(sg.ctx, sg.attn_mask_swa, GGML_TYPE_F16);
 
+    sg.kv_idx = ggml_new_tensor_1d(sg.ctx, GGML_TYPE_I32, n_tokens);
+    ggml_set_input(sg.kv_idx);
+
     ggml_tensor * layer_out = build_laguna_layer(
         sg.ctx, sg.gf, w, cache, layer_idx, inp, sg.positions,
-        mask_full_f16, kv_start, n_tokens, mask_swa_f16);
+        mask_full_f16, kv_start, n_tokens, mask_swa_f16,
+        /*hyb=*/nullptr, kvflash ? kv_pad : 0, sg.kv_idx);
     if (!layer_out) return false;
 
     ggml_tensor * out_view = ggml_view_2d(

--- a/server/src/qwen35/graph_builders.cpp
+++ b/server/src/qwen35/graph_builders.cpp
@@ -23,7 +23,9 @@ bool build_layer_step(
     bool with_mask,
     bool capture,
     int fa_window,
-    int kq_stride_pad) {
+    int kq_stride_pad,
+    bool kvflash) {
+    if (kvflash) with_mask = true;
     step_graph_free(sg);
 
     const bool is_attn = (((layer_idx + 1) % w.full_attention_interval) == 0);
@@ -49,14 +51,26 @@ bool build_layer_step(
         ggml_set_input(sg.positions);
 
         if (with_mask) {
-            // Use max_ctx for allocation so gallocr buffer doesn't grow
-            // as kv_start advances during chunked prefill.
-            const int max_win_len = cache.max_ctx + n_tokens;
+            int phys_ctx = cache.max_ctx;
+            if (kvflash) {
+                for (ggml_tensor * t : cache.attn_k) {
+                    if (t) { phys_ctx = std::min(phys_ctx, (int)t->ne[1]); break; }
+                }
+            }
+            // Size from the fixed physical capacity so gallocr doesn't grow
+            // as kv_start advances. Under kvflash this is the resident pool.
+            const int max_win_len = phys_ctx + n_tokens;
             const int kv_pad = align_up(max_win_len, kq_stride_pad);
             const int q_pad  = align_up(n_tokens, KQ_MASK_PAD);
             sg.attn_mask = ggml_new_tensor_2d(sg.ctx, GGML_TYPE_F16, kv_pad, q_pad);
             ggml_set_name(sg.attn_mask, "attn_mask");
             ggml_set_input(sg.attn_mask);
+        }
+        if (kvflash) {
+            sg.kv_write_rows = ggml_new_tensor_2d(sg.ctx, GGML_TYPE_I64,
+                                                  n_tokens, w.n_head_kv);
+            ggml_set_name(sg.kv_write_rows, "kv_write_rows");
+            ggml_set_input(sg.kv_write_rows);
         }
     }
 
@@ -65,7 +79,9 @@ bool build_layer_step(
     ggml_tensor * layer_out = build_qwen35_layer(
         sg.ctx, sg.gf, w, cache, layer_idx,
         sg.inp_embed, sg.positions, sg.attn_mask,
-        kv_start, n_tokens, capture, fa_window);
+        kv_start, n_tokens, capture, fa_window,
+        /*q_tail_capture=*/nullptr, /*q_tail_start=*/0,
+        sg.kv_write_rows);
     if (!layer_out) return false;
 
     ggml_tensor * out_view = ggml_view_2d(sg.ctx, act_out,

--- a/server/src/qwen35/graph_builders.h
+++ b/server/src/qwen35/graph_builders.h
@@ -38,7 +38,8 @@ bool build_layer_step(
     bool with_mask,
     bool capture,
     int fa_window = 0,
-    int kq_stride_pad = KQ_MASK_PAD);
+    int kq_stride_pad = KQ_MASK_PAD,
+    bool kvflash = false);
 
 // `kvflash`: pooled mode — KV rows go through a set_rows input
 // (sg.kv_write_rows, [n_tokens, n_head_kv] ne0-major slots) and the mask

--- a/server/src/qwen35/layer_split_forward.cpp
+++ b/server/src/qwen35/layer_split_forward.cpp
@@ -7,6 +7,7 @@
 #include "dflash_feature_ring.h"
 #include "dflash_capture.h"
 #include "attn_masks.h"
+#include "common/kvflash_pager.h"
 
 #include "ggml.h"
 #include "ggml-alloc.h"
@@ -14,8 +15,68 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstring>
 
 namespace dflash::common {
+
+namespace {
+
+bool fill_qwen35_kvflash_inputs(
+        StepGraph & sg,
+        const TargetWeights & w,
+        const KvFlashPager & pager,
+        int kv_start,
+        int n_tokens) {
+    if (!sg.kv_write_rows) {
+        std::fprintf(stderr, "target-split kvflash requires set_rows path\n");
+        return false;
+    }
+    std::vector<int64_t> rows((size_t)n_tokens * w.n_head_kv);
+    for (int i = 0; i < n_tokens; ++i) {
+        const int slot = pager.slot_of(kv_start + i);
+        if (slot < 0) {
+            std::fprintf(stderr,
+                "target-split kvflash slot missing @%d (alloc_span not called?)\n",
+                kv_start + i);
+            return false;
+        }
+        for (int h = 0; h < w.n_head_kv; ++h) {
+            rows[(size_t)h * n_tokens + i] = slot;
+        }
+    }
+    ggml_backend_tensor_set(sg.kv_write_rows, rows.data(), 0,
+                            sizeof(int64_t) * rows.size());
+
+    if (!sg.attn_mask) return true;
+    const size_t kvd = (size_t)sg.attn_mask->ne[0];
+    const int q_pad = (int)sg.attn_mask->ne[1];
+    std::vector<int32_t> slot_pos((size_t)pager.pool_tokens(), -1);
+    pager.fill_slot_pos(slot_pos.data());
+    std::vector<uint16_t> mask((size_t)kvd * q_pad, F16_NEG_INF);
+    const int s_hi = std::min((int)kvd, (int)slot_pos.size());
+    for (int s = 0; s < s_hi; ++s) {
+        const int p = slot_pos[(size_t)s];
+        if (p >= 0 && p < kv_start) {
+            mask[(size_t)s] = F16_ZERO;
+        }
+    }
+    for (int q = 1; q < n_tokens; ++q) {
+        std::memcpy(mask.data() + (size_t)q * kvd, mask.data(), kvd * sizeof(uint16_t));
+    }
+    for (int q = 0; q < n_tokens; ++q) {
+        for (int i = 0; i <= q; ++i) {
+            const int slot = pager.slot_of(kv_start + i);
+            if (slot >= 0 && slot < (int)kvd) {
+                mask[(size_t)q * kvd + (size_t)slot] = F16_ZERO;
+            }
+        }
+    }
+    ggml_backend_tensor_set(sg.attn_mask, mask.data(), 0,
+                            sizeof(uint16_t) * mask.size());
+    return true;
+}
+
+}  // namespace
 
 bool compute_target_split_projection(
         StepGraph & sg,
@@ -103,12 +164,18 @@ bool run_qwen35_layer_split_forward(
         std::vector<int32_t> * argmax_out,
         std::vector<float> * logits_out,
         DFlashDraftIpcClient * remote_draft,
-        ggml_type activation_type) {
+        ggml_type activation_type,
+        KvFlashPager * kvflash) {
     if (shards.empty() || tokens.empty()) return false;
     const int hidden = shards.front().weights.n_embd;
     const int vocab = shards.front().weights.n_vocab;
     const int n_tokens_total = (int)tokens.size();
     ubatch = std::max(1, ubatch);
+    if (kvflash && fa_window > 0) {
+        std::fprintf(stderr,
+            "target-split kvflash requires full attention (fa_window=0)\n");
+        return false;
+    }
     if ((feature_ring || remote_draft) && activation_type != GGML_TYPE_F32) {
         std::fprintf(stderr,
             "target-split capture requires F32 activation; got %s\n",
@@ -182,11 +249,17 @@ bool run_qwen35_layer_split_forward(
             const int n = std::min(ubatch, n_tokens_total - start);
             const int kv_start = base_pos + start;
             const int kv_len = kv_start + n;
-            const bool with_mask = (kq_stride_pad > KQ_MASK_PAD) || (n > 1);
+            const bool with_mask = kvflash ||
+                (kq_stride_pad > KQ_MASK_PAD) || (n > 1);
+            if (is_attn && kvflash && !kvflash->alloc_span(kv_start, n)) {
+                activation_pair_free(acts);
+                return false;
+            }
             if (!build_layer_step(shard->layer_graph, shard->weights, shard->cache,
                                   shard->backend, il, act_in, act_out,
                                   start, n, kv_start, with_mask,
-                                  /*capture=*/false, fa_window, kq_stride_pad)) {
+                                  /*capture=*/false, fa_window, kq_stride_pad,
+                                  kvflash != nullptr)) {
                 std::fprintf(stderr, "target-split build layer=%d @%d gpu=%d\n",
                              il, start, shard->gpu);
                 activation_pair_free(acts);
@@ -204,7 +277,14 @@ bool run_qwen35_layer_split_forward(
                 ggml_backend_tensor_set(shard->layer_graph.positions, pos_buf.data(), 0,
                                         sizeof(int32_t) * pos_buf.size());
             }
-            if (is_attn && with_mask && shard->layer_graph.attn_mask) {
+            if (is_attn && kvflash) {
+                if (!fill_qwen35_kvflash_inputs(
+                        shard->layer_graph, shard->weights, *kvflash,
+                        kv_start, n)) {
+                    activation_pair_free(acts);
+                    return false;
+                }
+            } else if (is_attn && with_mask && shard->layer_graph.attn_mask) {
                 const int win_start_l = (fa_window > 0 && kv_start > fa_window)
                                             ? (kv_start - fa_window) : 0;
                 const int win_len_l = kv_len - win_start_l;
@@ -280,8 +360,14 @@ bool run_qwen35_layer_split_layers_from_activation(
         int fa_window,
         std::vector<Qwen35TargetCaptureSlice> * captures_out,
         DraftFeatureMirror * feature_ring,
-        DFlashDraftIpcClient * remote_draft) {
+        DFlashDraftIpcClient * remote_draft,
+        KvFlashPager * kvflash) {
     if (shards.empty() || !acts.a || !acts.b || n_tokens_total <= 0) return false;
+    if (kvflash && fa_window > 0) {
+        std::fprintf(stderr,
+            "target-split kvflash requires full attention (fa_window=0)\n");
+        return false;
+    }
     const int hidden = shards.front().weights.n_embd;
     ubatch = std::max(1, ubatch);
 
@@ -321,11 +407,16 @@ bool run_qwen35_layer_split_layers_from_activation(
             const int n = std::min(ubatch, n_tokens_total - start);
             const int kv_start = base_pos + start;
             const int kv_len = kv_start + n;
-            const bool with_mask = (kq_stride_pad > KQ_MASK_PAD) || (n > 1);
+            const bool with_mask = kvflash ||
+                (kq_stride_pad > KQ_MASK_PAD) || (n > 1);
+            if (is_attn && kvflash && !kvflash->alloc_span(kv_start, n)) {
+                return false;
+            }
             if (!build_layer_step(shard->layer_graph, shard->weights, shard->cache,
                                   shard->backend, il, act_in, act_out,
                                   start, n, kv_start, with_mask,
-                                  /*capture=*/false, fa_window, kq_stride_pad)) {
+                                  /*capture=*/false, fa_window, kq_stride_pad,
+                                  kvflash != nullptr)) {
                 std::fprintf(stderr, "target-split build layer=%d @%d gpu=%d\n",
                              il, start, shard->gpu);
                 return false;
@@ -342,7 +433,13 @@ bool run_qwen35_layer_split_layers_from_activation(
                 ggml_backend_tensor_set(shard->layer_graph.positions, pos_buf.data(), 0,
                                         sizeof(int32_t) * pos_buf.size());
             }
-            if (is_attn && with_mask && shard->layer_graph.attn_mask) {
+            if (is_attn && kvflash) {
+                if (!fill_qwen35_kvflash_inputs(
+                        shard->layer_graph, shard->weights, *kvflash,
+                        kv_start, n)) {
+                    return false;
+                }
+            } else if (is_attn && with_mask && shard->layer_graph.attn_mask) {
                 const int win_start_l = (fa_window > 0 && kv_start > fa_window)
                                             ? (kv_start - fa_window) : 0;
                 const int win_len_l = kv_len - win_start_l;
@@ -415,10 +512,11 @@ bool run_qwen35_layer_split_forward_from_activation(
         int fa_window,
         std::vector<int32_t> * argmax_out,
         std::vector<float> * logits_out,
-        std::vector<Qwen35TargetCaptureSlice> * captures_out) {
+        std::vector<Qwen35TargetCaptureSlice> * captures_out,
+        KvFlashPager * kvflash) {
     if (!run_qwen35_layer_split_layers_from_activation(
             shards, acts, base_pos, n_tokens_total, ubatch, kq_stride_pad,
-            fa_window, captures_out, nullptr, nullptr)) {
+            fa_window, captures_out, nullptr, nullptr, kvflash)) {
         return false;
     }
 
@@ -494,7 +592,8 @@ bool run_qwen35_mixed_layer_split_forward(
 
     if (!run_qwen35_layer_split_layers_from_activation(
             local_shards, acts, base_pos, n_tokens_total, ubatch,
-            kq_stride_pad, fa_window, nullptr, feature_ring, remote_draft)) {
+            kq_stride_pad, fa_window, nullptr, feature_ring, remote_draft,
+            nullptr)) {
         activation_pair_free(acts);
         return false;
     }

--- a/server/src/qwen35/layer_split_forward.h
+++ b/server/src/qwen35/layer_split_forward.h
@@ -20,6 +20,8 @@
 
 namespace dflash::common {
 
+class KvFlashPager;
+
 // Compute argmax(logits) for a slice of the activation tensor via
 // out_norm + lm_head projection.
 bool compute_target_split_argmax(
@@ -61,7 +63,8 @@ bool run_qwen35_layer_split_forward(
         std::vector<int32_t> * argmax_out = nullptr,
         std::vector<float> * logits_out = nullptr,
         DFlashDraftIpcClient * remote_draft = nullptr,
-        ggml_type activation_type = GGML_TYPE_F32);
+        ggml_type activation_type = GGML_TYPE_F32,
+        KvFlashPager * kvflash = nullptr);
 
 bool run_qwen35_layer_split_forward_from_activation(
         std::vector<Qwen35LayerSplitShard> & shards,
@@ -74,7 +77,8 @@ bool run_qwen35_layer_split_forward_from_activation(
         int fa_window,
         std::vector<int32_t> * argmax_out = nullptr,
         std::vector<float> * logits_out = nullptr,
-        std::vector<Qwen35TargetCaptureSlice> * captures_out = nullptr);
+        std::vector<Qwen35TargetCaptureSlice> * captures_out = nullptr,
+        KvFlashPager * kvflash = nullptr);
 
 bool run_qwen35_mixed_layer_split_forward(
         std::vector<Qwen35LayerSplitShard> & local_shards,

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -1,6 +1,7 @@
 // Qwen35DFlashTarget — DFlashTarget adapter for qwen35 hybrid models.
 
 #include "qwen35_dflash_target.h"
+#include "common/gpu_runtime_compat.h"
 #include "graph_builders.h"
 #include "step_graph.h"
 #include "attn_masks.h"

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -12,6 +12,8 @@
 #include "qwen35/layer_split_forward.h"
 #include "qwen35/qwen35_layer_split_dflash_target.h"
 #include "qwen3/qwen3_drafter.h"
+#include "qwen3/qwen3_kvflash_scorer.h"
+#include "kv_quant.h"
 
 #include "ggml-cuda.h"
 #include "ggml-cpu.h"
@@ -67,20 +69,36 @@ bool Qwen35LayerSplitAdapter::init() {
         const TargetLoadPlan plan =
             make_layer_split_load_plan<TargetLoadPlan>(shard, &shard == &shards_.back());
         if (!load_target_gguf_partial(cfg_.target_path, shard.backend, plan,
-                                      shard.weights) ||
-            !create_target_cache_partial(shard.weights, cfg_.device.max_ctx,
+                                      shard.weights)) {
+            std::fprintf(stderr, "[target-split] load gpu=%d: %s\n",
+                         shard.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+    kvflash_read_config();
+    if (kvflash_active() && cfg_.fa_window > 0) {
+        std::fprintf(stderr,
+            "[target-split][kvflash] fa_window must be 0 because pool slots "
+            "need full slot-space masks\n");
+        return false;
+    }
+
+    for (auto & shard : shards_) {
+        if (!create_target_cache_partial(shard.weights, cfg_.device.max_ctx,
                                          cfg_.max_verify_tokens, shard.backend,
                                          shard.cache,
                                          /*prefill_only=*/!cfg_.run_dflash,
                                          shard.layer_begin, shard.layer_end,
-                                         /*allocate_target_feat=*/false)) {
-            std::fprintf(stderr, "[target-split] load/cache gpu=%d: %s\n",
+                                         /*allocate_target_feat=*/false,
+                                         kvflash_tokens_)) {
+            std::fprintf(stderr, "[target-split] cache gpu=%d: %s\n",
                          shard.gpu, dflash27b_last_error());
             return false;
         }
         std::fprintf(stderr, "[target-split] gpu=%d layers=[%d,%d)\n",
                      shard.gpu, shard.layer_begin, shard.layer_end);
     }
+    if (!kvflash_attach()) return false;
 
     if (cfg_.draft_path && cfg_.run_dflash && !load_draft()) {
         return false;
@@ -97,6 +115,171 @@ bool Qwen35LayerSplitAdapter::init() {
     draft_feature_snapshots_.resize(PREFIX_SLOTS);
 
     return true;
+}
+
+void Qwen35LayerSplitAdapter::kvflash_read_config() {
+    if (!std::getenv("DFLASH_KVFLASH") || shards_.empty()) return;
+    kvflash_drafter_path_ = kvflash_find_drafter(cfg_.target_path);
+
+    ggml_type kv_k = GGML_TYPE_Q8_0;
+    ggml_type kv_v = GGML_TYPE_Q8_0;
+    dflash::resolve_kv_types(kv_k, kv_v);
+
+    int64_t min_free = std::numeric_limits<int64_t>::max();
+    int64_t max_bytes_per_token = 0;
+    for (const auto & shard : shards_) {
+        size_t gpu_free = 0, gpu_total = 0;
+        if (ggml_backend_dev_t dev = ggml_backend_get_device(shard.backend)) {
+            ggml_backend_dev_memory(dev, &gpu_free, &gpu_total);
+        }
+        min_free = std::min<int64_t>(min_free, (int64_t)gpu_free);
+
+        int owned_full = 0;
+        for (int il = shard.layer_begin; il < shard.layer_end; ++il) {
+            if (((il + 1) % shard.weights.full_attention_interval) == 0) {
+                ++owned_full;
+            }
+        }
+        const int64_t bpt = (int64_t)owned_full * shard.weights.n_head_kv *
+            (int64_t)(ggml_row_size(kv_k, shard.weights.n_embd_head_k) +
+                      ggml_row_size(kv_v, shard.weights.n_embd_head_v));
+        max_bytes_per_token = std::max<int64_t>(max_bytes_per_token, bpt);
+    }
+    if (min_free == std::numeric_limits<int64_t>::max()) min_free = 0;
+
+    KvFlashAutoBudget budget;
+    budget.free_bytes = min_free;
+    budget.bytes_per_token = max_bytes_per_token;
+    budget.reserve_bytes = (int64_t)(1.5 * 1073741824.0) +
+        (kvflash_drafter_path_.empty() ? 0 : (int64_t)(1.7 * 1073741824.0));
+    kvflash_tokens_ = kvflash_pool_from_env(
+        cfg_.device.max_ctx, KvFlashConfig{},
+        !kvflash_drafter_path_.empty(), budget);
+    if (kvflash_tokens_ > 0) {
+        const char * tau = std::getenv("DFLASH_KVFLASH_TAU");
+        kvflash_tau_ = std::max(1, tau ? std::atoi(tau) : 64);
+    }
+}
+
+bool Qwen35LayerSplitAdapter::kvflash_attach() {
+    if (!kvflash_active()) return true;
+    std::vector<ggml_tensor *> full_k;
+    std::vector<ggml_tensor *> full_v;
+    const int n_full = shards_.front().weights.n_layer /
+        shards_.front().weights.full_attention_interval;
+    for (int i = 0; i < n_full; ++i) {
+        ggml_tensor * k = nullptr;
+        ggml_tensor * v = nullptr;
+        for (auto & shard : shards_) {
+            if (i < (int)shard.cache.attn_k.size() && shard.cache.attn_k[(size_t)i]) {
+                k = shard.cache.attn_k[(size_t)i];
+                v = shard.cache.attn_v[(size_t)i];
+                break;
+            }
+        }
+        if (k && v) {
+            full_k.push_back(k);
+            full_v.push_back(v);
+        }
+    }
+    KvFlashConfig pc;
+    pc.pool_tokens = kvflash_tokens_;
+    if (!kvflash_pager_.attach(pc, full_k, full_v)) {
+        std::fprintf(stderr,
+            "[target-split][kvflash] pager attach failed pool=%d layers=%zu\n",
+            kvflash_tokens_, full_k.size());
+        return false;
+    }
+    std::printf("[target-split][kvflash] resident pool %d tokens over %zu "
+                "full-attn layers (logical max_ctx %d), tau=%d, policy=%s\n",
+                kvflash_tokens_, full_k.size(), cfg_.device.max_ctx,
+                kvflash_tau_,
+                !kvflash_drafter_path_.empty()
+                    ? "drafter (attaches on first reselect)"
+                    : "lru (recency-only: no Qwen3-0.6B drafter found)");
+    std::fflush(stdout);
+    return true;
+}
+
+bool Qwen35LayerSplitAdapter::kvflash_sync_identity(int committed) {
+    if (!kvflash_active()) return true;
+    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+        std::fprintf(stderr,
+            "[target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
+            committed, kvflash_tokens_);
+        return false;
+    }
+    kvflash_pager_.reset();
+    for (int p = 0; p < committed; ++p) {
+        const int slot = kvflash_pager_.slot_for(p);
+        if (slot != p) {
+            std::fprintf(stderr,
+                "[target-split][kvflash] identity slot mismatch %d != %d\n",
+                slot, p);
+            return false;
+        }
+    }
+    kvflash_pager_.zero_free_blocks();
+    return true;
+}
+
+void Qwen35LayerSplitAdapter::kvflash_sync_history(
+        const std::vector<int32_t> & tokens, int base_pos) {
+    if (!kvflash_active()) return;
+    if (base_pos == 0) {
+        kvflash_history_.assign(tokens.begin(), tokens.end());
+        return;
+    }
+    if ((int)kvflash_history_.size() > base_pos) {
+        kvflash_history_.resize((size_t)base_pos);
+    } else if ((int)kvflash_history_.size() < base_pos) {
+        kvflash_history_.resize((size_t)base_pos, 0);
+    }
+    kvflash_history_.insert(kvflash_history_.end(), tokens.begin(), tokens.end());
+}
+
+void Qwen35LayerSplitAdapter::kvflash_maybe_reselect(int generated) {
+    if (!kvflash_active() || kvflash_tau_ <= 0) return;
+    if (use_mixed_target_split()) return;
+    const int tau = std::max<int>(kvflash_tau_, (int)(kvflash_history_.size() / 45));
+    if (generated % tau != 0) return;
+    if (!kvflash_scorer_) {
+        if (kvflash_drafter_path_.empty() || kvflash_drafter_failed_) return;
+        if (!kvflash_drafter_loaded_) {
+            for (auto & shard : shards_) ggml_backend_synchronize(shard.backend);
+            std::fprintf(stderr,
+                "[target-split][kvflash] loading residency drafter: %s\n",
+                kvflash_drafter_path_.c_str());
+            if (!load_drafter(kvflash_drafter_path_, /*gpu_layers=*/999,
+                              shards_.front().gpu, kvflash_drafter_)) {
+                std::fprintf(stderr,
+                    "[target-split][kvflash] drafter load failed (%s); "
+                    "staying on LRU residency\n",
+                    dflash27b_last_error());
+                kvflash_drafter_failed_ = true;
+                return;
+            }
+            kvflash_drafter_loaded_ = true;
+        }
+        kvflash_scorer_ =
+            std::make_unique<KvFlashDrafterScorer>(&kvflash_drafter_);
+        std::fprintf(stderr,
+            "[target-split][kvflash] drafter scorer attached (tau=%d)\n",
+            kvflash_tau_);
+    }
+    if (!kvflash_scorer_->score_chunks(
+            kvflash_history_, kvflash_pager_.chunk_tokens(), kvflash_scores_)) {
+        return;
+    }
+    kvflash_pager_.score_hook = [this](int c) {
+        return c < (int)kvflash_scores_.size() ? kvflash_scores_[(size_t)c] : 1e30f;
+    };
+    const int events = kvflash_pager_.reselect();
+    if (events > 0) {
+        std::fprintf(stderr,
+            "[target-split][kvflash] reselect @gen=%d: %d page events\n",
+            generated, events);
+    }
 }
 
 bool Qwen35LayerSplitAdapter::init_mixed_target_split() {
@@ -167,14 +350,21 @@ bool Qwen35LayerSplitAdapter::init_mixed_target_split() {
         const TargetLoadPlan local_plan =
             make_layer_split_load_plan<TargetLoadPlan>(local, /*is_last_shard=*/false);
         if (!load_target_gguf_partial(cfg_.target_path, local.backend, local_plan,
-                                      local.weights) ||
-            !create_target_cache_partial(local.weights, cfg_.device.max_ctx,
+                                      local.weights)) {
+            std::fprintf(stderr, "[target-split] mixed local load gpu=%d: %s\n",
+                         local.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+
+    for (auto & local : shards_) {
+        if (!create_target_cache_partial(local.weights, cfg_.device.max_ctx,
                                          cfg_.max_verify_tokens, local.backend,
                                          local.cache,
                                          /*prefill_only=*/!cfg_.run_dflash,
                                          local.layer_begin, local.layer_end,
                                          /*allocate_target_feat=*/false)) {
-            std::fprintf(stderr, "[target-split] mixed local load/cache gpu=%d: %s\n",
+            std::fprintf(stderr, "[target-split] mixed local cache gpu=%d: %s\n",
                          local.gpu, dflash27b_last_error());
             return false;
         }
@@ -320,6 +510,12 @@ void Qwen35LayerSplitAdapter::begin_request(const GenerateRequest & req) {
 
 void Qwen35LayerSplitAdapter::reset_request_state() {
     for (auto & shard : shards_) reset_target_cache(shard.cache);
+    if (!use_mixed_target_split() && kvflash_active()) {
+        kvflash_pager_.reset();
+        kvflash_history_.clear();
+        kvflash_scores_.clear();
+        kvflash_pager_.score_hook = nullptr;
+    }
     if (use_mixed_target_split() &&
         !remote_target_shard_.reset_request_state()) {
         std::fprintf(stderr,
@@ -329,6 +525,9 @@ void Qwen35LayerSplitAdapter::reset_request_state() {
 }
 
 int Qwen35LayerSplitAdapter::prefill_chunk_tokens() const {
+    if (!use_mixed_target_split() && kvflash_active()) {
+        return kvflash_pager_.chunk_tokens();
+    }
     return cfg_.chunk > 0 ? cfg_.chunk : 0;
 }
 
@@ -346,7 +545,7 @@ bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
         ubatch = std::max(1, std::atoi(s));
     }
     if (use_mixed_target_split()) {
-        return run_qwen35_mixed_layer_split_forward(
+        const bool ok = run_qwen35_mixed_layer_split_forward(
             shards_, remote_target_shard_, shards_.front().weights,
             prompt, base_pos, ubatch, last_tok,
             cfg_.kq_stride_pad, /*fa_window=*/0,
@@ -354,15 +553,22 @@ bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
             &prefill_last_logits_,
             (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
             remote_draft_.active() ? &remote_draft_ : nullptr);
+        return ok;
     }
-    return run_qwen35_layer_split_forward(
+    const bool ok = run_qwen35_layer_split_forward(
         shards_, shards_.front().weights, prompt, base_pos, ubatch, last_tok,
         cfg_.kq_stride_pad, /*fa_window=*/0,
         (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
         /*argmax_out=*/nullptr,
         &prefill_last_logits_,
         cfg_.run_dflash ? &remote_draft_ : nullptr,
-        activation_type_);
+        activation_type_,
+        kvflash_active() ? &kvflash_pager_ : nullptr);
+    if (ok && kvflash_active()) {
+        kvflash_sync_history(prompt, base_pos);
+        kvflash_pager_.zero_free_blocks();
+    }
+    return ok;
 }
 
 bool Qwen35LayerSplitAdapter::snapshot_slot_valid(int slot) const {
@@ -374,6 +580,18 @@ bool Qwen35LayerSplitAdapter::snapshot_slot_valid(int slot) const {
 bool Qwen35LayerSplitAdapter::snapshot_save(int slot) {
     if (!snapshot_slot_valid(slot)) return false;
     if (snapshot_backends_.size() != shards_.size()) return false;
+    const int cur_pos = shards_.empty() ? 0 : shards_.front().cache.cur_pos;
+    if (!use_mixed_target_split() && kvflash_active() &&
+        (cur_pos > kvflash_tokens_ || !kvflash_pager_.is_identity())) {
+        static bool warned = false;
+        if (!warned) {
+            std::fprintf(stderr,
+                "[target-split][kvflash] snapshot skipped: pooled layout "
+                "needs page-table serialization\n");
+            warned = true;
+        }
+        return false;
+    }
     snapshot_free(slot);
     auto & snaps = prefix_snapshots_[(size_t)slot];
     if (snaps.size() != shards_.size()) snaps.resize(shards_.size());
@@ -392,6 +610,16 @@ bool Qwen35LayerSplitAdapter::snapshot_save(int slot) {
     }
     if (snapshot_prefill_logits_.size() != (size_t)PREFIX_SLOTS) return false;
     snapshot_prefill_logits_[(size_t)slot] = prefill_last_logits_;
+    if (!use_mixed_target_split() && kvflash_active() &&
+        kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        auto & history_snap = kvflash_history_snapshots_[(size_t)slot];
+        history_snap.clear();
+        const size_t keep = (size_t)std::min(cur_pos, (int)kvflash_history_.size());
+        history_snap.assign(kvflash_history_.begin(), kvflash_history_.begin() + keep);
+        if ((int)history_snap.size() < cur_pos) {
+            history_snap.resize((size_t)cur_pos, 0);
+        }
+    }
     if (!snapshot_draft_features(slot)) {
         snapshot_free(slot);
         return false;
@@ -435,6 +663,9 @@ void Qwen35LayerSplitAdapter::snapshot_free(int slot) {
     }
     if (snapshot_prefill_logit_tensors_.size() == (size_t)PREFIX_SLOTS) {
         snapshot_prefill_logit_tensors_[(size_t)slot].clear();
+    }
+    if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        kvflash_history_snapshots_[(size_t)slot].clear();
     }
     if (use_mixed_target_split()) {
         remote_target_shard_.snapshot_free(slot);
@@ -483,6 +714,20 @@ bool Qwen35LayerSplitAdapter::snapshot_restore(int slot) {
     }
     if (snapshot_prefill_logits_.size() != (size_t)PREFIX_SLOTS) return false;
     prefill_last_logits_ = snapshot_prefill_logits_[(size_t)slot];
+    if (!use_mixed_target_split() && kvflash_active()) {
+        if (!kvflash_sync_identity(cur_pos)) return false;
+        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS &&
+            !kvflash_history_snapshots_[(size_t)slot].empty()) {
+            kvflash_history_ = kvflash_history_snapshots_[(size_t)slot];
+        } else {
+            kvflash_history_.clear();
+        }
+        if ((int)kvflash_history_.size() > cur_pos) {
+            kvflash_history_.resize((size_t)cur_pos);
+        } else if ((int)kvflash_history_.size() < cur_pos) {
+            kvflash_history_.resize((size_t)cur_pos, 0);
+        }
+    }
     if (!restore_draft_features(slot)) return false;
     return true;
 }
@@ -721,6 +966,10 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
         disk_snapshot_backends_.size() != (size_t)PREFIX_SLOTS) {
         return false;
     }
+    if (!mixed_target_split && kvflash_active() &&
+        kvflash_history_snapshots_.size() != (size_t)PREFIX_SLOTS) {
+        return false;
+    }
 
     ggml_tensor * logits_tensor = nullptr;
     ggml_tensor * dflash_feature_meta = nullptr;
@@ -746,6 +995,9 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
         for (auto & snap : snaps) snap = PrefixSnapshot{};
         snapshot_prefill_logits_[(size_t)slot].clear();
         snapshot_prefill_logit_tensors_[(size_t)slot].clear();
+        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+            kvflash_history_snapshots_[(size_t)slot].clear();
+        }
         free_draft_feature_snapshot(slot);
         if (mixed_target_split) {
             remote_target_shard_.snapshot_free(slot);
@@ -768,6 +1020,9 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     }
     snapshot_prefill_logits_[(size_t)slot].clear();
     snapshot_prefill_logit_tensors_[(size_t)slot].assign(shards_.size(), nullptr);
+    if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
+        kvflash_history_snapshots_[(size_t)slot].clear();
+    }
 
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t; t = ggml_get_next_tensor(ctx, t)) {
         if (!t->name[0]) continue;
@@ -921,6 +1176,9 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     } else {
         free_draft_feature_snapshot(slot);
     }
+    if (!mixed_target_split && kvflash_active()) {
+        kvflash_history_snapshots_[(size_t)slot].assign((size_t)cur_pos, 0);
+    }
 
     for (auto & snap : snaps) {
         snap.ctx = ctx;
@@ -1036,7 +1294,7 @@ bool Qwen35LayerSplitAdapter::decode_ar(
     if (n_gen <= 0) return true;
     const auto & w = shards_.front().weights;
     const int vocab = w.n_vocab;
-    return run_layer_split_ar_decode(
+    const bool ok = run_layer_split_ar_decode(
         last_tok, committed, n_gen, vocab, prefill_last_logits_, sampler_,
         sampler_rng_,
         [&](const std::vector<int32_t> & one, int pos, int & next_tok,
@@ -1058,10 +1316,16 @@ bool Qwen35LayerSplitAdapter::decode_ar(
                 /*argmax_out=*/nullptr,
                 logits_out,
                 cfg_.run_dflash ? &remote_draft_ : nullptr,
-                activation_type_);
+                activation_type_,
+                kvflash_active() ? &kvflash_pager_ : nullptr);
         },
         [&](int tok) { return is_eos_tok(tok, w); },
         out_tokens, io);
+    if (ok && !use_mixed_target_split() && kvflash_active()) {
+        kvflash_sync_history(out_tokens, committed);
+        kvflash_maybe_reselect((int)out_tokens.size());
+    }
+    return ok;
 }
 
 bool Qwen35LayerSplitAdapter::can_dflash_decode() const {
@@ -1078,7 +1342,8 @@ bool Qwen35LayerSplitAdapter::decode_dflash(
         shards_, use_remote_draft ? nullptr : &feature_ring_,
         cfg_.kq_stride_pad, cfg_.fa_window,
         use_remote_draft ? &remote_draft_ : nullptr,
-        use_mixed_target_split() ? &remote_target_shard_ : nullptr);
+        use_mixed_target_split() ? &remote_target_shard_ : nullptr,
+        (!use_mixed_target_split() && kvflash_active()) ? &kvflash_pager_ : nullptr);
     DaemonIO collect_io = io.with_token_callback([&](int32_t tok) -> bool {
         out_tokens.push_back(tok);
         return true;
@@ -1090,6 +1355,10 @@ bool Qwen35LayerSplitAdapter::decode_dflash(
         use_remote_draft ? &remote_draft_ : nullptr, /*hint_tokens=*/nullptr, base_pos,
         &accept_rate);
     accept_rate_out = (float)accept_rate;
+    if (ok && !use_mixed_target_split() && kvflash_active()) {
+        kvflash_sync_history(out_tokens, base_pos + (int)prompt.size());
+        kvflash_maybe_reselect((int)out_tokens.size());
+    }
     return ok;
 }
 
@@ -1135,6 +1404,11 @@ void Qwen35LayerSplitAdapter::free_drafter() {
         dflash::common::free_drafter(pflash_drafter_);
         pflash_drafter_loaded_ = false;
     }
+    kvflash_scorer_.reset();
+    if (kvflash_drafter_loaded_) {
+        dflash::common::free_drafter(kvflash_drafter_);
+        kvflash_drafter_loaded_ = false;
+    }
     step_graph_destroy(draft_sg_);
     step_graph_destroy(proj_sg_);
 }
@@ -1146,7 +1420,8 @@ DFlashTarget * Qwen35LayerSplitAdapter::dflash_target() {
             (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
             cfg_.kq_stride_pad, cfg_.fa_window,
             remote_draft_.active() ? &remote_draft_ : nullptr,
-            use_mixed_target_split() ? &remote_target_shard_ : nullptr);
+            use_mixed_target_split() ? &remote_target_shard_ : nullptr,
+            (!use_mixed_target_split() && kvflash_active()) ? &kvflash_pager_ : nullptr);
     }
     return dflash_target_.get();
 }
@@ -1163,6 +1438,7 @@ void Qwen35LayerSplitAdapter::shutdown() {
     prefix_snapshots_.clear();
     snapshot_prefill_logits_.clear();
     snapshot_prefill_logit_tensors_.clear();
+    kvflash_history_snapshots_.clear();
     disk_snapshot_contexts_.clear();
     disk_snapshot_buffers_.clear();
     disk_snapshot_backends_.clear();

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -113,6 +113,9 @@ bool Qwen35LayerSplitAdapter::init() {
     disk_snapshot_buffers_.assign(PREFIX_SLOTS, nullptr);
     disk_snapshot_backends_.assign(PREFIX_SLOTS, nullptr);
     draft_feature_snapshots_.resize(PREFIX_SLOTS);
+    if (kvflash_active()) {
+        kvflash_history_snapshots_.resize(PREFIX_SLOTS);
+    }
 
     return true;
 }
@@ -203,7 +206,7 @@ bool Qwen35LayerSplitAdapter::kvflash_attach() {
 
 bool Qwen35LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+    if (committed > kvflash_tokens_) {
         std::fprintf(stderr,
             "[target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);
@@ -968,7 +971,7 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     }
     if (!mixed_target_split && kvflash_active() &&
         kvflash_history_snapshots_.size() != (size_t)PREFIX_SLOTS) {
-        return false;
+        kvflash_history_snapshots_.resize(PREFIX_SLOTS);
     }
 
     ggml_tensor * logits_tensor = nullptr;

--- a/server/src/qwen35/qwen35_layer_split_adapter.h
+++ b/server/src/qwen35/qwen35_layer_split_adapter.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include "common/dflash_draft_ipc.h"
+#include "common/kvflash_pager.h"
+#include "common/kvflash_scorer.h"
 #include "common/layer_split_backend.h"
 #include "dflash_feature_ring.h"
 #include "layer_split_types.h"
@@ -92,6 +94,12 @@ public:
 private:
     bool load_draft();
     bool init_mixed_target_split();
+    void kvflash_read_config();
+    bool kvflash_attach();
+    bool kvflash_active() const { return kvflash_tokens_ > 0; }
+    bool kvflash_sync_identity(int committed);
+    void kvflash_sync_history(const std::vector<int32_t> & tokens, int base_pos);
+    void kvflash_maybe_reselect(int generated);
     bool use_mixed_target_split() const {
         return remote_target_shard_.active() && !shards_.empty();
     }
@@ -114,10 +122,21 @@ private:
     ggml_type activation_type_ = GGML_TYPE_F32;
     DrafterContext pflash_drafter_;
     bool pflash_drafter_loaded_ = false;
+    KvFlashPager kvflash_pager_;
+    std::unique_ptr<KvFlashScorer> kvflash_scorer_;
+    DrafterContext kvflash_drafter_;
+    std::vector<int32_t> kvflash_history_;
+    std::vector<float> kvflash_scores_;
+    std::string kvflash_drafter_path_;
+    int kvflash_tokens_ = 0;
+    int kvflash_tau_ = 64;
+    bool kvflash_drafter_loaded_ = false;
+    bool kvflash_drafter_failed_ = false;
     static constexpr int PREFIX_SLOTS = ModelBackend::kMaxSlots;
     std::vector<std::vector<PrefixSnapshot>> prefix_snapshots_;
     std::vector<std::vector<float>> snapshot_prefill_logits_;
     std::vector<std::vector<ggml_tensor *>> snapshot_prefill_logit_tensors_;
+    std::vector<std::vector<int32_t>> kvflash_history_snapshots_;
     std::vector<ggml_context *> disk_snapshot_contexts_;
     std::vector<ggml_backend_buffer_t> disk_snapshot_buffers_;
     std::vector<ggml_backend_t> disk_snapshot_backends_;

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
@@ -5,6 +5,7 @@
 #include "internal.h"
 #include "graph_builders.h"
 #include "step_graph.h"
+#include "common/kvflash_pager.h"
 
 namespace dflash::common {
 
@@ -18,13 +19,15 @@ Qwen35LayerSplitDFlashTarget::Qwen35LayerSplitDFlashTarget(
         int kq_stride_pad,
         int fa_window,
         DFlashDraftIpcClient * remote_draft,
-        Qwen35TargetShardIpcClient * remote_target_shard)
+        Qwen35TargetShardIpcClient * remote_target_shard,
+        KvFlashPager * kvflash)
     : shards_(shards),
       feature_ring_(feature_ring),
       kq_stride_pad_(kq_stride_pad),
       fa_window_(fa_window),
       remote_draft_(remote_draft),
-      remote_target_shard_(remote_target_shard) {
+      remote_target_shard_(remote_target_shard),
+      kvflash_(kvflash) {
     if (!shards_.empty()) {
         const TargetWeights & w = shards_.front().weights;
         capture_ids_.assign(w.capture_layer_ids,
@@ -49,7 +52,8 @@ bool Qwen35LayerSplitDFlashTarget::verify_batch(
         shards_, shards_.front().weights, tokens, base_pos, (int)tokens.size(),
         last_tok, kq_stride_pad_, fa_window_,
         feature_ring_,
-        all_argmax, /*logits_out=*/nullptr, remote_draft_);
+        all_argmax, /*logits_out=*/nullptr, remote_draft_,
+        /*activation_type=*/GGML_TYPE_F32, kvflash_);
 }
 
 bool Qwen35LayerSplitDFlashTarget::snapshot_kv() {

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.h
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.h
@@ -24,6 +24,8 @@
 
 namespace dflash::common {
 
+class KvFlashPager;
+
 class Qwen35LayerSplitDFlashTarget : public DFlashTarget {
 public:
     // All references/pointers are non-owning; caller controls lifetime.
@@ -32,7 +34,8 @@ public:
                                  int kq_stride_pad,
                                  int fa_window,
                                  DFlashDraftIpcClient * remote_draft = nullptr,
-                                 Qwen35TargetShardIpcClient * remote_target_shard = nullptr);
+                                 Qwen35TargetShardIpcClient * remote_target_shard = nullptr,
+                                 KvFlashPager * kvflash = nullptr);
 
     ~Qwen35LayerSplitDFlashTarget() override;
 
@@ -65,6 +68,7 @@ private:
     int                                  fa_window_;
     DFlashDraftIpcClient *               remote_draft_;
     Qwen35TargetShardIpcClient *         remote_target_shard_;
+    KvFlashPager *                       kvflash_;
 
     std::vector<int> capture_ids_;
     StepGraph        proj_sg_;

--- a/server/src/qwen35/qwen35_target_graph.cpp
+++ b/server/src/qwen35/qwen35_target_graph.cpp
@@ -1027,7 +1027,8 @@ static ggml_tensor * build_single_layer(
     int                   fa_window = 0,
     ggml_tensor *         q_tail_capture = nullptr,
     int                   q_tail_start = 0,
-    ggml_tensor **        moe_selected_out = nullptr)
+    ggml_tensor **        moe_selected_out = nullptr,
+    ggml_tensor *         kv_write_rows = nullptr)
 {
     const int hidden = w.n_embd;
     const float eps   = w.rms_eps;
@@ -1052,7 +1053,8 @@ static ggml_tensor * build_single_layer(
                                     cache.kv_k_type, cache.kv_v_type,
                                     cache.kv_k_rotated,
                                     fa_window,
-                                    q_tail_capture, q_tail_start);
+                                    q_tail_capture, q_tail_start,
+                                    kv_write_rows);
     } else {
         int dn_idx = 0;
         for (int il = 0; il < layer_idx; il++) {
@@ -1295,11 +1297,13 @@ ggml_tensor * build_qwen35_layer(
     bool                  capture,
     int                   fa_window,
     ggml_tensor *         q_tail_capture,
-    int                   q_tail_start)
+    int                   q_tail_start,
+    ggml_tensor *         kv_write_rows)
 {
     return build_single_layer(ctx, gf, w, cache, layer_idx, inp, positions,
                               attn_mask, kv_start, n_tokens, capture, fa_window,
-                              q_tail_capture, q_tail_start, nullptr);
+                              q_tail_capture, q_tail_start, nullptr,
+                              kv_write_rows);
 }
 
 ggml_tensor * build_qwen35_layer(
@@ -1317,11 +1321,13 @@ ggml_tensor * build_qwen35_layer(
     int                   fa_window,
     ggml_tensor *         q_tail_capture,
     int                   q_tail_start,
-    ggml_tensor **        moe_selected_out)
+    ggml_tensor **        moe_selected_out,
+    ggml_tensor *         kv_write_rows)
 {
     return build_single_layer(ctx, gf, w, cache, layer_idx, inp, positions,
                               attn_mask, kv_start, n_tokens, capture, fa_window,
-                              q_tail_capture, q_tail_start, moe_selected_out);
+                              q_tail_capture, q_tail_start, moe_selected_out,
+                              kv_write_rows);
 }
 
 QwenLayerPrefnOutputs build_qwen35_layer_prefn(


### PR DESCRIPTION
## Summary

This PR extends KV Flash bounded KV residency to same-backend target layer split, so split targets can use a pool-sized KV cache instead of allocating full-context KV on every shard. The same-backend path is wired for Qwen35, Gemma4, and Laguna.

## Changes

- Add KV Flash pool allocation and pager lifecycle support to Qwen35, Gemma4, and Laguna same-backend target layer split.
- Thread `KvFlashPager` through same-backend layer-split prefill/decode paths, including Qwen35 DFlash verify.
- Build layer-split attention graphs in pool-slot mode when KV Flash is enabled, including set-rows KV writes and slot-space attention masks.
- Align Gemma4 split boundaries so KV-sharing layers stay on the same shard as their source layer.
- Guard Laguna KV Flash mask uploads so only tensors allocated for the current graph are written.

## Notes

- Local same-backend runtime smoke passed on dual Pro VII HIP with Qwen3.6-27B Q3, `--target-devices hip:0,hip:1 --target-layer-split 1,1`, and `DFLASH_KVFLASH=1024`; the request returned a valid OpenAI-compatible response.
- Local same-backend runtime smoke passed on dual Pro VII HIP with Gemma4 E2B Q4, `--target-devices hip:0,hip:1 --target-layer-split 1,1`, and `DFLASH_KVFLASH=512`; the server auto-aligned shards to `[0,14)+[14,35)` and returned a valid OpenAI-compatible response.
- Local same-backend runtime smoke passed on dual Pro VII HIP with Laguna-XS.2 Q4, `--target-devices hip:0,hip:1 --target-layer-split 1,1`, and `DFLASH_KVFLASH=512`; the pool was raised to 768 tokens for the SWA tail requirement and the request returned a valid OpenAI-compatible response.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

