### PR TITLE
feat(spec-decode): make fast-rollback the default

### DIFF
--- a/server/src/common/backend_factory.h
+++ b/server/src/common/backend_factory.h
@@ -48,7 +48,7 @@ struct BackendArgs {
     int             kq_stride_pad    = 32;
     int             draft_swa_window = 0;
     int             draft_ctx_max    = 4096;
-    bool            fast_rollback    = false;
+    bool            fast_rollback    = true;
     bool            seq_verify       = false;
     bool            ddtree_mode      = false;
     int             ddtree_budget    = 22;

--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -996,11 +996,16 @@ int Qwen35Backend::do_prefill(const std::vector<int32_t> & tokens,
     // already migrated when the snapshot was taken; re-running migrate would
     // clobber the restored state.
     if (kv_offset == 0) {
-        migrate_prefill_cache(w_, cfg_.device.max_ctx,
-                              cfg_.ddtree_mode
-                                  ? std::max<int>(dw_.block_size, cfg_.ddtree_budget + 1)
-                                  : dw_.block_size,
-                              target_backend_, cache_);
+        const int max_verify_tokens = cfg_.ddtree_mode
+            ? std::max<int>(dw_.block_size, cfg_.ddtree_budget + 1)
+            : dw_.block_size;
+        if (!migrate_prefill_cache(w_, cfg_.device.max_ctx,
+                                   max_verify_tokens,
+                                   target_backend_, cache_)) {
+            std::fprintf(stderr, "prefill: rollback cache migration failed: %s\n",
+                         dflash27b_last_error());
+            return -1;
+        }
     }
 
     // Chunked prefill
@@ -1762,6 +1767,18 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
     DFlashTarget * target = dflash_target();
     const bool use_remote_draft = cfg_.remote_draft.enabled() && remote_draft_.active();
     const int q_len = dw_.block_size > 0 ? dw_.block_size : DFLASH27B_DRAFT_BLOCK_SIZE;
+    const int max_verify_tokens = cfg_.ddtree_mode
+        ? std::max<int>(dw_.block_size, cfg_.ddtree_budget + 1)
+        : dw_.block_size;
+    if ((cfg_.fast_rollback || cfg_.ddtree_mode) && !cache_.rollback_ctx) {
+        if (!migrate_prefill_cache(w_, cfg_.device.max_ctx,
+                                   max_verify_tokens,
+                                   target_backend_, cache_)) {
+            std::fprintf(stderr, "spec-decode: rollback cache migration failed: %s\n",
+                         dflash27b_last_error());
+            return false;
+        }
+    }
 
     StepGraph draft_sg;
 
@@ -1780,6 +1797,14 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
     int n_accept_sum    = 0;
     int n_hint_proposed = 0;
     int n_hint_accepted = 0;
+    int target_forwards = 0;
+
+    auto log_target_forward_stats = [&]() {
+        std::fprintf(stderr, "[spec-decode] target_forwards=%d forwards_per_token=%.6f forwards_per_step=%.3f\n",
+                     target_forwards,
+                     n_generated > 0 ? (double)target_forwards / n_generated : 0.0,
+                     n_draft_steps > 0 ? (double)target_forwards / n_draft_steps : 0.0);
+    };
 
     auto t_dec0 = std::chrono::steady_clock::now();
 
@@ -1800,6 +1825,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             cache_.last_tok = out_tokens.back();
             const int ar_n_gen = n_gen - n_generated;
             if (ar_n_gen <= 0) {
+                log_target_forward_stats();
                 io.emit(-1);
                 return true;
             }
@@ -1807,6 +1833,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             bool ok = do_ar_decode(committed, ar_n_gen, out_tokens, io,
                                     tail_hook, forced_close_out,
                                     degenerate_close_out);
+            log_target_forward_stats();
             io.emit(-1);
             return ok;
         }
@@ -1934,57 +1961,120 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 step_graph_destroy(draft_sg);
                 return false;
             }
