### PR TITLE
feat(qwen35): sampled tree-verify for --ddtree at temperature

### DIFF
--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1918,9 +1918,9 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
         // draft tree from per-position top-K, verify all nodes in one
         // ancestor-masked target forward, walk the verified path, then roll
         // recurrent/KV state forward to the accepted path. Higher acceptance
-        // per step than chain verify. Local draft only; greedy bonus token
-        // (sampled tree-verify is a follow-up). On any failure we fall through
-        // is unsafe (draft graph already built for chain), so we bail to false.
+        // per step than chain verify. Local draft only. On any failure we
+        // fall through is unsafe (draft graph already built for chain), so we
+        // bail to false.
         // The tree path handles plain generation only. Requests using features
         // the tree branch does not implement — thinking-budget forced close,
         // tool-call hint injection, stall recovery, or the min-tokens floor
@@ -1932,10 +1932,7 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             stall_tool_prefix_tokens == nullptr &&
             (int)out_tokens.size() >= _min_floor;
         if (cfg_.ddtree_mode && target->supports_tree_verify() &&
-            !use_remote_draft && q_len > 1 && tree_special_inactive &&
-            !sampled_verify) {  // tree walk is greedy-only; sampled requests use
-                                // chain sampled-verify instead (a greedy tree accept
-                                // would corrupt the target sampling distribution)
+            !use_remote_draft && q_len > 1 && tree_special_inactive) {
             const int L = q_len - 1;
             const int K = (cfg_.ddtree_budget > L) ? 8 : 1;
             std::vector<float>   top_lp;
@@ -1947,6 +1944,9 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
                 return false;
             }
             // Tree depth L draws from draft rows 1..q_len-1 (row 0 = the seed).
+            // Known limitation: branch descendants beyond depth 1 still come
+            // from one spine-conditioned block-draft forward, so a confident
+            // draft may not beat the chain.
             DDTree tree = build_ddtree(top_lp.data() + (size_t)K, top_ids.data() + (size_t)K,
                                        L, K, cfg_.ddtree_budget, cfg_.ddtree_chain_seed);
             const int N = cfg_.ddtree_budget + 1;   // fixed alloc width
@@ -1956,7 +1956,9 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             for (int i = 0; i < tree.n_nodes; i++) flat_tokens[1 + i] = tree.token_ids[i];
 
             std::vector<int32_t> posterior;
-            if (!target->verify_tree(committed, tree, flat_tokens, N, posterior, nullptr)) {
+            std::vector<float>   node_logits;
+            if (!target->verify_tree(committed, tree, flat_tokens, N, posterior,
+                                     sampled_verify ? &node_logits : nullptr)) {
                 std::fprintf(stderr, "spec-decode: verify_tree failed\n");
                 step_graph_destroy(draft_sg);
                 return false;
@@ -1964,8 +1966,30 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             target_forwards++;
 
             int next_token = -1, bonus_node = 0;
-            std::vector<int> accepted =
-                follow_verified_tree(tree, posterior.data(), next_token, &bonus_node);
+            std::vector<int> accepted;
+            if (!sampled_verify) {
+                accepted =
+                    follow_verified_tree(tree, posterior.data(), next_token, &bonus_node);
+            } else {
+                accepted.reserve((size_t)tree.n_nodes + 1);
+                accepted.push_back(0);
+                std::vector<int32_t> hist = out_tokens;
+                hist.push_back(last_tok);
+                const int vocab = w_.n_vocab;
+                int cur = 0;
+                int stok = sample_logits(node_logits.data() + (size_t)cur * vocab,
+                                         vocab, sampler_, hist, sampler_rng_);
+                while (true) {
+                    auto it = tree.child_maps[cur].find(stok);
+                    if (it == tree.child_maps[cur].end()) break;
+                    cur = it->second;
+                    accepted.push_back(cur);
+                    hist.push_back(stok);
+                    stok = sample_logits(node_logits.data() + (size_t)cur * vocab,
+                                         vocab, sampler_, hist, sampler_rng_);
+                }
+                next_token = stok;
+            }
 
             int accepted_n = (int)accepted.size();        // root + accepted children
             if (accepted_n > need_commit_budget) accepted_n = need_commit_budget;


### PR DESCRIPTION
## Summary
Makes `--ddtree` tree-verify work under sampling (temperature > 0). Stacked on #412.

Tree-verify previously had only a greedy (argmax) walk, so sampled requests with `--ddtree` fell back to the chain. This adds a sample-and-match walk:

- greedy keeps the argmax `follow_verified_tree`;
- sampled samples each node's ancestor-masked verify logits and matches the draft child; a miss takes the sampled token as the bonus;
- distribution-preserving: every committed token is a target sample.

## Measured (RTX 3090, Qwen3.6-27B-Q4_K_M + dflash-draft-3.6-q8)
- temp=0 sampled tree is byte-identical to the greedy tree (md5 `244be532b48f`) — the sampled walk reduces exactly to greedy.
- sampling (temp=1, top_p 0.95, top_k 20): tree `avg_commit` 6.74 vs chain 5.57 (+21% acceptance).

With this draft the sampled tree adds one bonus-replay forward per step, so the acceptance gain is roughly offset on forwards/token (draft-quality-gated, same as the greedy tree-vs-chain comparison). Correctness and acceptance hold unconditionally; the speed win scales with draft quality.

## Test
- enabled with `DFLASH_SAMPLED_VERIFY=1` + `--ddtree` + `--fa-window 0`.
- temp=0 path byte-identical to greedy `--ddtree`; temp=1 path coherent with the acceptance numbers above.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

