### PR TITLE
chore(ci): add dependabot and harden action pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       interval: "weekly"
     labels: ["dependencies", "docker"]
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies", "ci"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies", "docker"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies", "python"]
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
           token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: Jimver/cuda-toolkit@v0.2.35
+      - uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
         with:
           # Keep the existing upstream CUDA toolkit version; the uv workspace
           # only replaces Python environment setup.
@@ -133,7 +133,7 @@ jobs:
       group: lucebox3-gpu-runner
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
           token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
@@ -205,7 +205,7 @@ jobs:
       group: lucebox3-rocm-runner
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: KFD health (diagnose instead of hanging)
         # rocminfo on a wedged KFD blocks in uninterruptible sleep and eats

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Derive image metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Suffix every tag with the variant so future CUDA stacks can


### PR DESCRIPTION
## Context

No `.github/dependabot.yml` exists. GitHub Actions versions go stale silently and security vulnerabilities accumulate. Additionally, 3 action references are pinned by tag only (not SHA), creating supply-chain risk:

| Reference | File | Runner | Risk |
|-----------|------|--------|------|
| `Jimver/cuda-toolkit@v0.2.35` | ci.yml:34 | GitHub-hosted | Medium — tag mutable, installs CUDA toolkit |
| `actions/checkout@v4` | ci.yml:136 | Self-hosted (lucebox3) | **High** — tag mutable, runs on physical hardware |
| `actions/checkout@v4` | ci.yml:208 | Self-hosted (lucebox3) | **High** — same |

All other action references in both workflows are already SHA-pinned. These 3 are the inconsistency.

## Bug

- `actions/checkout` is at v4 (latest v6) — 2 major versions behind
- `docker/metadata-action` is at v5 (latest v6) — 1 major version behind
- No Dependabot config means these will never be auto-updated
- Self-hosted runner jobs have the weakest pinning on the most sensitive hardware

## Fix

1. Add `.github/dependabot.yml` for github-actions, docker, and pip ecosystems
2. SHA-pin the 3 unpinned action references
3. Bump `docker/metadata-action` v5 → v6 (Node 24 runtime, no breaking changes)

## Changes

- `.github/dependabot.yml` — new file, weekly schedule, patch updates ignored for pip
- `.github/workflows/ci.yml` — SHA-pin `Jimver/cuda-toolkit` and 2 `actions/checkout` refs on self-hosted jobs
- `.github/workflows/docker.yml` — bump `docker/metadata-action` v5 → v6

## Verification

- All SHA pins verified against upstream tag refs via `gh api`
- `docker/metadata-action` v6 has no breaking changes for `images`, `tags`, `flavor`, or `bake-file` outputs
- `actions/checkout` SHA `34e11487...` matches v4 tag (same SHA already used in 3 other references)
- `Jimver/cuda-toolkit` SHA `3d45d157...` matches v0.2.35 tag
- Dependabot config covers all 3 ecosystems: `github-actions`, `docker`, `pip`

## Notes

- `actions/checkout` v4 → v6 bump is deferred to a separate PR (requires verifying self-hosted runner version ≥ v2.329.0)
- Docker action bumps (setup-buildx, login, bake) are deferred — higher risk due to context model changes in bake v6
- Dependabot will auto-create PRs for future version updates after merge


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