+            target_forwards++;
 
             int next_token = -1, bonus_node = 0;
             std::vector<int> accepted =
                 follow_verified_tree(tree, posterior.data(), next_token, &bonus_node);
 
-            int commit_n = (int)accepted.size();          // root + accepted children
-            if (commit_n > need_commit_budget) commit_n = need_commit_budget;
-            if (commit_n <= 0) { step_graph_destroy(draft_sg); break; }
+            int accepted_n = (int)accepted.size();        // root + accepted children
+            if (accepted_n > need_commit_budget) accepted_n = need_commit_budget;
+            if (accepted_n <= 0) { step_graph_destroy(draft_sg); break; }
 
             // Emit the accepted path: slot 0 = last_tok (pending from prev iter),
             // each subsequent accepted node = its tree token.
             bool hit_eos = false;
-            int emitted = 0;
-            for (int i = 0; i < commit_n; i++) {
+            int accepted_emitted = 0;
+            for (int i = 0; i < accepted_n; i++) {
                 const int dfs = accepted[i];
                 const int32_t tok = (dfs == 0) ? last_tok : tree.token_ids[dfs - 1];
                 out_tokens.push_back(tok);
                 io.emit(tok);
-                emitted++;
+                accepted_emitted++;
                 if (io.cancelled) { hit_eos = true; break; }
                 if (target->is_eos(tok)) { hit_eos = true; break; }
             }
-            last_tok = next_token;
 
             // Telemetry: accepted children (exclude the always-committed root).
-            n_accept_sum += std::max(0, emitted - 1);
-            n_draft_steps++;
+            n_accept_sum += std::max(0, accepted_emitted - 1);
 
-            if (hit_eos || last_tok < 0 || target->is_eos(last_tok)) {
-                committed   += emitted;
-                n_generated += emitted;
-                break;
-            }
+            if (accepted_emitted <= 0) { step_graph_destroy(draft_sg); break; }
 
             // Roll recurrent + KV state forward to the committed accepted path.
             std::vector<int> accepted_committed(accepted.begin(),
-                                                accepted.begin() + emitted);
+                                                accepted.begin() + accepted_emitted);
             if (!target->rollback_to_tree(committed, tree, accepted_committed)) {
                 std::fprintf(stderr, "spec-decode: rollback_to_tree failed\n");
                 step_graph_destroy(draft_sg);
                 return false;
             }
 
-            // Sync draft-side feature mirror over the committed range.
-            if (feature_mirror_.target_feat && !draft_parked_) {
-                draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
-                                                feature_mirror_, committed, emitted);
+            if (!sampled_verify) {
+                last_tok = next_token;
+
+                // Greedy production path: defer the bonus as next step's root.
+                // No extra target forward and no feature sync beyond accepted path.
+                if (feature_mirror_.target_feat && !draft_parked_) {
+                    draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                    feature_mirror_, committed, accepted_emitted);
+                }
+
+                committed   += accepted_emitted;
+                cache_.cur_pos = committed;
+                n_generated += accepted_emitted;
+                n_draft_steps++;
+                if (hit_eos || io.cancelled || n_generated >= n_gen ||
+                    last_tok < 0 || target->is_eos(last_tok)) {
+                    break;
+                }
+                continue;
             }
 
