### PR TITLE
fix(qwen35): adaptive replay for greedy tree-verify (ddtree >= chain)

### DIFF
--- a/server/src/qwen35/qwen35_backend.cpp
+++ b/server/src/qwen35/qwen35_backend.cpp
@@ -1955,6 +1955,11 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
             flat_tokens[0] = last_tok;
             for (int i = 0; i < tree.n_nodes; i++) flat_tokens[1 + i] = tree.token_ids[i];
 
+            if (!sampled_verify && !target->snapshot_kv()) {
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+
             std::vector<int32_t> posterior;
             std::vector<float>   node_logits;
             if (!target->verify_tree(committed, tree, flat_tokens, N, posterior,
@@ -2014,34 +2019,105 @@ bool Qwen35Backend::do_spec_decode(int committed, int n_gen,
 
             if (accepted_emitted <= 0) { step_graph_destroy(draft_sg); break; }
 
-            // Roll recurrent + KV state forward to the committed accepted path.
-            std::vector<int> accepted_committed(accepted.begin(),
-                                                accepted.begin() + accepted_emitted);
-            if (!target->rollback_to_tree(committed, tree, accepted_committed)) {
-                std::fprintf(stderr, "spec-decode: rollback_to_tree failed\n");
-                step_graph_destroy(draft_sg);
-                return false;
-            }
-
             if (!sampled_verify) {
-                last_tok = next_token;
+                const int root_last_tok = last_tok;
+                constexpr int kFastRollbackThreshold = 5;
+                const bool use_tree_fast_rollback =
+                    target->supports_fast_rollback() &&
+                    accepted_emitted >= kFastRollbackThreshold;
 
-                // Greedy production path: defer the bonus as next step's root.
-                // No extra target forward and no feature sync beyond accepted path.
-                if (feature_mirror_.target_feat && !draft_parked_) {
-                    draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
-                                                    feature_mirror_, committed, accepted_emitted);
+                if (use_tree_fast_rollback) {
+                    // Fast greedy production path: restore to the accepted path
+                    // from tree captures and defer the bonus as next step's root.
+                    std::vector<int> accepted_committed(accepted.begin(),
+                                                        accepted.begin() + accepted_emitted);
+                    if (!target->rollback_to_tree(committed, tree, accepted_committed)) {
+                        std::fprintf(stderr, "spec-decode: rollback_to_tree failed\n");
+                        step_graph_destroy(draft_sg);
+                        return false;
+                    }
+                    last_tok = next_token;
+
+                    if (feature_mirror_.target_feat && !draft_parked_) {
+                        draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                        feature_mirror_, committed, accepted_emitted);
+                    }
+
+                    committed   += accepted_emitted;
+                    cache_.cur_pos = committed;
+                    n_generated += accepted_emitted;
+                    n_draft_steps++;
+                    if (hit_eos || io.cancelled || n_generated >= n_gen ||
+                        last_tok < 0 || target->is_eos(last_tok)) {
+                        break;
+                    }
+                    continue;
                 }
 
-                committed   += accepted_emitted;
+                // Low-accept greedy path: mirror the chain's exact replay so the
+                // next step starts from replayed F32 recurrent state. The accepted
+                // path has already been emitted above; only emit the bonus here.
+                int total_emitted = accepted_emitted;
+                const bool can_commit_bonus =
+                    !hit_eos && !io.cancelled && next_token >= 0 &&
+                    total_emitted < need_commit_budget;
+
+                std::vector<int32_t> replay_batch;
+                replay_batch.reserve((size_t)accepted_emitted + (can_commit_bonus ? 1 : 0));
+                for (int i = 0; i < accepted_emitted; i++) {
+                    const int dfs = accepted[i];
+                    replay_batch.push_back((dfs == 0) ? root_last_tok : tree.token_ids[dfs - 1]);
+                }
+                if (can_commit_bonus) replay_batch.push_back(next_token);
+
+                if (!target->restore_kv()) {
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+                int replay_last_tok = -1;
+                if (!target->verify_batch(replay_batch, committed, replay_last_tok, nullptr)) {
+                    std::fprintf(stderr, "spec-decode: tree replay failed\n");
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+                target_forwards++;
+
+                if (can_commit_bonus) {
+                    out_tokens.push_back(next_token);
+                    io.emit(next_token);
+                    total_emitted++;
+                    if (io.cancelled) {
+                        hit_eos = true;
+                    } else if (target->is_eos(next_token)) {
+                        hit_eos = true;
+                    }
+                }
+
+                last_tok = replay_last_tok;
+                if (feature_mirror_.target_feat && !draft_parked_) {
+                    draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                    feature_mirror_, committed, total_emitted);
+                }
+
+                committed   += total_emitted;
                 cache_.cur_pos = committed;
-                n_generated += accepted_emitted;
+                n_generated += total_emitted;
                 n_draft_steps++;
                 if (hit_eos || io.cancelled || n_generated >= n_gen ||
                     last_tok < 0 || target->is_eos(last_tok)) {
                     break;
                 }
                 continue;
+            }
+
+            // Sampled path keeps the distribution-preserving bonus replay but
+            // still needs tree rollback for the accepted prefix first.
+            std::vector<int> accepted_committed(accepted.begin(),
+                                                accepted.begin() + accepted_emitted);
+            if (!target->rollback_to_tree(committed, tree, accepted_committed)) {
+                std::fprintf(stderr, "spec-decode: rollback_to_tree failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
             }
 
             int total_emitted = accepted_emitted;


### PR DESCRIPTION
## Summary
Greedy `--ddtree` was accepting **fewer** tokens/step than the chain, which is wrong — a tree that explores branches should accept ≥ a linear chain. Root cause: the greedy tree path always used the approximate F16 `rollback_to_tree` and never did the chain's exact-state replay, so recurrent (gated-DeltaNet SSM + conv) state drift compounded across steps. With no branches at all (spine-only, linear tokens identical to the chain) the tree accepted **4.92 vs the chain's 5.82** — a ~0.9 tok/step deficit on identical work.

The chain is adaptive: fast F16 rollback only when `accept_n >= kFastRollbackThreshold (5)`, otherwise `restore_kv()` + `verify_batch` replay that recomputes exact F32 state. The greedy tree path skipped that. This change mirrors the chain's policy on the greedy tree path:

- `snapshot_kv()` before `verify_tree` (greedy only);
- `accept_n >= 5 && supports_fast_rollback()` → keep `rollback_to_tree` + deferred bonus (fast, no extra forward);
- otherwise → `restore_kv()` + `verify_batch` replay of the accepted path plus bonus, recomputing exact F32 recurrent state; emit only the bonus (the accepted path is already emitted), seed `last_tok = replay_last_tok`;
- `rollback_to_tree` now runs only on the fast path and the sampled branch.

For a linear spine the rollback indices already line up with the chain (`ssm_intermediate[rollback_dfs] == chain[commit_n-1]`, conv likewise), so this is not an off-by-one — purely the missing exact replay on low-accept steps.

## Measured (RTX 3090, Qwen3.6-27B-Q4_K_M + dflash-draft-3.6-q8, quicksort)
Greedy (avg_commit / forwards_per_step):
| mode | before | after |
| --- | --- | --- |
| chain | 5.82 / 1.523 | — |
| ddtree spine-only (budget 15) | 4.92 / 1.000 | 5.69 / 1.467 |
| ddtree branches (budget 22) | 5.33 / 1.000 | **6.40 / 1.400** |

After the fix greedy ddtree = **+10% acceptance over chain (6.40 vs 5.82) at fewer forwards/step (1.40 vs 1.52)** ≈ 1.2× faster — both axes win. Sampling is unaffected (ddtree `avg_commit` 6.74 vs chain 5.57). Output coherent in all configs.

## Scope
`--ddtree` tree-verify is implemented only on the qwen35 backend (`supports_tree_verify()` is true only for `Qwen35DFlashTarget`). Other backends fall back to chain spec decode and are unaffected. Builds on the sampled tree-verify in #414 (the `sampled_verify` branch split it reuses is already on main).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

