### PR TITLE
qwen35: include gpu_runtime_compat.h for HIP builds

### DIFF
--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -4,6 +4,11 @@
 #include "graph_builders.h"
 #include "step_graph.h"
 #include "attn_masks.h"
+// gpu_runtime_compat.h maps the raw cudaStream_t / cudaMemcpy* symbols used
+// below (rollback_to / rollback_to_tree) onto their HIP equivalents. Without
+// it the file only compiles on CUDA via a transitive <cuda_runtime.h>; HIP
+// builds (e.g. gfx1151) fail with "cudaStream_t undeclared".
+#include "common/gpu_runtime_compat.h"
 
 #include <cstring>
 


### PR DESCRIPTION
## Problem

`server/src/qwen35/qwen35_dflash_target.cpp` uses raw CUDA runtime symbols but never includes the `common/gpu_runtime_compat.h` shim:

- `cudaStream_t` in the `to_fp32_cuda_t` typedef (line ~12)
- `cudaMemcpy2DAsync`, `cudaMemcpyAsync`, `cudaMemcpyDeviceToDevice`, `cudaSuccess`, `cudaError_t`, `cudaGetErrorString` in `rollback_to` and `rollback_to_tree` (the fast-rollback + DDTree tree-rollback paths added in #389)

It compiled on CUDA only because an upstream header transitively pulled in `<cuda_runtime.h>`. Under HIP there is no `<cuda_runtime.h>` in the include chain, so every one of those symbols is undeclared and the translation unit fails to build. A `gfx1151` (Strix Halo) ROCm build of `dflash_server` dies with `cudaStream_t undeclared` and friends.

## Fix

Add `#include "common/gpu_runtime_compat.h"` (the existing shim that already maps `cuda*` -> `hip*`). The shim defines every symbol this file uses (`cudaStream_t`, `cudaError_t`, `cudaMemcpy2DAsync`, `cudaMemcpyAsync`, `cudaMemcpyDeviceToDevice`, `cudaSuccess`, `cudaGetErrorString`, `cudaStreamSynchronize`). No behavior change on CUDA.

One file, +5 lines (include + explanatory comment).

## Verification

Built `dflash_server` for **gfx1151 (AMD Strix Halo, Ryzen AI MAX+ 395, Radeon 8060S)** with ROCm 7.2.2:

```
-DDFLASH27B_GPU_BACKEND=hip -DDFLASH27B_HIP_ARCHITECTURES=gfx1151
-DDFLASH27B_HIP_SM80_EQUIV=ON -DGGML_HIP=ON
```

- Before: `make` fails compiling `qwen35_dflash_target.cpp` (`cudaStream_t` / `cudaMemcpy2DAsync` / `cudaSuccess` undeclared).
- After: clean compile + link, and `dflash_server` runs the full **AR / DFlash / DFlash+DDTree** decode path end to end on Qwen3.6-27B Q4_K_M (no crash). DFlash+DDTree reaches ~2.1x mean / 2.8x peak over autoregressive on the APU.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