-            committed   += emitted;
-            n_generated += emitted;
+            int total_emitted = accepted_emitted;
+            int bonus_last_tok = -1;
+            std::vector<float> bonus_logits;
+            const bool can_commit_bonus =
+                !hit_eos && !io.cancelled && next_token >= 0 &&
+                total_emitted < need_commit_budget;
+            if (can_commit_bonus) {
+                const int bonus_pos = committed + total_emitted;
+                std::vector<int32_t> bonus_vec(1, next_token);
+                if (!target->verify_batch(bonus_vec, bonus_pos, bonus_last_tok, nullptr)) {
+                    std::fprintf(stderr, "spec-decode: tree bonus replay failed\n");
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+                target_forwards++;
+                if (!target->read_verify_logits(1, bonus_logits)) {
+                    std::fprintf(stderr, "spec-decode: tree bonus logits read failed\n");
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+                if (bonus_logits.empty()) {
+                    std::fprintf(stderr, "spec-decode: tree bonus logits empty\n");
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+
+                out_tokens.push_back(next_token);
+                io.emit(next_token);
+                total_emitted++;
+                if (io.cancelled) {
+                    hit_eos = true;
+                } else if (target->is_eos(next_token)) {
+                    hit_eos = true;
+                }
+
+                const int vocab_v = (int)bonus_logits.size();
+                last_tok = sample_logits(bonus_logits.data(), vocab_v,
+                                         sampler_, out_tokens, sampler_rng_);
+            } else {
+                last_tok = next_token;
+            }
+
+            // Sampled path commits the bonus in-step, so sync accepted+bonus.
+            if (feature_mirror_.target_feat && !draft_parked_) {
+                draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                feature_mirror_, committed, total_emitted);
+            }
+
+            committed   += total_emitted;
+            cache_.cur_pos = committed;
+            n_generated += total_emitted;
+            n_draft_steps++;
+            if (hit_eos || io.cancelled || n_generated >= n_gen || last_tok < 0) {
+                break;
+            }
             continue;
         }
 
@@ -2018,6 +2108,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             step_graph_destroy(draft_sg);
             return false;
         }
+        target_forwards++;
 
         // 5. Acceptance. Greedy: longest matching prefix between draft and
         // target argmax. Sampled-verify: walk the chain drawing each next
@@ -2153,6 +2244,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 step_graph_destroy(draft_sg);
                 return false;
             }
+            target_forwards++;
         }
 
         // Build replay_tok for emitting committed tokens.
@@ -2263,6 +2355,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                     step_graph_destroy(draft_sg);
                     return false;
                 }
+                target_forwards++;
             }
             committed += emitted;
             cache_.cur_pos = committed;
@@ -2274,6 +2367,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                     step_graph_destroy(draft_sg);
                     return false;
                 }
+                target_forwards++;
                 for (int32_t tok : *stall_tool_prefix_tokens) {
                     out_tokens.push_back(tok);
                     io.emit(tok);
@@ -2325,6 +2419,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 (float)((double)n_accept_sum / (double)total_draft_pos);
             const int ar_n_gen = n_gen - n_generated;
             if (ar_n_gen <= 0) {
+                log_target_forward_stats();
                 io.emit(-1);
                 return true;
             }
@@ -2332,6 +2427,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             bool ok = do_ar_decode(committed, ar_n_gen, out_tokens, io,
                                     tail_hook, forced_close_out,
                                     degenerate_close_out);
+            log_target_forward_stats();
             io.emit(-1);
             return ok;
         }
@@ -2355,6 +2451,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                     step_graph_destroy(draft_sg);
                     return false;
                 }
+                target_forwards++;
             }
             committed += emitted;
             cache_.cur_pos = committed;
@@ -2365,6 +2462,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 (float)((double)n_accept_sum / (double)total_draft_pos);
             const int ar_n_gen = n_gen - n_generated;
             if (ar_n_gen <= 0) {
+                log_target_forward_stats();
                 io.emit(-1);
                 return true;
             }
@@ -2373,6 +2471,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             bool ok = do_ar_decode(committed, ar_n_gen, out_tokens, io,
                                     tail_hook, forced_close_out,
                                     degenerate_close_out);
+            log_target_forward_stats();
             io.emit(-1);
             return ok;
         }
@@ -2392,6 +2491,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                  n_generated > 0 ? n_generated / decode_s : 0.0,
                  n_draft_steps, n_accept_sum, total_draft_pos, accept_pct,
                  n_draft_steps > 0 ? (double)n_generated / (double)n_draft_steps : 0.0);
