### PR TITLE
Greedy decode by default for a fast first impression

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Then hit `:8000/v1/chat/completions` (OpenAI-compatible).
 
 ## Run the Server
 
-Default: Qwen 3.6-27B Q4_K_M target + Lucebox Q4_K_M DFlash drafter on RTX 3090. DDTree budget=22, TQ3_0 KV cache, sliding FA window 2048. OpenAI-compatible HTTP on `:8000`.
+Default: Qwen 3.6-27B Q4_K_M target + Lucebox Q4_K_M DFlash drafter on RTX 3090. DDTree budget=22, TQ3_0 KV cache, full attention. OpenAI-compatible HTTP on `:8000`.
 
 ```bash
 # build (CUDA 12+, CMake 3.18+)
@@ -229,8 +229,24 @@ hf download Lucebox/Qwen3.6-27B-DFlash-GGUF dflash-draft-3.6-q4_k_m.gguf --local
 DFLASH27B_KV_TQ3=1 \
 ./server/build/dflash_server server/models/Qwen3.6-27B-Q4_K_M.gguf \
   --draft server/models/draft/dflash-draft-3.6-q4_k_m.gguf \
-  --ddtree --ddtree-budget 22 --fa-window 2048 --port 8000
+  --ddtree --ddtree-budget 22 --port 8000
 ```
+
+### Making requests
+
+The server decodes **greedy by default**: when a request omits `temperature` it uses
+`temperature: 0`. Greedy gives the highest spec-decode acceptance and a deterministic,
+fast response, so the default request is already the fastest path:
+
+```bash
+curl :8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "dflash",
+  "messages": [{"role": "user", "content": "Write quicksort in Python."}]
+}'
+```
+
+To sample instead, pass an explicit `temperature` (> 0); the model card's `top_p`/`top_k`
+fill any unset sampling fields.
 
 ### Server flags
 
@@ -252,7 +268,7 @@ DFLASH27B_KV_TQ3=1 \
 |---|---|---|
 | `--ddtree` | off (chain) | Enable tree verify |
 | `--ddtree-budget N` | `22` | Tree size. 22 on 3090 (default), 40 on 5090, re-sweep on GB10 |
-| `--fa-window N` | `2048` | Sliding FA window; `0` = full attention |
+| `--fa-window N` | `0` (full attention) | Sliding FA window. Leave at 0: a finite window breaks tool calls on Qwen3.6 (full-attn layers lose the system prompt/tools). Advanced / long-context only. |
 | `--draft-residency {auto,persistent,request-scoped}` | `auto` | When draft weights are evicted from VRAM. `request-scoped` parks/frees them after each request's draft work (frees VRAM for the target on tight GPUs); `persistent` keeps them resident across requests; `auto` preserves current behavior while honoring the low-VRAM / `--lazy-draft` hint. Reported at `/props.runtime.draft_residency`. |
 | `--lazy-draft` | off | Legacy alias for `--draft-residency=request-scoped` (defer draft load until first request, release after) |
 

--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -1401,8 +1401,11 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
         // the model card's sampling defaults (spec §3.3); when the card
         // doesn't supply one either, use the hard-coded default.
         const auto & sd = config_.sampler_defaults;
-        req.sampler.temp = body.value("temperature",
-                                      sd.has_temperature ? sd.temperature : 0.0f);
+        // Default to greedy (temp=0) when the request omits temperature: highest
+        // spec-decode acceptance and a deterministic, fast first impression. An
+        // explicit temperature > 0 still samples, and the card top_p/top_k fill
+        // unset fields there.
+        req.sampler.temp = body.value("temperature", 0.0f);
         req.sampler.top_p = body.value("top_p",
                                        sd.has_top_p ? sd.top_p : 1.0f);
         req.sampler.top_k = body.value("top_k",


### PR DESCRIPTION
## What
Default `temperature` to **0 (greedy)** when a request omits it, instead of the model card's `temp=1.0`.

## Why
Out of the box, a request that omits `temperature` resolved to the Qwen3.6 model card's `temperature: 1.0` (sampling). On `main`, spec decode is greedy-only, so those requests silently fell back to **autoregressive decode** — slow and with no acceptance stats. New users following the README quickstart saw ~34 tok/s AR and assumed spec decode was broken (this came up from a user on a fresh 3090).

Greedy-by-default makes the out-of-box request run spec decode: fastest (highest acceptance), deterministic, best first impression. An explicit `temperature > 0` still samples, and the card's `top_p`/`top_k` fill unset fields.

## Validation (lucebox2, RTX 3090, Qwen3.6-27B-Q4_K_M + dflash-draft-3.6)
- Omitted-temperature requests now decode **greedy spec decode** (deterministic, identical output across runs, coherent), avg_commit ~4.5 — previously `[ar-decode]`.
- Greedy decode itself unchanged; explicit `temperature` still honored.

## README
- Dropped `--fa-window 2048` from the quickstart command: a finite window **breaks tool calls** on Qwen3.6 (full-attn layers lose the system prompt/tools), and the binary default is full attention. Fixed the flags-table default (`0`, not `2048`) with a warning.
- Added a "Making requests" section documenting the greedy default and how to sample.

🧙 Built with [WOZCODE](https://wozcode.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

