### PR TITLE
fix(ci): add push trigger for main branch with path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,19 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+      - 'harness/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   uv-workspace:


### PR DESCRIPTION
## Context

CI triggers are `pull_request` on main + `workflow_dispatch`. There is no `push` trigger. Direct pushes to main are never tested.

Of the ~15 most recent commits, ~9 (~60%) are direct pushes — including docs, CI fixes, features, and bugfixes. None of these were tested by CI before landing on main.

## Bug

Direct pushes to main bypass the entire test suite (CUDA build, GPU tests, Python lint, server unit tests). A broken commit can reach main untested.

## Fix

1. Add `push` trigger on main with path filters (only `server/`, `harness/`, `pyproject.toml`, `uv.lock`, and the CI workflow itself)
2. Add a concurrency group to prevent duplicate runs when a PR is merged (PR trigger + push trigger fire simultaneously)

## Changes

- `.github/workflows/ci.yml` — added push trigger with path filters, added concurrency group

## Verification

- Path filters exclude docs-only commits (README, images, markdown) — no wasted GPU runner minutes
- Concurrency group `ci-${{ github.ref }}` deduplicates PR merge + push events
- `cancel-in-progress: true` only for PRs (pushes to main should complete)
- Docker workflow already has its own push trigger — no changes needed there

## Notes

- Path filter is conservative: only code paths that affect builds/tests trigger CI
- Docs-only pushes (README.md, assets/, optimizations/) are excluded
- The concurrency group prevents the duplicate-run waste that would otherwise occur on every PR merge


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