+    log_target_forward_stats();
     if (n_hint_proposed > 0) {
         std::fprintf(stderr, "[spec-decode] hint tokens: %d/%d accepted (%.1f%%)\n",
                      n_hint_accepted, n_hint_proposed,

--- a/server/src/qwen35/qwen35_backend.h
+++ b/server/src/qwen35/qwen35_backend.h
@@ -59,7 +59,7 @@ struct Qwen35Config {
     int          draft_yarn_orig_ctx  = 4096;
 
     // Speculative decode strategy
-    bool         fast_rollback   = false;
+    bool         fast_rollback   = true;
     bool         seq_verify      = false;
     bool         ddtree_mode     = false;
     int          ddtree_budget   = 22;

--- a/server/src/qwen35/qwen35_daemon.h
+++ b/server/src/qwen35/qwen35_daemon.h
@@ -27,7 +27,7 @@ struct Qwen35DaemonArgs {
     int          draft_ctx_max    = 4096;
 
     // Speculative decode strategy
-    bool         fast_rollback     = false;
+    bool         fast_rollback     = true;
     bool         seq_verify        = false;
     bool         ddtree_mode       = false;
     int          ddtree_budget     = 22;

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -10,6 +10,7 @@
 // builds (e.g. gfx1151) fail with "cudaStream_t undeclared".
 #include "common/gpu_runtime_compat.h"
 
+#include <cstdlib>
 #include <cstring>
 
 // ggml_get_to_fp32_cuda is not in any public header — it lives in
@@ -447,21 +448,42 @@ bool Qwen35DFlashTarget::restore_kv() {
 }
 
 bool Qwen35DFlashTarget::supports_fast_rollback() const {
-    return fast_rollback_;
+    return fast_rollback_ && pager_ == nullptr;
 }
 
 bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
-    if (!fast_rollback_) return false;
+    static const bool kFastRollbackDiag = []() {
+        const char * e = std::getenv("FAST_ROLLBACK_DIAG");
+        return e != nullptr && std::strcmp(e, "0") != 0;
+    }();
+
+    if (!fast_rollback_) {
+        if (kFastRollbackDiag) {
+            std::fprintf(stderr, "rollback_to: fast_rollback disabled\n");
+        }
+        return false;
+    }
 
     // commit_n must be a positive count. `commit_n - 1` below indexes the
     // per-step intermediates; a non-positive value underflows to a huge
     // size_t byte offset and triggers an out-of-bounds GPU read. A zero/neg
     // commit means "nothing to keep" — signal failure so the caller falls
     // back to the full restore_kv path.
-    if (commit_n <= 0) return false;
+    if (commit_n <= 0) {
+        if (kFastRollbackDiag) {
+            std::fprintf(stderr, "rollback_to: commit_n <= 0 commit_n=%d\n",
+                         commit_n);
+        }
+        return false;
+    }
 
     const int n_delta = (int)sg_.delta_captures.size();
-    if (n_delta == 0) return false;
+    if (n_delta == 0) {
+        if (kFastRollbackDiag) {
+            std::fprintf(stderr, "rollback_to: no delta_captures\n");
+        }
+        return false;
+    }
 
     // If all tokens accepted, the SSM state after processing all q_len tokens
     // is exactly what we want — no rollback needed, just fix cur_pos.
@@ -476,8 +498,26 @@ bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
 
     for (int il = 0; il < n_delta; il++) {
         const DeltaNetCapture & cap = sg_.delta_captures[il];
-        if (!cap.ssm_intermediate_states || !cap.conv_input) {
-            std::fprintf(stderr, "rollback_to: missing capture at layer %d\n", il);
+        if (!cap.ssm_intermediate_states) {
+            if (kFastRollbackDiag) {
+                std::fprintf(stderr, "rollback_to: null ssm_intermediate_states layer=%d\n",
+                             il);
+            }
+            return false;
+        }
+        if (!cap.conv_input) {
+            if (kFastRollbackDiag) {
+                std::fprintf(stderr, "rollback_to: null conv_input layer=%d\n",
+                             il);
+            }
+            return false;
+        }
+        if (rollback_idx >= (int)cap.ssm_intermediate_states->ne[3]) {
+            if (kFastRollbackDiag) {
+                std::fprintf(stderr,
+                             "rollback_to: rollback_idx OOB rollback_idx=%d slots=%d layer=%d\n",
+                             rollback_idx, (int)cap.ssm_intermediate_states->ne[3], il);
+            }
             return false;
         }
 
@@ -492,8 +532,10 @@ bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
             (const char *)cap.ssm_intermediate_states->data + ssm_src_offset;
         const auto to_fp32 = ggml_get_to_fp32_cuda(cap.ssm_intermediate_states->type);
         if (!to_fp32) {
-            std::fprintf(stderr, "rollback_to: no fp32 converter for ssm type %d (layer %d)\n",
-                         (int)cap.ssm_intermediate_states->type, il);
+            if (kFastRollbackDiag) {
+                std::fprintf(stderr, "rollback_to: no fp32 converter type=%d layer=%d\n",
+                             (int)cap.ssm_intermediate_states->type, il);
+            }
             return false;
         }
         to_fp32(ssm_src, (float *)cache_.ssm_state[il]->data,
@@ -502,6 +544,15 @@ bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
         // Conv rollback: copy conv_input[commit_n..commit_n+K-2, :, :]
         // into cache.conv_state[il].
         const int K_conv = 4;
+        if (commit_n + K_conv - 1 > (int)cap.conv_input->ne[0]) {
+            if (kFastRollbackDiag) {
+                std::fprintf(stderr,
+                             "rollback_to: conv_input OOB commit_n=%d needed=%d slots=%d layer=%d\n",
+                             commit_n, commit_n + K_conv - 1,
+                             (int)cap.conv_input->ne[0], il);
+            }
+            return false;
+        }
         const int row_cnt = (int)cap.conv_input->ne[1];
         const size_t elt = ggml_element_size(cap.conv_input);
         const size_t dpitch = (K_conv - 1) * elt;
@@ -514,8 +565,10 @@ bool Qwen35DFlashTarget::rollback_to(int base_pos, int commit_n) {
                                            width, row_cnt,
                                            cudaMemcpyDeviceToDevice, stream);
         if (ce != cudaSuccess) {
-            std::fprintf(stderr, "rollback_to: cudaMemcpy2D conv il=%d: %s\n",
-                         il, cudaGetErrorString(ce));
+            if (kFastRollbackDiag) {
+                std::fprintf(stderr, "rollback_to: cudaMemcpy2D conv layer=%d: %s\n",
+                             il, cudaGetErrorString(ce));
+            }
             return false;
         }
     }

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -221,6 +221,8 @@ static void print_usage(const char * prog) {
         "                       from attention at long contexts. Use 0 for tools.\n"
         "  --model-name <name>  Model name for /v1/models (default: dflash)\n"
         "  --prefix-cache-slots <N>  Prefix cache slots (default: 32, 0 disables)\n"
+        "  --fast-rollback     Enable speculative fast rollback (default: on)\n"
+        "  --no-fast-rollback  Disable speculative fast rollback, even with --ddtree\n"
         "  --ddtree             Enable DDTree speculative decode\n"
         "  --ddtree-budget <N>  DDTree budget (default: 22)\n"
         "  --no-cors            Disable CORS headers\n"
@@ -322,6 +324,7 @@ int main(int argc, char ** argv) {
     std::string cache_type_v;  // explicit --cache-type-v override
     bool target_device_seen = false;
     bool target_devices_seen = false;
+    bool fast_rollback_forced_off = false;
 
     // Track which thinking-budget tunables the operator set via CLI.
     // Those values win over the model card (spec §3.1: "Explicit CLI
@@ -420,11 +423,16 @@ int main(int argc, char ** argv) {
             sconfig.model_name = argv[++i];
         } else if (std::strcmp(argv[i], "--prefix-cache-slots") == 0 && i + 1 < argc) {
             sconfig.prefix_cache_cap = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--fast-rollback") == 0) {
+            bargs.fast_rollback = true;
         } else if (std::strcmp(argv[i], "--ddtree") == 0) {
             bargs.ddtree_mode = true;
             bargs.fast_rollback = true;
         } else if (std::strcmp(argv[i], "--ddtree-budget") == 0 && i + 1 < argc) {
             bargs.ddtree_budget = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--no-fast-rollback") == 0) {
+            fast_rollback_forced_off = true;
+            bargs.fast_rollback = false;
         } else if (std::strcmp(argv[i], "--kvflash") == 0 && i + 1 < argc) {
             // Bounded KV residency: attention KV lives in a fixed pool of N
             // tokens; cold 64-token chunks page to host. Works with or
@@ -609,6 +617,7 @@ int main(int argc, char ** argv) {
             return 2;
         }
     }
+    if (fast_rollback_forced_off) bargs.fast_rollback = false;
 
     if (!validate_server_placement(bargs, sconfig)) return 2;
 
@@ -1050,6 +1059,7 @@ int main(int argc, char ** argv) {
                              "[server] │     Use --fa-window 0 for tool-call workloads.\n");
     }
     std::fprintf(stderr, "[server] │  ddtree          = %s\n", bargs.ddtree_mode ? "ON" : "off");
+    std::fprintf(stderr, "[server] │  fast_rollback   = %s\n", bargs.fast_rollback ? "ON" : "off");
     std::fprintf(stderr, "[server] │  ddtree_budget   = %d\n", bargs.ddtree_budget);
     std::fprintf(stderr, "[server] │  prefix_cache    = %d slots\n", sconfig.prefix_cache_cap);
     std::fprintf(stderr, "[server] │  cors            = %s\n", sconfig.enable_cors ? "ON" : "off");


### PR DESCRIPTION
## Summary
Decouples fast-rollback from `--ddtree` so the plain speculative-decoding chain also skips the legacy replay forward.

- `fast_rollback` now defaults to **on**; adds `--fast-rollback` / `--no-fast-rollback` (`--no-fast-rollback` wins regardless of position; `--ddtree` still implies it).
- `migrate_prefill_cache` runs when fast-rollback or ddtree is set, so the chain path also gets the rollback buffers.
- `supports_fast_rollback()` / `supports_tree_verify()` gated on `pager_ == nullptr`, so a `--kvflash` run never attempts an unsupported rollback now that fast-rollback is default-on.
- Adds `target_forwards` telemetry (`forwards_per_token` / `forwards_per_step`) to `do_spec_decode` for deterministic speed measurement.

## Measured (RTX 3090, Qwen3.6-27B-Q4_K_M + dflash-draft-3.6-q8, greedy)
Target forwards/token, lower = faster:

| mode | fwd/step | avg_commit | fwd/token |
| --- | --- | --- | --- |
| chain, `--no-fast-rollback` (legacy) | 2.000 | 6.40 | 0.3125 |
| chain, fast-rollback (new default) | 1.523 | 5.82 | 0.262 (1.19x) |
| `--ddtree` | 1.000 | 5.33 | 0.188 (1.67x) |

## Test
- default-on chain: banner `fast_rollback = ON`, 1.52 fwd/step, 0 rollback failures, coherent output.
- `--no-fast-rollback`: banner `off`, 2.00 fwd/step (legacy restored).
- `--no-fast-rollback --ddtree`: banner `off` (flag wins regardless of position).
- `--kvflash auto` and `--ddtree --kvflash auto`: coherent, no rollback/crash messages.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

