### PR TITLE
feat(server): support KV Flash mixed-backend layer split with model adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
   build:
     name: Build (cmake + uv sync --extra megakernel)
     runs-on: ubuntu-latest
+    env:
+      LD_LIBRARY_PATH: ${{ runner.temp }}/cuda-stubs:/usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs:/usr/local/cuda-12.8/lib64
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -53,6 +55,12 @@ jobs:
           method: network
           sub-packages: '["nvcc", "cudart-dev", "thrust", "driver-dev"]'
           non-cuda-sub-packages: '["libcublas-dev"]'
+
+      - name: Provide CUDA driver stub for hosted tests
+        run: |
+          mkdir -p "$RUNNER_TEMP/cuda-stubs"
+          ln -sf "$CUDA_PATH/targets/x86_64-linux/lib/stubs/libcuda.so" \
+            "$RUNNER_TEMP/cuda-stubs/libcuda.so.1"
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
   build:
     name: Build (cmake + uv sync --extra megakernel)
     runs-on: ubuntu-latest
-    env:
-      LD_LIBRARY_PATH: ${{ runner.temp }}/cuda-stubs:/usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs:/usr/local/cuda-12.8/lib64
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -61,6 +59,9 @@ jobs:
           mkdir -p "$RUNNER_TEMP/cuda-stubs"
           ln -sf "$CUDA_PATH/targets/x86_64-linux/lib/stubs/libcuda.so" \
             "$RUNNER_TEMP/cuda-stubs/libcuda.so.1"
+          {
+            echo "LD_LIBRARY_PATH=$RUNNER_TEMP/cuda-stubs:/usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs:/usr/local/cuda-12.8/lib64"
+          } >> "$GITHUB_ENV"
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -251,6 +251,8 @@ add_library(dflash_common STATIC
     src/laguna/laguna_backend.cpp
     src/laguna/laguna_layer_split_adapter.cpp
     src/common/backend_ipc.cpp
+    src/common/target_shard_ipc.cpp
+    src/common/target_shard_ipc_daemon.cpp
     src/common/dflash_feature_ring.cpp
     src/common/dflash_capture.cpp
     src/common/dflash_draft_ipc.cpp
@@ -351,6 +353,12 @@ elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
     # hip_compat shim is needed by ALL dflash_common sources (peer_access.cpp,
     # dflash_feature_ring.cpp, flashprefill.cpp), not just the SM80_EQUIV path.
     target_include_directories(dflash_common PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/hip_compat)
+endif()
+
+if(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
+    target_link_libraries(dflash_common PUBLIC CUDA::cudart)
+elseif(DFLASH27B_GPU_BACKEND STREQUAL "hip")
+    target_link_libraries(dflash_common PUBLIC hip::host)
 endif()
 
 # FlashPrefill custom kernels.

--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -131,6 +131,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
             LagunaLayerSplitAdapterConfig cfg;
             cfg.target_path = args.model_path;
             cfg.device      = args.device;
+            cfg.remote_target_shard = args.remote_target_shard;
             cfg.chunk       = args.chunk;
 
             auto adapter = std::make_unique<LagunaLayerSplitAdapter>(cfg);
@@ -175,6 +176,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
             Gemma4LayerSplitAdapterConfig cfg;
             cfg.target_path = args.model_path;
             cfg.device      = args.device;
+            cfg.remote_target_shard = args.remote_target_shard;
             cfg.chunk       = args.chunk;
             cfg.fa_window   = args.fa_window;
 

--- a/server/src/common/backend_ipc.cpp
+++ b/server/src/common/backend_ipc.cpp
@@ -26,6 +26,7 @@ namespace dflash::common {
 
 const char * backend_ipc_mode_name(BackendIpcMode mode) {
     switch (mode) {
+        case BackendIpcMode::Invalid: return "invalid";
         case BackendIpcMode::DFlashDraft: return "dflash-draft";
         case BackendIpcMode::PFlashCompress: return "pflash-compress";
         case BackendIpcMode::Qwen35TargetShard: return "qwen35-target-shard";

--- a/server/src/common/backend_ipc.cpp
+++ b/server/src/common/backend_ipc.cpp
@@ -29,6 +29,8 @@ const char * backend_ipc_mode_name(BackendIpcMode mode) {
         case BackendIpcMode::DFlashDraft: return "dflash-draft";
         case BackendIpcMode::PFlashCompress: return "pflash-compress";
         case BackendIpcMode::Qwen35TargetShard: return "qwen35-target-shard";
+        case BackendIpcMode::Gemma4TargetShard: return "gemma4-target-shard";
+        case BackendIpcMode::LagunaTargetShard: return "laguna-target-shard";
     }
     return "unknown";
 }
@@ -44,6 +46,14 @@ bool parse_backend_ipc_mode(const std::string & value, BackendIpcMode & out) {
     }
     if (value == "qwen35-target-shard") {
         out = BackendIpcMode::Qwen35TargetShard;
+        return true;
+    }
+    if (value == "gemma4-target-shard") {
+        out = BackendIpcMode::Gemma4TargetShard;
+        return true;
+    }
+    if (value == "laguna-target-shard") {
+        out = BackendIpcMode::LagunaTargetShard;
         return true;
     }
     return false;

--- a/server/src/common/backend_ipc.h
+++ b/server/src/common/backend_ipc.h
@@ -24,6 +24,8 @@ enum class BackendIpcMode {
     DFlashDraft,
     PFlashCompress,
     Qwen35TargetShard,
+    Gemma4TargetShard,
+    LagunaTargetShard,
 };
 
 const char * backend_ipc_mode_name(BackendIpcMode mode);

--- a/server/src/common/backend_ipc.h
+++ b/server/src/common/backend_ipc.h
@@ -21,6 +21,7 @@
 namespace dflash::common {
 
 enum class BackendIpcMode {
+    Invalid,
     DFlashDraft,
     PFlashCompress,
     Qwen35TargetShard,

--- a/server/src/common/layer_split_backend.cpp
+++ b/server/src/common/layer_split_backend.cpp
@@ -252,6 +252,14 @@ bool LayerSplitBackend::supports_remote_draft() const {
     return adapter_ && adapter_->supports_remote_draft();
 }
 
+bool LayerSplitBackend::supports_kvflash() const {
+    return adapter_ && adapter_->supports_kvflash();
+}
+
+bool LayerSplitBackend::supports_mixed_backend_layer_split() const {
+    return adapter_ && adapter_->supports_mixed_backend_layer_split();
+}
+
 void LayerSplitBackend::shutdown() {
     if (shutdown_done_) return;
     shutdown_done_ = true;

--- a/server/src/common/layer_split_backend.h
+++ b/server/src/common/layer_split_backend.h
@@ -47,6 +47,8 @@ public:
     virtual bool supports_dflash_spec_decode() const { return false; }
     virtual DFlashTarget * dflash_target() { return nullptr; }
     virtual bool supports_remote_draft() const { return false; }
+    virtual bool supports_kvflash() const { return false; }
+    virtual bool supports_mixed_backend_layer_split() const { return false; }
 
     virtual const char * default_compress_drafter_path() const { return ""; }
     virtual ModelBackend::CompressResult
@@ -114,6 +116,8 @@ public:
     bool supports_dflash_spec_decode() const override;
     DFlashTarget * dflash_target() override;
     bool supports_remote_draft() const override;
+    bool supports_kvflash() const override;
+    bool supports_mixed_backend_layer_split() const override;
 
     void shutdown() override;
 

--- a/server/src/common/layer_split_kvflash.h
+++ b/server/src/common/layer_split_kvflash.h
@@ -1,0 +1,100 @@
+// Shared KVFlash helpers for target layer-split adapters.
+//
+// Model adapters still own model-specific KV tensor discovery, scoring, and
+// remote-shard synchronization. These helpers keep the common pager/history
+// contracts identical across Qwen, Gemma, and Laguna layer-split backends.
+
+#pragma once
+
+#include "kvflash_pager.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace dflash::common {
+
+inline bool layer_split_kvflash_sync_identity(
+        KvFlashPager & pager,
+        int committed,
+        int pool_tokens,
+        const char * log_prefix) {
+    const char * prefix = log_prefix ? log_prefix : "target-split";
+    if (committed < 0) {
+        std::fprintf(stderr,
+            "[%s][kvflash] invalid committed position %d\n",
+            prefix, committed);
+        return false;
+    }
+    if (committed > pool_tokens) {
+        std::fprintf(stderr,
+            "[%s][kvflash] prefix (%d) exceeds resident pool %d\n",
+            prefix, committed, pool_tokens);
+        return false;
+    }
+    pager.reset();
+    for (int p = 0; p < committed; ++p) {
+        const int slot = pager.slot_for(p);
+        if (slot != p) {
+            std::fprintf(stderr,
+                "[%s][kvflash] identity slot mismatch %d != %d\n",
+                prefix, slot, p);
+            return false;
+        }
+    }
+    pager.zero_free_blocks();
+    return pager.is_identity();
+}
+
+inline void layer_split_kvflash_sync_history(
+        std::vector<int32_t> & history,
+        const std::vector<int32_t> & tokens,
+        int base_pos) {
+    if (base_pos <= 0) {
+        history.assign(tokens.begin(), tokens.end());
+        return;
+    }
+    if ((int)history.size() > base_pos) {
+        history.resize((size_t)base_pos);
+    } else if ((int)history.size() < base_pos) {
+        history.resize((size_t)base_pos, 0);
+    }
+    history.insert(history.end(), tokens.begin(), tokens.end());
+}
+
+inline void layer_split_kvflash_restore_history(
+        std::vector<int32_t> & history,
+        const std::vector<std::vector<int32_t>> & snapshots,
+        int slot,
+        int cur_pos) {
+    if (slot >= 0 && slot < (int)snapshots.size() &&
+        !snapshots[(size_t)slot].empty()) {
+        history = snapshots[(size_t)slot];
+    } else {
+        history.clear();
+    }
+    if (cur_pos <= 0) {
+        history.clear();
+    } else if ((int)history.size() > cur_pos) {
+        history.resize((size_t)cur_pos);
+    } else if ((int)history.size() < cur_pos) {
+        history.resize((size_t)cur_pos, 0);
+    }
+}
+
+inline void layer_split_kvflash_save_history_snapshot(
+        const std::vector<int32_t> & history,
+        int cur_pos,
+        std::vector<int32_t> & snapshot) {
+    snapshot.clear();
+    if (cur_pos <= 0) return;
+    const size_t keep = (size_t)std::min(cur_pos, (int)history.size());
+    snapshot.assign(history.begin(), history.begin() + keep);
+    if ((int)snapshot.size() < cur_pos) {
+        snapshot.resize((size_t)cur_pos, 0);
+    }
+}
+
+}  // namespace dflash::common

--- a/server/src/common/layer_split_utils.cpp
+++ b/server/src/common/layer_split_utils.cpp
@@ -109,9 +109,6 @@ bool compute_target_shard_layer_split_plan(
     if (device.is_mixed_layer_split()) {
         return compute_mixed_layer_split_plan(device, local_backend, out, prefix);
     }
-    if (device.layer_split_backends.size() < 2) {
-        return false;
-    }
     out.remote_begin = 1;
     out.remote_backend = local_backend;
     return true;

--- a/server/src/common/layer_split_utils.cpp
+++ b/server/src/common/layer_split_utils.cpp
@@ -43,6 +43,80 @@ std::vector<LayerSplitRange> compute_layer_ranges(
     return ranges;
 }
 
+bool compute_mixed_layer_split_plan(
+        const DevicePlacement & device,
+        PlacementBackend local_backend,
+        MixedLayerSplitPlan & out,
+        const char * log_prefix) {
+    const char * prefix = log_prefix ? log_prefix : "target-split";
+    out = MixedLayerSplitPlan{};
+    if (!device.is_mixed_layer_split() || device.layer_split_gpus.size() < 2) {
+        std::fprintf(stderr, "[%s] mixed layer split requires at least two shards\n",
+                     prefix);
+        return false;
+    }
+    if (device.layer_split_backend(0) != local_backend) {
+        std::fprintf(stderr,
+            "[%s] first mixed shard must match compiled backend (%s)\n",
+            prefix, placement_backend_name(local_backend));
+        return false;
+    }
+    size_t remote_begin = 0;
+    while (remote_begin < device.layer_split_gpus.size() &&
+           device.layer_split_backend(remote_begin) == local_backend) {
+        ++remote_begin;
+    }
+    if (remote_begin == 0 || remote_begin >= device.layer_split_gpus.size()) {
+        std::fprintf(stderr,
+            "[%s] mixed layer split requires one local backend group followed by "
+            "one remote backend group\n", prefix);
+        return false;
+    }
+    const PlacementBackend remote_backend =
+        device.layer_split_backend(remote_begin);
+    for (size_t i = remote_begin; i < device.layer_split_gpus.size(); ++i) {
+        if (device.layer_split_backend(i) != remote_backend) {
+            std::fprintf(stderr,
+                "[%s] mixed layer split supports only one backend boundary\n",
+                prefix);
+            return false;
+        }
+    }
+    out.remote_begin = remote_begin;
+    out.remote_backend = remote_backend;
+    return true;
+}
+
+bool compute_target_shard_layer_split_plan(
+        const DevicePlacement & device,
+        PlacementBackend local_backend,
+        MixedLayerSplitPlan & out,
+        const char * log_prefix) {
+    const char * prefix = log_prefix ? log_prefix : "target-split";
+    out = MixedLayerSplitPlan{};
+    if (!device.is_layer_split() || device.layer_split_gpus.size() < 2) {
+        std::fprintf(stderr,
+            "[%s] target-shard layer split requires at least two shards\n",
+            prefix);
+        return false;
+    }
+    if (device.layer_split_backend(0) != local_backend) {
+        std::fprintf(stderr,
+            "[%s] first target-shard split shard must match compiled backend (%s)\n",
+            prefix, placement_backend_name(local_backend));
+        return false;
+    }
+    if (device.is_mixed_layer_split()) {
+        return compute_mixed_layer_split_plan(device, local_backend, out, prefix);
+    }
+    if (device.layer_split_backends.size() < 2) {
+        return false;
+    }
+    out.remote_begin = 1;
+    out.remote_backend = local_backend;
+    return true;
+}
+
 bool init_layer_split_shard_metas(
         std::vector<LayerSplitShardMeta *> shards,
         const std::vector<int> & gpus,

--- a/server/src/common/layer_split_utils.h
+++ b/server/src/common/layer_split_utils.h
@@ -27,6 +27,11 @@ struct LayerSplitShardMeta {
     ggml_backend_t backend = nullptr;
 };
 
+struct MixedLayerSplitPlan {
+    size_t remote_begin = 0;
+    PlacementBackend remote_backend = PlacementBackend::Auto;
+};
+
 template <typename LoadPlan>
 inline LoadPlan make_layer_split_load_plan(
         const LayerSplitShardMeta & shard,
@@ -67,6 +72,18 @@ std::vector<LayerSplitRange> compute_layer_ranges(
     int n_layer,
     int n_gpus,
     const std::vector<double> & weights);
+
+bool compute_mixed_layer_split_plan(
+    const DevicePlacement & device,
+    PlacementBackend local_backend,
+    MixedLayerSplitPlan & out,
+    const char * log_prefix);
+
+bool compute_target_shard_layer_split_plan(
+    const DevicePlacement & device,
+    PlacementBackend local_backend,
+    MixedLayerSplitPlan & out,
+    const char * log_prefix);
 
 bool init_layer_split_shard_metas(
     std::vector<LayerSplitShardMeta *> shards,

--- a/server/src/common/model_backend.h
+++ b/server/src/common/model_backend.h
@@ -323,6 +323,11 @@ struct ModelBackend {
     // the server before startup.
     virtual bool supports_remote_draft() const { return false; }
 
+    // Layer-split capability introspection. Non layer-split backends keep the
+    // default false; LayerSplitBackend proxies model-adapter support.
+    virtual bool supports_kvflash() const { return false; }
+    virtual bool supports_mixed_backend_layer_split() const { return false; }
+
     // ── Routing data collection ──────────────────────────────────────
     // Set an external routing collector that the backend will call for each
     // token/layer during decode (hidden state + expert IDs). Used by

--- a/server/src/common/target_shard_ipc.cpp
+++ b/server/src/common/target_shard_ipc.cpp
@@ -1,0 +1,366 @@
+// Generic target-shard IPC session for mixed-backend layer split.
+
+#include "target_shard_ipc.h"
+
+#include "common/io_utils.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <inttypes.h>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dflash::common {
+
+namespace {
+
+bool checked_mul_size(size_t a, size_t b, size_t & out) {
+    if (a != 0 && b > std::numeric_limits<size_t>::max() / a) return false;
+    out = a * b;
+    return true;
+}
+
+size_t required_shared_bytes(int hidden, int max_tokens) {
+    if (hidden <= 0 || max_tokens <= 0) return 0;
+    size_t elems = 0;
+    size_t bytes = 0;
+    if (!checked_mul_size((size_t)hidden, (size_t)max_tokens, elems) ||
+        !checked_mul_size(elems, sizeof(float), bytes)) {
+        return 0;
+    }
+    return bytes;
+}
+
+size_t shared_bytes_from_env(size_t required_bytes) {
+    const char * raw = std::getenv("DFLASH_TARGET_SHARD_IPC_SHARED_BYTES");
+    if (!raw || !*raw) return required_bytes;
+    if (raw[0] == '-') return required_bytes;
+    char * end = nullptr;
+    const unsigned long long parsed = std::strtoull(raw, &end, 10);
+    if (end == raw || *end != '\0' ||
+        parsed > (unsigned long long)std::numeric_limits<size_t>::max()) {
+        return required_bytes;
+    }
+    return std::max((size_t)parsed, required_bytes);
+}
+
+BackendIpcPayloadTransport target_shard_ipc_transport_from_env() {
+    const char * raw = std::getenv("DFLASH_TARGET_SHARD_IPC_TRANSPORT");
+    if (!raw || !*raw) return BackendIpcPayloadTransport::Stream;
+    BackendIpcPayloadTransport transport = BackendIpcPayloadTransport::Stream;
+    if (!parse_backend_ipc_payload_transport(raw, transport)) {
+        return BackendIpcPayloadTransport::Stream;
+    }
+    return transport;
+}
+
+bool write_int32_vec_fd(int fd, const std::vector<int32_t> & values) {
+    return values.empty() || write_exact_fd(fd, values.data(),
+                                           sizeof(int32_t) * values.size());
+}
+
+bool copy_activation_row_to_host(const ggml_tensor * act,
+                                 size_t offset,
+                                 int hidden,
+                                 float * dst) {
+    if (!act || !dst || hidden <= 0) return false;
+    if (act->type == GGML_TYPE_F32) {
+        ggml_backend_tensor_get(act, dst, offset, (size_t)hidden * sizeof(float));
+        return true;
+    }
+    if (act->type == GGML_TYPE_F16) {
+        std::vector<ggml_fp16_t> tmp((size_t)hidden);
+        ggml_backend_tensor_get(act, tmp.data(), offset,
+                                tmp.size() * sizeof(ggml_fp16_t));
+        ggml_fp16_to_fp32_row(tmp.data(), dst, hidden);
+        return true;
+    }
+    if (act->type == GGML_TYPE_BF16) {
+        std::vector<ggml_bf16_t> tmp((size_t)hidden);
+        ggml_backend_tensor_get(act, tmp.data(), offset,
+                                tmp.size() * sizeof(ggml_bf16_t));
+        ggml_bf16_to_fp32_row(tmp.data(), dst, hidden);
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+bool copy_activation_to_host(const ggml_tensor * act,
+                             ggml_backend_t src_backend,
+                             int token_offset,
+                             int n_tokens,
+                             int hidden,
+                             std::vector<float> & out) {
+    if (!act || !src_backend || token_offset < 0 || n_tokens <= 0 || hidden <= 0) {
+        return false;
+    }
+    const size_t row_bytes = ggml_row_size(act->type, hidden);
+    if (row_bytes == 0) return false;
+    const size_t src_stride = act->nb[1];
+    out.assign((size_t)n_tokens * (size_t)hidden, 0.0f);
+    ggml_backend_synchronize(src_backend);
+    for (int i = 0; i < n_tokens; ++i) {
+        if (!copy_activation_row_to_host(
+                act, (size_t)(token_offset + i) * src_stride,
+                hidden, out.data() + (size_t)i * (size_t)hidden)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool TargetShardIpcSession::start(const TargetShardIpcLaunchConfig & cfg) {
+#if defined(_WIN32)
+    (void)cfg;
+    std::fprintf(stderr, "target shard IPC is only implemented on POSIX hosts\n");
+    return false;
+#else
+    close();
+    if (cfg.bin.empty() || cfg.target_path.empty() || cfg.gpus.empty() ||
+        cfg.gpus.size() != cfg.layer_begins.size() ||
+        cfg.gpus.size() != cfg.layer_ends.size() ||
+        cfg.max_ctx <= 0 || cfg.hidden <= 0 || cfg.vocab <= 0 ||
+        cfg.max_tokens <= 0) {
+        return false;
+    }
+    for (size_t i = 0; i < cfg.gpus.size(); ++i) {
+        if (cfg.gpus[i] < 0 || cfg.layer_begins[i] < 0 ||
+            cfg.layer_ends[i] <= cfg.layer_begins[i]) {
+            return false;
+        }
+        if (i > 0 && cfg.layer_begins[i] != cfg.layer_ends[i - 1]) {
+            return false;
+        }
+    }
+
+    BackendIpcLaunchConfig launch;
+    launch.bin = cfg.bin;
+    launch.mode = cfg.mode;
+    launch.payload_path = cfg.target_path;
+    launch.work_dir = cfg.work_dir;
+    launch.payload_transport = target_shard_ipc_transport_from_env();
+    launch.shared_payload_bytes = shared_bytes_from_env(
+        required_shared_bytes(cfg.hidden, cfg.max_tokens));
+    std::string gpu_list;
+    std::string layer_begin_list;
+    std::string layer_end_list;
+    for (size_t i = 0; i < cfg.gpus.size(); ++i) {
+        if (i > 0) {
+            gpu_list += ",";
+            layer_begin_list += ",";
+            layer_end_list += ",";
+        }
+        gpu_list += std::to_string(cfg.gpus[i]);
+        layer_begin_list += std::to_string(cfg.layer_begins[i]);
+        layer_end_list += std::to_string(cfg.layer_ends[i]);
+    }
+    launch.args.push_back("--target-gpus=" + gpu_list);
+    launch.args.push_back("--layer-begins=" + layer_begin_list);
+    launch.args.push_back("--layer-ends=" + layer_end_list);
+    launch.args.push_back("--max-ctx=" + std::to_string(cfg.max_ctx));
+    launch.args.push_back("--hidden=" + std::to_string(cfg.hidden));
+    launch.args.push_back("--vocab=" + std::to_string(cfg.vocab));
+    launch.args.push_back("--max-tokens=" + std::to_string(cfg.max_tokens));
+    launch.args.push_back("--fa-window=" + std::to_string(cfg.fa_window));
+    if (cfg.kvflash_pool_tokens > 0) {
+        launch.args.push_back("--kvflash-pool=" +
+                              std::to_string(cfg.kvflash_pool_tokens));
+    }
+    for (const std::string & arg : cfg.model_args) {
+        if (!arg.empty()) launch.args.push_back(arg);
+    }
+    if (!process_.start(launch)) {
+        std::fprintf(stderr, "target shard backend process start failed\n");
+        return false;
+    }
+
+    mode_ = cfg.mode;
+    hidden_ = cfg.hidden;
+    vocab_ = cfg.vocab;
+    active_ = true;
+    std::printf("[target-shard-ipc] ready mode=%s bin=%s shards=%zu layers=[%d,%d) work_dir=%s\n",
+                backend_ipc_mode_name(cfg.mode), cfg.bin.c_str(), cfg.gpus.size(),
+                cfg.layer_begins.front(), cfg.layer_ends.back(),
+                process_.work_dir().c_str());
+    return true;
+#endif
+}
+
+bool TargetShardIpcSession::forward(
+        const TargetShardForwardRequest & req,
+        TargetShardForwardResponse & resp) {
+#if defined(_WIN32)
+    (void)req; (void)resp;
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    const int payload_fd = process_.payload_fd();
+    const int base_pos = req.base_pos;
+    const int n_tokens = req.n_tokens;
+    const std::vector<int32_t> * token_ids = req.token_ids;
+    const int ubatch = req.ubatch;
+    if (!active_ || !cmd || stream_fd < 0 || base_pos < 0 || n_tokens <= 0 ||
+        hidden_ <= 0 || vocab_ <= 0 || !req.boundary_activation) {
+        return false;
+    }
+    const std::vector<float> & boundary_activation = *req.boundary_activation;
+    const size_t expected = (size_t)n_tokens * (size_t)hidden_;
+    if (boundary_activation.size() != expected) return false;
+    if (token_ids && (int)token_ids->size() != n_tokens) return false;
+    const size_t bytes = boundary_activation.size() * sizeof(float);
+    const int want_argmax = req.want_argmax ? 1 : 0;
+    const int want_logits = req.want_logits ? 1 : 0;
+    const int forward_ubatch = ubatch > 0 ? ubatch : n_tokens;
+    std::vector<int32_t> empty_ids;
+    const std::vector<int32_t> * ids = token_ids ? token_ids : &empty_ids;
+
+    if (process_.resolved_payload_transport() == BackendIpcPayloadTransport::Shared) {
+        uint64_t seq = 0;
+        if (!process_.write_shared_payload(boundary_activation.data(), bytes, seq)) {
+            std::fprintf(stderr,
+                         "target-shard shared payload too large bytes=%zu capacity=%zu\n",
+                         bytes, process_.shared_payload_capacity());
+            return false;
+        }
+        std::fprintf(cmd, "forward_shared %d %d %d %d %zu %" PRIu64 " %d %d %d\n",
+                     base_pos, n_tokens, want_argmax, want_logits, bytes, seq,
+                     token_ids ? 1 : 0, forward_ubatch, (int)ids->size());
+        std::fflush(cmd);
+    } else if (payload_fd >= 0) {
+        std::fprintf(cmd, "forward_pipe %d %d %d %d %zu %d %d %d\n",
+                     base_pos, n_tokens, want_argmax, want_logits, bytes,
+                     token_ids ? 1 : 0, forward_ubatch, (int)ids->size());
+        std::fflush(cmd);
+        if (!write_exact_fd(payload_fd, boundary_activation.data(), bytes)) {
+            std::fprintf(stderr, "target-shard payload write failed\n");
+            return false;
+        }
+    } else {
+        return false;
+    }
+    if (token_ids && !write_int32_vec_fd(payload_fd >= 0 ? payload_fd : stream_fd, *token_ids)) {
+        return false;
+    }
+
+    int32_t status = -1;
+    int32_t remote_last_tok = -1;
+    if (!read_exact_fd(stream_fd, &status, sizeof(status)) || status != 0 ||
+        !read_exact_fd(stream_fd, &remote_last_tok, sizeof(remote_last_tok))) {
+        std::fprintf(stderr, "target-shard forward failed status=%d\n", status);
+        return false;
+    }
+    resp.last_tok = remote_last_tok;
+
+    if (resp.argmax_out) {
+        resp.argmax_out->assign((size_t)n_tokens, 0);
+        if (!read_exact_fd(stream_fd, resp.argmax_out->data(),
+                           sizeof(int32_t) * (size_t)n_tokens)) {
+            return false;
+        }
+    }
+    if (req.want_logits) {
+        if (!resp.logits_out) return false;
+        const int logits_tokens = resp.argmax_out ? n_tokens : 1;
+        resp.logits_out->assign((size_t)vocab_ * (size_t)logits_tokens, 0.0f);
+        if (!read_exact_fd(stream_fd, resp.logits_out->data(),
+                           sizeof(float) * resp.logits_out->size())) {
+            return false;
+        }
+    }
+    return true;
+#endif
+}
+
+bool TargetShardIpcSession::reset_request_state() {
+#if defined(_WIN32)
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0) return false;
+    std::fprintf(cmd, "reset_request_state\n");
+    std::fflush(cmd);
+    int32_t status = -1;
+    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
+#endif
+}
+
+bool TargetShardIpcSession::kvflash_sync_identity(int committed) {
+#if defined(_WIN32)
+    (void)committed;
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0 || committed < 0) return false;
+    std::fprintf(cmd, "kvflash_sync_identity %d\n", committed);
+    std::fflush(cmd);
+    int32_t status = -1;
+    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
+#endif
+}
+
+bool TargetShardIpcSession::snapshot_save(int slot) {
+#if defined(_WIN32)
+    (void)slot;
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
+    std::fprintf(cmd, "prefix_snapshot_save %d\n", slot);
+    std::fflush(cmd);
+    int32_t status = -1;
+    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
+#endif
+}
+
+void TargetShardIpcSession::snapshot_free(int slot) {
+#if defined(_WIN32)
+    (void)slot;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return;
+    std::fprintf(cmd, "prefix_snapshot_free %d\n", slot);
+    std::fflush(cmd);
+    int32_t status = -1;
+    (void)read_exact_fd(stream_fd, &status, sizeof(status));
+#endif
+}
+
+bool TargetShardIpcSession::snapshot_restore(int slot) {
+#if defined(_WIN32)
+    (void)slot;
+    return false;
+#else
+    FILE * cmd = process_.command_stream();
+    const int stream_fd = process_.stream_fd();
+    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
+    std::fprintf(cmd, "prefix_snapshot_restore %d\n", slot);
+    std::fflush(cmd);
+    int32_t status = -1;
+    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
+#endif
+}
+
+void TargetShardIpcSession::close() {
+    process_.close();
+    active_ = false;
+    hidden_ = 0;
+    vocab_ = 0;
+}
+
+}  // namespace dflash::common

--- a/server/src/common/target_shard_ipc.cpp
+++ b/server/src/common/target_shard_ipc.cpp
@@ -127,6 +127,12 @@ bool TargetShardIpcSession::start(const TargetShardIpcLaunchConfig & cfg) {
     return false;
 #else
     close();
+    if (cfg.mode != BackendIpcMode::Qwen35TargetShard &&
+        cfg.mode != BackendIpcMode::Gemma4TargetShard &&
+        cfg.mode != BackendIpcMode::LagunaTargetShard) {
+        std::fprintf(stderr, "target shard IPC requires an explicit target-shard mode\n");
+        return false;
+    }
     if (cfg.bin.empty() || cfg.target_path.empty() || cfg.gpus.empty() ||
         cfg.gpus.size() != cfg.layer_begins.size() ||
         cfg.gpus.size() != cfg.layer_ends.size() ||
@@ -219,6 +225,8 @@ bool TargetShardIpcSession::forward(
     const size_t expected = (size_t)n_tokens * (size_t)hidden_;
     if (boundary_activation.size() != expected) return false;
     if (token_ids && (int)token_ids->size() != n_tokens) return false;
+    if (req.want_argmax != (resp.argmax_out != nullptr)) return false;
+    if (req.want_logits != (resp.logits_out != nullptr)) return false;
     const size_t bytes = boundary_activation.size() * sizeof(float);
     const int want_argmax = req.want_argmax ? 1 : 0;
     const int want_logits = req.want_logits ? 1 : 0;
@@ -263,7 +271,7 @@ bool TargetShardIpcSession::forward(
     }
     resp.last_tok = remote_last_tok;
 
-    if (resp.argmax_out) {
+    if (req.want_argmax) {
         resp.argmax_out->assign((size_t)n_tokens, 0);
         if (!read_exact_fd(stream_fd, resp.argmax_out->data(),
                            sizeof(int32_t) * (size_t)n_tokens)) {
@@ -271,8 +279,7 @@ bool TargetShardIpcSession::forward(
         }
     }
     if (req.want_logits) {
-        if (!resp.logits_out) return false;
-        const int logits_tokens = resp.argmax_out ? n_tokens : 1;
+        const int logits_tokens = req.want_argmax ? n_tokens : 1;
         resp.logits_out->assign((size_t)vocab_ * (size_t)logits_tokens, 0.0f);
         if (!read_exact_fd(stream_fd, resp.logits_out->data(),
                            sizeof(float) * resp.logits_out->size())) {
@@ -361,6 +368,7 @@ void TargetShardIpcSession::close() {
     active_ = false;
     hidden_ = 0;
     vocab_ = 0;
+    mode_ = BackendIpcMode::Invalid;
 }
 
 }  // namespace dflash::common

--- a/server/src/common/target_shard_ipc.h
+++ b/server/src/common/target_shard_ipc.h
@@ -15,7 +15,7 @@
 namespace dflash::common {
 
 struct TargetShardIpcLaunchConfig {
-    BackendIpcMode mode = BackendIpcMode::Qwen35TargetShard;
+    BackendIpcMode mode = BackendIpcMode::Invalid;
     std::string bin;
     std::string target_path;
     std::vector<int> gpus;
@@ -83,7 +83,7 @@ public:
 
 private:
     BackendIpcProcess process_;
-    BackendIpcMode mode_ = BackendIpcMode::DFlashDraft;
+    BackendIpcMode mode_ = BackendIpcMode::Invalid;
     bool active_ = false;
     int hidden_ = 0;
     int vocab_ = 0;

--- a/server/src/common/target_shard_ipc.h
+++ b/server/src/common/target_shard_ipc.h
@@ -1,0 +1,101 @@
+// Generic target-shard IPC client for mixed-backend layer split.
+
+#pragma once
+
+#include "backend_ipc.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace dflash::common {
+
+struct TargetShardIpcLaunchConfig {
+    BackendIpcMode mode = BackendIpcMode::Qwen35TargetShard;
+    std::string bin;
+    std::string target_path;
+    std::vector<int> gpus;
+    std::vector<int> layer_begins;
+    std::vector<int> layer_ends;
+    int max_ctx = 0;
+    int hidden = 0;
+    int vocab = 0;
+    int max_tokens = 0;
+    std::string work_dir;
+    int kvflash_pool_tokens = 0;
+    int fa_window = 0;
+    std::vector<std::string> model_args;
+};
+
+struct TargetShardForwardRequest {
+    int base_pos = 0;
+    int n_tokens = 0;
+    const std::vector<float> * boundary_activation = nullptr;
+    const std::vector<int32_t> * token_ids = nullptr;
+    int ubatch = 0;
+    bool want_argmax = false;
+    bool want_logits = false;
+};
+
+struct TargetShardForwardResponse {
+    int last_tok = -1;
+    std::vector<int32_t> * argmax_out = nullptr;
+    std::vector<float> * logits_out = nullptr;
+};
+
+class TargetShardIpcSession {
+public:
+    TargetShardIpcSession() = default;
+    TargetShardIpcSession(const TargetShardIpcSession &) = delete;
+    TargetShardIpcSession & operator=(const TargetShardIpcSession &) = delete;
+    ~TargetShardIpcSession() { close(); }
+
+    bool start(const TargetShardIpcLaunchConfig & cfg);
+
+    bool forward(const TargetShardForwardRequest & req,
+                 TargetShardForwardResponse & resp);
+
+    bool reset_request_state();
+    bool kvflash_sync_identity(int committed);
+    bool snapshot_save(int slot);
+    void snapshot_free(int slot);
+    bool snapshot_restore(int slot);
+
+    bool active() const { return active_; }
+    FILE * command_stream() const { return process_.command_stream(); }
+    int payload_fd() const { return process_.payload_fd(); }
+    int stream_fd() const { return process_.stream_fd(); }
+    BackendIpcPayloadTransport resolved_payload_transport() const {
+        return process_.resolved_payload_transport();
+    }
+    size_t shared_payload_capacity() const {
+        return process_.shared_payload_capacity();
+    }
+    const std::string & work_dir() const { return process_.work_dir(); }
+    bool write_shared_payload(const void * data, size_t bytes, uint64_t & seq) {
+        return process_.write_shared_payload(data, bytes, seq);
+    }
+    void close();
+
+private:
+    BackendIpcProcess process_;
+    BackendIpcMode mode_ = BackendIpcMode::DFlashDraft;
+    bool active_ = false;
+    int hidden_ = 0;
+    int vocab_ = 0;
+};
+
+using TargetShardIpcClient = TargetShardIpcSession;
+
+bool copy_activation_to_host(const ggml_tensor * act,
+                             ggml_backend_t src_backend,
+                             int token_offset,
+                             int n_tokens,
+                             int hidden,
+                             std::vector<float> & out);
+
+}  // namespace dflash::common

--- a/server/src/common/target_shard_ipc_daemon.cpp
+++ b/server/src/common/target_shard_ipc_daemon.cpp
@@ -43,6 +43,7 @@ bool stream_daemon_status(const TargetShardDaemonCallbacks & callbacks,
 
 int run_target_shard_ipc_daemon_loop(
         int hidden,
+        int vocab,
         int stream_fd,
         int payload_fd,
         int shared_payload_fd,
@@ -50,6 +51,7 @@ int run_target_shard_ipc_daemon_loop(
         TargetShardDaemonCallbacks callbacks) {
 #if defined(_WIN32)
     (void)hidden;
+    (void)vocab;
     (void)stream_fd;
     (void)payload_fd;
     (void)shared_payload_fd;
@@ -59,7 +61,7 @@ int run_target_shard_ipc_daemon_loop(
     return 2;
 #else
     const char * prefix = daemon_prefix(callbacks);
-    if (hidden <= 0 || stream_fd < 0 || !callbacks.forward) {
+    if (hidden <= 0 || vocab <= 0 || stream_fd < 0 || !callbacks.forward) {
         std::fprintf(stderr, "[%s] bad daemon configuration\n", prefix);
         if (stream_fd >= 0) stream_daemon_status(callbacks, stream_fd, -1);
         return 2;
@@ -230,7 +232,10 @@ int run_target_shard_ipc_daemon_loop(
             }
         }
         if (want_logits) {
-            if (resp.logits.empty() ||
+            const int logits_tokens = want_argmax ? n_tokens : 1;
+            const size_t expected_logits =
+                (size_t)logits_tokens * (size_t)vocab;
+            if (resp.logits.size() != expected_logits ||
                 !write_exact_fd(stream_fd, resp.logits.data(),
                                 sizeof(float) * resp.logits.size())) {
                 break;

--- a/server/src/common/target_shard_ipc_daemon.cpp
+++ b/server/src/common/target_shard_ipc_daemon.cpp
@@ -1,0 +1,248 @@
+// Generic target-shard IPC daemon loop for mixed-backend layer split.
+
+#include "target_shard_ipc_daemon.h"
+
+#include "backend_ipc.h"
+#include "io_utils.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#if !defined(_WIN32)
+#  include <sys/mman.h>
+#endif
+
+namespace dflash::common {
+
+namespace {
+
+const char * daemon_prefix(const TargetShardDaemonCallbacks & callbacks) {
+    return callbacks.log_prefix ? callbacks.log_prefix : "target-shard-daemon";
+}
+
+bool stream_daemon_status(const TargetShardDaemonCallbacks & callbacks,
+                          int stream_fd,
+                          int status) {
+    const int32_t status_i32 = (int32_t)status;
+    if (!write_exact_fd(stream_fd, &status_i32, sizeof(status_i32))) {
+        std::fprintf(stderr, "[%s] failed to write status=%d\n",
+                     daemon_prefix(callbacks), status);
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+int run_target_shard_ipc_daemon_loop(
+        int hidden,
+        int stream_fd,
+        int payload_fd,
+        int shared_payload_fd,
+        size_t shared_payload_bytes,
+        TargetShardDaemonCallbacks callbacks) {
+#if defined(_WIN32)
+    (void)hidden;
+    (void)stream_fd;
+    (void)payload_fd;
+    (void)shared_payload_fd;
+    (void)shared_payload_bytes;
+    (void)callbacks;
+    std::fprintf(stderr, "target shard IPC daemon is only implemented on POSIX hosts\n");
+    return 2;
+#else
+    const char * prefix = daemon_prefix(callbacks);
+    if (hidden <= 0 || stream_fd < 0 || !callbacks.forward) {
+        std::fprintf(stderr, "[%s] bad daemon configuration\n", prefix);
+        if (stream_fd >= 0) stream_daemon_status(callbacks, stream_fd, -1);
+        return 2;
+    }
+
+    void * shared_payload = nullptr;
+    void * shared_payload_data = nullptr;
+    size_t shared_payload_capacity = 0;
+    size_t shared_payload_map_bytes = 0;
+    if (shared_payload_fd >= 0 || shared_payload_bytes > 0) {
+        if (shared_payload_fd < 0 || shared_payload_bytes == 0 ||
+            !backend_ipc_shared_payload_map_bytes(shared_payload_bytes,
+                                                  shared_payload_map_bytes)) {
+            std::fprintf(stderr, "[%s] bad shared payload fd/size\n", prefix);
+            stream_daemon_status(callbacks, stream_fd, -1);
+            return 1;
+        }
+        shared_payload = ::mmap(nullptr, shared_payload_map_bytes,
+                                PROT_READ | PROT_WRITE, MAP_SHARED,
+                                shared_payload_fd, 0);
+        if (shared_payload == MAP_FAILED) {
+            std::fprintf(stderr, "[%s] shared payload mmap failed\n", prefix);
+            stream_daemon_status(callbacks, stream_fd, -1);
+            return 1;
+        }
+        shared_payload_data =
+            static_cast<char *>(shared_payload) + backend_ipc_shared_payload_header_bytes();
+        shared_payload_capacity = shared_payload_bytes;
+    }
+
+    if (!stream_daemon_status(callbacks, stream_fd, 0)) {
+        if (shared_payload && shared_payload != MAP_FAILED) {
+            ::munmap(shared_payload, shared_payload_map_bytes);
+        }
+        return 1;
+    }
+
+    std::vector<float> host_act;
+    std::vector<int32_t> token_ids;
+    std::string line;
+    while (std::getline(std::cin, line)) {
+        std::istringstream iss(line);
+        std::string cmd;
+        iss >> cmd;
+        if (cmd == "quit" || cmd == "exit") {
+            break;
+        }
+
+        int base_pos = -1;
+        int n_tokens = 0;
+        int want_argmax = 0;
+        int want_logits = 0;
+        int has_token_ids = 0;
+        int forward_ubatch = 0;
+        int token_count = 0;
+        size_t bytes = 0;
+        bool payload_ok = false;
+
+        if (cmd == "forward_pipe") {
+            iss >> base_pos >> n_tokens >> want_argmax >> want_logits >> bytes >>
+                has_token_ids >> forward_ubatch >> token_count;
+            const size_t expected_bytes =
+                (size_t)std::max(0, n_tokens) * (size_t)hidden * sizeof(float);
+            if (payload_fd >= 0 && n_tokens > 0 && bytes == expected_bytes) {
+                host_act.assign(bytes / sizeof(float), 0.0f);
+                payload_ok = read_exact_fd(payload_fd, host_act.data(), bytes);
+            }
+        } else if (cmd == "forward_shared") {
+            uint64_t seq = 0;
+            iss >> base_pos >> n_tokens >> want_argmax >> want_logits >> bytes >> seq >>
+                has_token_ids >> forward_ubatch >> token_count;
+            const size_t expected_bytes =
+                (size_t)std::max(0, n_tokens) * (size_t)hidden * sizeof(float);
+            const auto * header =
+                static_cast<const BackendIpcSharedPayloadHeader *>(shared_payload);
+            if (shared_payload && shared_payload != MAP_FAILED && shared_payload_data &&
+                seq != 0 && n_tokens > 0 && bytes == expected_bytes &&
+                backend_ipc_payload_in_bounds(0, bytes, shared_payload_capacity) &&
+                header->sequence == seq && header->bytes == (uint64_t)bytes) {
+                host_act.assign(bytes / sizeof(float), 0.0f);
+                std::memcpy(host_act.data(), shared_payload_data, bytes);
+                payload_ok = true;
+            }
+        } else {
+            if (cmd == "reset_request_state") {
+                const bool ok = callbacks.reset_request_state
+                    ? callbacks.reset_request_state()
+                    : false;
+                stream_daemon_status(callbacks, stream_fd, ok ? 0 : -1);
+                continue;
+            }
+            if (cmd == "kvflash_sync_identity") {
+                int committed = -1;
+                iss >> committed;
+                const bool ok = callbacks.kvflash_sync_identity
+                    ? callbacks.kvflash_sync_identity(committed)
+                    : false;
+                stream_daemon_status(callbacks, stream_fd, ok ? 0 : -1);
+                continue;
+            }
+            if (cmd == "prefix_snapshot_save") {
+                int slot = -1;
+                iss >> slot;
+                const bool ok = callbacks.snapshot_save
+                    ? callbacks.snapshot_save(slot)
+                    : false;
+                stream_daemon_status(callbacks, stream_fd, ok ? 0 : -1);
+                continue;
+            }
+            if (cmd == "prefix_snapshot_free") {
+                int slot = -1;
+                iss >> slot;
+                if (callbacks.snapshot_free) callbacks.snapshot_free(slot);
+                stream_daemon_status(callbacks, stream_fd, 0);
+                continue;
+            }
+            if (cmd == "prefix_snapshot_restore") {
+                int slot = -1;
+                iss >> slot;
+                const bool ok = callbacks.snapshot_restore
+                    ? callbacks.snapshot_restore(slot)
+                    : false;
+                stream_daemon_status(callbacks, stream_fd, ok ? 0 : -1);
+                continue;
+            }
+            std::fprintf(stderr, "[%s] unknown command: %s\n",
+                         prefix, line.c_str());
+            stream_daemon_status(callbacks, stream_fd, -1);
+            continue;
+        }
+
+        bool ok = payload_ok && base_pos >= 0 && n_tokens > 0;
+        if (ok && has_token_ids) {
+            ok = payload_fd >= 0 && token_count == n_tokens;
+            if (ok) {
+                token_ids.assign((size_t)n_tokens, 0);
+                ok = read_exact_fd(payload_fd, token_ids.data(),
+                                   sizeof(int32_t) * token_ids.size());
+            }
+        } else {
+            token_ids.clear();
+            ok = ok && token_count == 0;
+        }
+
+        TargetShardDaemonForwardResponse resp;
+        if (ok) {
+            TargetShardDaemonForwardRequest req;
+            req.base_pos = base_pos;
+            req.n_tokens = n_tokens;
+            req.ubatch = forward_ubatch > 0 ? forward_ubatch : n_tokens;
+            req.want_argmax = want_argmax != 0;
+            req.want_logits = want_logits != 0;
+            req.boundary_activation = &host_act;
+            req.token_ids = has_token_ids ? &token_ids : nullptr;
+            ok = callbacks.forward(req, resp);
+        }
+
+        const int32_t status = ok ? 0 : -1;
+        if (!write_exact_fd(stream_fd, &status, sizeof(status))) break;
+        if (!ok) continue;
+
+        if (!write_exact_fd(stream_fd, &resp.last_tok, sizeof(resp.last_tok))) break;
+        if (want_argmax) {
+            if ((int)resp.argmax.size() != n_tokens ||
+                !write_exact_fd(stream_fd, resp.argmax.data(),
+                                sizeof(int32_t) * resp.argmax.size())) {
+                break;
+            }
+        }
+        if (want_logits) {
+            if (resp.logits.empty() ||
+                !write_exact_fd(stream_fd, resp.logits.data(),
+                                sizeof(float) * resp.logits.size())) {
+                break;
+            }
+        }
+    }
+
+    if (shared_payload && shared_payload != MAP_FAILED) {
+        ::munmap(shared_payload, shared_payload_map_bytes);
+    }
+    return 0;
+#endif
+}
+
+}  // namespace dflash::common

--- a/server/src/common/target_shard_ipc_daemon.h
+++ b/server/src/common/target_shard_ipc_daemon.h
@@ -39,6 +39,7 @@ struct TargetShardDaemonCallbacks {
 
 int run_target_shard_ipc_daemon_loop(
     int hidden,
+    int vocab,
     int stream_fd,
     int payload_fd,
     int shared_payload_fd,

--- a/server/src/common/target_shard_ipc_daemon.h
+++ b/server/src/common/target_shard_ipc_daemon.h
@@ -1,0 +1,48 @@
+// Generic target-shard IPC daemon loop for mixed-backend layer split.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace dflash::common {
+
+struct TargetShardDaemonForwardRequest {
+    int base_pos = 0;
+    int n_tokens = 0;
+    int ubatch = 0;
+    bool want_argmax = false;
+    bool want_logits = false;
+    const std::vector<float> * boundary_activation = nullptr;
+    const std::vector<int32_t> * token_ids = nullptr;
+};
+
+struct TargetShardDaemonForwardResponse {
+    int32_t last_tok = -1;
+    std::vector<int32_t> argmax;
+    std::vector<float> logits;
+};
+
+struct TargetShardDaemonCallbacks {
+    const char * log_prefix = "target-shard-daemon";
+
+    std::function<bool(const TargetShardDaemonForwardRequest &,
+                       TargetShardDaemonForwardResponse &)> forward;
+    std::function<bool()> reset_request_state;
+    std::function<bool(int)> kvflash_sync_identity;
+    std::function<bool(int)> snapshot_save;
+    std::function<void(int)> snapshot_free;
+    std::function<bool(int)> snapshot_restore;
+};
+
+int run_target_shard_ipc_daemon_loop(
+    int hidden,
+    int stream_fd,
+    int payload_fd,
+    int shared_payload_fd,
+    size_t shared_payload_bytes,
+    TargetShardDaemonCallbacks callbacks);
+
+}  // namespace dflash::common

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -1642,6 +1642,13 @@ int run_gemma4_target_shard_ipc_daemon(const char * target_path,
         }
         const int snap_pos = shards.empty() ? 0 : shards.front().cache.cur_pos;
         if (snap_pos <= 0) return false;
+        if (kvflash_pool_tokens > 0 &&
+            (snap_pos > kvflash_pool_tokens || !kvflash_pager.is_identity())) {
+            std::fprintf(stderr,
+                "[gemma4-target-shard-daemon][kvflash] cannot snapshot non-identity pool at pos=%d pool=%d\n",
+                snap_pos, kvflash_pool_tokens);
+            return false;
+        }
         free_slot(slot);
         auto & snap = snapshots[(size_t)slot];
         if (snap.shards.size() != shards.size()) snap.shards.resize(shards.size());
@@ -1746,7 +1753,7 @@ int run_gemma4_target_shard_ipc_daemon(const char * target_path,
         "[gemma4-target-shard-daemon] ready shards=%zu layers=[%d,%d)\n",
         shards.size(), shards.front().layer_begin, shards.back().layer_end);
     const int rc = run_target_shard_ipc_daemon_loop(
-        hidden, stream_fd, payload_fd, shared_payload_fd,
+        hidden, shards.front().weights.n_vocab, stream_fd, payload_fd, shared_payload_fd,
         shared_payload_bytes, std::move(callbacks));
     for (int slot = 0; slot < ModelBackend::kMaxSlots; ++slot) free_slot(slot);
     auto metas = layer_split_shard_metas(shards);

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -7,7 +7,9 @@
 #include "common/gguf_inspect.h"
 #include "common/layer_split_utils.h"
 #include "common/layer_split_runtime.h"
+#include "common/target_shard_ipc_daemon.h"
 #include "dflash27b.h"
+#include "placement/placement_backend.h"
 #include "qwen3/qwen3_kvflash_scorer.h"
 
 #include "ggml-cuda.h"
@@ -99,6 +101,10 @@ Gemma4LayerSplitAdapter::~Gemma4LayerSplitAdapter() noexcept {
 }
 
 bool Gemma4LayerSplitAdapter::init() {
+    if (cfg_.device.is_layer_split() && cfg_.remote_target_shard.enabled()) {
+        return init_mixed_target_split();
+    }
+
     const LayerSplitRuntimeInit runtime_cfg{
         cfg_.target_path,
         &cfg_.device,
@@ -173,6 +179,154 @@ bool Gemma4LayerSplitAdapter::init() {
     }
     kvflash_history_snapshots_.resize(PREFIX_SLOTS);
 
+    return true;
+}
+
+bool Gemma4LayerSplitAdapter::init_mixed_target_split() {
+    if (!cfg_.remote_target_shard.enabled() ||
+        cfg_.device.layer_split_gpus.size() < 2) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] mixed target split requires remote target shard IPC\n");
+        return false;
+    }
+    MixedLayerSplitPlan mixed_plan;
+    if (!compute_target_shard_layer_split_plan(
+            cfg_.device, compiled_placement_backend(), mixed_plan,
+            "gemma4-target-split")) {
+        return false;
+    }
+
+    const auto info = inspect_gguf_model_info(cfg_.target_path);
+    const int n_layer = info.n_layer;
+    if (n_layer <= 0) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] failed to inspect target layer count\n");
+        return false;
+    }
+    auto ranges = compute_layer_ranges(
+        n_layer, (int)cfg_.device.layer_split_gpus.size(),
+        cfg_.device.layer_split_weights);
+    if (ranges.size() != cfg_.device.layer_split_gpus.size()) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] bad mixed layer split for %zu GPUs and %d layers\n",
+            cfg_.device.layer_split_gpus.size(), n_layer);
+        return false;
+    }
+    std::vector<Gemma4LayerSplitShard> plan_shards(ranges.size());
+    for (size_t i = 0; i < ranges.size(); ++i) {
+        plan_shards[i].layer_begin = ranges[i].begin;
+        plan_shards[i].layer_end = ranges[i].end;
+    }
+    if (!gemma4_align_split_for_kv_sharing(cfg_.target_path, plan_shards)) {
+        return false;
+    }
+    for (size_t i = 0; i < ranges.size(); ++i) {
+        ranges[i].begin = plan_shards[i].layer_begin;
+        ranges[i].end = plan_shards[i].layer_end;
+    }
+
+    const size_t remote_begin = mixed_plan.remote_begin;
+    shards_.resize(remote_begin);
+    for (size_t i = 0; i < remote_begin; ++i) {
+        auto & shard = shards_[i];
+        shard.placement_backend = cfg_.device.layer_split_backend(i);
+        shard.gpu = cfg_.device.layer_split_gpus[i];
+        shard.layer_begin = ranges[i].begin;
+        shard.layer_end = ranges[i].end;
+        shard.backend = ggml_backend_cuda_init(shard.gpu);
+        if (!shard.backend) {
+            std::fprintf(stderr,
+                "[gemma4-target-split] local backend init failed gpu=%d\n",
+                shard.gpu);
+            return false;
+        }
+    }
+    std::vector<ggml_backend_t> shard_backends;
+    shard_backends.reserve(shards_.size());
+    for (const auto & shard : shards_) shard_backends.push_back(shard.backend);
+    const BackendActivationPolicy activation_policy =
+        select_common_activation_precision_policy(
+            shard_backends, /*force_f32=*/false,
+            "LUCEBOX_LAYER_SPLIT_ACT_TYPE");
+    activation_type_ = activation_policy.activation_type;
+
+    for (auto & shard : shards_) {
+        const TargetLoadPlan plan =
+            make_layer_split_load_plan<TargetLoadPlan>(
+                shard, /*is_last_shard=*/false);
+        if (!load_gemma4_gguf_partial(cfg_.target_path, shard.backend,
+                                      plan, shard.weights)) {
+            std::fprintf(stderr,
+                "[gemma4-target-split] mixed local load gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+
+    kvflash_read_config();
+    if (kvflash_active() && cfg_.fa_window > 0) {
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] fa_window is incompatible with "
+            "pooled full-attention slots\n");
+        return false;
+    }
+
+    for (auto & shard : shards_) {
+        if (!create_gemma4_cache_partial(shard.backend, shard.weights,
+                                         cfg_.device.max_ctx,
+                                         shard.layer_begin, shard.layer_end,
+                                         shard.cache, kvflash_tokens_)) {
+            std::fprintf(stderr,
+                "[gemma4-target-split] mixed local cache gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            return false;
+        }
+        shard.cache.fa_window = cfg_.fa_window;
+    }
+    if (!kvflash_attach()) return false;
+
+    std::vector<int> remote_gpus;
+    std::vector<int> remote_layer_begins;
+    std::vector<int> remote_layer_ends;
+    for (size_t i = remote_begin; i < cfg_.device.layer_split_gpus.size(); ++i) {
+        remote_gpus.push_back(cfg_.device.layer_split_gpus[i]);
+        remote_layer_begins.push_back(ranges[i].begin);
+        remote_layer_ends.push_back(ranges[i].end);
+    }
+
+    const Gemma4Weights & ref = shards_.front().weights;
+    TargetShardIpcLaunchConfig launch;
+    launch.mode = BackendIpcMode::Gemma4TargetShard;
+    launch.bin = cfg_.remote_target_shard.ipc_bin;
+    launch.target_path = cfg_.target_path ? cfg_.target_path : "";
+    launch.gpus = remote_gpus;
+    launch.layer_begins = remote_layer_begins;
+    launch.layer_ends = remote_layer_ends;
+    launch.max_ctx = cfg_.device.max_ctx;
+    launch.hidden = ref.n_embd;
+    launch.vocab = ref.n_vocab;
+    launch.max_tokens = std::max(1, cfg_.device.max_ctx);
+    launch.work_dir = cfg_.remote_target_shard.work_dir;
+    launch.fa_window = cfg_.fa_window;
+    launch.kvflash_pool_tokens = kvflash_tokens_;
+    if (!remote_target_shard_.start(launch)) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] remote target shard start failed layers=[%d,%d)\n",
+            remote_layer_begins.front(), remote_layer_ends.back());
+        return false;
+    }
+
+    snapshots_.resize(PREFIX_SLOTS);
+    for (auto & slot : snapshots_) {
+        slot.shards.resize(shards_.size());
+    }
+    snapshot_backends_.assign(shards_.size(), nullptr);
+    auto shard_metas = layer_split_shard_metas(shards_);
+    if (!init_layer_split_snapshot_backends(
+            shard_metas, snapshot_backends_, "gemma4-target-split")) {
+        return false;
+    }
+    kvflash_history_snapshots_.resize(PREFIX_SLOTS);
     return true;
 }
 
@@ -262,35 +416,29 @@ bool Gemma4LayerSplitAdapter::kvflash_attach() {
 
 bool Gemma4LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_) {
-        std::fprintf(stderr,
-            "[gemma4-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
-            committed, kvflash_tokens_);
+    if (!layer_split_kvflash_sync_identity(
+            kvflash_pager_, committed, kvflash_tokens_, "gemma4-target-split")) {
         return false;
     }
-    kvflash_pager_.reset();
-    if (!kvflash_pager_.alloc_span(0, committed)) return false;
-    kvflash_pager_.zero_free_blocks();
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.kvflash_sync_identity(committed)) {
+        std::fprintf(stderr,
+            "[gemma4-target-split][kvflash] remote identity sync failed pos=%d\n",
+            committed);
+        return false;
+    }
     return true;
 }
 
 void Gemma4LayerSplitAdapter::kvflash_sync_history(
         const std::vector<int32_t> & tokens, int base_pos) {
     if (!kvflash_active()) return;
-    if (base_pos == 0) {
-        kvflash_history_.assign(tokens.begin(), tokens.end());
-        return;
-    }
-    if ((int)kvflash_history_.size() > base_pos) {
-        kvflash_history_.resize((size_t)base_pos);
-    } else if ((int)kvflash_history_.size() < base_pos) {
-        kvflash_history_.resize((size_t)base_pos, 0);
-    }
-    kvflash_history_.insert(kvflash_history_.end(), tokens.begin(), tokens.end());
+    layer_split_kvflash_sync_history(kvflash_history_, tokens, base_pos);
 }
 
 void Gemma4LayerSplitAdapter::kvflash_maybe_reselect(int generated) {
     if (!kvflash_active() || kvflash_tau_ <= 0) return;
+    if (use_mixed_target_split()) return;
     const int tau = std::max<int>(kvflash_tau_, (int)(kvflash_history_.size() / 45));
     if (generated % tau != 0) return;
     if (!kvflash_scorer_) {
@@ -350,6 +498,11 @@ void Gemma4LayerSplitAdapter::reset_request_state() {
         kvflash_history_.clear();
         kvflash_scores_.clear();
         kvflash_pager_.score_hook = nullptr;
+    }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.reset_request_state()) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] remote shard reset_request_state failed\n");
     }
     prefill_last_logits_.clear();
 }
@@ -605,10 +758,277 @@ bool Gemma4LayerSplitAdapter::run_forward(
     return true;
 }
 
+bool Gemma4LayerSplitAdapter::run_mixed_forward(
+        const std::vector<int32_t> & tokens,
+        int base_pos,
+        int & last_tok,
+        std::vector<float> * logits_out) {
+    if (!use_mixed_target_split() || tokens.empty()) return false;
+    const Gemma4Weights & ref = shards_.front().weights;
+    const int hidden = ref.n_embd;
+    const int n_tokens_total = (int)tokens.size();
+    int ubatch = cfg_.chunk > 0 ? cfg_.chunk : 512;
+    if (const char * e = std::getenv("DFLASH_GEMMA4_LAYER_SPLIT_UBATCH")) {
+        ubatch = std::max(1, std::atoi(e));
+    }
+    if (base_pos < 0 || base_pos + n_tokens_total > cfg_.device.max_ctx) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] mixed range [%d,%d) exceeds max_ctx=%d\n",
+            base_pos, base_pos + n_tokens_total, cfg_.device.max_ctx);
+        return false;
+    }
+
+    ActivationPair acts;
+    if (!activation_pair_init(acts, shards_.front().backend, hidden,
+                              n_tokens_total, activation_type_)) {
+        std::fprintf(stderr,
+            "[gemma4-target-split] mixed activation alloc failed gpu=%d\n",
+            shards_.front().gpu);
+        return false;
+    }
+    ActivationBuffer orig;
+    if (!activation_buffer_init(orig, shards_.front().backend, hidden,
+                                n_tokens_total, activation_type_,
+                                "gemma4_target_split_orig_embed")) {
+        activation_pair_free(acts);
+        return false;
+    }
+
+    {
+        constexpr int kEmbedBatch = 4096;
+        std::vector<float> emb((size_t)hidden * std::min(kEmbedBatch, n_tokens_total));
+        const float scale = std::sqrt((float)hidden);
+        for (int i = 0; i < n_tokens_total; i += kEmbedBatch) {
+            const int n = std::min(kEmbedBatch, n_tokens_total - i);
+            if ((int)emb.size() < hidden * n) emb.resize((size_t)hidden * n);
+            if (!ref.embedder.embed(tokens.data() + i, n, emb.data())) {
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            for (int j = 0; j < hidden * n; ++j) emb[(size_t)j] *= scale;
+            const size_t off = (size_t)i * acts.a->nb[1];
+            const size_t elems = (size_t)hidden * (size_t)n;
+            if (!set_activation_tensor_from_f32(acts.a, emb.data(), off, elems) ||
+                !set_activation_tensor_from_f32(orig.tensor, emb.data(), off, elems)) {
+                std::fprintf(stderr,
+                    "[gemma4-target-split] unsupported activation type: %s\n",
+                    ggml_type_name(acts.a->type));
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+        }
+    }
+
+    ggml_tensor * act_in = acts.a;
+    ggml_tensor * act_out = acts.b;
+    Gemma4LayerSplitShard * current_shard = &shards_.front();
+    for (int il = shards_.front().layer_begin; il < shards_.back().layer_end; ++il) {
+        Gemma4LayerSplitShard * shard = find_layer_split_shard(shards_, il);
+        if (!shard) {
+            std::fprintf(stderr,
+                "[gemma4-target-split] mixed missing local owner for layer %d\n",
+                il);
+            activation_buffer_free(orig);
+            activation_pair_free(acts);
+            return false;
+        }
+        if (shard != current_shard) {
+            ActivationPair next_acts;
+            if (!activation_pair_init(next_acts, shard->backend, hidden,
+                                      n_tokens_total, activation_type_)) {
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            ActivationBuffer next_orig;
+            if (!activation_buffer_init(next_orig, shard->backend, hidden,
+                                        n_tokens_total, activation_type_,
+                                        "gemma4_target_split_orig_embed")) {
+                activation_pair_free(next_acts);
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            ggml_backend_synchronize(current_shard->backend);
+            ggml_backend_tensor_copy(act_in, next_acts.a);
+            ggml_backend_tensor_copy(orig.tensor, next_orig.tensor);
+            ggml_backend_synchronize(shard->backend);
+            activation_pair_free(acts);
+            activation_buffer_free(orig);
+            acts = next_acts;
+            orig = next_orig;
+            act_in = acts.a;
+            act_out = acts.b;
+            current_shard = shard;
+        }
+
+        for (int start = 0; start < n_tokens_total;) {
+            int n = std::min(ubatch, n_tokens_total - start);
+            const int kv_start = base_pos + start;
+            if (shard->cache.swa_size > 0 &&
+                shard->cache.swa_size < shard->cache.max_ctx) {
+                const int swa_remaining =
+                    shard->cache.swa_size - (kv_start % shard->cache.swa_size);
+                n = std::min(n, swa_remaining);
+            }
+            const bool use_kvflash =
+                kvflash_active() && !gemma4_is_swa_layer(ref, il);
+            if (use_kvflash && !kvflash_pager_.alloc_span(kv_start, n)) {
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            if (!build_gemma4_layer_step(
+                    shard->layer_graph, shard->weights, shard->cache,
+                    shard->backend, il, act_in, orig.tensor, act_out,
+                    start, n, kv_start,
+                    use_kvflash ? &kvflash_pager_ : nullptr)) {
+                std::fprintf(stderr,
+                    "[gemma4-target-split] mixed build layer=%d @%d gpu=%d\n",
+                    il, start, shard->gpu);
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+
+            std::vector<int32_t> pos((size_t)n);
+            for (int i = 0; i < n; ++i) pos[(size_t)i] = kv_start + i;
+            if (!tensor_ready(shard->layer_graph.positions)) {
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            ggml_backend_tensor_set(shard->layer_graph.positions, pos.data(), 0,
+                                    sizeof(int32_t) * pos.size());
+            if (tensor_ready(shard->layer_graph.token_ids)) {
+                ggml_backend_tensor_set(shard->layer_graph.token_ids,
+                                        tokens.data() + start, 0,
+                                        sizeof(int32_t) * (size_t)n);
+            }
+
+            if (tensor_ready(shard->layer_graph.kv_idx_full)) {
+                if (use_kvflash) {
+                    std::vector<int32_t> rows;
+                    std::vector<float> mfull;
+                    if (!kvflash_fill_rows_and_masks(
+                            kvflash_pager_, kv_start, n,
+                            (int)shard->layer_graph.attn_mask_full->ne[0],
+                            /*swa_window=*/0, rows, &mfull, nullptr)) {
+                        activation_buffer_free(orig);
+                        activation_pair_free(acts);
+                        return false;
+                    }
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx_full,
+                                            rows.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx_full));
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask_full,
+                                            mfull.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask_full));
+                } else {
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx_full,
+                                            pos.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx_full));
+                }
+            }
+            if (!use_kvflash && tensor_ready(shard->layer_graph.attn_mask_full)) {
+                const int kv_len_raw = kv_start + n;
+                const int kv_len_padded =
+                    (int)shard->layer_graph.attn_mask_full->ne[0];
+                std::vector<float> mfull((size_t)kv_len_padded * n, -INFINITY);
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    for (int k = 0; k <= abs_q && k < kv_len_raw &&
+                                    k < kv_len_padded; ++k) {
+                        mfull[(size_t)q * kv_len_padded + k] = 0.0f;
+                    }
+                }
+                ggml_backend_tensor_set(shard->layer_graph.attn_mask_full,
+                                        mfull.data(), 0,
+                                        ggml_nbytes(shard->layer_graph.attn_mask_full));
+            }
+
+            const int swa_size = shard->cache.swa_size;
+            const int swa_len_raw = std::min(kv_start + n, swa_size);
+            const int swa_len_padded = tensor_ready(shard->layer_graph.attn_mask_swa)
+                ? (int)shard->layer_graph.attn_mask_swa->ne[0]
+                : ((swa_len_raw + 255) & ~255);
+            if (tensor_ready(shard->layer_graph.kv_idx_swa)) {
+                std::vector<int32_t> ring((size_t)n);
+                for (int i = 0; i < n; ++i) ring[(size_t)i] =
+                    (kv_start + i) % swa_size;
+                ggml_backend_tensor_set(shard->layer_graph.kv_idx_swa,
+                                        ring.data(), 0,
+                                        ggml_nbytes(shard->layer_graph.kv_idx_swa));
+            }
+            std::vector<float> mswa((size_t)swa_len_padded * n, -INFINITY);
+            for (int q = 0; q < n; ++q) {
+                const int abs_q = kv_start + q;
+                const int win_lo = std::max(0, abs_q - ref.sliding_window + 1);
+                for (int abs_k = win_lo; abs_k <= abs_q; ++abs_k) {
+                    const int slot = abs_k % swa_size;
+                    if (slot < swa_len_raw) {
+                        mswa[(size_t)q * swa_len_padded + slot] = 0.0f;
+                    }
+                }
+            }
+            if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                ggml_backend_tensor_set(shard->layer_graph.attn_mask_swa,
+                                        mswa.data(), 0,
+                                        ggml_nbytes(shard->layer_graph.attn_mask_swa));
+            }
+
+            auto st = ggml_backend_graph_compute(shard->backend,
+                                                 shard->layer_graph.gf);
+            if (st != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr,
+                    "[gemma4-target-split] mixed compute layer=%d @%d gpu=%d status=%d\n",
+                    il, start, shard->gpu, (int)st);
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            start += n;
+        }
+        std::swap(act_in, act_out);
+    }
+
+    std::vector<float> boundary;
+    if (!copy_activation_to_host(act_in, shards_.back().backend, 0,
+                                 n_tokens_total, hidden, boundary)) {
+        activation_buffer_free(orig);
+        activation_pair_free(acts);
+        return false;
+    }
+    activation_buffer_free(orig);
+    activation_pair_free(acts);
+
+    TargetShardForwardRequest req;
+    req.base_pos = base_pos;
+    req.n_tokens = n_tokens_total;
+    req.boundary_activation = &boundary;
+    req.token_ids = &tokens;
+    req.ubatch = ubatch;
+    req.want_argmax = false;
+    req.want_logits = logits_out != nullptr;
+    TargetShardForwardResponse resp;
+    resp.logits_out = logits_out;
+    if (!remote_target_shard_.forward(req, resp)) return false;
+    last_tok = resp.last_tok;
+    for (auto & shard : shards_) {
+        shard.cache.cur_pos = base_pos + n_tokens_total;
+        shard.cache.last_tok = last_tok;
+    }
+    return true;
+}
+
 bool Gemma4LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
                                       int base_pos,
                                       int & last_tok) {
-    const bool ok = run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
+    const bool ok = use_mixed_target_split()
+        ? run_mixed_forward(prompt, base_pos, last_tok, &prefill_last_logits_)
+        : run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
     if (ok && kvflash_active()) {
         kvflash_sync_history(prompt, base_pos);
         kvflash_pager_.zero_free_blocks();
@@ -632,7 +1052,9 @@ bool Gemma4LayerSplitAdapter::decode_ar(
         sampler_rng_,
         [&](const std::vector<int32_t> & one, int pos, int & next_tok,
             std::vector<float> * logits_out) {
-            return run_forward(one, pos - 1, next_tok, logits_out);
+            return use_mixed_target_split()
+                ? run_mixed_forward(one, pos - 1, next_tok, logits_out)
+                : run_forward(one, pos - 1, next_tok, logits_out);
         },
         [&](int tok) { return tok == w.eos_id || tok == w.eos_chat_id; },
         out_tokens, io);
@@ -714,18 +1136,18 @@ bool Gemma4LayerSplitAdapter::snapshot_save(int slot) {
         ss.cur_pos = snap_pos;
         ss.last_tok = shards_[i].cache.last_tok;
     }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.snapshot_save(slot)) {
+        snapshot_free(slot);
+        return false;
+    }
     snap.cur_pos = snap_pos;
     snap.last_tok = shards_.front().cache.last_tok;
     snap.prefill_last_logits = prefill_last_logits_;
     if (kvflash_active() &&
         kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
-        auto & history_snap = kvflash_history_snapshots_[(size_t)slot];
-        history_snap.clear();
-        const size_t keep = (size_t)std::min(snap_pos, (int)kvflash_history_.size());
-        history_snap.assign(kvflash_history_.begin(), kvflash_history_.begin() + keep);
-        if ((int)history_snap.size() < snap_pos) {
-            history_snap.resize((size_t)snap_pos, 0);
-        }
+        layer_split_kvflash_save_history_snapshot(
+            kvflash_history_, snap_pos, kvflash_history_snapshots_[(size_t)slot]);
     }
     return true;
 }
@@ -743,6 +1165,9 @@ void Gemma4LayerSplitAdapter::snapshot_free(int slot) {
         kvflash_history_snapshots_[(size_t)slot].clear();
     }
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
+    if (use_mixed_target_split()) {
+        remote_target_shard_.snapshot_free(slot);
+    }
 }
 
 bool Gemma4LayerSplitAdapter::snapshot_used(int slot) const {
@@ -792,20 +1217,15 @@ bool Gemma4LayerSplitAdapter::snapshot_restore(int slot) {
         shards_[i].cache.cur_pos = snap.cur_pos;
         shards_[i].cache.last_tok = snap.last_tok;
     }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.snapshot_restore(slot)) {
+        return false;
+    }
     prefill_last_logits_ = snap.prefill_last_logits;
     if (kvflash_active()) {
         if (!kvflash_sync_identity(snap.cur_pos)) return false;
-        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS &&
-            !kvflash_history_snapshots_[(size_t)slot].empty()) {
-            kvflash_history_ = kvflash_history_snapshots_[(size_t)slot];
-        } else {
-            kvflash_history_.clear();
-        }
-        if ((int)kvflash_history_.size() > snap.cur_pos) {
-            kvflash_history_.resize((size_t)snap.cur_pos);
-        } else if ((int)kvflash_history_.size() < snap.cur_pos) {
-            kvflash_history_.resize((size_t)snap.cur_pos, 0);
-        }
+        layer_split_kvflash_restore_history(
+            kvflash_history_, kvflash_history_snapshots_, slot, snap.cur_pos);
     }
     return true;
 }
@@ -825,6 +1245,7 @@ void Gemma4LayerSplitAdapter::shutdown() {
     kvflash_history_snapshots_.clear();
     auto shard_metas = layer_split_shard_metas(shards_);
     free_layer_split_snapshot_backends(shard_metas, snapshot_backends_);
+    remote_target_shard_.close();
     free_gemma4_layer_split_shards(shards_);
 }
 
@@ -840,6 +1261,499 @@ void free_gemma4_layer_split_shards(
         }
     }
     shards.clear();
+}
+
+int run_gemma4_target_shard_ipc_daemon(const char * target_path,
+                                       const std::vector<int> & gpus,
+                                       const std::vector<int> & layer_begins,
+                                       const std::vector<int> & layer_ends,
+                                       int max_ctx,
+                                       int fa_window,
+                                       int stream_fd,
+                                       int payload_fd,
+                                       int shared_payload_fd,
+                                       size_t shared_payload_bytes,
+                                       int kvflash_pool_tokens) {
+#if defined(_WIN32)
+    (void)target_path; (void)gpus; (void)layer_begins; (void)layer_ends;
+    (void)max_ctx; (void)fa_window; (void)stream_fd; (void)payload_fd;
+    (void)shared_payload_fd; (void)shared_payload_bytes; (void)kvflash_pool_tokens;
+    std::fprintf(stderr, "Gemma4 target shard IPC daemon is only implemented on POSIX hosts\n");
+    return 2;
+#else
+    if (!target_path || gpus.empty() || gpus.size() != layer_begins.size() ||
+        gpus.size() != layer_ends.size() || max_ctx <= 0 || stream_fd < 0) {
+        std::fprintf(stderr,
+            "usage: backend_ipc_daemon --backend-ipc-mode=gemma4-target-shard "
+            "<target.gguf> --target-gpus=N[,N...] "
+            "--layer-begins=N[,N...] --layer-ends=N[,N...] "
+            "--max-ctx=N --stream-fd=FD [--payload-fd=FD]\n");
+        return 2;
+    }
+    for (size_t i = 0; i < gpus.size(); ++i) {
+        if (gpus[i] < 0 || layer_begins[i] < 0 ||
+            layer_ends[i] <= layer_begins[i] ||
+            (i > 0 && layer_begins[i] != layer_ends[i - 1])) {
+            std::fprintf(stderr,
+                "[gemma4-target-shard-daemon] bad shard config\n");
+            return 2;
+        }
+    }
+
+    std::vector<Gemma4LayerSplitShard> shards(gpus.size());
+    for (size_t i = 0; i < shards.size(); ++i) {
+        auto & shard = shards[i];
+        shard.gpu = gpus[i];
+        shard.layer_begin = layer_begins[i];
+        shard.layer_end = layer_ends[i];
+        shard.backend = ggml_backend_cuda_init(shard.gpu);
+        if (!shard.backend) {
+            std::fprintf(stderr,
+                "[gemma4-target-shard-daemon] backend init failed gpu=%d\n",
+                shard.gpu);
+            free_gemma4_layer_split_shards(shards);
+            return 1;
+        }
+    }
+
+    for (size_t i = 0; i < shards.size(); ++i) {
+        auto & shard = shards[i];
+        const bool is_last = i + 1 == shards.size();
+        const TargetLoadPlan plan =
+            make_layer_split_load_plan<TargetLoadPlan>(shard, is_last);
+        if (!load_gemma4_gguf_partial(target_path, shard.backend, plan,
+                                      shard.weights) ||
+            !create_gemma4_cache_partial(shard.backend, shard.weights,
+                                         max_ctx, shard.layer_begin,
+                                         shard.layer_end, shard.cache,
+                                         kvflash_pool_tokens)) {
+            std::fprintf(stderr,
+                "[gemma4-target-shard-daemon] load/cache failed gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            free_gemma4_layer_split_shards(shards);
+            return 1;
+        }
+        shard.cache.fa_window = fa_window;
+    }
+
+    std::vector<ggml_backend_t> snapshot_backends;
+    if (!init_layer_split_snapshot_backends(
+            layer_split_shard_metas(shards), snapshot_backends,
+            "gemma4-target-shard-daemon")) {
+        free_gemma4_layer_split_shards(shards);
+        return 1;
+    }
+    std::vector<Gemma4LayerSplitSnapshot> snapshots(
+        (size_t)ModelBackend::kMaxSlots);
+    for (auto & slot : snapshots) slot.shards.resize(shards.size());
+    auto free_slot = [&](int slot) {
+        if (slot < 0 || slot >= ModelBackend::kMaxSlots) return;
+        auto & snap = snapshots[(size_t)slot];
+        for (auto & ss : snap.shards) free_gemma4_snapshot(ss);
+        snap.cur_pos = 0;
+        snap.last_tok = -1;
+        snap.prefill_last_logits.clear();
+        if (snap.shards.size() != shards.size()) snap.shards.resize(shards.size());
+    };
+
+    KvFlashPager kvflash_pager;
+    if (kvflash_pool_tokens > 0) {
+        if (fa_window > 0) {
+            std::fprintf(stderr,
+                "[gemma4-target-shard-daemon][kvflash] fa_window must be 0\n");
+            auto metas = layer_split_shard_metas(shards);
+            free_layer_split_snapshot_backends(metas, snapshot_backends);
+            free_gemma4_layer_split_shards(shards);
+            return 1;
+        }
+        std::vector<ggml_tensor *> full_k;
+        std::vector<ggml_tensor *> full_v;
+        const int n_layer = shards.front().weights.n_layer;
+        for (int il = 0; il < n_layer; ++il) {
+            if (!gemma4_has_kv(shards.front().weights, il) ||
+                gemma4_is_swa_layer(shards.front().weights, il)) {
+                continue;
+            }
+            ggml_tensor * k = nullptr;
+            ggml_tensor * v = nullptr;
+            for (auto & shard : shards) {
+                if (il < (int)shard.cache.k.size() &&
+                    shard.cache.k[(size_t)il]) {
+                    k = shard.cache.k[(size_t)il];
+                    v = shard.cache.v[(size_t)il];
+                    break;
+                }
+            }
+            if (k && v) {
+                full_k.push_back(k);
+                full_v.push_back(v);
+            }
+        }
+        KvFlashConfig pc;
+        pc.pool_tokens = kvflash_pool_tokens;
+        if (!kvflash_pager.attach(pc, full_k, full_v)) {
+            auto metas = layer_split_shard_metas(shards);
+            free_layer_split_snapshot_backends(metas, snapshot_backends);
+            free_gemma4_layer_split_shards(shards);
+            return 1;
+        }
+    }
+
+    const int hidden = shards.front().weights.n_embd;
+    std::vector<float> prefill_last_logits;
+    TargetShardDaemonCallbacks callbacks;
+    callbacks.log_prefix = "gemma4-target-shard-daemon";
+    callbacks.forward = [&](const TargetShardDaemonForwardRequest & req,
+                            TargetShardDaemonForwardResponse & resp) -> bool {
+        if (!req.boundary_activation || !req.token_ids ||
+            req.n_tokens <= 0 ||
+            (int)req.boundary_activation->size() != hidden * req.n_tokens ||
+            (int)req.token_ids->size() != req.n_tokens ||
+            req.base_pos < 0 || req.base_pos + req.n_tokens > max_ctx) {
+            return false;
+        }
+        const int n_tokens = req.n_tokens;
+        int ubatch = std::max(1, req.ubatch > 0 ? req.ubatch : n_tokens);
+        ActivationPair acts;
+        if (!activation_pair_init(acts, shards.front().backend, hidden, n_tokens)) {
+            return false;
+        }
+        ActivationBuffer orig;
+        if (!activation_buffer_init(orig, shards.front().backend, hidden, n_tokens,
+                                    GGML_TYPE_F32,
+                                    "gemma4_target_shard_orig_embed")) {
+            activation_pair_free(acts);
+            return false;
+        }
+        ggml_backend_tensor_set(acts.a, req.boundary_activation->data(), 0,
+                                sizeof(float) * req.boundary_activation->size());
+        {
+            std::vector<float> emb((size_t)hidden * (size_t)n_tokens);
+            const float scale = std::sqrt((float)hidden);
+            if (!shards.front().weights.embedder.embed(
+                    req.token_ids->data(), n_tokens, emb.data())) {
+                activation_buffer_free(orig);
+                activation_pair_free(acts);
+                return false;
+            }
+            for (float & v : emb) v *= scale;
+            ggml_backend_tensor_set(orig.tensor, emb.data(), 0,
+                                    sizeof(float) * emb.size());
+        }
+
+        ggml_tensor * act_in = acts.a;
+        ggml_tensor * act_out = acts.b;
+        Gemma4LayerSplitShard * current_shard = &shards.front();
+        bool ok = true;
+        for (int il = shards.front().layer_begin;
+             ok && il < shards.back().layer_end; ++il) {
+            Gemma4LayerSplitShard * shard = find_layer_split_shard(shards, il);
+            if (!shard) {
+                ok = false;
+                break;
+            }
+            if (shard != current_shard) {
+                ActivationPair next_acts;
+                ActivationBuffer next_orig;
+                if (!activation_pair_init(next_acts, shard->backend, hidden,
+                                          n_tokens) ||
+                    !activation_buffer_init(next_orig, shard->backend, hidden,
+                                            n_tokens, GGML_TYPE_F32,
+                                            "gemma4_target_shard_orig_embed")) {
+                    activation_pair_free(next_acts);
+                    activation_buffer_free(next_orig);
+                    ok = false;
+                    break;
+                }
+                ggml_backend_synchronize(current_shard->backend);
+                ggml_backend_tensor_copy(act_in, next_acts.a);
+                ggml_backend_tensor_copy(orig.tensor, next_orig.tensor);
+                ggml_backend_synchronize(shard->backend);
+                activation_pair_free(acts);
+                activation_buffer_free(orig);
+                acts = next_acts;
+                orig = next_orig;
+                act_in = acts.a;
+                act_out = acts.b;
+                current_shard = shard;
+            }
+            for (int start = 0; ok && start < n_tokens;) {
+                int n = std::min(ubatch, n_tokens - start);
+                const int kv_start = req.base_pos + start;
+                if (shard->cache.swa_size > 0 &&
+                    shard->cache.swa_size < shard->cache.max_ctx) {
+                    const int swa_remaining =
+                        shard->cache.swa_size - (kv_start % shard->cache.swa_size);
+                    n = std::min(n, swa_remaining);
+                }
+                const bool use_kvflash =
+                    kvflash_pool_tokens > 0 &&
+                    !gemma4_is_swa_layer(shard->weights, il);
+                if (use_kvflash && !kvflash_pager.alloc_span(kv_start, n)) {
+                    ok = false;
+                    break;
+                }
+                if (!build_gemma4_layer_step(
+                        shard->layer_graph, shard->weights, shard->cache,
+                        shard->backend, il, act_in, orig.tensor, act_out,
+                        start, n, kv_start,
+                        use_kvflash ? &kvflash_pager : nullptr)) {
+                    ok = false;
+                    break;
+                }
+                std::vector<int32_t> pos((size_t)n);
+                for (int i = 0; i < n; ++i) pos[(size_t)i] = kv_start + i;
+                if (!tensor_ready(shard->layer_graph.positions)) {
+                    ok = false;
+                    break;
+                }
+                ggml_backend_tensor_set(shard->layer_graph.positions,
+                                        pos.data(), 0,
+                                        sizeof(int32_t) * pos.size());
+                if (tensor_ready(shard->layer_graph.token_ids)) {
+                    ggml_backend_tensor_set(shard->layer_graph.token_ids,
+                                            req.token_ids->data() + start, 0,
+                                            sizeof(int32_t) * (size_t)n);
+                }
+                if (tensor_ready(shard->layer_graph.kv_idx_full)) {
+                    if (use_kvflash) {
+                        std::vector<int32_t> rows;
+                        std::vector<float> mfull;
+                        if (!kvflash_fill_rows_and_masks(
+                                kvflash_pager, kv_start, n,
+                                (int)shard->layer_graph.attn_mask_full->ne[0],
+                                0, rows, &mfull, nullptr)) {
+                            ok = false;
+                            break;
+                        }
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.kv_idx_full, rows.data(), 0,
+                            ggml_nbytes(shard->layer_graph.kv_idx_full));
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.attn_mask_full, mfull.data(), 0,
+                            ggml_nbytes(shard->layer_graph.attn_mask_full));
+                    } else {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.kv_idx_full, pos.data(), 0,
+                            ggml_nbytes(shard->layer_graph.kv_idx_full));
+                    }
+                }
+                if (!use_kvflash &&
+                    tensor_ready(shard->layer_graph.attn_mask_full)) {
+                    const int kv_len_raw = kv_start + n;
+                    const int kv_len_padded =
+                        (int)shard->layer_graph.attn_mask_full->ne[0];
+                    std::vector<float> mfull(
+                        (size_t)kv_len_padded * n, -INFINITY);
+                    for (int q = 0; q < n; ++q) {
+                        const int abs_q = kv_start + q;
+                        for (int k = 0; k <= abs_q && k < kv_len_raw &&
+                                        k < kv_len_padded; ++k) {
+                            mfull[(size_t)q * kv_len_padded + k] = 0.0f;
+                        }
+                    }
+                    ggml_backend_tensor_set(
+                        shard->layer_graph.attn_mask_full, mfull.data(), 0,
+                        ggml_nbytes(shard->layer_graph.attn_mask_full));
+                }
+                const int swa_size = shard->cache.swa_size;
+                const int swa_len_raw = std::min(kv_start + n, swa_size);
+                const int swa_len_padded =
+                    tensor_ready(shard->layer_graph.attn_mask_swa)
+                    ? (int)shard->layer_graph.attn_mask_swa->ne[0]
+                    : ((swa_len_raw + 255) & ~255);
+                if (tensor_ready(shard->layer_graph.kv_idx_swa)) {
+                    std::vector<int32_t> ring((size_t)n);
+                    for (int i = 0; i < n; ++i) {
+                        ring[(size_t)i] = (kv_start + i) % swa_size;
+                    }
+                    ggml_backend_tensor_set(
+                        shard->layer_graph.kv_idx_swa, ring.data(), 0,
+                        ggml_nbytes(shard->layer_graph.kv_idx_swa));
+                }
+                std::vector<float> mswa((size_t)swa_len_padded * n, -INFINITY);
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    const int win_lo = std::max(
+                        0, abs_q - shard->weights.sliding_window + 1);
+                    for (int abs_k = win_lo; abs_k <= abs_q; ++abs_k) {
+                        const int slot = abs_k % swa_size;
+                        if (slot < swa_len_raw) {
+                            mswa[(size_t)q * swa_len_padded + slot] = 0.0f;
+                        }
+                    }
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                    ggml_backend_tensor_set(
+                        shard->layer_graph.attn_mask_swa, mswa.data(), 0,
+                        ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                }
+                auto st = ggml_backend_graph_compute(shard->backend,
+                                                     shard->layer_graph.gf);
+                ok = st == GGML_STATUS_SUCCESS;
+                start += n;
+            }
+            std::swap(act_in, act_out);
+        }
+        if (ok) {
+            std::vector<int32_t> argmax;
+            Gemma4LayerSplitShard & last = shards.back();
+            ok = compute_gemma4_split_projection(
+                last.backend, last.weights, act_in,
+                req.want_argmax ? 0 : n_tokens - 1,
+                req.want_argmax ? n_tokens : 1,
+                &argmax, req.want_logits ? &resp.logits : nullptr);
+            if (ok && !argmax.empty()) {
+                resp.last_tok = argmax.back();
+                if (req.want_argmax) resp.argmax = std::move(argmax);
+                if (req.want_logits) prefill_last_logits = resp.logits;
+            } else {
+                ok = false;
+            }
+        }
+        activation_buffer_free(orig);
+        activation_pair_free(acts);
+        if (!ok) return false;
+        for (auto & shard : shards) {
+            shard.cache.cur_pos = req.base_pos + n_tokens;
+            shard.cache.last_tok = resp.last_tok;
+        }
+        return true;
+    };
+    callbacks.reset_request_state = [&]() {
+        for (auto & shard : shards) {
+            shard.cache.cur_pos = 0;
+            shard.cache.last_tok = -1;
+        }
+        if (kvflash_pool_tokens > 0) kvflash_pager.reset();
+        prefill_last_logits.clear();
+        return true;
+    };
+    callbacks.kvflash_sync_identity = [&](int committed) {
+        if (kvflash_pool_tokens <= 0) return true;
+        return layer_split_kvflash_sync_identity(
+            kvflash_pager, committed, kvflash_pool_tokens,
+            "gemma4-target-shard-daemon");
+    };
+    callbacks.snapshot_save = [&](int slot) {
+        if (slot < 0 || slot >= ModelBackend::kMaxSlots ||
+            snapshot_backends.size() != shards.size()) {
+            return false;
+        }
+        const int snap_pos = shards.empty() ? 0 : shards.front().cache.cur_pos;
+        if (snap_pos <= 0) return false;
+        free_slot(slot);
+        auto & snap = snapshots[(size_t)slot];
+        if (snap.shards.size() != shards.size()) snap.shards.resize(shards.size());
+        for (size_t i = 0; i < shards.size(); ++i) {
+            const int n_layer = shards[i].cache.n_layer;
+            auto & ss = snap.shards[i];
+            ggml_init_params ip{};
+            ip.mem_size = ggml_tensor_overhead() * (size_t)(n_layer * 2 + 4) + 4096;
+            ip.no_alloc = true;
+            ss.ctx = ggml_init(ip);
+            if (!ss.ctx) {
+                free_slot(slot);
+                return false;
+            }
+            ss.k_snap.resize((size_t)n_layer, nullptr);
+            ss.v_snap.resize((size_t)n_layer, nullptr);
+            for (int il = 0; il < n_layer; ++il) {
+                ggml_tensor * ck = shards[i].cache.k[il];
+                if (!ck) continue;
+                const int save_pos = std::min(snap_pos, (int)ck->ne[1]);
+                ss.k_snap[(size_t)il] = ggml_new_tensor_3d(
+                    ss.ctx, ck->type, ck->ne[0], save_pos, ck->ne[2]);
+                ss.v_snap[(size_t)il] = ggml_new_tensor_3d(
+                    ss.ctx, ck->type, ck->ne[0], save_pos, ck->ne[2]);
+            }
+            ss.buf = ggml_backend_alloc_ctx_tensors(ss.ctx, snapshot_backends[i]);
+            if (!ss.buf) {
+                free_slot(slot);
+                return false;
+            }
+            for (int il = 0; il < n_layer; ++il) {
+                ggml_tensor * ck = shards[i].cache.k[il];
+                if (!ck || !ss.k_snap[(size_t)il]) continue;
+                const int D = (int)ck->ne[0];
+                const int Hk = (int)ck->ne[2];
+                const int cache_len = (int)ck->ne[1];
+                const int save_pos = std::min(snap_pos, cache_len);
+                const size_t elem_sz = ggml_element_size(ck);
+                const size_t head_bytes_src = (size_t)D * cache_len * elem_sz;
+                const size_t head_bytes_dst = (size_t)D * save_pos * elem_sz;
+                for (int h = 0; h < Hk; ++h) {
+                    ggml_backend_tensor_get(
+                        shards[i].cache.k[il],
+                        (char *)ss.k_snap[(size_t)il]->data + h * head_bytes_dst,
+                        h * head_bytes_src, head_bytes_dst);
+                    ggml_backend_tensor_get(
+                        shards[i].cache.v[il],
+                        (char *)ss.v_snap[(size_t)il]->data + h * head_bytes_dst,
+                        h * head_bytes_src, head_bytes_dst);
+                }
+            }
+            ss.cur_pos = snap_pos;
+            ss.last_tok = shards[i].cache.last_tok;
+        }
+        snap.cur_pos = snap_pos;
+        snap.last_tok = shards.front().cache.last_tok;
+        snap.prefill_last_logits = prefill_last_logits;
+        return true;
+    };
+    callbacks.snapshot_free = [&](int slot) { free_slot(slot); };
+    callbacks.snapshot_restore = [&](int slot) {
+        if (slot < 0 || slot >= ModelBackend::kMaxSlots) return false;
+        auto & snap = snapshots[(size_t)slot];
+        if (snap.cur_pos <= 0 || snap.shards.size() != shards.size()) return false;
+        for (size_t i = 0; i < shards.size(); ++i) {
+            const auto & ss = snap.shards[i];
+            if (ss.cur_pos != snap.cur_pos || !ss.ctx) return false;
+            for (int il = 0; il < shards[i].cache.n_layer; ++il) {
+                ggml_tensor * ck = shards[i].cache.k[il];
+                if (!ck || !ss.k_snap[(size_t)il]) continue;
+                const int D = (int)ck->ne[0];
+                const int Hk = (int)ck->ne[2];
+                const int cache_len = (int)ck->ne[1];
+                const int save_pos = (int)ss.k_snap[(size_t)il]->ne[1];
+                const size_t elem_sz = ggml_element_size(ck);
+                const size_t head_bytes_src = (size_t)D * save_pos * elem_sz;
+                const size_t head_bytes_dst = (size_t)D * cache_len * elem_sz;
+                for (int h = 0; h < Hk; ++h) {
+                    ggml_backend_tensor_set(
+                        shards[i].cache.k[il],
+                        (const char *)ss.k_snap[(size_t)il]->data + h * head_bytes_src,
+                        h * head_bytes_dst, head_bytes_src);
+                    ggml_backend_tensor_set(
+                        shards[i].cache.v[il],
+                        (const char *)ss.v_snap[(size_t)il]->data + h * head_bytes_src,
+                        h * head_bytes_dst, head_bytes_src);
+                }
+            }
+            shards[i].cache.cur_pos = snap.cur_pos;
+            shards[i].cache.last_tok = snap.last_tok;
+        }
+        prefill_last_logits = snap.prefill_last_logits;
+        if (kvflash_pool_tokens > 0) {
+            return layer_split_kvflash_sync_identity(
+                kvflash_pager, snap.cur_pos, kvflash_pool_tokens,
+                "gemma4-target-shard-daemon");
+        }
+        return true;
+    };
+
+    std::fprintf(stderr,
+        "[gemma4-target-shard-daemon] ready shards=%zu layers=[%d,%d)\n",
+        shards.size(), shards.front().layer_begin, shards.back().layer_end);
+    const int rc = run_target_shard_ipc_daemon_loop(
+        hidden, stream_fd, payload_fd, shared_payload_fd,
+        shared_payload_bytes, std::move(callbacks));
+    for (int slot = 0; slot < ModelBackend::kMaxSlots; ++slot) free_slot(slot);
+    auto metas = layer_split_shard_metas(shards);
+    free_layer_split_snapshot_backends(metas, snapshot_backends);
+    free_gemma4_layer_split_shards(shards);
+    return rc;
+#endif
 }
 
 }  // namespace dflash::common

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -262,7 +262,7 @@ bool Gemma4LayerSplitAdapter::kvflash_attach() {
 
 bool Gemma4LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_) {
+    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
         std::fprintf(stderr,
             "[gemma4-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/gemma4/gemma4_layer_split_adapter.cpp
+++ b/server/src/gemma4/gemma4_layer_split_adapter.cpp
@@ -262,7 +262,7 @@ bool Gemma4LayerSplitAdapter::kvflash_attach() {
 
 bool Gemma4LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+    if (committed > kvflash_tokens_) {
         std::fprintf(stderr,
             "[gemma4-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/gemma4/gemma4_layer_split_adapter.h
+++ b/server/src/gemma4/gemma4_layer_split_adapter.h
@@ -3,11 +3,14 @@
 #pragma once
 
 #include "common/layer_split_backend.h"
+#include "common/layer_split_kvflash.h"
 #include "common/layer_split_utils.h"
 #include "common/kvflash_pager.h"
 #include "common/kvflash_scorer.h"
+#include "common/target_shard_ipc.h"
 #include "gemma4_internal.h"
 #include "placement/placement_config.h"
+#include "placement/remote_target_shard_config.h"
 #include "qwen3/qwen3_drafter.h"
 
 #include "ggml-backend.h"
@@ -21,6 +24,7 @@ namespace dflash::common {
 struct Gemma4LayerSplitAdapterConfig {
     const char * target_path = nullptr;
     DevicePlacement device;
+    RemoteTargetShardConfig remote_target_shard;
     int chunk = 512;
     int fa_window = 0;
 };
@@ -59,6 +63,10 @@ public:
                    std::vector<int32_t> & out_tokens,
                    const DaemonIO & io) override;
     bool supports_cpu_sampling() const override { return true; }
+    bool supports_kvflash() const override { return kvflash_active(); }
+    bool supports_mixed_backend_layer_split() const override {
+        return use_mixed_target_split();
+    }
 
     bool snapshot_save(int slot) override;
     void snapshot_free(int slot) override;
@@ -75,15 +83,24 @@ private:
                      int base_pos,
                      int & last_tok,
                      std::vector<float> * logits_out = nullptr);
+    bool init_mixed_target_split();
+    bool run_mixed_forward(const std::vector<int32_t> & tokens,
+                           int base_pos,
+                           int & last_tok,
+                           std::vector<float> * logits_out);
     void kvflash_read_config();
     bool kvflash_attach();
     bool kvflash_active() const { return kvflash_tokens_ > 0; }
     bool kvflash_sync_identity(int committed);
     void kvflash_sync_history(const std::vector<int32_t> & tokens, int base_pos);
     void kvflash_maybe_reselect(int generated);
+    bool use_mixed_target_split() const {
+        return remote_target_shard_.active() && !shards_.empty();
+    }
 
     Gemma4LayerSplitAdapterConfig cfg_;
     std::vector<Gemma4LayerSplitShard> shards_;
+    TargetShardIpcSession remote_target_shard_;
     std::vector<ggml_backend_t> snapshot_backends_;
     std::vector<Gemma4LayerSplitSnapshot> snapshots_;
     ggml_type activation_type_ = GGML_TYPE_F32;
@@ -105,5 +122,17 @@ private:
 };
 
 void free_gemma4_layer_split_shards(std::vector<Gemma4LayerSplitShard> & shards);
+
+int run_gemma4_target_shard_ipc_daemon(const char * target_path,
+                                       const std::vector<int> & gpus,
+                                       const std::vector<int> & layer_begins,
+                                       const std::vector<int> & layer_ends,
+                                       int max_ctx,
+                                       int fa_window,
+                                       int stream_fd,
+                                       int payload_fd = -1,
+                                       int shared_payload_fd = -1,
+                                       size_t shared_payload_bytes = 0,
+                                       int kvflash_pool_tokens = 0);
 
 }  // namespace dflash::common

--- a/server/src/ipc/backend_ipc_main.cpp
+++ b/server/src/ipc/backend_ipc_main.cpp
@@ -2,6 +2,8 @@
 
 #include "backend_ipc.h"
 #include "dflash_draft_ipc.h"
+#include "gemma4/gemma4_layer_split_adapter.h"
+#include "laguna/laguna_layer_split_adapter.h"
 #include "pflash_drafter_ipc.h"
 #include "qwen35_target_shard_ipc.h"
 
@@ -113,7 +115,17 @@ int main(int argc, char ** argv) {
             "--stream-fd=FD [--draft-gpu=N]\n"
             "   or: %s --backend-ipc-mode=qwen35-target-shard <target.gguf> "
             "--stream-fd=FD --target-gpu=N --layer-begin=N --layer-end=N "
-            "--max-ctx=N\n",
+            "--max-ctx=N [--hidden=N --vocab=N --max-tokens=N]\n"
+            "   or: %s --backend-ipc-mode=gemma4-target-shard <target.gguf> "
+            "--stream-fd=FD --target-gpus=N[,N...] --layer-begins=N[,N...] "
+            "--layer-ends=N[,N...] --max-ctx=N "
+            "[--hidden=N --vocab=N --max-tokens=N]\n"
+            "   or: %s --backend-ipc-mode=laguna-target-shard <target.gguf> "
+            "--stream-fd=FD --target-gpus=N[,N...] --layer-begins=N[,N...] "
+            "--layer-ends=N[,N...] --max-ctx=N "
+            "[--hidden=N --vocab=N --max-tokens=N]\n",
+            argv[0],
+            argv[0],
             argv[0],
             argv[0],
             argv[0]);
@@ -130,6 +142,9 @@ int main(int argc, char ** argv) {
     int layer_end = -1;
     int max_ctx = 8192;
     int max_verify_tokens = DFLASH27B_DRAFT_BLOCK_SIZE;
+    int target_hidden = 0;
+    int target_vocab = 0;
+    int target_max_tokens = 0;
     int kq_stride_pad = 32;
     int fa_window = 0;
     int payload_fd = -1;
@@ -137,6 +152,7 @@ int main(int argc, char ** argv) {
     int shared_payload_fd = -1;
     size_t shared_payload_bytes = 0;
     bool enable_dflash = false;
+    int kvflash_pool_tokens = 0;
     for (int i = arg_begin; i < argc; i++) {
         if (std::strncmp(argv[i], "--ring-cap=", 11) == 0) {
             if (!parse_nonnegative_int(argv[i] + 11, ring_cap)) return 2;
@@ -200,6 +216,24 @@ int main(int argc, char ** argv) {
             max_verify_tokens = std::atoi(argv[i] + 20);
         } else if (std::strcmp(argv[i], "--max-verify-tokens") == 0) {
             if (i + 1 < argc) max_verify_tokens = std::atoi(argv[++i]);
+        } else if (std::strncmp(argv[i], "--hidden=", 9) == 0) {
+            if (!parse_nonnegative_int(argv[i] + 9, target_hidden)) return 2;
+        } else if (std::strcmp(argv[i], "--hidden") == 0) {
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--hidden", value) ||
+                !parse_nonnegative_int(value, target_hidden)) return 2;
+        } else if (std::strncmp(argv[i], "--vocab=", 8) == 0) {
+            if (!parse_nonnegative_int(argv[i] + 8, target_vocab)) return 2;
+        } else if (std::strcmp(argv[i], "--vocab") == 0) {
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--vocab", value) ||
+                !parse_nonnegative_int(value, target_vocab)) return 2;
+        } else if (std::strncmp(argv[i], "--max-tokens=", 13) == 0) {
+            if (!parse_nonnegative_int(argv[i] + 13, target_max_tokens)) return 2;
+        } else if (std::strcmp(argv[i], "--max-tokens") == 0) {
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--max-tokens", value) ||
+                !parse_nonnegative_int(value, target_max_tokens)) return 2;
         } else if (std::strncmp(argv[i], "--kq-stride-pad=", 16) == 0) {
             kq_stride_pad = std::atoi(argv[i] + 16);
         } else if (std::strcmp(argv[i], "--kq-stride-pad") == 0) {
@@ -234,11 +268,20 @@ int main(int argc, char ** argv) {
                 !parse_size_arg(value, shared_payload_bytes)) return 2;
         } else if (std::strcmp(argv[i], "--enable-dflash") == 0) {
             enable_dflash = true;
+        } else if (std::strncmp(argv[i], "--kvflash-pool=", 15) == 0) {
+            if (!parse_nonnegative_int(argv[i] + 15, kvflash_pool_tokens)) return 2;
+        } else if (std::strcmp(argv[i], "--kvflash-pool") == 0) {
+            const char * value = nullptr;
+            if (!require_value(i, argc, argv, "--kvflash-pool", value)) return 2;
+            if (!parse_nonnegative_int(value, kvflash_pool_tokens)) return 2;
         } else {
             std::fprintf(stderr, "[backend-ipc-daemon] unknown option: %s\n", argv[i]);
             return 2;
         }
     }
+    (void)target_hidden;
+    (void)target_vocab;
+    (void)target_max_tokens;
 
     switch (mode) {
         case BackendIpcMode::DFlashDraft:
@@ -256,7 +299,23 @@ int main(int argc, char ** argv) {
                 payload_path, target_gpus, layer_begins, layer_ends, max_ctx,
                 max_verify_tokens, kq_stride_pad, fa_window, stream_fd,
                 payload_fd, shared_payload_fd, shared_payload_bytes,
-                enable_dflash);
+                enable_dflash, kvflash_pool_tokens);
+        case BackendIpcMode::Gemma4TargetShard:
+            if (target_gpus.empty()) target_gpus.push_back(target_gpu);
+            if (layer_begins.empty()) layer_begins.push_back(layer_begin);
+            if (layer_ends.empty()) layer_ends.push_back(layer_end);
+            return run_gemma4_target_shard_ipc_daemon(
+                payload_path, target_gpus, layer_begins, layer_ends, max_ctx,
+                fa_window, stream_fd, payload_fd, shared_payload_fd,
+                shared_payload_bytes, kvflash_pool_tokens);
+        case BackendIpcMode::LagunaTargetShard:
+            if (target_gpus.empty()) target_gpus.push_back(target_gpu);
+            if (layer_begins.empty()) layer_begins.push_back(layer_begin);
+            if (layer_ends.empty()) layer_ends.push_back(layer_end);
+            return run_laguna_target_shard_ipc_daemon(
+                payload_path, target_gpus, layer_begins, layer_ends, max_ctx,
+                stream_fd, payload_fd, shared_payload_fd, shared_payload_bytes,
+                kvflash_pool_tokens);
     }
     std::fprintf(stderr, "[backend-ipc-daemon] unsupported mode\n");
     return 2;

--- a/server/src/ipc/backend_ipc_main.cpp
+++ b/server/src/ipc/backend_ipc_main.cpp
@@ -284,6 +284,8 @@ int main(int argc, char ** argv) {
     (void)target_max_tokens;
 
     switch (mode) {
+        case BackendIpcMode::Invalid:
+            break;
         case BackendIpcMode::DFlashDraft:
             return run_dflash_draft_ipc_daemon(payload_path, ring_cap, draft_gpu,
                                                stream_fd, payload_fd,

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -1597,7 +1597,8 @@ int run_laguna_target_shard_ipc_daemon(const char * target_path,
         "[laguna-target-shard-daemon] ready shards=%zu layers=[%d,%d)\n",
         shards.size(), shards.front().layer_begin, shards.back().layer_end);
     const int rc = run_target_shard_ipc_daemon_loop(
-        hidden, stream_fd, payload_fd, shared_payload_fd,
+        hidden, (int)shards.front().weights.embedder.n_vocab,
+        stream_fd, payload_fd, shared_payload_fd,
         shared_payload_bytes, std::move(callbacks));
     for (int slot = 0; slot < ModelBackend::kMaxSlots; ++slot) free_slot(slot);
     auto metas = layer_split_shard_metas(shards);

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -8,7 +8,9 @@
 #include "common/layer_split_utils.h"
 #include "common/sampler.h"
 #include "common/layer_split_runtime.h"
+#include "common/target_shard_ipc_daemon.h"
 #include "dflash27b.h"
+#include "placement/placement_backend.h"
 #include "qwen3/qwen3_kvflash_scorer.h"
 
 #include "ggml-cuda.h"
@@ -41,6 +43,10 @@ LagunaLayerSplitAdapter::LagunaLayerSplitAdapter(
 LagunaLayerSplitAdapter::~LagunaLayerSplitAdapter() { shutdown(); }
 
 bool LagunaLayerSplitAdapter::init() {
+    if (cfg_.device.is_layer_split() && cfg_.remote_target_shard.enabled()) {
+        return init_mixed_target_split();
+    }
+
     const LayerSplitRuntimeInit runtime_cfg{
         cfg_.target_path,
         &cfg_.device,
@@ -107,6 +113,135 @@ bool LagunaLayerSplitAdapter::init() {
     disk_snapshot_contexts_.assign(PREFIX_SLOTS, nullptr);
     disk_snapshot_buffers_.assign(PREFIX_SLOTS, nullptr);
     disk_snapshot_backends_.assign(PREFIX_SLOTS, nullptr);
+    kvflash_history_snapshots_.resize(PREFIX_SLOTS);
+    return true;
+}
+
+bool LagunaLayerSplitAdapter::init_mixed_target_split() {
+    if (!cfg_.remote_target_shard.enabled() ||
+        cfg_.device.layer_split_gpus.size() < 2) {
+        std::fprintf(stderr,
+            "[laguna-target-split] mixed target split requires remote target shard IPC\n");
+        return false;
+    }
+    MixedLayerSplitPlan mixed_plan;
+    if (!compute_target_shard_layer_split_plan(
+            cfg_.device, compiled_placement_backend(), mixed_plan,
+            "laguna-target-split")) {
+        return false;
+    }
+
+    const auto info = inspect_gguf_model_info(cfg_.target_path);
+    const int n_layer = info.n_layer;
+    if (n_layer <= 0) {
+        std::fprintf(stderr,
+            "[laguna-target-split] failed to inspect target layer count\n");
+        return false;
+    }
+    const auto ranges = compute_layer_ranges(
+        n_layer, (int)cfg_.device.layer_split_gpus.size(),
+        cfg_.device.layer_split_weights);
+    if (ranges.size() != cfg_.device.layer_split_gpus.size()) {
+        std::fprintf(stderr,
+            "[laguna-target-split] bad mixed layer split for %zu GPUs and %d layers\n",
+            cfg_.device.layer_split_gpus.size(), n_layer);
+        return false;
+    }
+
+    const size_t remote_begin = mixed_plan.remote_begin;
+    shards_.resize(remote_begin);
+    for (size_t i = 0; i < remote_begin; ++i) {
+        auto & shard = shards_[i];
+        shard.placement_backend = cfg_.device.layer_split_backend(i);
+        shard.gpu = cfg_.device.layer_split_gpus[i];
+        shard.layer_begin = ranges[i].begin;
+        shard.layer_end = ranges[i].end;
+        shard.backend = ggml_backend_cuda_init(shard.gpu);
+        if (!shard.backend) {
+            std::fprintf(stderr,
+                "[laguna-target-split] local backend init failed gpu=%d\n",
+                shard.gpu);
+            return false;
+        }
+    }
+
+    std::vector<ggml_backend_t> shard_backends;
+    shard_backends.reserve(shards_.size());
+    for (const auto & shard : shards_) shard_backends.push_back(shard.backend);
+    const BackendActivationPolicy activation_policy =
+        select_common_activation_precision_policy(
+            shard_backends, /*force_f32=*/false,
+            "LUCEBOX_LAYER_SPLIT_ACT_TYPE");
+    activation_type_ = activation_policy.activation_type;
+
+    for (auto & shard : shards_) {
+        const TargetLoadPlan plan =
+            make_layer_split_load_plan<TargetLoadPlan>(
+                shard, /*is_last_shard=*/false);
+        if (!load_target_gguf_laguna_partial(
+                cfg_.target_path, shard.backend, plan, shard.weights)) {
+            std::fprintf(stderr,
+                "[laguna-target-split] mixed local load gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+
+    kvflash_read_config();
+    for (auto & shard : shards_) {
+        if (!create_laguna_target_cache_partial(
+                shard.weights, cfg_.device.max_ctx, shard.backend,
+                shard.layer_begin, shard.layer_end, shard.cache,
+                kvflash_tokens_)) {
+            std::fprintf(stderr,
+                "[laguna-target-split] mixed local cache gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            return false;
+        }
+    }
+    if (!kvflash_attach()) return false;
+
+    std::vector<int> remote_gpus;
+    std::vector<int> remote_layer_begins;
+    std::vector<int> remote_layer_ends;
+    for (size_t i = remote_begin; i < cfg_.device.layer_split_gpus.size(); ++i) {
+        remote_gpus.push_back(cfg_.device.layer_split_gpus[i]);
+        remote_layer_begins.push_back(ranges[i].begin);
+        remote_layer_ends.push_back(ranges[i].end);
+    }
+
+    const LagunaTargetWeights & ref = shards_.front().weights;
+    TargetShardIpcLaunchConfig launch;
+    launch.mode = BackendIpcMode::LagunaTargetShard;
+    launch.bin = cfg_.remote_target_shard.ipc_bin;
+    launch.target_path = cfg_.target_path ? cfg_.target_path : "";
+    launch.gpus = remote_gpus;
+    launch.layer_begins = remote_layer_begins;
+    launch.layer_ends = remote_layer_ends;
+    launch.max_ctx = cfg_.device.max_ctx;
+    launch.hidden = ref.n_embd;
+    launch.vocab = (int)ref.embedder.n_vocab;
+    launch.max_tokens = std::max(1, cfg_.device.max_ctx);
+    launch.work_dir = cfg_.remote_target_shard.work_dir;
+    launch.kvflash_pool_tokens = kvflash_tokens_;
+    if (!remote_target_shard_.start(launch)) {
+        std::fprintf(stderr,
+            "[laguna-target-split] remote target shard start failed layers=[%d,%d)\n",
+            remote_layer_begins.front(), remote_layer_ends.back());
+        return false;
+    }
+
+    snapshots_.resize(PREFIX_SLOTS);
+    for (auto & slot : snapshots_) slot.shards.resize(shards_.size());
+    snapshot_prefill_logit_tensors_.resize(PREFIX_SLOTS);
+    disk_snapshot_contexts_.assign(PREFIX_SLOTS, nullptr);
+    disk_snapshot_buffers_.assign(PREFIX_SLOTS, nullptr);
+    disk_snapshot_backends_.assign(PREFIX_SLOTS, nullptr);
+    auto shard_metas = layer_split_shard_metas(shards_);
+    if (!init_layer_split_snapshot_backends(
+            shard_metas, snapshot_backends_, "laguna-target-split")) {
+        return false;
+    }
     kvflash_history_snapshots_.resize(PREFIX_SLOTS);
     return true;
 }
@@ -201,35 +336,29 @@ bool LagunaLayerSplitAdapter::kvflash_attach() {
 
 bool LagunaLayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_) {
-        std::fprintf(stderr,
-            "[laguna-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
-            committed, kvflash_tokens_);
+    if (!layer_split_kvflash_sync_identity(
+            kvflash_pager_, committed, kvflash_tokens_, "laguna-target-split")) {
         return false;
     }
-    kvflash_pager_.reset();
-    if (!kvflash_pager_.alloc_span(0, committed)) return false;
-    kvflash_pager_.zero_free_blocks();
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.kvflash_sync_identity(committed)) {
+        std::fprintf(stderr,
+            "[laguna-target-split][kvflash] remote identity sync failed pos=%d\n",
+            committed);
+        return false;
+    }
     return true;
 }
 
 void LagunaLayerSplitAdapter::kvflash_sync_history(
         const std::vector<int32_t> & tokens, int base_pos) {
     if (!kvflash_active()) return;
-    if (base_pos == 0) {
-        kvflash_history_.assign(tokens.begin(), tokens.end());
-        return;
-    }
-    if ((int)kvflash_history_.size() > base_pos) {
-        kvflash_history_.resize((size_t)base_pos);
-    } else if ((int)kvflash_history_.size() < base_pos) {
-        kvflash_history_.resize((size_t)base_pos, 0);
-    }
-    kvflash_history_.insert(kvflash_history_.end(), tokens.begin(), tokens.end());
+    layer_split_kvflash_sync_history(kvflash_history_, tokens, base_pos);
 }
 
 void LagunaLayerSplitAdapter::kvflash_maybe_reselect(int generated) {
     if (!kvflash_active() || kvflash_tau_ <= 0) return;
+    if (use_mixed_target_split()) return;
     const int tau = std::max<int>(kvflash_tau_, (int)(kvflash_history_.size() / 45));
     if (generated % tau != 0) return;
     if (!kvflash_scorer_) {
@@ -288,6 +417,11 @@ void LagunaLayerSplitAdapter::reset_request_state() {
         kvflash_history_.clear();
         kvflash_scores_.clear();
         kvflash_pager_.score_hook = nullptr;
+    }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.reset_request_state()) {
+        std::fprintf(stderr,
+            "[laguna-target-split] remote shard reset_request_state failed\n");
     }
     prefill_last_logits_.clear();
 }
@@ -496,10 +630,220 @@ bool LagunaLayerSplitAdapter::run_forward(
     return true;
 }
 
+bool LagunaLayerSplitAdapter::run_mixed_forward(
+        const std::vector<int32_t> & tokens,
+        int base_pos,
+        int & last_tok,
+        std::vector<float> * logits_out) {
+    if (!use_mixed_target_split() || tokens.empty()) return false;
+    const LagunaTargetWeights & ref = shards_.front().weights;
+    const int hidden = ref.n_embd;
+    const int n_tokens_total = (int)tokens.size();
+    int ubatch = cfg_.chunk > 0 ? cfg_.chunk : 2048;
+    if (const char * e = std::getenv("DFLASH_LAGUNA_LAYER_SPLIT_UBATCH")) {
+        ubatch = std::max(1, std::atoi(e));
+    }
+    if (base_pos < 0 || base_pos + n_tokens_total > cfg_.device.max_ctx) {
+        std::fprintf(stderr,
+            "[laguna-target-split] mixed range [%d,%d) exceeds max_ctx=%d\n",
+            base_pos, base_pos + n_tokens_total, cfg_.device.max_ctx);
+        return false;
+    }
+
+    ActivationPair acts;
+    if (!activation_pair_init(acts, shards_.front().backend, hidden,
+                              n_tokens_total, activation_type_)) {
+        std::fprintf(stderr,
+            "[laguna-target-split] mixed activation alloc failed gpu=%d\n",
+            shards_.front().gpu);
+        return false;
+    }
+
+    {
+        constexpr int kEmbedBatch = 4096;
+        std::vector<float> emb((size_t)hidden * std::min(kEmbedBatch, n_tokens_total));
+        for (int i = 0; i < n_tokens_total; i += kEmbedBatch) {
+            const int n = std::min(kEmbedBatch, n_tokens_total - i);
+            if ((int)emb.size() < hidden * n) emb.resize((size_t)hidden * n);
+            if (!ref.embedder.embed(tokens.data() + i, n, emb.data())) {
+                activation_pair_free(acts);
+                return false;
+            }
+            const size_t off = (size_t)i * acts.a->nb[1];
+            if (!set_activation_tensor_from_f32(
+                    acts.a, emb.data(), off, (size_t)hidden * (size_t)n)) {
+                activation_pair_free(acts);
+                return false;
+            }
+        }
+    }
+
+    ggml_tensor * act_in = acts.a;
+    ggml_tensor * act_out = acts.b;
+    LagunaLayerSplitShard * current_shard = &shards_.front();
+    for (int il = shards_.front().layer_begin; il < shards_.back().layer_end; ++il) {
+        LagunaLayerSplitShard * shard = find_layer_split_shard(shards_, il);
+        if (!shard) {
+            std::fprintf(stderr,
+                "[laguna-target-split] mixed missing local owner for layer %d\n",
+                il);
+            activation_pair_free(acts);
+            return false;
+        }
+        if (shard != current_shard) {
+            ActivationPair next_acts;
+            if (!activation_pair_init(next_acts, shard->backend, hidden,
+                                      n_tokens_total, activation_type_)) {
+                activation_pair_free(acts);
+                return false;
+            }
+            ggml_backend_synchronize(current_shard->backend);
+            ggml_backend_tensor_copy(act_in, next_acts.a);
+            ggml_backend_synchronize(shard->backend);
+            activation_pair_free(acts);
+            acts = next_acts;
+            act_in = acts.a;
+            act_out = acts.b;
+            current_shard = shard;
+        }
+
+        for (int start = 0; start < n_tokens_total;) {
+            const int n = std::min(ubatch, n_tokens_total - start);
+            const int kv_start = base_pos + start;
+            if (kvflash_active() && !kvflash_pager_.alloc_span(kv_start, n)) {
+                activation_pair_free(acts);
+                return false;
+            }
+            if (!build_laguna_layer_step(
+                    shard->layer_graph, shard->weights, shard->cache,
+                    shard->backend, il, act_in, act_out, start, n, kv_start,
+                    kvflash_active() ? &kvflash_pager_ : nullptr)) {
+                std::fprintf(stderr,
+                    "[laguna-target-split] mixed build layer=%d @%d gpu=%d\n",
+                    il, start, shard->gpu);
+                activation_pair_free(acts);
+                return false;
+            }
+
+            std::vector<int32_t> pos((size_t)n);
+            for (int i = 0; i < n; ++i) pos[(size_t)i] = kv_start + i;
+            if (!tensor_ready(shard->layer_graph.positions)) {
+                activation_pair_free(acts);
+                return false;
+            }
+            ggml_backend_tensor_set(shard->layer_graph.positions, pos.data(), 0,
+                                    sizeof(int32_t) * pos.size());
+
+            if (kvflash_active()) {
+                std::vector<int32_t> rows;
+                std::vector<float> mfull;
+                std::vector<float> mswa;
+                const ggml_tensor * mask_ref =
+                    shard->layer_graph.attn_mask ? shard->layer_graph.attn_mask
+                                                 : shard->layer_graph.attn_mask_swa;
+                if (!mask_ref ||
+                    !kvflash_fill_rows_and_masks(
+                        kvflash_pager_, kv_start, n,
+                        (int)mask_ref->ne[0],
+                        ref.sliding_window, rows, &mfull, &mswa)) {
+                    activation_pair_free(acts);
+                    return false;
+                }
+                if (tensor_ready(shard->layer_graph.kv_idx)) {
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx,
+                                            rows.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx));
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask,
+                                            mfull.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask));
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask_swa,
+                                            mswa.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                }
+            } else {
+                const int kv_len = kv_start + n;
+                std::vector<float> mfull((size_t)kv_len * n, -INFINITY);
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    for (int k = 0; k <= abs_q && k < kv_len; ++k) {
+                        mfull[(size_t)q * kv_len + k] = 0.0f;
+                    }
+                }
+                if (tensor_ready(shard->layer_graph.kv_idx)) {
+                    ggml_backend_tensor_set(shard->layer_graph.kv_idx,
+                                            pos.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.kv_idx));
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask,
+                                            mfull.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask));
+                }
+                std::vector<float> mswa((size_t)kv_len * n, -INFINITY);
+                for (int q = 0; q < n; ++q) {
+                    const int abs_q = kv_start + q;
+                    const int win_lo = std::max(0, abs_q - ref.sliding_window + 1);
+                    for (int k = win_lo; k <= abs_q && k < kv_len; ++k) {
+                        mswa[(size_t)q * kv_len + k] = 0.0f;
+                    }
+                }
+                if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                    ggml_backend_tensor_set(shard->layer_graph.attn_mask_swa,
+                                            mswa.data(), 0,
+                                            ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                }
+            }
+
+            auto st = ggml_backend_graph_compute(shard->backend,
+                                                 shard->layer_graph.gf);
+            if (st != GGML_STATUS_SUCCESS) {
+                std::fprintf(stderr,
+                    "[laguna-target-split] mixed compute layer=%d @%d gpu=%d status=%d\n",
+                    il, start, shard->gpu, (int)st);
+                activation_pair_free(acts);
+                return false;
+            }
+            start += n;
+        }
+        std::swap(act_in, act_out);
+    }
+
+    std::vector<float> boundary;
+    if (!copy_activation_to_host(act_in, shards_.back().backend, 0,
+                                 n_tokens_total, hidden, boundary)) {
+        activation_pair_free(acts);
+        return false;
+    }
+    activation_pair_free(acts);
+
+    TargetShardForwardRequest req;
+    req.base_pos = base_pos;
+    req.n_tokens = n_tokens_total;
+    req.boundary_activation = &boundary;
+    req.ubatch = ubatch;
+    req.want_argmax = false;
+    req.want_logits = logits_out != nullptr;
+    TargetShardForwardResponse resp;
+    resp.logits_out = logits_out;
+    if (!remote_target_shard_.forward(req, resp)) return false;
+    last_tok = resp.last_tok;
+    for (auto & shard : shards_) {
+        shard.cache.cur_pos = base_pos + n_tokens_total;
+        shard.cache.last_tok = last_tok;
+    }
+    return true;
+}
+
 bool LagunaLayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
                                       int base_pos,
                                       int & last_tok) {
-    const bool ok = run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
+    const bool ok = use_mixed_target_split()
+        ? run_mixed_forward(prompt, base_pos, last_tok, &prefill_last_logits_)
+        : run_forward(prompt, base_pos, last_tok, &prefill_last_logits_);
     if (ok && kvflash_active()) {
         kvflash_sync_history(prompt, base_pos);
         kvflash_pager_.zero_free_blocks();
@@ -523,7 +867,9 @@ bool LagunaLayerSplitAdapter::decode_ar(
         sampler_rng_,
         [&](const std::vector<int32_t> & one, int pos, int & next_tok,
             std::vector<float> * logits_out) {
-            return run_forward(one, pos - 1, next_tok, logits_out);
+            return use_mixed_target_split()
+                ? run_mixed_forward(one, pos - 1, next_tok, logits_out)
+                : run_forward(one, pos - 1, next_tok, logits_out);
         },
         [&](int tok) { return tok == w.eos_id || tok == w.eos_chat_id; },
         out_tokens, io);
@@ -564,22 +910,24 @@ bool LagunaLayerSplitAdapter::snapshot_save(int slot) {
             return false;
         }
     }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.snapshot_save(slot)) {
+        snapshot_free(slot);
+        return false;
+    }
     snap.cur_pos = snap_pos;
     snap.last_tok = shards_.front().cache.last_tok;
     snap.prefill_last_logits = prefill_last_logits_;
     if (kvflash_active() &&
         kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
-        auto & history_snap = kvflash_history_snapshots_[(size_t)slot];
-        history_snap.clear();
-        const size_t keep = (size_t)std::min(snap_pos, (int)kvflash_history_.size());
-        history_snap.assign(kvflash_history_.begin(), kvflash_history_.begin() + keep);
-        if ((int)history_snap.size() < snap_pos) {
-            history_snap.resize((size_t)snap_pos, 0);
-        }
+        layer_split_kvflash_save_history_snapshot(
+            kvflash_history_, snap_pos, kvflash_history_snapshots_[(size_t)slot]);
     }
-    if (!rebuild_disk_snapshot(slot)) {
-        snapshot_free(slot);
-        return false;
+    if (!use_mixed_target_split()) {
+        if (!rebuild_disk_snapshot(slot)) {
+            snapshot_free(slot);
+            return false;
+        }
     }
     return true;
 }
@@ -620,6 +968,9 @@ void LagunaLayerSplitAdapter::snapshot_free(int slot) {
         kvflash_history_snapshots_[(size_t)slot].clear();
     }
     if (snap.shards.size() != shards_.size()) snap.shards.resize(shards_.size());
+    if (use_mixed_target_split()) {
+        remote_target_shard_.snapshot_free(slot);
+    }
 }
 
 bool LagunaLayerSplitAdapter::snapshot_used(int slot) const {
@@ -650,25 +1001,21 @@ bool LagunaLayerSplitAdapter::snapshot_restore(int slot) {
         }
         shards_[i].cache.last_tok = snap.last_tok;
     }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.snapshot_restore(slot)) {
+        return false;
+    }
     prefill_last_logits_ = snap.prefill_last_logits;
     if (kvflash_active()) {
         if (!kvflash_sync_identity(snap.cur_pos)) return false;
-        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS &&
-            !kvflash_history_snapshots_[(size_t)slot].empty()) {
-            kvflash_history_ = kvflash_history_snapshots_[(size_t)slot];
-        } else {
-            kvflash_history_.clear();
-        }
-        if ((int)kvflash_history_.size() > snap.cur_pos) {
-            kvflash_history_.resize((size_t)snap.cur_pos);
-        } else if ((int)kvflash_history_.size() < snap.cur_pos) {
-            kvflash_history_.resize((size_t)snap.cur_pos, 0);
-        }
+        layer_split_kvflash_restore_history(
+            kvflash_history_, kvflash_history_snapshots_, slot, snap.cur_pos);
     }
     return true;
 }
 
 bool LagunaLayerSplitAdapter::rebuild_disk_snapshot(int slot) {
+    if (use_mixed_target_split()) return false;
     if (!snapshot_used(slot) ||
         slot < 0 || slot >= (int)snapshots_.size() ||
         disk_snapshot_contexts_.size() != (size_t)PREFIX_SLOTS ||
@@ -880,6 +1227,7 @@ void LagunaLayerSplitAdapter::shutdown() {
     kvflash_history_snapshots_.clear();
     auto shard_metas = layer_split_shard_metas(shards_);
     free_layer_split_snapshot_backends(shard_metas, snapshot_backends_);
+    remote_target_shard_.close();
     free_laguna_layer_split_shards(shards_);
 }
 
@@ -895,6 +1243,368 @@ void free_laguna_layer_split_shards(
         }
     }
     shards.clear();
+}
+
+int run_laguna_target_shard_ipc_daemon(const char * target_path,
+                                       const std::vector<int> & gpus,
+                                       const std::vector<int> & layer_begins,
+                                       const std::vector<int> & layer_ends,
+                                       int max_ctx,
+                                       int stream_fd,
+                                       int payload_fd,
+                                       int shared_payload_fd,
+                                       size_t shared_payload_bytes,
+                                       int kvflash_pool_tokens) {
+#if defined(_WIN32)
+    (void)target_path; (void)gpus; (void)layer_begins; (void)layer_ends;
+    (void)max_ctx; (void)stream_fd; (void)payload_fd; (void)shared_payload_fd;
+    (void)shared_payload_bytes; (void)kvflash_pool_tokens;
+    std::fprintf(stderr, "Laguna target shard IPC daemon is only implemented on POSIX hosts\n");
+    return 2;
+#else
+    if (!target_path || gpus.empty() || gpus.size() != layer_begins.size() ||
+        gpus.size() != layer_ends.size() || max_ctx <= 0 || stream_fd < 0) {
+        std::fprintf(stderr,
+            "usage: backend_ipc_daemon --backend-ipc-mode=laguna-target-shard "
+            "<target.gguf> --target-gpus=N[,N...] "
+            "--layer-begins=N[,N...] --layer-ends=N[,N...] "
+            "--max-ctx=N --stream-fd=FD [--payload-fd=FD]\n");
+        return 2;
+    }
+    for (size_t i = 0; i < gpus.size(); ++i) {
+        if (gpus[i] < 0 || layer_begins[i] < 0 ||
+            layer_ends[i] <= layer_begins[i] ||
+            (i > 0 && layer_begins[i] != layer_ends[i - 1])) {
+            std::fprintf(stderr,
+                "[laguna-target-shard-daemon] bad shard config\n");
+            return 2;
+        }
+    }
+
+    std::vector<LagunaLayerSplitShard> shards(gpus.size());
+    for (size_t i = 0; i < shards.size(); ++i) {
+        auto & shard = shards[i];
+        shard.gpu = gpus[i];
+        shard.layer_begin = layer_begins[i];
+        shard.layer_end = layer_ends[i];
+        shard.backend = ggml_backend_cuda_init(shard.gpu);
+        if (!shard.backend) {
+            std::fprintf(stderr,
+                "[laguna-target-shard-daemon] backend init failed gpu=%d\n",
+                shard.gpu);
+            free_laguna_layer_split_shards(shards);
+            return 1;
+        }
+    }
+    for (size_t i = 0; i < shards.size(); ++i) {
+        auto & shard = shards[i];
+        const bool is_last = i + 1 == shards.size();
+        const TargetLoadPlan plan =
+            make_layer_split_load_plan<TargetLoadPlan>(shard, is_last);
+        if (!load_target_gguf_laguna_partial(
+                target_path, shard.backend, plan, shard.weights) ||
+            !create_laguna_target_cache_partial(
+                shard.weights, max_ctx, shard.backend,
+                shard.layer_begin, shard.layer_end, shard.cache,
+                kvflash_pool_tokens)) {
+            std::fprintf(stderr,
+                "[laguna-target-shard-daemon] load/cache failed gpu=%d: %s\n",
+                shard.gpu, dflash27b_last_error());
+            free_laguna_layer_split_shards(shards);
+            return 1;
+        }
+    }
+
+    std::vector<ggml_backend_t> snapshot_backends;
+    if (!init_layer_split_snapshot_backends(
+            layer_split_shard_metas(shards), snapshot_backends,
+            "laguna-target-shard-daemon")) {
+        free_laguna_layer_split_shards(shards);
+        return 1;
+    }
+    std::vector<LagunaLayerSplitSnapshot> snapshots(
+        (size_t)ModelBackend::kMaxSlots);
+    for (auto & slot : snapshots) slot.shards.resize(shards.size());
+    auto free_slot = [&](int slot) {
+        if (slot < 0 || slot >= ModelBackend::kMaxSlots) return;
+        auto & snap = snapshots[(size_t)slot];
+        for (auto & ss : snap.shards) laguna_snapshot_free(ss);
+        snap.cur_pos = 0;
+        snap.last_tok = -1;
+        snap.prefill_last_logits.clear();
+        if (snap.shards.size() != shards.size()) snap.shards.resize(shards.size());
+    };
+
+    KvFlashPager kvflash_pager;
+    if (kvflash_pool_tokens > 0) {
+        std::vector<ggml_tensor *> all_k;
+        std::vector<ggml_tensor *> all_v;
+        const int n_layer = shards.front().weights.n_layer;
+        for (int il = 0; il < n_layer; ++il) {
+            ggml_tensor * k = nullptr;
+            ggml_tensor * v = nullptr;
+            for (auto & shard : shards) {
+                if (il < (int)shard.cache.attn_k.size() &&
+                    shard.cache.attn_k[(size_t)il]) {
+                    k = shard.cache.attn_k[(size_t)il];
+                    v = shard.cache.attn_v[(size_t)il];
+                    break;
+                }
+            }
+            if (k && v) {
+                all_k.push_back(k);
+                all_v.push_back(v);
+            }
+        }
+        KvFlashConfig pc;
+        pc.pool_tokens = kvflash_pool_tokens;
+        if (!all_k.empty()) {
+            pc.tail_window_chunks =
+                std::max(4, (shards.front().weights.sliding_window +
+                             pc.chunk_tokens - 1) / pc.chunk_tokens + 1);
+        }
+        if (!kvflash_pager.attach(pc, all_k, all_v)) {
+            auto metas = layer_split_shard_metas(shards);
+            free_layer_split_snapshot_backends(metas, snapshot_backends);
+            free_laguna_layer_split_shards(shards);
+            return 1;
+        }
+    }
+
+    const int hidden = shards.front().weights.n_embd;
+    std::vector<float> prefill_last_logits;
+    TargetShardDaemonCallbacks callbacks;
+    callbacks.log_prefix = "laguna-target-shard-daemon";
+    callbacks.forward = [&](const TargetShardDaemonForwardRequest & req,
+                            TargetShardDaemonForwardResponse & resp) -> bool {
+        if (!req.boundary_activation || req.n_tokens <= 0 ||
+            (int)req.boundary_activation->size() != hidden * req.n_tokens ||
+            req.base_pos < 0 || req.base_pos + req.n_tokens > max_ctx) {
+            return false;
+        }
+        const int n_tokens = req.n_tokens;
+        int ubatch = std::max(1, req.ubatch > 0 ? req.ubatch : n_tokens);
+        ActivationPair acts;
+        if (!activation_pair_init(acts, shards.front().backend, hidden, n_tokens)) {
+            return false;
+        }
+        ggml_backend_tensor_set(acts.a, req.boundary_activation->data(), 0,
+                                sizeof(float) * req.boundary_activation->size());
+        ggml_tensor * act_in = acts.a;
+        ggml_tensor * act_out = acts.b;
+        LagunaLayerSplitShard * current_shard = &shards.front();
+        bool ok = true;
+        for (int il = shards.front().layer_begin;
+             ok && il < shards.back().layer_end; ++il) {
+            LagunaLayerSplitShard * shard = find_layer_split_shard(shards, il);
+            if (!shard) {
+                ok = false;
+                break;
+            }
+            if (shard != current_shard) {
+                ActivationPair next_acts;
+                if (!activation_pair_init(next_acts, shard->backend,
+                                          hidden, n_tokens)) {
+                    ok = false;
+                    break;
+                }
+                ggml_backend_synchronize(current_shard->backend);
+                ggml_backend_tensor_copy(act_in, next_acts.a);
+                ggml_backend_synchronize(shard->backend);
+                activation_pair_free(acts);
+                acts = next_acts;
+                act_in = acts.a;
+                act_out = acts.b;
+                current_shard = shard;
+            }
+            for (int start = 0; ok && start < n_tokens;) {
+                const int n = std::min(ubatch, n_tokens - start);
+                const int kv_start = req.base_pos + start;
+                if (kvflash_pool_tokens > 0 &&
+                    !kvflash_pager.alloc_span(kv_start, n)) {
+                    ok = false;
+                    break;
+                }
+                if (!build_laguna_layer_step(
+                        shard->layer_graph, shard->weights, shard->cache,
+                        shard->backend, il, act_in, act_out, start, n,
+                        kv_start,
+                        kvflash_pool_tokens > 0 ? &kvflash_pager : nullptr)) {
+                    ok = false;
+                    break;
+                }
+                std::vector<int32_t> pos((size_t)n);
+                for (int i = 0; i < n; ++i) pos[(size_t)i] = kv_start + i;
+                if (!tensor_ready(shard->layer_graph.positions)) {
+                    ok = false;
+                    break;
+                }
+                ggml_backend_tensor_set(shard->layer_graph.positions,
+                                        pos.data(), 0,
+                                        sizeof(int32_t) * pos.size());
+                if (kvflash_pool_tokens > 0) {
+                    std::vector<int32_t> rows;
+                    std::vector<float> mfull;
+                    std::vector<float> mswa;
+                    const ggml_tensor * mask_ref =
+                        shard->layer_graph.attn_mask
+                            ? shard->layer_graph.attn_mask
+                            : shard->layer_graph.attn_mask_swa;
+                    if (!mask_ref ||
+                        !kvflash_fill_rows_and_masks(
+                            kvflash_pager, kv_start, n, (int)mask_ref->ne[0],
+                            shard->weights.sliding_window,
+                            rows, &mfull, &mswa)) {
+                        ok = false;
+                        break;
+                    }
+                    if (tensor_ready(shard->layer_graph.kv_idx)) {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.kv_idx, rows.data(), 0,
+                            ggml_nbytes(shard->layer_graph.kv_idx));
+                    }
+                    if (tensor_ready(shard->layer_graph.attn_mask)) {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.attn_mask, mfull.data(), 0,
+                            ggml_nbytes(shard->layer_graph.attn_mask));
+                    }
+                    if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.attn_mask_swa, mswa.data(), 0,
+                            ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                    }
+                } else {
+                    const int kv_len = kv_start + n;
+                    std::vector<float> mfull((size_t)kv_len * n, -INFINITY);
+                    for (int q = 0; q < n; ++q) {
+                        const int abs_q = kv_start + q;
+                        for (int k = 0; k <= abs_q && k < kv_len; ++k) {
+                            mfull[(size_t)q * kv_len + k] = 0.0f;
+                        }
+                    }
+                    if (tensor_ready(shard->layer_graph.kv_idx)) {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.kv_idx, pos.data(), 0,
+                            ggml_nbytes(shard->layer_graph.kv_idx));
+                    }
+                    if (tensor_ready(shard->layer_graph.attn_mask)) {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.attn_mask, mfull.data(), 0,
+                            ggml_nbytes(shard->layer_graph.attn_mask));
+                    }
+                    std::vector<float> mswa((size_t)kv_len * n, -INFINITY);
+                    for (int q = 0; q < n; ++q) {
+                        const int abs_q = kv_start + q;
+                        const int win_lo = std::max(
+                            0, abs_q - shard->weights.sliding_window + 1);
+                        for (int k = win_lo; k <= abs_q && k < kv_len; ++k) {
+                            mswa[(size_t)q * kv_len + k] = 0.0f;
+                        }
+                    }
+                    if (tensor_ready(shard->layer_graph.attn_mask_swa)) {
+                        ggml_backend_tensor_set(
+                            shard->layer_graph.attn_mask_swa, mswa.data(), 0,
+                            ggml_nbytes(shard->layer_graph.attn_mask_swa));
+                    }
+                }
+                auto st = ggml_backend_graph_compute(shard->backend,
+                                                     shard->layer_graph.gf);
+                ok = st == GGML_STATUS_SUCCESS;
+                start += n;
+            }
+            std::swap(act_in, act_out);
+        }
+        if (ok) {
+            std::vector<int32_t> argmax;
+            LagunaLayerSplitShard & last = shards.back();
+            ok = compute_laguna_split_projection(
+                last.backend, last.weights, act_in,
+                req.want_argmax ? 0 : n_tokens - 1,
+                req.want_argmax ? n_tokens : 1,
+                &argmax, req.want_logits ? &resp.logits : nullptr);
+            if (ok && !argmax.empty()) {
+                resp.last_tok = argmax.back();
+                if (req.want_argmax) resp.argmax = std::move(argmax);
+                if (req.want_logits) prefill_last_logits = resp.logits;
+            } else {
+                ok = false;
+            }
+        }
+        activation_pair_free(acts);
+        if (!ok) return false;
+        for (auto & shard : shards) {
+            shard.cache.cur_pos = req.base_pos + n_tokens;
+            shard.cache.last_tok = resp.last_tok;
+        }
+        return true;
+    };
+    callbacks.reset_request_state = [&]() {
+        for (auto & shard : shards) reset_laguna_target_cache(shard.cache);
+        if (kvflash_pool_tokens > 0) kvflash_pager.reset();
+        prefill_last_logits.clear();
+        return true;
+    };
+    callbacks.kvflash_sync_identity = [&](int committed) {
+        if (kvflash_pool_tokens <= 0) return true;
+        return layer_split_kvflash_sync_identity(
+            kvflash_pager, committed, kvflash_pool_tokens,
+            "laguna-target-shard-daemon");
+    };
+    callbacks.snapshot_save = [&](int slot) {
+        if (slot < 0 || slot >= ModelBackend::kMaxSlots ||
+            snapshot_backends.size() != shards.size()) {
+            return false;
+        }
+        free_slot(slot);
+        auto & snap = snapshots[(size_t)slot];
+        if (snap.shards.size() != shards.size()) snap.shards.resize(shards.size());
+        for (size_t i = 0; i < shards.size(); ++i) {
+            if (!laguna_snapshot_save(
+                    shards[i].cache, snapshot_backends[i],
+                    shards[i].weights.n_layer, shards[i].weights.n_head_kv,
+                    shards[i].weights.head_dim, snap.shards[i])) {
+                free_slot(slot);
+                return false;
+            }
+        }
+        snap.cur_pos = shards.front().cache.cur_pos;
+        snap.last_tok = shards.front().cache.last_tok;
+        snap.prefill_last_logits = prefill_last_logits;
+        return true;
+    };
+    callbacks.snapshot_free = [&](int slot) { free_slot(slot); };
+    callbacks.snapshot_restore = [&](int slot) {
+        if (slot < 0 || slot >= ModelBackend::kMaxSlots) return false;
+        auto & snap = snapshots[(size_t)slot];
+        if (snap.cur_pos <= 0 || snap.shards.size() != shards.size()) return false;
+        for (size_t i = 0; i < shards.size(); ++i) {
+            if (snap.shards[i].cur_pos != snap.cur_pos ||
+                !laguna_snapshot_restore(snap.shards[i], shards[i].cache)) {
+                return false;
+            }
+            shards[i].cache.last_tok = snap.last_tok;
+        }
+        prefill_last_logits = snap.prefill_last_logits;
+        if (kvflash_pool_tokens > 0) {
+            return layer_split_kvflash_sync_identity(
+                kvflash_pager, snap.cur_pos, kvflash_pool_tokens,
+                "laguna-target-shard-daemon");
+        }
+        return true;
+    };
+
+    std::fprintf(stderr,
+        "[laguna-target-shard-daemon] ready shards=%zu layers=[%d,%d)\n",
+        shards.size(), shards.front().layer_begin, shards.back().layer_end);
+    const int rc = run_target_shard_ipc_daemon_loop(
+        hidden, stream_fd, payload_fd, shared_payload_fd,
+        shared_payload_bytes, std::move(callbacks));
+    for (int slot = 0; slot < ModelBackend::kMaxSlots; ++slot) free_slot(slot);
+    auto metas = layer_split_shard_metas(shards);
+    free_layer_split_snapshot_backends(metas, snapshot_backends);
+    free_laguna_layer_split_shards(shards);
+    return rc;
+#endif
 }
 
 }  // namespace dflash::common

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -201,7 +201,7 @@ bool LagunaLayerSplitAdapter::kvflash_attach() {
 
 bool LagunaLayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+    if (committed > kvflash_tokens_) {
         std::fprintf(stderr,
             "[laguna-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/laguna/laguna_layer_split_adapter.cpp
+++ b/server/src/laguna/laguna_layer_split_adapter.cpp
@@ -201,7 +201,7 @@ bool LagunaLayerSplitAdapter::kvflash_attach() {
 
 bool LagunaLayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_) {
+    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
         std::fprintf(stderr,
             "[laguna-target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/laguna/laguna_layer_split_adapter.h
+++ b/server/src/laguna/laguna_layer_split_adapter.h
@@ -3,11 +3,14 @@
 #pragma once
 
 #include "common/layer_split_backend.h"
+#include "common/layer_split_kvflash.h"
 #include "common/layer_split_utils.h"
 #include "common/kvflash_pager.h"
 #include "common/kvflash_scorer.h"
+#include "common/target_shard_ipc.h"
 #include "laguna_internal.h"
 #include "placement/placement_config.h"
+#include "placement/remote_target_shard_config.h"
 #include "qwen3/qwen3_drafter.h"
 
 #include "ggml-backend.h"
@@ -22,6 +25,7 @@ namespace dflash::common {
 struct LagunaLayerSplitAdapterConfig {
     const char * target_path = nullptr;
     DevicePlacement device;
+    RemoteTargetShardConfig remote_target_shard;
     int chunk = 2048;
 };
 
@@ -58,6 +62,10 @@ public:
                    std::vector<int32_t> & out_tokens,
                    const DaemonIO & io) override;
     bool supports_cpu_sampling() const override { return true; }
+    bool supports_kvflash() const override { return kvflash_active(); }
+    bool supports_mixed_backend_layer_split() const override {
+        return use_mixed_target_split();
+    }
 
     bool snapshot_save(int slot) override;
     void snapshot_free(int slot) override;
@@ -78,6 +86,11 @@ private:
                      int base_pos,
                      int & last_tok,
                      std::vector<float> * logits_out = nullptr);
+    bool init_mixed_target_split();
+    bool run_mixed_forward(const std::vector<int32_t> & tokens,
+                           int base_pos,
+                           int & last_tok,
+                           std::vector<float> * logits_out);
     bool rebuild_disk_snapshot(int slot);
     KvFlashConfig kvflash_config() const;
     void kvflash_read_config();
@@ -86,9 +99,13 @@ private:
     bool kvflash_sync_identity(int committed);
     void kvflash_sync_history(const std::vector<int32_t> & tokens, int base_pos);
     void kvflash_maybe_reselect(int generated);
+    bool use_mixed_target_split() const {
+        return remote_target_shard_.active() && !shards_.empty();
+    }
 
     LagunaLayerSplitAdapterConfig cfg_;
     std::vector<LagunaLayerSplitShard> shards_;
+    TargetShardIpcSession remote_target_shard_;
     std::vector<ggml_backend_t> snapshot_backends_;
     std::vector<LagunaLayerSplitSnapshot> snapshots_;
     std::vector<std::vector<ggml_tensor *>> snapshot_prefill_logit_tensors_;
@@ -114,5 +131,16 @@ private:
 };
 
 void free_laguna_layer_split_shards(std::vector<LagunaLayerSplitShard> & shards);
+
+int run_laguna_target_shard_ipc_daemon(const char * target_path,
+                                       const std::vector<int> & gpus,
+                                       const std::vector<int> & layer_begins,
+                                       const std::vector<int> & layer_ends,
+                                       int max_ctx,
+                                       int stream_fd,
+                                       int payload_fd = -1,
+                                       int shared_payload_fd = -1,
+                                       size_t shared_payload_bytes = 0,
+                                       int kvflash_pool_tokens = 0);
 
 }  // namespace dflash::common

--- a/server/src/laguna/laguna_target_graph.cpp
+++ b/server/src/laguna/laguna_target_graph.cpp
@@ -834,8 +834,7 @@ bool build_laguna_layer_step(
     ggml_set_input(sg.positions);
 
     const int kv_len = kv_start + n_tokens;
-    const int kv_cap = cache.attn_k[(size_t)layer_idx]
-        ? (int)cache.attn_k[(size_t)layer_idx]->ne[1] : cache.max_ctx;
+    const int kv_cap = (int)cache.attn_k[(size_t)layer_idx]->ne[1];
     const int kv_pad = std::min((kv_len + 255) & ~255, kv_cap);
     const int mk_w = kvflash ? kv_pad : kv_len;
     sg.attn_mask = ggml_new_tensor_4d(sg.ctx, GGML_TYPE_F32, mk_w, n_tokens, 1, 1);

--- a/server/src/qwen35/layer_split_forward.cpp
+++ b/server/src/qwen35/layer_split_forward.cpp
@@ -361,7 +361,8 @@ bool run_qwen35_layer_split_layers_from_activation(
         std::vector<Qwen35TargetCaptureSlice> * captures_out,
         DraftFeatureMirror * feature_ring,
         DFlashDraftIpcClient * remote_draft,
-        KvFlashPager * kvflash) {
+        KvFlashPager * kvflash,
+        bool kvflash_preallocated = false) {
     if (shards.empty() || !acts.a || !acts.b || n_tokens_total <= 0) return false;
     if (kvflash && fa_window > 0) {
         std::fprintf(stderr,
@@ -409,7 +410,8 @@ bool run_qwen35_layer_split_layers_from_activation(
             const int kv_len = kv_start + n;
             const bool with_mask = kvflash ||
                 (kq_stride_pad > KQ_MASK_PAD) || (n > 1);
-            if (is_attn && kvflash && !kvflash->alloc_span(kv_start, n)) {
+            if (is_attn && kvflash && !kvflash_preallocated &&
+                !kvflash->alloc_span(kv_start, n)) {
                 return false;
             }
             if (!build_layer_step(shard->layer_graph, shard->weights, shard->cache,
@@ -513,10 +515,12 @@ bool run_qwen35_layer_split_forward_from_activation(
         std::vector<int32_t> * argmax_out,
         std::vector<float> * logits_out,
         std::vector<Qwen35TargetCaptureSlice> * captures_out,
-        KvFlashPager * kvflash) {
+        KvFlashPager * kvflash,
+        bool kvflash_preallocated) {
     if (!run_qwen35_layer_split_layers_from_activation(
             shards, acts, base_pos, n_tokens_total, ubatch, kq_stride_pad,
-            fa_window, captures_out, nullptr, nullptr, kvflash)) {
+            fa_window, captures_out, nullptr, nullptr, kvflash,
+            kvflash_preallocated)) {
         return false;
     }
 
@@ -556,7 +560,8 @@ bool run_qwen35_mixed_layer_split_forward(
         std::vector<int32_t> * argmax_out,
         std::vector<float> * logits_out,
         DraftFeatureMirror * feature_ring,
-        DFlashDraftIpcClient * remote_draft) {
+        DFlashDraftIpcClient * remote_draft,
+        KvFlashPager * kvflash) {
     if (!remote_shard.active() || tokens.empty() ||
         local_shards.empty() || local_shards.front().layer_begin != 0 ||
         local_shards.back().layer_end <= 0) {
@@ -565,6 +570,19 @@ bool run_qwen35_mixed_layer_split_forward(
     const int hidden = local_shards.front().weights.n_embd;
     const int n_tokens_total = (int)tokens.size();
     ubatch = std::max(1, ubatch);
+    if (kvflash && fa_window > 0) {
+        std::fprintf(stderr,
+            "mixed target-split kvflash requires full attention (fa_window=0)\n");
+        return false;
+    }
+    if (kvflash) {
+        for (int start = 0; start < n_tokens_total; start += ubatch) {
+            const int n = std::min(ubatch, n_tokens_total - start);
+            if (!kvflash->alloc_span(base_pos + start, n)) {
+                return false;
+            }
+        }
+    }
 
     ActivationPair acts;
     if (!activation_pair_init(acts, local_shards.front().backend, hidden, n_tokens_total)) {
@@ -593,7 +611,7 @@ bool run_qwen35_mixed_layer_split_forward(
     if (!run_qwen35_layer_split_layers_from_activation(
             local_shards, acts, base_pos, n_tokens_total, ubatch,
             kq_stride_pad, fa_window, nullptr, feature_ring, remote_draft,
-            nullptr)) {
+            kvflash, kvflash != nullptr)) {
         activation_pair_free(acts);
         return false;
     }
@@ -612,7 +630,8 @@ bool run_qwen35_mixed_layer_split_forward(
         (feature_ring || remote_draft) ? &remote_captures : nullptr;
     if (!remote_shard.forward(base_pos, n_tokens_total, boundary,
                               logits_out != nullptr, last_tok,
-                              argmax_out, logits_out, remote_captures_out)) {
+                              argmax_out, logits_out, remote_captures_out,
+                              ubatch)) {
         return false;
     }
     for (const auto & capture : remote_captures) {

--- a/server/src/qwen35/layer_split_forward.h
+++ b/server/src/qwen35/layer_split_forward.h
@@ -78,7 +78,8 @@ bool run_qwen35_layer_split_forward_from_activation(
         std::vector<int32_t> * argmax_out = nullptr,
         std::vector<float> * logits_out = nullptr,
         std::vector<Qwen35TargetCaptureSlice> * captures_out = nullptr,
-        KvFlashPager * kvflash = nullptr);
+        KvFlashPager * kvflash = nullptr,
+        bool kvflash_preallocated = false);
 
 bool run_qwen35_mixed_layer_split_forward(
         std::vector<Qwen35LayerSplitShard> & local_shards,
@@ -93,7 +94,8 @@ bool run_qwen35_mixed_layer_split_forward(
         std::vector<int32_t> * argmax_out = nullptr,
         std::vector<float> * logits_out = nullptr,
         DraftFeatureMirror * feature_ring = nullptr,
-        DFlashDraftIpcClient * remote_draft = nullptr);
+        DFlashDraftIpcClient * remote_draft = nullptr,
+        KvFlashPager * kvflash = nullptr);
 
 // Free all shards (weights, cache, backend).
 void free_qwen35_layer_split_shards(std::vector<Qwen35LayerSplitShard> & shards);

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -122,7 +122,9 @@ bool Qwen35LayerSplitAdapter::init() {
 
 void Qwen35LayerSplitAdapter::kvflash_read_config() {
     if (!std::getenv("DFLASH_KVFLASH") || shards_.empty()) return;
-    kvflash_drafter_path_ = cfg_.device.is_mixed_layer_split()
+    const bool target_shard_split =
+        cfg_.device.is_layer_split() && cfg_.remote_target_shard.enabled();
+    kvflash_drafter_path_ = target_shard_split
         ? std::string{}
         : kvflash_find_drafter(cfg_.target_path);
 

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -206,7 +206,7 @@ bool Qwen35LayerSplitAdapter::kvflash_attach() {
 
 bool Qwen35LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
+    if (committed > kvflash_tokens_) {
         std::fprintf(stderr,
             "[target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -34,7 +34,7 @@ Qwen35LayerSplitAdapter::Qwen35LayerSplitAdapter(
 Qwen35LayerSplitAdapter::~Qwen35LayerSplitAdapter() { shutdown(); }
 
 bool Qwen35LayerSplitAdapter::init() {
-    if (cfg_.device.is_mixed_layer_split()) {
+    if (cfg_.device.is_layer_split() && cfg_.remote_target_shard.enabled()) {
         return init_mixed_target_split();
     }
 
@@ -122,7 +122,9 @@ bool Qwen35LayerSplitAdapter::init() {
 
 void Qwen35LayerSplitAdapter::kvflash_read_config() {
     if (!std::getenv("DFLASH_KVFLASH") || shards_.empty()) return;
-    kvflash_drafter_path_ = kvflash_find_drafter(cfg_.target_path);
+    kvflash_drafter_path_ = cfg_.device.is_mixed_layer_split()
+        ? std::string{}
+        : kvflash_find_drafter(cfg_.target_path);
 
     ggml_type kv_k = GGML_TYPE_Q8_0;
     ggml_type kv_v = GGML_TYPE_Q8_0;
@@ -206,39 +208,24 @@ bool Qwen35LayerSplitAdapter::kvflash_attach() {
 
 bool Qwen35LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_) {
-        std::fprintf(stderr,
-            "[target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
-            committed, kvflash_tokens_);
+    if (!layer_split_kvflash_sync_identity(
+            kvflash_pager_, committed, kvflash_tokens_, "target-split")) {
         return false;
     }
-    kvflash_pager_.reset();
-    for (int p = 0; p < committed; ++p) {
-        const int slot = kvflash_pager_.slot_for(p);
-        if (slot != p) {
-            std::fprintf(stderr,
-                "[target-split][kvflash] identity slot mismatch %d != %d\n",
-                slot, p);
-            return false;
-        }
+    if (use_mixed_target_split() &&
+        !remote_target_shard_.kvflash_sync_identity(committed)) {
+        std::fprintf(stderr,
+            "[target-split][kvflash] remote identity sync failed pos=%d\n",
+            committed);
+        return false;
     }
-    kvflash_pager_.zero_free_blocks();
     return true;
 }
 
 void Qwen35LayerSplitAdapter::kvflash_sync_history(
         const std::vector<int32_t> & tokens, int base_pos) {
     if (!kvflash_active()) return;
-    if (base_pos == 0) {
-        kvflash_history_.assign(tokens.begin(), tokens.end());
-        return;
-    }
-    if ((int)kvflash_history_.size() > base_pos) {
-        kvflash_history_.resize((size_t)base_pos);
-    } else if ((int)kvflash_history_.size() < base_pos) {
-        kvflash_history_.resize((size_t)base_pos, 0);
-    }
-    kvflash_history_.insert(kvflash_history_.end(), tokens.begin(), tokens.end());
+    layer_split_kvflash_sync_history(kvflash_history_, tokens, base_pos);
 }
 
 void Qwen35LayerSplitAdapter::kvflash_maybe_reselect(int generated) {
@@ -293,30 +280,14 @@ bool Qwen35LayerSplitAdapter::init_mixed_target_split() {
             "remote target shard IPC\n");
         return false;
     }
-    if (cfg_.device.layer_split_backend(0) != compiled_placement_backend()) {
-        std::fprintf(stderr,
-            "[target-split] first mixed shard must match compiled backend\n");
+    MixedLayerSplitPlan mixed_plan;
+    if (!compute_target_shard_layer_split_plan(
+            cfg_.device, compiled_placement_backend(), mixed_plan,
+            "target-split")) {
         return false;
     }
-    size_t remote_begin = 0;
-    while (remote_begin < cfg_.device.layer_split_gpus.size() &&
-           cfg_.device.layer_split_backend(remote_begin) == compiled_placement_backend()) {
-        ++remote_begin;
-    }
-    if (remote_begin == 0 || remote_begin >= cfg_.device.layer_split_gpus.size()) {
-        std::fprintf(stderr,
-            "[target-split] mixed target split requires one local backend group "
-            "followed by one remote backend group\n");
-        return false;
-    }
-    const PlacementBackend remote_backend = cfg_.device.layer_split_backend(remote_begin);
-    for (size_t i = remote_begin; i < cfg_.device.layer_split_gpus.size(); ++i) {
-        if (cfg_.device.layer_split_backend(i) != remote_backend) {
-            std::fprintf(stderr,
-                "[target-split] mixed target split supports one backend boundary only\n");
-            return false;
-        }
-    }
+    const size_t remote_begin = mixed_plan.remote_begin;
+    const PlacementBackend remote_backend = mixed_plan.remote_backend;
 
     const auto info = inspect_gguf_model_info(cfg_.target_path);
     const int n_layer = info.n_layer;
@@ -360,18 +331,28 @@ bool Qwen35LayerSplitAdapter::init_mixed_target_split() {
         }
     }
 
+    kvflash_read_config();
+    if (kvflash_active() && cfg_.fa_window > 0) {
+        std::fprintf(stderr,
+            "[target-split][kvflash] fa_window must be 0 because pool slots "
+            "need full slot-space masks\n");
+        return false;
+    }
+
     for (auto & local : shards_) {
         if (!create_target_cache_partial(local.weights, cfg_.device.max_ctx,
                                          cfg_.max_verify_tokens, local.backend,
                                          local.cache,
                                          /*prefill_only=*/!cfg_.run_dflash,
                                          local.layer_begin, local.layer_end,
-                                         /*allocate_target_feat=*/false)) {
+                                         /*allocate_target_feat=*/false,
+                                         kvflash_tokens_)) {
             std::fprintf(stderr, "[target-split] mixed local cache gpu=%d: %s\n",
                          local.gpu, dflash27b_last_error());
             return false;
         }
     }
+    if (!kvflash_attach()) return false;
 
     std::vector<int> remote_gpus;
     std::vector<int> remote_layer_begins;
@@ -388,7 +369,8 @@ bool Qwen35LayerSplitAdapter::init_mixed_target_split() {
             shards_.front().weights.n_embd, shards_.front().weights.n_vocab,
             std::max(1, cfg_.device.max_ctx),
             cfg_.remote_target_shard.work_dir,
-            cfg_.run_dflash)) {
+            cfg_.run_dflash,
+            kvflash_tokens_)) {
         std::fprintf(stderr,
             "[target-split] remote target shard start failed layers=[%d,%d)\n",
             remote_layer_begins.front(), remote_layer_ends.back());
@@ -430,6 +412,9 @@ bool Qwen35LayerSplitAdapter::init_mixed_target_split() {
     disk_snapshot_buffers_.assign(PREFIX_SLOTS, nullptr);
     disk_snapshot_backends_.assign(PREFIX_SLOTS, nullptr);
     draft_feature_snapshots_.resize(PREFIX_SLOTS);
+    if (kvflash_active()) {
+        kvflash_history_snapshots_.resize(PREFIX_SLOTS);
+    }
     return true;
 }
 
@@ -513,7 +498,7 @@ void Qwen35LayerSplitAdapter::begin_request(const GenerateRequest & req) {
 
 void Qwen35LayerSplitAdapter::reset_request_state() {
     for (auto & shard : shards_) reset_target_cache(shard.cache);
-    if (!use_mixed_target_split() && kvflash_active()) {
+    if (kvflash_active()) {
         kvflash_pager_.reset();
         kvflash_history_.clear();
         kvflash_scores_.clear();
@@ -528,7 +513,7 @@ void Qwen35LayerSplitAdapter::reset_request_state() {
 }
 
 int Qwen35LayerSplitAdapter::prefill_chunk_tokens() const {
-    if (!use_mixed_target_split() && kvflash_active()) {
+    if (kvflash_active()) {
         return kvflash_pager_.chunk_tokens();
     }
     return cfg_.chunk > 0 ? cfg_.chunk : 0;
@@ -555,7 +540,12 @@ bool Qwen35LayerSplitAdapter::prefill(const std::vector<int32_t> & prompt,
             /*argmax_out=*/nullptr,
             &prefill_last_logits_,
             (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
-            remote_draft_.active() ? &remote_draft_ : nullptr);
+            remote_draft_.active() ? &remote_draft_ : nullptr,
+            kvflash_active() ? &kvflash_pager_ : nullptr);
+        if (ok && kvflash_active()) {
+            kvflash_sync_history(prompt, base_pos);
+            kvflash_pager_.zero_free_blocks();
+        }
         return ok;
     }
     const bool ok = run_qwen35_layer_split_forward(
@@ -584,7 +574,7 @@ bool Qwen35LayerSplitAdapter::snapshot_save(int slot) {
     if (!snapshot_slot_valid(slot)) return false;
     if (snapshot_backends_.size() != shards_.size()) return false;
     const int cur_pos = shards_.empty() ? 0 : shards_.front().cache.cur_pos;
-    if (!use_mixed_target_split() && kvflash_active() &&
+    if (kvflash_active() &&
         (cur_pos > kvflash_tokens_ || !kvflash_pager_.is_identity())) {
         static bool warned = false;
         if (!warned) {
@@ -613,15 +603,10 @@ bool Qwen35LayerSplitAdapter::snapshot_save(int slot) {
     }
     if (snapshot_prefill_logits_.size() != (size_t)PREFIX_SLOTS) return false;
     snapshot_prefill_logits_[(size_t)slot] = prefill_last_logits_;
-    if (!use_mixed_target_split() && kvflash_active() &&
+    if (kvflash_active() &&
         kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS) {
-        auto & history_snap = kvflash_history_snapshots_[(size_t)slot];
-        history_snap.clear();
-        const size_t keep = (size_t)std::min(cur_pos, (int)kvflash_history_.size());
-        history_snap.assign(kvflash_history_.begin(), kvflash_history_.begin() + keep);
-        if ((int)history_snap.size() < cur_pos) {
-            history_snap.resize((size_t)cur_pos, 0);
-        }
+        layer_split_kvflash_save_history_snapshot(
+            kvflash_history_, cur_pos, kvflash_history_snapshots_[(size_t)slot]);
     }
     if (!snapshot_draft_features(slot)) {
         snapshot_free(slot);
@@ -717,19 +702,10 @@ bool Qwen35LayerSplitAdapter::snapshot_restore(int slot) {
     }
     if (snapshot_prefill_logits_.size() != (size_t)PREFIX_SLOTS) return false;
     prefill_last_logits_ = snapshot_prefill_logits_[(size_t)slot];
-    if (!use_mixed_target_split() && kvflash_active()) {
+    if (kvflash_active()) {
         if (!kvflash_sync_identity(cur_pos)) return false;
-        if (kvflash_history_snapshots_.size() == (size_t)PREFIX_SLOTS &&
-            !kvflash_history_snapshots_[(size_t)slot].empty()) {
-            kvflash_history_ = kvflash_history_snapshots_[(size_t)slot];
-        } else {
-            kvflash_history_.clear();
-        }
-        if ((int)kvflash_history_.size() > cur_pos) {
-            kvflash_history_.resize((size_t)cur_pos);
-        } else if ((int)kvflash_history_.size() < cur_pos) {
-            kvflash_history_.resize((size_t)cur_pos, 0);
-        }
+        layer_split_kvflash_restore_history(
+            kvflash_history_, kvflash_history_snapshots_, slot, cur_pos);
     }
     if (!restore_draft_features(slot)) return false;
     return true;
@@ -969,7 +945,7 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
         disk_snapshot_backends_.size() != (size_t)PREFIX_SLOTS) {
         return false;
     }
-    if (!mixed_target_split && kvflash_active() &&
+    if (kvflash_active() &&
         kvflash_history_snapshots_.size() != (size_t)PREFIX_SLOTS) {
         kvflash_history_snapshots_.resize(PREFIX_SLOTS);
     }
@@ -1179,7 +1155,7 @@ bool Qwen35LayerSplitAdapter::snapshot_adopt(int slot,
     } else {
         free_draft_feature_snapshot(slot);
     }
-    if (!mixed_target_split && kvflash_active()) {
+    if (kvflash_active()) {
         kvflash_history_snapshots_[(size_t)slot].assign((size_t)cur_pos, 0);
     }
 
@@ -1310,7 +1286,8 @@ bool Qwen35LayerSplitAdapter::decode_ar(
                     /*argmax_out=*/nullptr,
                     logits_out,
                     (cfg_.run_dflash && !remote_draft_.active()) ? &feature_ring_ : nullptr,
-                    remote_draft_.active() ? &remote_draft_ : nullptr);
+                    remote_draft_.active() ? &remote_draft_ : nullptr,
+                    kvflash_active() ? &kvflash_pager_ : nullptr);
             }
             return run_qwen35_layer_split_forward(
                 shards_, shards_.front().weights, one, pos, 1, next_tok,
@@ -1324,7 +1301,7 @@ bool Qwen35LayerSplitAdapter::decode_ar(
         },
         [&](int tok) { return is_eos_tok(tok, w); },
         out_tokens, io);
-    if (ok && !use_mixed_target_split() && kvflash_active()) {
+    if (ok && kvflash_active()) {
         kvflash_sync_history(out_tokens, committed);
         kvflash_maybe_reselect((int)out_tokens.size());
     }
@@ -1346,7 +1323,7 @@ bool Qwen35LayerSplitAdapter::decode_dflash(
         cfg_.kq_stride_pad, cfg_.fa_window,
         use_remote_draft ? &remote_draft_ : nullptr,
         use_mixed_target_split() ? &remote_target_shard_ : nullptr,
-        (!use_mixed_target_split() && kvflash_active()) ? &kvflash_pager_ : nullptr);
+        kvflash_active() ? &kvflash_pager_ : nullptr);
     DaemonIO collect_io = io.with_token_callback([&](int32_t tok) -> bool {
         out_tokens.push_back(tok);
         return true;
@@ -1358,7 +1335,7 @@ bool Qwen35LayerSplitAdapter::decode_dflash(
         use_remote_draft ? &remote_draft_ : nullptr, /*hint_tokens=*/nullptr, base_pos,
         &accept_rate);
     accept_rate_out = (float)accept_rate;
-    if (ok && !use_mixed_target_split() && kvflash_active()) {
+    if (ok && kvflash_active()) {
         kvflash_sync_history(out_tokens, base_pos + (int)prompt.size());
         kvflash_maybe_reselect((int)out_tokens.size());
     }
@@ -1424,7 +1401,7 @@ DFlashTarget * Qwen35LayerSplitAdapter::dflash_target() {
             cfg_.kq_stride_pad, cfg_.fa_window,
             remote_draft_.active() ? &remote_draft_ : nullptr,
             use_mixed_target_split() ? &remote_target_shard_ : nullptr,
-            (!use_mixed_target_split() && kvflash_active()) ? &kvflash_pager_ : nullptr);
+            kvflash_active() ? &kvflash_pager_ : nullptr);
     }
     return dflash_target_.get();
 }

--- a/server/src/qwen35/qwen35_layer_split_adapter.cpp
+++ b/server/src/qwen35/qwen35_layer_split_adapter.cpp
@@ -206,7 +206,7 @@ bool Qwen35LayerSplitAdapter::kvflash_attach() {
 
 bool Qwen35LayerSplitAdapter::kvflash_sync_identity(int committed) {
     if (!kvflash_active()) return true;
-    if (committed > kvflash_tokens_) {
+    if (committed > kvflash_tokens_ - kvflash_pager_.chunk_tokens()) {
         std::fprintf(stderr,
             "[target-split][kvflash] prefix (%d) exceeds resident pool %d\n",
             committed, kvflash_tokens_);

--- a/server/src/qwen35/qwen35_layer_split_adapter.h
+++ b/server/src/qwen35/qwen35_layer_split_adapter.h
@@ -6,6 +6,7 @@
 #include "common/kvflash_pager.h"
 #include "common/kvflash_scorer.h"
 #include "common/layer_split_backend.h"
+#include "common/layer_split_kvflash.h"
 #include "dflash_feature_ring.h"
 #include "layer_split_types.h"
 #include "placement/placement_config.h"
@@ -88,6 +89,10 @@ public:
     bool supports_dflash_spec_decode() const override { return true; }
     DFlashTarget * dflash_target() override;
     bool supports_remote_draft() const override { return true; }
+    bool supports_kvflash() const override { return kvflash_active(); }
+    bool supports_mixed_backend_layer_split() const override {
+        return use_mixed_target_split();
+    }
 
     void shutdown() override;
 

--- a/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_layer_split_dflash_target.cpp
@@ -46,7 +46,8 @@ bool Qwen35LayerSplitDFlashTarget::verify_batch(
         return run_qwen35_mixed_layer_split_forward(
             shards_, *remote_target_shard_, shards_.front().weights, tokens,
             base_pos, (int)tokens.size(), last_tok, kq_stride_pad_, fa_window_,
-            all_argmax, /*logits_out=*/nullptr, feature_ring_, remote_draft_);
+            all_argmax, /*logits_out=*/nullptr, feature_ring_, remote_draft_,
+            kvflash_);
     }
     return run_qwen35_layer_split_forward(
         shards_, shards_.front().weights, tokens, base_pos, (int)tokens.size(),

--- a/server/src/qwen35/qwen35_target_shard_ipc.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc.cpp
@@ -11,35 +11,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
-#include <cstdlib>
 #include <inttypes.h>
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace dflash::common {
 
 namespace {
-
-bool checked_mul_size(size_t a, size_t b, size_t & out) {
-    if (a != 0 && b > std::numeric_limits<size_t>::max() / a) {
-        return false;
-    }
-    out = a * b;
-    return true;
-}
-
-BackendIpcPayloadTransport target_shard_ipc_transport_from_env() {
-    const char * raw = std::getenv("DFLASH_TARGET_SHARD_IPC_TRANSPORT");
-    if (!raw || !*raw) {
-        return BackendIpcPayloadTransport::Stream;
-    }
-    BackendIpcPayloadTransport transport = BackendIpcPayloadTransport::Stream;
-    if (!parse_backend_ipc_payload_transport(raw, transport)) {
-        return BackendIpcPayloadTransport::Stream;
-    }
-    return transport;
-}
 
 bool write_snapshot_tensor_header_fd(int fd,
                                      const Qwen35TargetShardSnapshotTensor & t) {
@@ -87,63 +67,7 @@ bool read_snapshot_tensor_header_fd(int fd,
     return true;
 }
 
-size_t target_shard_required_shared_bytes(int hidden, int max_tokens) {
-    if (hidden <= 0 || max_tokens <= 0) return 0;
-    size_t elements = 0;
-    size_t bytes = 0;
-    if (!checked_mul_size((size_t)hidden, (size_t)max_tokens, elements) ||
-        !checked_mul_size(elements, sizeof(float), bytes)) {
-        return 0;
-    }
-    return bytes;
-}
-
-size_t target_shard_shared_bytes_from_env(size_t required_bytes) {
-    const char * raw = std::getenv("DFLASH_TARGET_SHARD_IPC_SHARED_BYTES");
-    if (!raw || !*raw) {
-        return required_bytes;
-    }
-    if (raw[0] == '-') {
-        return required_bytes;
-    }
-    char * end = nullptr;
-    const unsigned long long parsed = std::strtoull(raw, &end, 10);
-    if (end == raw || *end != '\0' ||
-        parsed > (unsigned long long)std::numeric_limits<size_t>::max()) {
-        return required_bytes;
-    }
-    return std::max((size_t)parsed, required_bytes);
-}
-
 }  // namespace
-
-bool copy_activation_to_host(const ggml_tensor * act,
-                             ggml_backend_t src_backend,
-                             int token_offset,
-                             int n_tokens,
-                             int hidden,
-                             std::vector<float> & out) {
-    if (!act || !src_backend || token_offset < 0 || n_tokens <= 0 || hidden <= 0) {
-        return false;
-    }
-    const size_t row_bytes = (size_t)hidden * sizeof(float);
-    const size_t src_stride = act->nb[1];
-    out.assign((size_t)n_tokens * (size_t)hidden, 0.0f);
-    ggml_backend_synchronize(src_backend);
-    if (src_stride == row_bytes) {
-        ggml_backend_tensor_get(act, out.data(),
-                                (size_t)token_offset * src_stride,
-                                row_bytes * (size_t)n_tokens);
-    } else {
-        for (int i = 0; i < n_tokens; i++) {
-            ggml_backend_tensor_get(act,
-                                    out.data() + (size_t)i * (size_t)hidden,
-                                    (size_t)(token_offset + i) * src_stride,
-                                    row_bytes);
-        }
-    }
-    return true;
-}
 
 bool Qwen35TargetShardIpcClient::start(
         const std::string & bin,
@@ -159,73 +83,50 @@ bool Qwen35TargetShardIpcClient::start(
         int vocab,
         int max_tokens,
         const std::string & work_dir,
-        bool enable_dflash) {
+        bool enable_dflash,
+        int kvflash_pool_tokens) {
 #if defined(_WIN32)
     (void)bin; (void)target_path; (void)gpus; (void)layer_begins; (void)layer_ends;
     (void)max_ctx; (void)max_verify_tokens; (void)kq_stride_pad; (void)fa_window;
     (void)hidden; (void)vocab; (void)max_tokens; (void)work_dir; (void)enable_dflash;
+    (void)kvflash_pool_tokens;
     std::fprintf(stderr, "Qwen35 target shard IPC is only implemented on POSIX hosts\n");
     return false;
 #else
-    close();
+    session_.close();
     if (bin.empty() || target_path.empty() || gpus.empty() ||
         gpus.size() != layer_begins.size() || gpus.size() != layer_ends.size() ||
-        max_ctx <= 0 || hidden <= 0 ||
-        vocab <= 0 || max_tokens <= 0) {
+        max_ctx <= 0 || hidden <= 0 || vocab <= 0 || max_tokens <= 0) {
         return false;
     }
-    for (size_t i = 0; i < gpus.size(); ++i) {
-        if (gpus[i] < 0 || layer_begins[i] < 0 ||
-            layer_ends[i] <= layer_begins[i]) {
-            return false;
-        }
-        if (i > 0 && layer_begins[i] != layer_ends[i - 1]) {
-            return false;
-        }
-    }
 
-    BackendIpcLaunchConfig launch;
-    launch.bin = bin;
+    TargetShardIpcLaunchConfig launch;
     launch.mode = BackendIpcMode::Qwen35TargetShard;
-    launch.payload_path = target_path;
+    launch.bin = bin;
+    launch.target_path = target_path;
+    launch.gpus = gpus;
+    launch.layer_begins = layer_begins;
+    launch.layer_ends = layer_ends;
+    launch.max_ctx = max_ctx;
+    launch.hidden = hidden;
+    launch.vocab = vocab;
+    launch.max_tokens = max_tokens;
     launch.work_dir = work_dir;
-    launch.payload_transport = target_shard_ipc_transport_from_env();
-    launch.shared_payload_bytes = target_shard_shared_bytes_from_env(
-        target_shard_required_shared_bytes(hidden, max_tokens));
-    std::string gpu_list;
-    std::string layer_begin_list;
-    std::string layer_end_list;
-    for (size_t i = 0; i < gpus.size(); ++i) {
-        if (i > 0) {
-            gpu_list += ",";
-            layer_begin_list += ",";
-            layer_end_list += ",";
-        }
-        gpu_list += std::to_string(gpus[i]);
-        layer_begin_list += std::to_string(layer_begins[i]);
-        layer_end_list += std::to_string(layer_ends[i]);
-    }
-    launch.args.push_back("--target-gpus=" + gpu_list);
-    launch.args.push_back("--layer-begins=" + layer_begin_list);
-    launch.args.push_back("--layer-ends=" + layer_end_list);
-    launch.args.push_back("--max-ctx=" + std::to_string(max_ctx));
-    launch.args.push_back("--max-verify-tokens=" + std::to_string(max_verify_tokens));
-    launch.args.push_back("--kq-stride-pad=" + std::to_string(kq_stride_pad));
-    launch.args.push_back("--fa-window=" + std::to_string(fa_window));
-    if (enable_dflash) {
-        launch.args.push_back("--enable-dflash");
-    }
-    if (!process_.start(launch)) {
+    launch.fa_window = fa_window;
+    launch.kvflash_pool_tokens = kvflash_pool_tokens;
+    launch.model_args.push_back("--max-verify-tokens=" + std::to_string(max_verify_tokens));
+    launch.model_args.push_back("--kq-stride-pad=" + std::to_string(kq_stride_pad));
+    if (enable_dflash) launch.model_args.push_back("--enable-dflash");
+    if (!session_.start(launch)) {
         std::fprintf(stderr, "qwen35-target-shard backend process start failed\n");
         return false;
     }
 
     hidden_ = hidden;
     vocab_ = vocab;
-    active_ = true;
     std::printf("[qwen35-target-shard-ipc] ready bin=%s shards=%zu layers=[%d,%d) work_dir=%s\n",
                 bin.c_str(), gpus.size(), layer_begins.front(), layer_ends.back(),
-                process_.work_dir().c_str());
+                session_.work_dir().c_str());
     return true;
 #endif
 }
@@ -238,16 +139,18 @@ bool Qwen35TargetShardIpcClient::forward(
         int & last_tok,
         std::vector<int32_t> * argmax_out,
         std::vector<float> * logits_out,
-        std::vector<Qwen35TargetCaptureSlice> * captures_out) {
+        std::vector<Qwen35TargetCaptureSlice> * captures_out,
+        int ubatch) {
 #if defined(_WIN32)
     (void)base_pos; (void)n_tokens; (void)boundary_activation; (void)need_logits;
     (void)last_tok; (void)argmax_out; (void)logits_out; (void)captures_out;
+    (void)ubatch;
     return false;
 #else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    const int payload_fd = process_.payload_fd();
-    if (!active_ || !cmd || stream_fd < 0 || base_pos < 0 ||
+    FILE * cmd = session_.command_stream();
+    const int stream_fd = session_.stream_fd();
+    const int payload_fd = session_.payload_fd();
+    if (!session_.active() || !cmd || stream_fd < 0 || base_pos < 0 ||
         n_tokens <= 0 || hidden_ <= 0 || vocab_ <= 0) {
         return false;
     }
@@ -257,24 +160,25 @@ bool Qwen35TargetShardIpcClient::forward(
     const int want_argmax = argmax_out ? 1 : 0;
     const int want_logits = need_logits ? 1 : 0;
     const int want_captures = captures_out ? 1 : 0;
+    const int forward_ubatch = ubatch > 0 ? ubatch : n_tokens;
     if (captures_out) captures_out->clear();
 
-    if (process_.resolved_payload_transport() == BackendIpcPayloadTransport::Shared) {
+    if (session_.resolved_payload_transport() == BackendIpcPayloadTransport::Shared) {
         uint64_t seq = 0;
-        if (!process_.write_shared_payload(boundary_activation.data(), bytes, seq)) {
+        if (!session_.write_shared_payload(boundary_activation.data(), bytes, seq)) {
             std::fprintf(stderr,
                          "qwen35-target-shard shared payload too large bytes=%zu capacity=%zu\n",
-                         bytes, process_.shared_payload_capacity());
+                         bytes, session_.shared_payload_capacity());
             return false;
         }
-        std::fprintf(cmd, "forward_shared %d %d %d %d %zu %" PRIu64 " %d\n",
+        std::fprintf(cmd, "forward_shared %d %d %d %d %zu %" PRIu64 " %d %d\n",
                      base_pos, n_tokens, want_argmax, want_logits, bytes, seq,
-                     want_captures);
+                     want_captures, forward_ubatch);
         std::fflush(cmd);
     } else if (payload_fd >= 0) {
-        std::fprintf(cmd, "forward_pipe %d %d %d %d %zu %d\n",
+        std::fprintf(cmd, "forward_pipe %d %d %d %d %zu %d %d\n",
                      base_pos, n_tokens, want_argmax, want_logits, bytes,
-                     want_captures);
+                     want_captures, forward_ubatch);
         std::fflush(cmd);
         if (!write_exact_fd(payload_fd, boundary_activation.data(), bytes)) {
             std::fprintf(stderr, "qwen35-target-shard payload write failed\n");
@@ -352,10 +256,10 @@ bool Qwen35TargetShardIpcClient::project_hidden_to_tokens(
     (void)hidden; (void)n_tokens; (void)tokens_out;
     return false;
 #else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    const int payload_fd = process_.payload_fd();
-    if (!active_ || !cmd || !hidden || stream_fd < 0 || payload_fd < 0 ||
+    FILE * cmd = session_.command_stream();
+    const int stream_fd = session_.stream_fd();
+    const int payload_fd = session_.payload_fd();
+    if (!session_.active() || !cmd || !hidden || stream_fd < 0 || payload_fd < 0 ||
         n_tokens <= 0 || hidden_ <= 0) {
         return false;
     }
@@ -380,9 +284,9 @@ bool Qwen35TargetShardIpcClient::snapshot_kv() {
 #if defined(_WIN32)
     return false;
 #else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0) return false;
+    FILE * cmd = session_.command_stream();
+    const int stream_fd = session_.stream_fd();
+    if (!session_.active() || !cmd || stream_fd < 0) return false;
     std::fprintf(cmd, "snapshot\n");
     std::fflush(cmd);
     int32_t status = -1;
@@ -394,9 +298,9 @@ bool Qwen35TargetShardIpcClient::restore_kv() {
 #if defined(_WIN32)
     return false;
 #else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0) return false;
+    FILE * cmd = session_.command_stream();
+    const int stream_fd = session_.stream_fd();
+    if (!session_.active() || !cmd || stream_fd < 0) return false;
     std::fprintf(cmd, "restore\n");
     std::fflush(cmd);
     int32_t status = -1;
@@ -405,61 +309,23 @@ bool Qwen35TargetShardIpcClient::restore_kv() {
 }
 
 bool Qwen35TargetShardIpcClient::reset_request_state() {
-#if defined(_WIN32)
-    return false;
-#else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0) return false;
-    std::fprintf(cmd, "reset_request_state\n");
-    std::fflush(cmd);
-    int32_t status = -1;
-    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
-#endif
+    return session_.reset_request_state();
+}
+
+bool Qwen35TargetShardIpcClient::kvflash_sync_identity(int committed) {
+    return session_.kvflash_sync_identity(committed);
 }
 
 bool Qwen35TargetShardIpcClient::snapshot_save(int slot) {
-#if defined(_WIN32)
-    (void)slot;
-    return false;
-#else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
-    std::fprintf(cmd, "prefix_snapshot_save %d\n", slot);
-    std::fflush(cmd);
-    int32_t status = -1;
-    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
-#endif
+    return session_.snapshot_save(slot);
 }
 
 void Qwen35TargetShardIpcClient::snapshot_free(int slot) {
-#if defined(_WIN32)
-    (void)slot;
-#else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return;
-    std::fprintf(cmd, "prefix_snapshot_free %d\n", slot);
-    std::fflush(cmd);
-    int32_t status = -1;
-    (void)read_exact_fd(stream_fd, &status, sizeof(status));
-#endif
+    session_.snapshot_free(slot);
 }
 
 bool Qwen35TargetShardIpcClient::snapshot_restore(int slot) {
-#if defined(_WIN32)
-    (void)slot;
-    return false;
-#else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
-    std::fprintf(cmd, "prefix_snapshot_restore %d\n", slot);
-    std::fflush(cmd);
-    int32_t status = -1;
-    return read_exact_fd(stream_fd, &status, sizeof(status)) && status == 0;
-#endif
+    return session_.snapshot_restore(slot);
 }
 
 bool Qwen35TargetShardIpcClient::snapshot_export(
@@ -469,9 +335,9 @@ bool Qwen35TargetShardIpcClient::snapshot_export(
     (void)slot; (void)out;
     return false;
 #else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    if (!active_ || !cmd || stream_fd < 0 || slot < 0) return false;
+    FILE * cmd = session_.command_stream();
+    const int stream_fd = session_.stream_fd();
+    if (!session_.active() || !cmd || stream_fd < 0 || slot < 0) return false;
     out = Qwen35TargetShardSnapshotData{};
     std::fprintf(cmd, "prefix_snapshot_export %d\n", slot);
     std::fflush(cmd);
@@ -522,10 +388,10 @@ bool Qwen35TargetShardIpcClient::snapshot_import(
     (void)slot; (void)data;
     return false;
 #else
-    FILE * cmd = process_.command_stream();
-    const int stream_fd = process_.stream_fd();
-    const int payload_fd = process_.payload_fd();
-    if (!active_ || !cmd || stream_fd < 0 || payload_fd < 0 || slot < 0 ||
+    FILE * cmd = session_.command_stream();
+    const int stream_fd = session_.stream_fd();
+    const int payload_fd = session_.payload_fd();
+    if (!session_.active() || !cmd || stream_fd < 0 || payload_fd < 0 || slot < 0 ||
         data.shard_count <= 0 || data.cur_pos <= 0 ||
         data.tensors.empty() || data.logits.empty() ||
         data.tensors.size() > (size_t)std::numeric_limits<int32_t>::max() ||
@@ -575,8 +441,7 @@ bool Qwen35TargetShardIpcClient::snapshot_import(
 }
 
 void Qwen35TargetShardIpcClient::close() {
-    process_.close();
-    active_ = false;
+    session_.close();
     hidden_ = 0;
     vocab_ = 0;
 }

--- a/server/src/qwen35/qwen35_target_shard_ipc.h
+++ b/server/src/qwen35/qwen35_target_shard_ipc.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "common/backend_ipc.h"
+#include "common/target_shard_ipc.h"
 #include "ggml-backend.h"
 
 #include <cstdint>
@@ -54,7 +54,8 @@ public:
                int vocab,
                int max_tokens,
                const std::string & work_dir,
-               bool enable_dflash);
+               bool enable_dflash,
+               int kvflash_pool_tokens = 0);
 
     bool forward(int base_pos,
                  int n_tokens,
@@ -63,7 +64,8 @@ public:
                  int & last_tok,
                  std::vector<int32_t> * argmax_out,
                  std::vector<float> * logits_out,
-                 std::vector<Qwen35TargetCaptureSlice> * captures_out = nullptr);
+                 std::vector<Qwen35TargetCaptureSlice> * captures_out = nullptr,
+                 int ubatch = 0);
 
     bool project_hidden_to_tokens(const float * hidden,
                                   int n_tokens,
@@ -72,28 +74,21 @@ public:
     bool snapshot_kv();
     bool restore_kv();
     bool reset_request_state();
+    bool kvflash_sync_identity(int committed);
     bool snapshot_save(int slot);
     void snapshot_free(int slot);
     bool snapshot_restore(int slot);
     bool snapshot_export(int slot, Qwen35TargetShardSnapshotData & out);
     bool snapshot_import(int slot, const Qwen35TargetShardSnapshotData & data);
 
-    bool active() const { return active_; }
+    bool active() const { return session_.active(); }
     void close();
 
 private:
-    BackendIpcProcess process_;
-    bool active_ = false;
+    TargetShardIpcSession session_;
     int hidden_ = 0;
     int vocab_ = 0;
 };
-
-bool copy_activation_to_host(const ggml_tensor * act,
-                             ggml_backend_t src_backend,
-                             int token_offset,
-                             int n_tokens,
-                             int hidden,
-                             std::vector<float> & out);
 
 int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                                        const std::vector<int> & gpus,
@@ -107,6 +102,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                                        int payload_fd = -1,
                                        int shared_payload_fd = -1,
                                        size_t shared_payload_bytes = 0,
-                                       bool enable_dflash = false);
+                                       bool enable_dflash = false,
+                                       int kvflash_pool_tokens = 0);
 
 }  // namespace dflash::common

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -8,6 +8,7 @@
 #include "common/io_utils.h"
 #include "common/layer_split_utils.h"
 #include "common/model_backend.h"
+#include "common/kvflash_pager.h"
 #include "common/snapshot_backend.h"
 #include "graph_builders.h"
 #include "internal.h"
@@ -177,12 +178,13 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                                        int payload_fd,
                                        int shared_payload_fd,
                                        size_t shared_payload_bytes,
-                                       bool enable_dflash) {
+                                       bool enable_dflash,
+                                       int kvflash_pool_tokens) {
 #if defined(_WIN32)
     (void)target_path; (void)gpus; (void)layer_begins; (void)layer_ends;
     (void)max_ctx; (void)max_verify_tokens; (void)kq_stride_pad; (void)fa_window;
     (void)stream_fd; (void)payload_fd; (void)shared_payload_fd;
-    (void)shared_payload_bytes; (void)enable_dflash;
+    (void)shared_payload_bytes; (void)enable_dflash; (void)kvflash_pool_tokens;
     std::fprintf(stderr, "Qwen35 target shard IPC daemon is only implemented on POSIX hosts\n");
     return 2;
 #else
@@ -264,7 +266,8 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                                          shard.backend, shard.cache,
                                          /*prefill_only=*/!enable_dflash,
                                          shard.layer_begin, shard.layer_end,
-                                         /*allocate_target_feat=*/false)) {
+                                         /*allocate_target_feat=*/false,
+                                         kvflash_pool_tokens)) {
             std::fprintf(stderr,
                          "[qwen35-target-shard-daemon] load/cache failed gpu=%d: %s\n",
                          shard.gpu, dflash27b_last_error());
@@ -334,6 +337,60 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
         return 1;
     }
 
+    KvFlashPager kvflash_pager;
+    if (kvflash_pool_tokens > 0) {
+        if (fa_window > 0) {
+            std::fprintf(stderr,
+                "[qwen35-target-shard-daemon][kvflash] fa_window must be 0\n");
+            stream_status(stream_fd, -1);
+            free_snapshot_backends();
+            free_qwen35_layer_split_shards(shards);
+            if (shared_payload && shared_payload != MAP_FAILED) {
+                ::munmap(shared_payload, shared_payload_map_bytes);
+            }
+            return 1;
+        }
+        std::vector<ggml_tensor *> full_k;
+        std::vector<ggml_tensor *> full_v;
+        const int n_full = shards.front().weights.n_layer /
+            shards.front().weights.full_attention_interval;
+        for (int i = 0; i < n_full; ++i) {
+            ggml_tensor * k = nullptr;
+            ggml_tensor * v = nullptr;
+            for (auto & shard : shards) {
+                if (i < (int)shard.cache.attn_k.size() &&
+                    shard.cache.attn_k[(size_t)i]) {
+                    k = shard.cache.attn_k[(size_t)i];
+                    v = shard.cache.attn_v[(size_t)i];
+                    break;
+                }
+            }
+            if (k && v) {
+                full_k.push_back(k);
+                full_v.push_back(v);
+            }
+        }
+        KvFlashConfig pc;
+        pc.pool_tokens = kvflash_pool_tokens;
+        if (!kvflash_pager.attach(pc, full_k, full_v)) {
+            std::fprintf(stderr,
+                "[qwen35-target-shard-daemon][kvflash] pager attach failed "
+                "pool=%d layers=%zu\n",
+                kvflash_pool_tokens, full_k.size());
+            stream_status(stream_fd, -1);
+            free_snapshot_backends();
+            free_qwen35_layer_split_shards(shards);
+            if (shared_payload && shared_payload != MAP_FAILED) {
+                ::munmap(shared_payload, shared_payload_map_bytes);
+            }
+            return 1;
+        }
+        std::fprintf(stderr,
+            "[qwen35-target-shard-daemon][kvflash] resident pool %d tokens "
+            "over %zu full-attn layers (logical max_ctx %d, policy=lru)\n",
+            kvflash_pool_tokens, full_k.size(), max_ctx);
+    }
+
     const int hidden = shards.front().weights.n_embd;
     std::vector<float> host_act;
     std::vector<int32_t> argmax_tokens;
@@ -354,12 +411,22 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                            const std::vector<float> & boundary,
                            bool want_argmax,
                            bool want_logits,
-                           bool want_captures) -> bool {
+                           bool want_captures,
+                           int forward_ubatch) -> bool {
         if (n_tokens <= 0 || (int)boundary.size() != hidden * n_tokens) {
             return false;
         }
         if (base_pos < 0 || base_pos + n_tokens > max_ctx) {
             return false;
+        }
+        forward_ubatch = std::max(1, forward_ubatch > 0 ? forward_ubatch : n_tokens);
+        if (kvflash_pool_tokens > 0) {
+            for (int start = 0; start < n_tokens; start += forward_ubatch) {
+                const int n = std::min(forward_ubatch, n_tokens - start);
+                if (!kvflash_pager.alloc_span(base_pos + start, n)) {
+                    return false;
+                }
+            }
         }
         ActivationPair acts;
         if (!activation_pair_init(acts, shards.front().backend, hidden, n_tokens)) {
@@ -373,11 +440,13 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
         std::vector<float> logits;
         std::vector<Qwen35TargetCaptureSlice> captures;
         const bool forward_ok = run_qwen35_layer_split_forward_from_activation(
-            shards, acts, base_pos, n_tokens, std::max(1, n_tokens), ignored_last_tok,
+            shards, acts, base_pos, n_tokens, forward_ubatch, ignored_last_tok,
             kq_stride_pad, fa_window,
             want_argmax ? &argmax_tokens : nullptr,
             want_logits ? &logits : nullptr,
-            want_captures ? &captures : nullptr);
+            want_captures ? &captures : nullptr,
+            kvflash_pool_tokens > 0 ? &kvflash_pager : nullptr,
+            kvflash_pool_tokens > 0);
         activation_pair_free(acts);
         if (!forward_ok) return false;
 
@@ -445,12 +514,14 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
         int want_argmax = 0;
         int want_logits = 0;
         int want_captures = 0;
+        int forward_ubatch = 0;
         size_t bytes = 0;
         bool payload_ok = false;
 
         if (cmd == "forward_pipe") {
             iss >> base_pos >> n_tokens >> want_argmax >> want_logits >> bytes;
             if (!(iss >> want_captures)) want_captures = 0;
+            if (!(iss >> forward_ubatch)) forward_ubatch = n_tokens;
             const size_t expected_bytes =
                 (size_t)n_tokens * (size_t)hidden * sizeof(float);
             if (payload_fd >= 0 && bytes == expected_bytes) {
@@ -461,6 +532,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
             uint64_t seq = 0;
             iss >> base_pos >> n_tokens >> want_argmax >> want_logits >> bytes >> seq;
             if (!(iss >> want_captures)) want_captures = 0;
+            if (!(iss >> forward_ubatch)) forward_ubatch = n_tokens;
             const size_t expected_bytes =
                 (size_t)n_tokens * (size_t)hidden * sizeof(float);
             const auto * header =
@@ -494,8 +566,28 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
             }
             if (cmd == "reset_request_state") {
                 for (auto & shard : shards) reset_target_cache(shard.cache);
+                if (kvflash_pool_tokens > 0) kvflash_pager.reset();
                 prefill_last_logits.clear();
                 stream_status(stream_fd, 0);
+                continue;
+            }
+            if (cmd == "kvflash_sync_identity") {
+                int committed = -1;
+                iss >> committed;
+                bool ok = kvflash_pool_tokens > 0 && committed >= 0 &&
+                          committed <= kvflash_pool_tokens;
+                if (ok) {
+                    kvflash_pager.reset();
+                    for (int p = 0; p < committed; ++p) {
+                        const int slot = kvflash_pager.slot_for(p);
+                        if (slot != p) {
+                            ok = false;
+                            break;
+                        }
+                    }
+                    if (ok) kvflash_pager.zero_free_blocks();
+                }
+                stream_status(stream_fd, ok ? 0 : -1);
                 continue;
             }
             if (cmd == "project_pipe") {
@@ -828,7 +920,7 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
         if (!payload_ok ||
             !run_forward(base_pos, n_tokens, host_act,
                          want_argmax != 0, want_logits != 0,
-                         want_captures != 0)) {
+                         want_captures != 0, forward_ubatch)) {
             const int32_t status = -1;
             write_exact_fd(stream_fd, &status, sizeof(status));
         }

--- a/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
+++ b/server/src/qwen35/qwen35_target_shard_ipc_daemon.cpp
@@ -577,6 +577,14 @@ int run_qwen35_target_shard_ipc_daemon(const char * target_path,
                 bool ok = kvflash_pool_tokens > 0 && committed >= 0 &&
                           committed <= kvflash_pool_tokens;
                 if (ok) {
+                    int min_cur_pos = std::numeric_limits<int>::max();
+                    for (const auto & shard : shards) {
+                        min_cur_pos = std::min(min_cur_pos, shard.cache.cur_pos);
+                    }
+                    ok = min_cur_pos != std::numeric_limits<int>::max() &&
+                         committed <= min_cur_pos;
+                }
+                if (ok) {
                     kvflash_pager.reset();
                     for (int p = 0; p < committed; ++p) {
                         const int slot = kvflash_pager.slot_for(p);

--- a/server/test/test_server_unit.cpp
+++ b/server/test/test_server_unit.cpp
@@ -24,7 +24,9 @@
 #include "common/io_utils.h"
 #include "placement/placement_config.h"
 #include "common/layer_split_backend.h"
+#include "common/layer_split_kvflash.h"
 #include "common/layer_split_utils.h"
+#include "common/kvflash_pager.h"
 #include "placement/draft_residency.h"
 #include "ggml-cpu.h"
 #include "server/prompt_normalize.h"
@@ -1749,6 +1751,100 @@ static void test_validate_layer_split_weights_shape() {
     TEST_ASSERT(validate_device_placement(placement, -1).empty());
 }
 
+static void test_target_shard_plan_same_backend_split() {
+    DevicePlacement placement;
+    TEST_ASSERT(parse_placement_device_list("cuda:0,cuda:1,cuda:2", placement));
+
+    MixedLayerSplitPlan plan;
+    TEST_ASSERT(compute_target_shard_layer_split_plan(
+        placement, PlacementBackend::Cuda, plan, "test-target-shard"));
+    TEST_ASSERT(plan.remote_begin == 1);
+    TEST_ASSERT(plan.remote_backend == PlacementBackend::Cuda);
+}
+
+static void test_target_shard_plan_mixed_backend_split() {
+    DevicePlacement placement;
+    TEST_ASSERT(parse_placement_device_list("cuda:0,cuda:1,hip:0,hip:1", placement));
+
+    MixedLayerSplitPlan plan;
+    TEST_ASSERT(compute_target_shard_layer_split_plan(
+        placement, PlacementBackend::Cuda, plan, "test-target-shard"));
+    TEST_ASSERT(plan.remote_begin == 2);
+    TEST_ASSERT(plan.remote_backend == PlacementBackend::Hip);
+}
+
+static void test_target_shard_plan_rejects_bad_local_backend() {
+    DevicePlacement placement;
+    TEST_ASSERT(parse_placement_device_list("cuda:0,hip:0", placement));
+
+    MixedLayerSplitPlan plan;
+    TEST_ASSERT(!compute_target_shard_layer_split_plan(
+        placement, PlacementBackend::Hip, plan, "test-target-shard"));
+}
+
+static bool kvflash_test_sync_identity(KvFlashPager & pager, int committed) {
+    return layer_split_kvflash_sync_identity(
+        pager, committed, pager.pool_tokens(), "test-target-split");
+}
+
+static void test_kvflash_pager_identity_sync_contract() {
+    KvFlashConfig cfg;
+    cfg.pool_tokens = 512;
+
+    KvFlashPager local;
+    KvFlashPager remote;
+    TEST_ASSERT(local.attach(cfg, {}, {}));
+    TEST_ASSERT(remote.attach(cfg, {}, {}));
+
+    TEST_ASSERT(kvflash_test_sync_identity(local, 256));
+    TEST_ASSERT(kvflash_test_sync_identity(remote, 256));
+    TEST_ASSERT(local.slot_of(255) == remote.slot_of(255));
+
+    TEST_ASSERT(kvflash_test_sync_identity(local, cfg.pool_tokens));
+    TEST_ASSERT(local.slot_of(cfg.pool_tokens - 1) == cfg.pool_tokens - 1);
+    TEST_ASSERT(local.is_identity());
+
+    const int relocated = local.slot_for(cfg.pool_tokens);
+    TEST_ASSERT(relocated >= 0);
+    TEST_ASSERT(relocated != cfg.pool_tokens);
+    TEST_ASSERT(!local.is_identity());
+
+    TEST_ASSERT(kvflash_test_sync_identity(local, 128));
+    TEST_ASSERT(local.slot_of(127) == 127);
+}
+
+static void test_layer_split_kvflash_history_contract() {
+    std::vector<int32_t> history;
+    layer_split_kvflash_sync_history(history, {1, 2, 3}, 0);
+    TEST_ASSERT((history == std::vector<int32_t>{1, 2, 3}));
+
+    layer_split_kvflash_sync_history(history, {4, 5}, 3);
+    TEST_ASSERT((history == std::vector<int32_t>{1, 2, 3, 4, 5}));
+
+    layer_split_kvflash_sync_history(history, {9}, 2);
+    TEST_ASSERT((history == std::vector<int32_t>{1, 2, 9}));
+
+    layer_split_kvflash_sync_history(history, {7}, 5);
+    TEST_ASSERT(history.size() == 6);
+    TEST_ASSERT(history[0] == 1);
+    TEST_ASSERT(history[1] == 2);
+    TEST_ASSERT(history[2] == 9);
+    TEST_ASSERT(history[3] == 0);
+    TEST_ASSERT(history[4] == 0);
+    TEST_ASSERT(history[5] == 7);
+
+    std::vector<std::vector<int32_t>> snapshots(2);
+    layer_split_kvflash_save_history_snapshot(history, 4, snapshots[1]);
+    TEST_ASSERT((snapshots[1] == std::vector<int32_t>{1, 2, 9, 0}));
+
+    history = {8, 8, 8};
+    layer_split_kvflash_restore_history(history, snapshots, 1, 6);
+    TEST_ASSERT((history == std::vector<int32_t>{1, 2, 9, 0, 0, 0}));
+
+    layer_split_kvflash_restore_history(history, snapshots, 0, 3);
+    TEST_ASSERT((history == std::vector<int32_t>{0, 0, 0}));
+}
+
 static void test_backend_precision_cuda_sm_policy() {
     TEST_ASSERT(select_cuda_backend_precision_type_for_sm(90) == GGML_TYPE_BF16);
     TEST_ASSERT(select_cuda_backend_precision_type_for_sm(80) == GGML_TYPE_BF16);
@@ -1796,6 +1892,8 @@ struct MockLayerSplitAdapter : LayerSplitAdapter {
     bool dflash_enabled = false;
     bool dflash_called = false;
     bool sampling_enabled = false;
+    bool kvflash_enabled = false;
+    bool mixed_backend_enabled = false;
     int shutdown_calls = 0;
     ModelBackend::CompressRequest last_compress_req;
     int prefill_chunk = 0;
@@ -1833,6 +1931,10 @@ struct MockLayerSplitAdapter : LayerSplitAdapter {
     }
     bool can_dflash_decode() const override { return dflash_enabled; }
     bool supports_cpu_sampling() const override { return sampling_enabled; }
+    bool supports_kvflash() const override { return kvflash_enabled; }
+    bool supports_mixed_backend_layer_split() const override {
+        return mixed_backend_enabled;
+    }
     bool decode_dflash(const std::vector<int32_t> & prompt, int base_pos,
                        int last_tok, int n_gen, std::vector<int32_t> & out_tokens,
                        const DaemonIO & io, float & accept_rate_out) override {
@@ -2028,6 +2130,19 @@ static void test_layer_split_backend_shutdown_is_idempotent() {
     backend.shutdown();
     backend.shutdown();
     TEST_ASSERT(raw->shutdown_calls == 1);
+}
+
+static void test_layer_split_backend_capability_proxy() {
+    auto * raw = new MockLayerSplitAdapter();
+    LayerSplitBackend backend{std::unique_ptr<LayerSplitAdapter>(raw)};
+
+    TEST_ASSERT(!backend.supports_kvflash());
+    TEST_ASSERT(!backend.supports_mixed_backend_layer_split());
+
+    raw->kvflash_enabled = true;
+    raw->mixed_backend_enabled = true;
+    TEST_ASSERT(backend.supports_kvflash());
+    TEST_ASSERT(backend.supports_mixed_backend_layer_split());
 }
 
 // Disk Prefix Cache Tests
@@ -3973,6 +4088,11 @@ int main() {
     RUN_TEST(test_parse_target_device_list_mixed_backend_multi_remote);
     RUN_TEST(test_parse_target_device_list_single_gpu_is_not_layer_split);
     RUN_TEST(test_validate_layer_split_weights_shape);
+    RUN_TEST(test_target_shard_plan_same_backend_split);
+    RUN_TEST(test_target_shard_plan_mixed_backend_split);
+    RUN_TEST(test_target_shard_plan_rejects_bad_local_backend);
+    RUN_TEST(test_kvflash_pager_identity_sync_contract);
+    RUN_TEST(test_layer_split_kvflash_history_contract);
     RUN_TEST(test_backend_precision_cuda_sm_policy);
     RUN_TEST(test_backend_precision_hip_arch_policy);
     RUN_TEST(test_backend_precision_activation_type_combine);
@@ -3982,6 +4102,7 @@ int main() {
     RUN_TEST(test_layer_split_compress_nopark_uses_default_drafter_path);
     RUN_TEST(test_layer_split_compress_rejects_bad_keep_ratio);
     RUN_TEST(test_layer_split_backend_shutdown_is_idempotent);
+    RUN_TEST(test_layer_split_backend_capability_proxy);
 
     std::fprintf(stderr, "\n── Disk prefix cache ──\n");
     RUN_TEST(test_disk_cache_config_defaults);


### PR DESCRIPTION
## Summary

This PR turns KV Flash target layer split into a shared adapter platform for both mixed-backend and same-backend target-shard execution.

The layer-split server path now depends on a common `LayerSplitAdapter` contract plus a generic target-shard IPC session/daemon loop. Qwen35, Gemma4, and Laguna plug into that contract with model-specific tensor discovery, partial-load ranges, forward calls, and KV Flash policy, while the placement planning, IPC command flow, KV Flash identity/history helpers, and capability reporting are shared.

Qwen35 keeps its DFlash-specific capture/verify path, but the target-shard transport itself is no longer Qwen-only. Gemma4 and Laguna use the same generic `TargetShardIpcSession`, and same-backend split can also take the IPC target-shard path so the runtime is exercised consistently.

## Changes

### 1) Shared foundation
- Add `supports_kvflash()` and `supports_mixed_backend_layer_split()` capability hooks on `ModelBackend` / `LayerSplitAdapter`, proxied through `LayerSplitBackend`.
- Share KV Flash identity-slot rehydration, token-history splicing, snapshot history, and request-reset helpers across Qwen35, Gemma4, and Laguna.
- Add target-shard layer-split planning that supports both mixed backend and same-backend IPC split.

### 2) Common runtime path
- Add generic target-shard IPC client/daemon helpers for boundary activations, token ids, argmax/logits responses, KV Flash identity sync, and snapshot save/free/restore.
- Parse generic target-shard daemon args in `backend_ipc_daemon` (`--hidden`, `--vocab`, `--max-tokens`) so all model adapters can launch through the same IPC executable.
- Keep Qwen35 DFlash target behavior working on top of the shared path, including parent-side span preallocation and local/remote identity sync after prefix restore.

### 3) Adapter implementations
- Wire Qwen35, Gemma4, and Laguna adapters to the shared target-shard IPC path with model-specific launch config and daemon callbacks.
- Keep model-specific tensor discovery, partial-load ranges, and residency policy inside each adapter instead of in the common runtime.
- Add unit coverage for target-shard split planning, KV Flash identity/history contracts, and `LayerSplitBackend` capability proxying.

### Diagram

```text
Request
  -> LayerSplitBackend
      -> shared split planner
      -> shared KV Flash helpers
      -> target-shard IPC session / daemon
           -> local backend shard(s)
           -> remote target shard daemon
      -> model adapter
           -> Qwen35 (DFlash extensions)
           -> Gemma4
           -> Laguna
```

## Validation

- Local real-machine smoke matrix covered Qwen35, Gemma4, and Laguna across mixed CUDA/HIP split plus same-backend HIP IPC split. Every run returned two successful chat completions, and the second request hit prefix restore.
- Remote `lucebox ssh` mixed-backend smoke covered Qwen35 with HIP parent + CUDA target shard. The daemon reported target-shard IPC ready, both chat completions returned `HTTP_STATUS:200`, and the second request hit prefix restore.
- CUDA and HIP `test_server_unit` passed locally and via `lucebox ssh`: `1979 assertions, 0 failures`.
