### PR TITLE
feat(laguna): DFlash speculative decoding — chain + DDTree + sampled-verify

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -250,6 +250,7 @@ add_library(dflash_common STATIC
     src/laguna/laguna_daemon.cpp
     src/laguna/laguna_backend.cpp
     src/laguna/laguna_layer_split_adapter.cpp
+    src/laguna/laguna_dflash_target.cpp
     src/common/backend_ipc.cpp
     src/common/dflash_feature_ring.cpp
     src/common/dflash_capture.cpp

--- a/server/scripts/convert_dflash_to_gguf.py
+++ b/server/scripts/convert_dflash_to_gguf.py
@@ -101,6 +101,11 @@ def load_arch(safetensors: Path, header: dict) -> dict:
         ):
             if val is not None:
                 a[dst] = val
+        dfc = c.get("dflash_config") or {}
+        _tli = (dfc.get("target_layer_ids") or c.get("target_layer_ids")
+                or c.get("aux_hidden_state_layer_ids"))
+        if _tli:
+            a["capture_layer_ids"] = [int(x) for x in _tli]
         print(f"[info] read arch from {cfg_path}")
     else:
         print(f"[warn] no config.json next to safetensors; using 27B defaults")
@@ -269,6 +274,15 @@ def main():
     writer.add_uint32(f"{ARCH}.dflash.n_target_layers", a["n_target_layers"])
     writer.add_uint32(f"{ARCH}.dflash.block_size",      a["block_size"])
     writer.add_uint32(f"{ARCH}.dflash.mask_token_id",   a["mask_token_id"])
+    # Explicit captured target-layer ids (from the drafter's config.json). Travels
+    # with the model so the server reads which target layers to capture instead of
+    # hardcoding a per-arch set. Emitted only when it matches the fc-derived count.
+    _cap_ids = a.get("capture_layer_ids")
+    if _cap_ids and len(_cap_ids) == a["n_target_layers"]:
+        writer.add_array(f"{ARCH}.dflash.target_layer_ids", [int(x) for x in _cap_ids])
+    elif _cap_ids:
+        print(f"[warn] capture_layer_ids len {len(_cap_ids)} != n_target_layers "
+              f"{a['n_target_layers']}; not embedding ids", file=sys.stderr)
 
     # Walk + add tensors. Sort: dflash.* singletons first, then output_*,
     # then per-layer in numeric order — keeps the on-disk layout stable.

--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -150,6 +150,7 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
         lcfg.ddtree_mode = args.ddtree_mode;
         lcfg.ddtree_budget = args.ddtree_budget;
         lcfg.ddtree_temp = args.ddtree_temp;
+        lcfg.verify_width = args.verify_width;
         lcfg.device      = args.device;
         lcfg.max_ctx     = args.device.max_ctx;
         lcfg.chunk       = args.chunk;

--- a/server/src/common/backend_factory.cpp
+++ b/server/src/common/backend_factory.cpp
@@ -144,6 +144,12 @@ std::unique_ptr<ModelBackend> create_backend(const BackendArgs & args) {
 
         LagunaBackendArgs lcfg;
         lcfg.target_path = args.model_path;
+        lcfg.draft_path  = args.draft_path ? args.draft_path : "";
+        lcfg.draft_gpu   = args.draft_device.gpu;
+        lcfg.draft_ctx_max = args.draft_ctx_max;
+        lcfg.ddtree_mode = args.ddtree_mode;
+        lcfg.ddtree_budget = args.ddtree_budget;
+        lcfg.ddtree_temp = args.ddtree_temp;
         lcfg.device      = args.device;
         lcfg.max_ctx     = args.device.max_ctx;
         lcfg.chunk       = args.chunk;

--- a/server/src/common/backend_factory.h
+++ b/server/src/common/backend_factory.h
@@ -54,6 +54,7 @@ struct BackendArgs {
     int             ddtree_budget    = 22;
     float           ddtree_temp      = 1.0f;
     bool            ddtree_chain_seed = true;
+    int             verify_width     = 0;  // chain spec verify width; 0 = adaptive
     bool            use_feature_mirror = false;
 };
 

--- a/server/src/draft/draft_gguf_loader.cpp
+++ b/server/src/draft/draft_gguf_loader.cpp
@@ -177,12 +177,20 @@ bool load_draft_gguf(const std::string & path,
     const uint32_t head_dim  = read_u32("attention.key_length",    0);
     const uint32_t block_sz  = read_u32("dflash.block_size",       0);
     uint32_t n_tgt_lay       = read_u32("dflash.n_target_layers",  0);
-    if (n_tgt_lay == 0) {
+    // Explicit captured target-layer ids (data-driven). Lets any DFlash drafter
+    // load without a hardcoded per-arch set; the array length also backstops
+    // n_target_layers when the scalar KV is absent.
+    {
         std::snprintf(key, sizeof(key), "%s.%s", A, "dflash.target_layer_ids");
         const int64_t target_ids_id = gguf_find_key(gctx, key);
         if (target_ids_id >= 0 &&
-            gguf_get_kv_type(gctx, target_ids_id) == GGUF_TYPE_ARRAY) {
-            n_tgt_lay = (uint32_t)gguf_get_arr_n(gctx, target_ids_id);
+            gguf_get_kv_type(gctx, target_ids_id) == GGUF_TYPE_ARRAY &&
+            gguf_get_arr_type(gctx, target_ids_id) == GGUF_TYPE_INT32) {
+            const uint32_t n = (uint32_t)gguf_get_arr_n(gctx, target_ids_id);
+            const int32_t * vals =
+                (const int32_t *)gguf_get_arr_data(gctx, target_ids_id);
+            out.capture_layer_ids.assign(vals, vals + n);
+            if (n_tgt_lay == 0) n_tgt_lay = n;
         }
     }
     if (n_tgt_lay == 0 && n_embd != 0) {

--- a/server/src/internal.h
+++ b/server/src/internal.h
@@ -277,6 +277,7 @@ struct DraftWeights {
     // DFlash draft-specific config (populated by loader or set by caller).
     int block_size      = DFLASH27B_DRAFT_BLOCK_SIZE;       // tokens per draft step (16 or 10)
     int n_target_layers = DFLASH27B_DRAFT_N_TARGET_LAYERS;  // captured target layers (5)
+    std::vector<int> capture_layer_ids;                     // explicit captured target-layer ids (GGUF dflash.target_layer_ids); empty = derive from count
     int mask_token_id   = DFLASH27B_DRAFT_MASK_TOKEN_ID;    // noise mask token
 };
 

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -346,7 +346,30 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
     if (last_tok < 0) return false;
 
     DFlashTarget * target = dflash_target_;
-    const int q_len = dw_.block_size;
+    const int block_size = dw_.block_size;
+    // [TAG_LAGUNA_VERIFY_WIDTH] Speculative verify width (chain). On this MoE
+    // target the batched verify forward's cost grows with the verify width: it
+    // reads the union of experts the batch routes to (bandwidth-bound), and above
+    // mmvq_mmid_max (8 for Q4_K/Q5_K on sm_86+) it also drops off the ggml
+    // CUDA-graph path (ggml-cuda.cu [TAG_MUL_MAT_ID_CUDA_GRAPHS]). The draft
+    // proposes block_size tokens but avg_commit is ~2.9, so verifying the whole
+    // block is wasteful. Measured (laguna-xs2 Q4_K_M, RTX 3090): width 8 -> 110
+    // tok/s, 4 -> 138, 3 -> 150 (== AR). We verify only the first q_len of the
+    // drafted block; the accept rule is unchanged, so this stays lossless. AUTO
+    // tracks an EWMA of the accepted length (held constant per request so the
+    // verify graph stays CUDA-graph-stable); --verify-width forces a fixed width.
+    int verify_width = args_.verify_width;
+    if (const char * e = std::getenv("DFLASH_LAGUNA_VERIFY_WIDTH")) {
+        const int w = std::atoi(e);
+        if (w > 0) verify_width = w;
+    }
+    const bool adaptive_width = (verify_width <= 0);
+    int chain_w = adaptive_width ? (int)spec_ewma_accept_ + 2 : verify_width;
+    if (chain_w < 2) chain_w = 2;
+    if (chain_w > std::min(block_size, 8)) chain_w = std::min(block_size, 8);
+    // DDTree sizes its batch via its budget; chain uses the width chosen above.
+    const int q_len = args_.ddtree_mode ? block_size : chain_w;
+
     const bool ignore_eos = (std::getenv("DFLASH_IGNORE_EOS") != nullptr);
     const bool sampled_verify = laguna_sampled_verify_enabled(sampler_, true);
     if (dflash_target_) {
@@ -355,13 +378,15 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
 
     StepGraph draft_sg;
 
-    std::vector<float>   noise_embed((size_t)hidden * (size_t)q_len);
-    std::vector<int32_t> noise_ids((size_t)q_len);
+    // The draft graph is always block_size-wide (build_draft_step uses
+    // dw_.block_size); chain reads/verifies only its first q_len outputs.
+    std::vector<float>   noise_embed((size_t)hidden * (size_t)block_size);
+    std::vector<int32_t> noise_ids((size_t)block_size);
     std::vector<int32_t> draft_tok((size_t)q_len);
     std::vector<int32_t> target_tok((size_t)q_len);
     std::vector<float>   verify_logits;
     std::vector<int32_t> verify_history;
-    std::vector<int32_t> pos_q((size_t)q_len);
+    std::vector<int32_t> pos_q((size_t)block_size);
     std::vector<int32_t> pos_k;
     std::vector<float>   local_hidden;
     std::vector<int32_t> sample_history =
@@ -489,8 +514,8 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
         }
 
         noise_ids[0] = last_tok;
-        for (int i = 1; i < q_len; i++) noise_ids[(size_t)i] = target->mask_token_id();
-        if (!target->embed_tokens(noise_ids.data(), q_len, noise_embed.data())) {
+        for (int i = 1; i < block_size; i++) noise_ids[(size_t)i] = target->mask_token_id();
+        if (!target->embed_tokens(noise_ids.data(), block_size, noise_embed.data())) {
             std::fprintf(stderr, "[laguna-spec] noise embed failed\n");
             step_graph_destroy(draft_sg);
             return false;
@@ -523,9 +548,9 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
 
         ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
                                 sizeof(float) * noise_embed.size());
-        pos_k.resize((size_t)draft_ctx + (size_t)q_len);
-        for (int i = 0; i < q_len; i++) pos_q[(size_t)i] = draft_ctx + i;
-        for (int i = 0; i < draft_ctx + q_len; i++) pos_k[(size_t)i] = i;
+        pos_k.resize((size_t)draft_ctx + (size_t)block_size);
+        for (int i = 0; i < block_size; i++) pos_q[(size_t)i] = draft_ctx + i;
+        for (int i = 0; i < draft_ctx + block_size; i++) pos_k[(size_t)i] = i;
         ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
                                 sizeof(int32_t) * pos_q.size());
         ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
@@ -773,6 +798,14 @@ bool LagunaBackend::do_spec_decode(int committed, int n_gen,
 
     if (accept_rate_out) {
         *accept_rate_out = (float)(n_accept_sum / (double)total_draft_pos);
+    }
+
+    // [TAG_LAGUNA_VERIFY_WIDTH] Update the persisted accepted-length EWMA so the
+    // AUTO width converges to the throughput optimum for the active draft (chain
+    // only; DDTree sizes via its budget and accounts accepts differently).
+    if (adaptive_width && !args_.ddtree_mode && n_draft_steps > 0) {
+        const double mean_accept = (double)n_accept_sum / (double)n_draft_steps;
+        spec_ewma_accept_ = 0.7 * spec_ewma_accept_ + 0.3 * mean_accept;
     }
 
     if (dflash_target_) {

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -2705,7 +2705,8 @@ bool LagunaBackend::load_decode_draft() {
     constexpr int TARGET_FEAT_CAP = 4096;
     const int feat_cap = std::min(args_.max_ctx, TARGET_FEAT_CAP);
     if (!cache_.target_feat &&
-        !create_laguna_target_feat(backend_, cache_, n_capture, w_.n_embd, feat_cap)) {
+        !create_laguna_target_feat(backend_, cache_, n_capture, w_.n_embd, feat_cap,
+                                   dw_.capture_layer_ids)) {
         std::fprintf(stderr, "[laguna] target_feat alloc failed\n");
         free_decode_draft();
         return false;

--- a/server/src/laguna/laguna_backend.cpp
+++ b/server/src/laguna/laguna_backend.cpp
@@ -10,6 +10,9 @@
 #include "laguna_internal.h"
 #include "qwen3/qwen3_kvflash_scorer.h"
 #include "dflash27b.h"
+#include "common/ddtree.h"
+#include "common/dflash_feature_ring.h"
+#include "common/dflash_draft_graph.h"
 
 #include <chrono>
 #include "../common/moe_hybrid_types.h"
@@ -37,6 +40,14 @@
 
 namespace dflash::common {
 
+static bool laguna_sampled_verify_enabled(const SamplerCfg & sampler, bool do_sample) {
+    static const bool kSampledVerify = []() {
+        const char * e = std::getenv("DFLASH_SAMPLED_VERIFY");
+        return e != nullptr && std::string(e) == "1";
+    }();
+    return kSampledVerify && do_sample && sampler.needs_logit_processing();
+}
+
 // ── Construction / initialisation ───────────────────────────────────────
 
 LagunaBackend::LagunaBackend(const LagunaBackendArgs & args)
@@ -58,11 +69,20 @@ bool LagunaBackend::init() {
         return false;
     }
 
-    // Always use dynamic placement (like qwen35moe): partial load first,
-    // compute budget, then reload full if all experts fit.
-    if (!init_hybrid_mode()) {
-        ggml_backend_free(backend_); backend_ = nullptr;
-        return false;
+    if (!args_.draft_path.empty()) {
+        if (!load_target_gguf_laguna(args_.target_path, backend_, w_)) {
+            std::fprintf(stderr, "[laguna] full load failed: %s\n", dflash27b_last_error());
+            ggml_backend_free(backend_); backend_ = nullptr;
+            return false;
+        }
+        hybrid_mode_ = false;
+    } else {
+        // Dynamic placement (like qwen35moe): partial load first, compute
+        // budget, then reload full if all experts fit.
+        if (!init_hybrid_mode()) {
+            ggml_backend_free(backend_); backend_ = nullptr;
+            return false;
+        }
     }
 
     cache_.kv_k_type = args_.kv_type;
@@ -78,6 +98,10 @@ bool LagunaBackend::init() {
     if (!kvflash_attach()) {
         ggml_backend_free(backend_); backend_ = nullptr;
         return false;
+    }
+
+    if (!args_.draft_path.empty() && !load_decode_draft()) {
+        std::fprintf(stderr, "[laguna] draft unavailable; speculative decode disabled\n");
     }
 
     return true;
@@ -200,9 +224,20 @@ void LagunaBackend::print_ready_banner() const {
 // ── Park / unpark ───────────────────────────────────────────────────────
 
 bool LagunaBackend::park(const std::string & what) {
+    const bool want_draft = (what.empty() || what == "all" || what == "draft");
     const bool want_target = (what.empty() || what == "all" || what == "target");
-    // "park draft" is a no-op on the laguna path (no DFlash draft).
+
+    if (want_draft && !draft_parked_ && !args_.draft_path.empty()) {
+        free_decode_draft();
+        draft_parked_ = true;
+        std::printf("[park] draft released\n"); std::fflush(stdout);
+    }
+
     if (want_target && !target_parked_) {
+        if (!draft_parked_ && !args_.draft_path.empty()) {
+            free_decode_draft();
+            draft_parked_ = true;
+        }
         free_laguna_target_cache(cache_);
         free_laguna_target_weights(w_);
         target_parked_ = true;
@@ -212,11 +247,20 @@ bool LagunaBackend::park(const std::string & what) {
 }
 
 bool LagunaBackend::unpark(const std::string & what) {
+    const bool want_draft = (what.empty() || what == "all" || what == "draft");
     const bool want_target = (what.empty() || what == "all" || what == "target");
     if (want_target && target_parked_) {
-        if (!load_target_gguf_laguna(args_.target_path, backend_, w_)) {
-            std::fprintf(stderr, "[unpark] target: %s\n", dflash27b_last_error());
-            return false;
+        if (!args_.draft_path.empty()) {
+            if (!load_target_gguf_laguna(args_.target_path, backend_, w_)) {
+                std::fprintf(stderr, "[unpark] target: %s\n", dflash27b_last_error());
+                return false;
+            }
+            hybrid_mode_ = false;
+        } else {
+            if (!init_hybrid_mode()) {
+                std::fprintf(stderr, "[unpark] target: %s\n", dflash27b_last_error());
+                return false;
+            }
         }
         cache_.kv_k_type = args_.kv_type;
         cache_.kv_v_type = args_.kv_type;
@@ -233,6 +277,9 @@ bool LagunaBackend::unpark(const std::string & what) {
         kvflash_drafter_failed_ = false;   // fresh VRAM: allow a retry
         target_parked_ = false;
         std::printf("[unpark] target restored\n"); std::fflush(stdout);
+    }
+    if (want_draft && draft_parked_ && !args_.draft_path.empty()) {
+        if (!load_decode_draft()) return false;
     }
     return true;
 }
@@ -285,6 +332,456 @@ int LagunaBackend::snapshot_cur_pos(int slot) const {
     return -1;
 }
 
+// Speculative decode
+
+bool LagunaBackend::do_spec_decode(int committed, int n_gen,
+                                    std::vector<int32_t> & out_tokens,
+                                    const DaemonIO & io,
+                                    const BudgetHook * budget_hook,
+                                    bool * forced_close_out,
+                                    float * accept_rate_out,
+                                    const std::vector<int32_t> * sample_history_prefix) {
+    const int hidden = w_.n_embd;
+    int32_t last_tok = cache_.last_tok;
+    if (last_tok < 0) return false;
+
+    DFlashTarget * target = dflash_target_;
+    const int q_len = dw_.block_size;
+    const bool ignore_eos = (std::getenv("DFLASH_IGNORE_EOS") != nullptr);
+    const bool sampled_verify = laguna_sampled_verify_enabled(sampler_, true);
+    if (dflash_target_) {
+        dflash_target_->set_keep_verify_logits(sampled_verify);
+    }
+
+    StepGraph draft_sg;
+
+    std::vector<float>   noise_embed((size_t)hidden * (size_t)q_len);
+    std::vector<int32_t> noise_ids((size_t)q_len);
+    std::vector<int32_t> draft_tok((size_t)q_len);
+    std::vector<int32_t> target_tok((size_t)q_len);
+    std::vector<float>   verify_logits;
+    std::vector<int32_t> verify_history;
+    std::vector<int32_t> pos_q((size_t)q_len);
+    std::vector<int32_t> pos_k;
+    std::vector<float>   local_hidden;
+    std::vector<int32_t> sample_history =
+        sample_history_prefix ? *sample_history_prefix : std::vector<int32_t>{};
+
+    int n_generated   = 0;
+    int n_draft_steps = 0;
+    int n_accept_sum  = 0;
+
+    auto argmax_logits = [](const std::vector<float> & ll) {
+        int best = 0;
+        float bv = ll.empty() ? 0.0f : ll[0];
+        for (size_t i = 1; i < ll.size(); ++i) {
+            if (ll[i] > bv) { bv = ll[i]; best = (int)i; }
+        }
+        return best;
+    };
+
+    auto run_ar_tail = [&](int ar_n_gen) -> bool {
+        std::vector<float> embed_step((size_t)hidden);
+        std::vector<float> logits;
+        bool budget_close_started = false;
+        int close_inject_pos = 0;
+        int32_t tok = last_tok;
+
+        auto maybe_force_close = [&](int32_t & t) {
+            if (!budget_hook || budget_hook->close_token_ids.empty()) return;
+            if (budget_close_started &&
+                close_inject_pos < (int)budget_hook->close_token_ids.size()) {
+                int32_t inj = budget_hook->close_token_ids[(size_t)close_inject_pos];
+                std::fprintf(stderr,
+                    "[budget-hook] laguna spec-tail close-seq continue %d/%zu: "
+                    "overriding sampled token %d with %d\n",
+                    close_inject_pos + 1,
+                    budget_hook->close_token_ids.size(), t, inj);
+                t = inj;
+                close_inject_pos++;
+                return;
+            }
+            if (budget_close_started) return;
+            const int remaining = n_gen - n_generated;
+            if (remaining <= budget_hook->hard_limit_remaining) {
+                int32_t first_close = budget_hook->close_token_ids.front();
+                if (t == first_close) {
+                    budget_close_started = true;
+                    close_inject_pos = 1;
+                    return;
+                }
+                std::fprintf(stderr,
+                    "[budget-hook] laguna spec-tail force-close at generated=%d/%d "
+                    "(remaining=%d <= hard_limit=%d): overriding token %d "
+                    "with close[0]=%d (seq len %zu)\n",
+                    n_generated, n_gen, remaining,
+                    budget_hook->hard_limit_remaining, t, first_close,
+                    budget_hook->close_token_ids.size());
+                t = first_close;
+                budget_close_started = true;
+                close_inject_pos = 1;
+                if (forced_close_out) *forced_close_out = true;
+            }
+        };
+
+        for (int s = 0; s < ar_n_gen; ++s) {
+            maybe_force_close(tok);
+            if (!ignore_eos && target->is_eos(tok)) break;
+
+            out_tokens.push_back(tok);
+            sample_history.push_back(tok);
+            io.emit(tok);
+            if (io.cancelled) break;
+
+            if (!target->embed_tokens(&tok, 1, embed_step.data())) return false;
+            if (!kvflash_alloc_span(committed, 1) ||
+                !laguna_step(backend_, w_, cache_, embed_step.data(), 1,
+                             committed, /*no_mask=*/false, logits,
+                             kvflash_active() ? &kvflash_pager_ : nullptr)) {
+                return false;
+            }
+            if (feature_mirror_.target_feat && cache_.target_feat) {
+                draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                feature_mirror_, committed, 1);
+            }
+
+            committed++;
+            cache_.cur_pos = committed;
+            n_generated++;
+            tok = sampled_verify
+                ? sample_logits(logits.data(), (int)logits.size(), sampler_,
+                                sample_history, sampler_rng_)
+                : argmax_logits(logits);
+        }
+
+        last_tok = tok;
+        cache_.last_tok = last_tok;
+        return true;
+    };
+
+    auto t_dec0 = std::chrono::steady_clock::now();
+
+    while (n_generated < n_gen) {
+        const int need_commit_budget = n_gen - n_generated;
+
+        if (budget_hook && !budget_hook->close_token_ids.empty()) {
+            const int hard = budget_hook->hard_limit_remaining;
+            if (need_commit_budget <= hard + q_len) {
+                std::fprintf(stderr,
+                    "[budget-hook] laguna spec-decode tail-off at committed=%d "
+                    "remaining=%d hard_limit=%d batch=%d - switching to AR\n",
+                    committed, need_commit_budget, hard, q_len);
+                step_graph_destroy(draft_sg);
+                const bool ok = run_ar_tail(need_commit_budget);
+                auto t_dec1 = std::chrono::steady_clock::now();
+                const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
+                const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+                const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
+                std::fprintf(stderr,
+                    "[laguna-spec] tail-off-stats tokens=%d time=%.3f s speed=%.2f tok/s "
+                    "steps=%d accepted=%d/%d (%.1f%%)\n",
+                    n_generated, decode_s,
+                    n_generated > 0 ? n_generated / decode_s : 0.0,
+                    n_draft_steps, n_accept_sum, total_draft_pos, accept_pct);
+                io.emit(-1);
+                return ok;
+            }
+        }
+
+        noise_ids[0] = last_tok;
+        for (int i = 1; i < q_len; i++) noise_ids[(size_t)i] = target->mask_token_id();
+        if (!target->embed_tokens(noise_ids.data(), q_len, noise_embed.data())) {
+            std::fprintf(stderr, "[laguna-spec] noise embed failed\n");
+            step_graph_destroy(draft_sg);
+            return false;
+        }
+
+        constexpr int DRAFT_CTX_MAX_DEFAULT = 2048;
+        const int ring_cap = feature_mirror_.cap;
+        const int draft_ctx = std::min(committed,
+            std::min(ring_cap, std::max(DRAFT_CTX_MAX_DEFAULT, args_.draft_ctx_max)));
+        const int draft_start = committed - draft_ctx;
+        int mirror_slot0 = 0;
+        const bool use_mirror_view =
+            draft_feature_mirror_can_view(feature_mirror_, committed, draft_ctx, mirror_slot0);
+
+        if (!build_draft_step(draft_sg, dw_, /*lm_head=*/nullptr, draft_backend_,
+                              draft_ctx, use_mirror_view ? &feature_mirror_ : nullptr,
+                              committed,
+                              std::min(ring_cap, std::max(DRAFT_CTX_MAX_DEFAULT, args_.draft_ctx_max)))) {
+            std::fprintf(stderr, "[laguna-spec] draft build failed\n");
+            step_graph_destroy(draft_sg);
+            return false;
+        }
+        if (!use_mirror_view &&
+            !copy_feature_ring_range_to_tensor(feature_mirror_, draft_sg.target_hidden_cat,
+                                               draft_start, draft_ctx)) {
+            std::fprintf(stderr, "[laguna-spec] feature copy failed\n");
+            step_graph_destroy(draft_sg);
+            return false;
+        }
+
+        ggml_backend_tensor_set(draft_sg.inp_embed, noise_embed.data(), 0,
+                                sizeof(float) * noise_embed.size());
+        pos_k.resize((size_t)draft_ctx + (size_t)q_len);
+        for (int i = 0; i < q_len; i++) pos_q[(size_t)i] = draft_ctx + i;
+        for (int i = 0; i < draft_ctx + q_len; i++) pos_k[(size_t)i] = i;
+        ggml_backend_tensor_set(draft_sg.positions, pos_q.data(), 0,
+                                sizeof(int32_t) * pos_q.size());
+        ggml_backend_tensor_set(draft_sg.positions_k, pos_k.data(), 0,
+                                sizeof(int32_t) * pos_k.size());
+
+        if (ggml_backend_graph_compute(draft_backend_, draft_sg.gf) != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "[laguna-spec] draft compute failed\n");
+            step_graph_destroy(draft_sg);
+            return false;
+        }
+
+        local_hidden.resize((size_t)hidden * (size_t)q_len);
+        ggml_backend_tensor_get(draft_sg.hidden_states, local_hidden.data(), 0,
+                                sizeof(float) * local_hidden.size());
+
+        if (!target->project_hidden_to_tokens(local_hidden.data(), q_len, draft_tok)) {
+            std::fprintf(stderr, "[laguna-spec] projection failed\n");
+            step_graph_destroy(draft_sg);
+            return false;
+        }
+        draft_tok[0] = last_tok;
+
+        const bool tree_special_inactive =
+            !(budget_hook && !budget_hook->close_token_ids.empty());
+        if (args_.ddtree_mode && target->supports_tree_verify() &&
+            q_len > 1 && tree_special_inactive && !sampled_verify) {
+            const int L = q_len - 1;
+            const int K = (args_.ddtree_budget > L) ? 8 : 1;
+            std::vector<float> top_lp;
+            std::vector<int32_t> top_ids;
+            if (!target->project_hidden_to_topk(local_hidden.data(), q_len, K,
+                                                args_.ddtree_temp, top_lp, top_ids)) {
+                std::fprintf(stderr, "[laguna-spec] ddtree topk projection failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+
+            DDTree tree = build_ddtree(top_lp.data() + (size_t)K,
+                                       top_ids.data() + (size_t)K,
+                                       L, K, args_.ddtree_budget,
+                                       /*chain_seed=*/true);
+            const int N = args_.ddtree_budget + 1;
+            std::vector<int32_t> flat_tokens((size_t)N, 0);
+            flat_tokens[0] = last_tok;
+            for (int i = 0; i < tree.n_nodes; ++i) {
+                flat_tokens[(size_t)i + 1] = tree.token_ids[(size_t)i];
+            }
+
+            std::vector<int32_t> posterior;
+            if (!target->verify_tree(committed, tree, flat_tokens, N, posterior, nullptr)) {
+                std::fprintf(stderr, "[laguna-spec] verify_tree failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+
+            int next_token = -1;
+            int bonus_node = 0;
+            std::vector<int> accepted =
+                follow_verified_tree(tree, posterior.data(), next_token, &bonus_node);
+            (void)bonus_node;
+
+            int commit_n = (int)accepted.size();
+            if (commit_n > need_commit_budget) commit_n = need_commit_budget;
+            if (commit_n <= 0) {
+                step_graph_destroy(draft_sg);
+                break;
+            }
+
+            bool hit_eos = false;
+            int emitted = 0;
+            for (int i = 0; i < commit_n; ++i) {
+                const int dfs = accepted[(size_t)i];
+                const int32_t tok = (dfs == 0) ? last_tok : tree.token_ids[(size_t)dfs - 1];
+                if (!ignore_eos && target->is_eos(tok)) { hit_eos = true; break; }
+                out_tokens.push_back(tok);
+                sample_history.push_back(tok);
+                io.emit(tok);
+                emitted++;
+                if (io.cancelled) break;
+            }
+
+            n_accept_sum += std::max(0, emitted - 1);
+            n_draft_steps++;
+            if (io.cancelled || hit_eos || emitted <= 0 || next_token < 0 ||
+                (!ignore_eos && target->is_eos(next_token))) {
+                committed += emitted;
+                cache_.cur_pos = committed;
+                n_generated += emitted;
+                last_tok = next_token;
+                cache_.last_tok = last_tok;
+                break;
+            }
+
+            std::vector<int> accepted_committed(accepted.begin(),
+                                                accepted.begin() + emitted);
+            if (!target->rollback_to_tree(committed, tree, accepted_committed)) {
+                std::fprintf(stderr, "[laguna-spec] rollback_to_tree failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+
+            if (feature_mirror_.target_feat && cache_.target_feat) {
+                draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                                feature_mirror_, committed, emitted);
+            }
+
+            last_tok = next_token;
+            cache_.last_tok = last_tok;
+            committed += emitted;
+            cache_.cur_pos = committed;
+            n_generated += emitted;
+            continue;
+        }
+
+        int verify_last_tok = -1;
+        if (!target->verify_batch(draft_tok, committed, verify_last_tok, &target_tok)) {
+            std::fprintf(stderr, "[laguna-spec] verify failed\n");
+            step_graph_destroy(draft_sg);
+            return false;
+        }
+
+        int accept_n = 1;
+        int bonus_tok = -1;
+        int verify_vocab = 0;
+        if (sampled_verify) {
+            if (!target->read_verify_logits(q_len, verify_logits)) {
+                std::fprintf(stderr, "[laguna-spec] verify logits read failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+            verify_vocab = (int)(verify_logits.size() / (size_t)q_len);
+            verify_history = sample_history;
+            verify_history.push_back(draft_tok[0]);
+            for (int i = 0; i < q_len - 1; ++i) {
+                const int sampled = sample_logits(
+                    verify_logits.data() + (size_t)i * (size_t)verify_vocab,
+                    verify_vocab, sampler_, verify_history, sampler_rng_);
+                if (draft_tok[(size_t)i + 1] == sampled) {
+                    accept_n++;
+                    verify_history.push_back(sampled);
+                } else {
+                    bonus_tok = sampled;
+                    break;
+                }
+            }
+        } else {
+            for (int i = 0; i < q_len - 1; i++) {
+                if (draft_tok[(size_t)i + 1] == target_tok[(size_t)i]) accept_n++;
+                else break;
+            }
+            bonus_tok = (accept_n < q_len) ? target_tok[(size_t)accept_n - 1] : -1;
+        }
+        int commit_n = accept_n + (bonus_tok >= 0 ? 1 : 0);
+        if (commit_n > need_commit_budget) {
+            commit_n = need_commit_budget;
+            if (commit_n <= accept_n) bonus_tok = -1;
+        }
+
+        std::vector<int32_t> replay_tok((size_t)commit_n);
+        for (int i = 0; i < commit_n; ++i) {
+            replay_tok[(size_t)i] = (i < accept_n) ? draft_tok[(size_t)i] : bonus_tok;
+        }
+        std::vector<int32_t> history_after_commit = sample_history;
+        for (int32_t tok : replay_tok) {
+            history_after_commit.push_back(tok);
+        }
+
+        cache_.cur_pos = committed + accept_n;
+
+        if (bonus_tok >= 0) {
+            std::vector<int32_t> bonus_vec = { bonus_tok };
+            int bonus_last = -1;
+            if (!target->verify_batch(bonus_vec, committed + accept_n, bonus_last, nullptr)) {
+                std::fprintf(stderr, "[laguna-spec] bonus forward failed\n");
+                step_graph_destroy(draft_sg);
+                return false;
+            }
+            if (sampled_verify) {
+                if (!target->read_verify_logits(1, verify_logits)) {
+                    std::fprintf(stderr, "[laguna-spec] bonus logits read failed\n");
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+                const int vocab_v = (int)verify_logits.size();
+                last_tok = sample_logits(verify_logits.data(), vocab_v, sampler_,
+                                         history_after_commit, sampler_rng_);
+            } else {
+                last_tok = bonus_last;
+            }
+        } else {
+            if (sampled_verify && commit_n > 0) {
+                if (verify_vocab <= 0) {
+                    std::fprintf(stderr, "[laguna-spec] invalid sampled verify vocab\n");
+                    step_graph_destroy(draft_sg);
+                    return false;
+                }
+                const int row = std::min(commit_n - 1, q_len - 1);
+                last_tok = sample_logits(
+                    verify_logits.data() + (size_t)row * (size_t)verify_vocab,
+                    verify_vocab, sampler_, history_after_commit, sampler_rng_);
+            } else {
+                last_tok = verify_last_tok;
+            }
+        }
+        cache_.last_tok = last_tok;
+
+        if (feature_mirror_.target_feat && cache_.target_feat) {
+            draft_feature_mirror_sync_range(cache_.target_feat, cache_.target_feat_cap,
+                                            feature_mirror_, committed, commit_n);
+        }
+
+        bool hit_eos = false;
+        int emitted = 0;
+        for (int i = 0; i < commit_n; i++) {
+            int tok = replay_tok[(size_t)i];
+            if (!ignore_eos && target->is_eos(tok)) { hit_eos = true; break; }
+            out_tokens.push_back(tok);
+            sample_history.push_back(tok);
+            io.emit(tok);
+            emitted++;
+            if (io.cancelled) break;
+        }
+
+        committed += emitted;
+        cache_.cur_pos = committed;
+        n_generated += emitted;
+        n_accept_sum += std::min(accept_n, emitted);
+        n_draft_steps++;
+        if (io.cancelled) break;
+        if (hit_eos) break;
+    }
+
+    step_graph_destroy(draft_sg);
+
+    auto t_dec1 = std::chrono::steady_clock::now();
+    const double decode_s = std::chrono::duration<double>(t_dec1 - t_dec0).count();
+    const int total_draft_pos = std::max(1, n_draft_steps * q_len);
+    const double accept_pct = 100.0 * (double)n_accept_sum / (double)total_draft_pos;
+    std::fprintf(stderr, "[laguna-spec] tokens=%d time=%.3f s speed=%.2f tok/s "
+                 "steps=%d accepted=%d/%d (%.1f%%) avg_commit=%.2f\n",
+                 n_generated, decode_s,
+                 n_generated > 0 ? n_generated / decode_s : 0.0,
+                 n_draft_steps, n_accept_sum, total_draft_pos, accept_pct,
+                 n_draft_steps > 0 ? (double)n_generated / (double)n_draft_steps : 0.0);
+
+    if (accept_rate_out) {
+        *accept_rate_out = (float)(n_accept_sum / (double)total_draft_pos);
+    }
+
+    if (dflash_target_) {
+        dflash_target_->set_keep_verify_logits(false);
+    }
+    io.emit(-1);
+    return true;
+}
+
 // ── Generation ──────────────────────────────────────────────────────────
 
 GenerateResult LagunaBackend::generate_impl(const GenerateRequest & req,
@@ -310,6 +807,10 @@ GenerateResult LagunaBackend::generate_impl(const GenerateRequest & req,
     DaemonIO out_io = io.with_token_callback(req.on_token);
     const bool should_emit = req.stream || (bool)out_io.on_token;
     const int N = (int)req.prompt.size();
+    sampler_ = req.sampler;
+    if (req.do_sample && sampler_.seed != 0) {
+        sampler_rng_.seed(sampler_.seed);
+    }
 
     if (N + req.n_gen > args_.max_ctx) {
         result.error = "overflow";
@@ -347,7 +848,8 @@ GenerateResult LagunaBackend::generate_impl(const GenerateRequest & req,
         ok = kvflash_alloc_span(kv_start, n_tok) &&
              laguna_step(backend_, w_, cache_,
                           embed_pf.data() + (size_t)kv_start * w_.n_embd,
-                          n_tok, kv_start, no_mask, last_logits, kvf);
+                          n_tok, kv_start, no_mask, last_logits, kvf,
+                          /*capture=*/true);
     }
     if (!ok) { result.error = "prefill"; return result; }
     auto t_pf1 = std::chrono::steady_clock::now();
@@ -386,12 +888,50 @@ GenerateResult LagunaBackend::generate_impl(const GenerateRequest & req,
 
     auto pick = [&](const std::vector<float> & ll) -> int {
         return req.do_sample
-            ? sample_logits(ll.data(), (int)ll.size(), req.sampler, history, sampler_rng_)
+            ? sample_logits(ll.data(), (int)ll.size(), sampler_, history, sampler_rng_)
             : argmax(ll);
     };
 
-    int next_tok = pick(last_logits);
+    cache_.last_tok = argmax(last_logits);
     result.tokens.reserve(req.n_gen);
+    const bool sampled_verify = laguna_sampled_verify_enabled(sampler_, req.do_sample);
+
+    const bool can_spec = req.n_gen > 0
+        && !req.force_ar_decode
+        && !args_.draft_path.empty()
+        && dflash_target_
+        && !draft_parked_
+        && feature_mirror_.target_feat
+        && cache_.target_feat
+        && (!sampler_.needs_logit_processing() || sampled_verify);
+
+    if (can_spec) {
+        if (sampled_verify) {
+            cache_.last_tok = sample_logits(last_logits.data(), (int)last_logits.size(),
+                                            sampler_, history, sampler_rng_);
+        }
+        auto t_g0 = std::chrono::steady_clock::now();
+        if (!draft_feature_mirror_sync_tail(cache_.target_feat, cache_.target_feat_cap,
+                                            feature_mirror_, N)) {
+            result.error = "feature_sync";
+            return result;
+        }
+        result.spec_decode_ran = true;
+        if (!do_spec_decode(N, req.n_gen, result.tokens, out_io,
+                            &req.budget_hook,
+                            &result.budget_forced_close,
+                            &result.accept_rate,
+                            &history)) {
+            result.error = "spec_decode";
+            return result;
+        }
+        auto t_g1 = std::chrono::steady_clock::now();
+        result.decode_s = std::chrono::duration<double>(t_g1 - t_g0).count();
+        result.ok = true;
+        return result;
+    }
+
+    int next_tok = pick(last_logits);
 
     // Budget force-close state — see model_backend.h BudgetHook docs.
     // Mirrors qwen35/do_ar_decode's maybe_force_close. Laguna has no
@@ -474,6 +1014,10 @@ GenerateResult LagunaBackend::restore_and_generate_impl(int slot,
     const bool no_mask = (std::getenv("DFLASH_NO_MASK") != nullptr);
     GenerateResult result;
     DaemonIO out_io = io.with_token_callback(req.on_token);
+    sampler_ = req.sampler;
+    if (req.do_sample && sampler_.seed != 0) {
+        sampler_rng_.seed(sampler_.seed);
+    }
 
     if (!laguna_snapshot_restore(snapshots_[slot], cache_)) {
         std::fprintf(stderr, "[snap] RESTORE slot=%d: %s\n",
@@ -533,7 +1077,8 @@ GenerateResult LagunaBackend::restore_and_generate_impl(int slot,
         ok = kvflash_alloc_span(starts, n_tok) &&
              laguna_step(backend_, w_, cache_,
                           embed_diff.data() + (size_t)off * w_.n_embd,
-                          n_tok, starts, no_mask, last_logits, kvf);
+                          n_tok, starts, no_mask, last_logits, kvf,
+                          /*capture=*/true);
     }
     if (!ok) { result.error = "prefill"; return result; }
 
@@ -547,9 +1092,49 @@ GenerateResult LagunaBackend::restore_and_generate_impl(int slot,
     std::vector<int32_t> history(req.prompt);
     auto pick = [&](const std::vector<float> & ll) {
         return req.do_sample
-            ? sample_logits(ll.data(), (int)ll.size(), req.sampler, history, sampler_rng_)
+            ? sample_logits(ll.data(), (int)ll.size(), sampler_, history, sampler_rng_)
             : argmax(ll);
     };
+
+    const int committed = cache_.cur_pos;
+    cache_.last_tok = argmax(last_logits);
+    result.tokens.reserve(req.n_gen);
+    const bool sampled_verify = laguna_sampled_verify_enabled(sampler_, req.do_sample);
+
+    const bool can_spec = req.n_gen > 0
+        && !req.force_ar_decode
+        && !args_.draft_path.empty()
+        && dflash_target_
+        && !draft_parked_
+        && feature_mirror_.target_feat
+        && cache_.target_feat
+        && (!sampler_.needs_logit_processing() || sampled_verify);
+
+    if (can_spec) {
+        if (sampled_verify) {
+            cache_.last_tok = sample_logits(last_logits.data(), (int)last_logits.size(),
+                                            sampler_, history, sampler_rng_);
+        }
+        auto t_g0 = std::chrono::steady_clock::now();
+        if (!draft_feature_mirror_sync_tail(cache_.target_feat, cache_.target_feat_cap,
+                                            feature_mirror_, committed)) {
+            result.error = "feature_sync";
+            return result;
+        }
+        result.spec_decode_ran = true;
+        if (!do_spec_decode(committed, req.n_gen, result.tokens, out_io,
+                            &req.budget_hook,
+                            &result.budget_forced_close,
+                            &result.accept_rate,
+                            &history)) {
+            result.error = "spec_decode";
+            return result;
+        }
+        auto t_g1 = std::chrono::steady_clock::now();
+        result.decode_s = std::chrono::duration<double>(t_g1 - t_g0).count();
+        result.ok = true;
+        return result;
+    }
 
     int next_tok = pick(last_logits);
 
@@ -2020,6 +2605,118 @@ void LagunaBackend::maybe_post_request_swap() {
     std::fflush(stdout);
 }
 
+bool LagunaBackend::load_decode_draft() {
+    if (args_.draft_path.empty()) return false;
+    if (draft_backend_ && feature_mirror_.target_feat) {
+        draft_parked_ = false;
+        return true;
+    }
+
+    const int draft_gpu = (args_.draft_gpu >= 0) ? args_.draft_gpu : args_.device.gpu;
+    if (args_.draft_gpu >= 0) {
+        draft_backend_ = ggml_backend_cuda_init(draft_gpu);
+        if (!draft_backend_) {
+            std::fprintf(stderr, "[laguna] draft CUDA init failed (gpu=%d)\n", draft_gpu);
+            return false;
+        }
+    } else {
+        draft_backend_ = backend_;
+    }
+
+    if (!load_draft_gguf(args_.draft_path, draft_backend_, dw_, nullptr)) {
+        std::fprintf(stderr, "[laguna] draft load failed: %s\n", dflash27b_last_error());
+        if (draft_backend_ && draft_backend_ != backend_) {
+            ggml_backend_free(draft_backend_);
+        }
+        draft_backend_ = nullptr;
+        return false;
+    }
+
+    dw_.mask_token_id = 12;
+    const int draft_hidden = (int)dw_.fc->ne[1];
+    const int fc_in = (int)dw_.fc->ne[0];
+    const int n_capture = fc_in / w_.n_embd;
+
+    if (draft_hidden != dw_.n_embd) {
+        std::printf("[laguna] draft: overriding n_embd %d -> %d (from fc weight)\n",
+                    dw_.n_embd, draft_hidden);
+        dw_.n_embd = draft_hidden;
+    }
+    if (dw_.n_layer > 0 && dw_.layers[0].wq) {
+        const int q_dim = (int)dw_.layers[0].wq->ne[1];
+        const int inferred_n_head = q_dim / dw_.head_dim;
+        if (inferred_n_head != dw_.n_head) {
+            std::printf("[laguna] draft: overriding n_head %d -> %d\n",
+                        dw_.n_head, inferred_n_head);
+            dw_.n_head = inferred_n_head;
+        }
+    }
+    if (dw_.n_layer > 0 && dw_.layers[0].w_gate) {
+        const int inferred_ff = (int)dw_.layers[0].w_gate->ne[1];
+        if (inferred_ff != dw_.n_ff) {
+            std::printf("[laguna] draft: overriding n_ff %d -> %d\n",
+                        dw_.n_ff, inferred_ff);
+            dw_.n_ff = inferred_ff;
+        }
+    }
+    dw_.n_target_layers = n_capture;
+    dw_.swa_window = 2048;
+    for (int i = 0; i < dw_.n_layer - 1 && i < (int)dw_.layers.size(); i++) {
+        dw_.layers[(size_t)i].is_swa = true;
+    }
+
+    std::printf("[laguna] draft loaded: fc_in=%d target_hidden=%d "
+                "draft_hidden=%d n_capture_layers=%d swa=%d\n",
+                fc_in, w_.n_embd, draft_hidden, n_capture, dw_.swa_window);
+
+    constexpr int TARGET_FEAT_CAP = 4096;
+    const int feat_cap = std::min(args_.max_ctx, TARGET_FEAT_CAP);
+    if (!cache_.target_feat &&
+        !create_laguna_target_feat(backend_, cache_, n_capture, w_.n_embd, feat_cap)) {
+        std::fprintf(stderr, "[laguna] target_feat alloc failed\n");
+        free_decode_draft();
+        return false;
+    }
+
+    const int mirror_cap = std::min(args_.draft_ctx_max, feat_cap);
+    if (!draft_feature_mirror_init(feature_mirror_, draft_backend_,
+                                   draft_gpu, args_.device.gpu, mirror_cap,
+                                   n_capture, w_.n_embd)) {
+        std::fprintf(stderr, "[laguna] feature mirror init failed\n");
+        free_decode_draft();
+        return false;
+    }
+
+    delete dflash_target_;
+    dflash_target_ = new LagunaDFlashTarget(w_, cache_, backend_);
+    if (kvflash_active()) dflash_target_->set_kvflash_pager(&kvflash_pager_);
+    draft_parked_ = false;
+
+    std::printf("[laguna] spec-decode ready: capture_layers=%d mirror_cap=%d\n",
+                n_capture, mirror_cap);
+    std::printf("[laguna] capture_layer_ids:");
+    for (int k = 0; k < (int)cache_.capture_layer_ids.size(); k++) {
+        std::printf(" %d", cache_.capture_layer_ids[(size_t)k]);
+    }
+    std::printf("\n");
+    std::fflush(stdout);
+    return true;
+}
+
+void LagunaBackend::free_decode_draft() {
+    delete dflash_target_;
+    dflash_target_ = nullptr;
+    draft_feature_mirror_free(feature_mirror_);
+    free_laguna_target_feat(cache_);
+    if (dw_.ctx) {
+        free_draft_weights(dw_);
+    }
+    if (draft_backend_ && draft_backend_ != backend_) {
+        ggml_backend_free(draft_backend_);
+    }
+    draft_backend_ = nullptr;
+}
+
 // ── Shutdown ────────────────────────────────────────────────────────────
 
 void LagunaBackend::shutdown() {
@@ -2028,6 +2725,7 @@ void LagunaBackend::shutdown() {
         dflash::common::free_drafter(drafter_ctx_);
         drafter_loaded_ = false;
     }
+    free_decode_draft();
     if (!target_parked_) {
         free_laguna_target_cache(cache_);
         free_laguna_target_weights(w_);

--- a/server/src/laguna/laguna_backend.h
+++ b/server/src/laguna/laguna_backend.h
@@ -41,6 +41,7 @@ struct LagunaBackendArgs {
     bool        ddtree_mode = false;
     int         ddtree_budget = 22;
     float       ddtree_temp = 1.0f;
+    int         verify_width = 0;   // chain verify width; 0 = adaptive (AUTO)
     DevicePlacement device;
     int         max_ctx   = 16384;
     int         chunk     = 2048;
@@ -103,6 +104,9 @@ private:
     DraftFeatureMirror                          feature_mirror_{};
     LagunaDFlashTarget *                        dflash_target_ = nullptr;
     bool                                        draft_parked_ = false;
+    // [TAG_LAGUNA_VERIFY_WIDTH] EWMA of the accepted block length, persisted
+    // across requests. Drives the AUTO chain verify width (seeded for width 3).
+    double                                      spec_ewma_accept_ = 1.5;
 
     // PFlash drafter (lazy-loaded on first compress command).
     DrafterContext                              drafter_ctx_{};

--- a/server/src/laguna/laguna_backend.h
+++ b/server/src/laguna/laguna_backend.h
@@ -8,6 +8,9 @@
 
 #include "model_backend.h"
 #include "laguna_internal.h"
+#include "laguna_dflash_target.h"
+#include "common/dflash_feature_ring.h"
+#include "common/dflash_draft_graph.h"
 #include "placement/placement_config.h"
 #include "qwen3_drafter.h"
 #include "kvflash_pager.h"
@@ -32,6 +35,12 @@ namespace dflash::common {
 
 struct LagunaBackendArgs {
     std::string target_path;
+    std::string draft_path;
+    int         draft_gpu = -1;
+    int         draft_ctx_max = 2048;
+    bool        ddtree_mode = false;
+    int         ddtree_budget = 22;
+    float       ddtree_temp = 1.0f;
     DevicePlacement device;
     int         max_ctx   = 16384;
     int         chunk     = 2048;
@@ -84,8 +93,16 @@ private:
     LagunaTargetWeights                         w_;
     LagunaTargetCache                           cache_;
     std::array<LagunaCacheSnapshot, kMaxSlots>  snapshots_{};
+    SamplerCfg                                  sampler_;
     std::mt19937_64                             sampler_rng_{std::random_device{}()};
     bool                                        target_parked_ = false;
+
+    // DFlash speculative decode
+    ggml_backend_t                              draft_backend_ = nullptr;
+    DraftWeights                                dw_{};
+    DraftFeatureMirror                          feature_mirror_{};
+    LagunaDFlashTarget *                        dflash_target_ = nullptr;
+    bool                                        draft_parked_ = false;
 
     // PFlash drafter (lazy-loaded on first compress command).
     DrafterContext                              drafter_ctx_{};
@@ -147,6 +164,16 @@ private:
                                   std::vector<float> & act_cur,
                                   int32_t & argmax_out);
     void maybe_post_request_swap();
+
+    bool load_decode_draft();
+    void free_decode_draft();
+    bool do_spec_decode(int committed, int n_gen,
+                        std::vector<int32_t> & out_tokens,
+                        const DaemonIO & io,
+                        const BudgetHook * budget_hook = nullptr,
+                        bool * forced_close_out = nullptr,
+                        float * accept_rate_out = nullptr,
+                        const std::vector<int32_t> * sample_history_prefix = nullptr);
 };
 
 }  // namespace dflash::common

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -1,0 +1,546 @@
+// LagunaDFlashTarget - DFlashTarget adapter for Poolside Laguna-XS.2.
+
+#include "laguna_dflash_target.h"
+#include "../common/kvflash_pager.h"
+
+#include "ggml-alloc.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+namespace dflash::common {
+
+namespace {
+
+int laguna_argmax_row(const float * row, int vocab) {
+    int best = 0;
+    float bv = row[0];
+    for (int v = 1; v < vocab; ++v) {
+        if (row[v] > bv) {
+            bv = row[v];
+            best = v;
+        }
+    }
+    return best;
+}
+
+}  // namespace
+
+LagunaDFlashTarget::LagunaDFlashTarget(
+        LagunaTargetWeights & w,
+        LagunaTargetCache & cache,
+        ggml_backend_t backend)
+    : w_(w), cache_(cache), backend_(backend) {
+    capture_ids_ = cache.capture_layer_ids;
+}
+
+LagunaDFlashTarget::~LagunaDFlashTarget() {
+    laguna_snapshot_free(verify_snap_);
+}
+
+bool LagunaDFlashTarget::verify_batch(
+        const std::vector<int32_t> & tokens,
+        int base_pos,
+        int & last_tok,
+        std::vector<int32_t> * all_argmax,
+        bool capture_ssm_intermediates) {
+    (void)capture_ssm_intermediates;
+    const int n_tokens = (int)tokens.size();
+    if (n_tokens <= 0) return false;
+
+    const int hidden = w_.n_embd;
+    std::vector<float> embed((size_t)n_tokens * (size_t)hidden);
+    if (!w_.embedder.embed(tokens.data(), n_tokens, embed.data())) {
+        std::fprintf(stderr, "laguna_verify_batch: embed failed\n");
+        return false;
+    }
+
+    if (pager_ && !pager_->alloc_span(base_pos, n_tokens)) {
+        return false;
+    }
+
+    std::vector<int32_t> argmax_buf;
+    std::vector<float> * logits_out = keep_verify_logits_ ? &verify_logits_ : nullptr;
+    if (!keep_verify_logits_) {
+        verify_logits_.clear();
+        verify_logits_n_ = 0;
+    }
+    if (!laguna_verify_batch(backend_, w_, cache_, embed.data(),
+                             tokens.data(), n_tokens, base_pos,
+                             argmax_buf, pager_, logits_out)) {
+        return false;
+    }
+    if (keep_verify_logits_) {
+        verify_logits_n_ = n_tokens;
+    }
+
+    last_tok = argmax_buf[n_tokens - 1];
+    if (all_argmax) {
+        *all_argmax = std::move(argmax_buf);
+    }
+    return true;
+}
+
+bool LagunaDFlashTarget::read_verify_logits(int n_tokens, std::vector<float> & out) {
+    if (n_tokens <= 0 || verify_logits_n_ <= 0 || verify_logits_.empty()) {
+        return false;
+    }
+    if (n_tokens > verify_logits_n_) {
+        return false;
+    }
+    const size_t vocab = verify_logits_.size() / (size_t)verify_logits_n_;
+    out.resize((size_t)n_tokens * vocab);
+    std::memcpy(out.data(), verify_logits_.data(), sizeof(float) * out.size());
+    return true;
+}
+
+// NOTE: the spec-decode loop (do_spec_decode) does not call snapshot_kv/
+// restore_kv — it manages KV via cur_pos truncation + overwrite, exactly like
+// the gemma4 path. These remain for DFlashTarget-interface completeness and any
+// future caller. They use device-to-device copies (ggml_backend_tensor_copy) on
+// backend_-resident dup tensors, mirroring Gemma4DFlashTarget — NOT the
+// host-backed laguna_snapshot_* helpers (those assume a CPU snapshot backend).
+bool LagunaDFlashTarget::snapshot_kv() {
+    if (cache_.cur_pos <= 0) return false;
+    if (!verify_snap_.ctx) {
+        ggml_init_params ip{};
+        ip.mem_size = ggml_tensor_overhead() * (size_t)(w_.n_layer * 2 + 8) + 4096;
+        ip.no_alloc = true;
+        verify_snap_.ctx = ggml_init(ip);
+        if (!verify_snap_.ctx) return false;
+        verify_snap_.attn_k.assign((size_t)w_.n_layer, nullptr);
+        verify_snap_.attn_v.assign((size_t)w_.n_layer, nullptr);
+        for (int il = 0; il < w_.n_layer; ++il) {
+            if (cache_.attn_k[(size_t)il] && cache_.attn_v[(size_t)il]) {
+                verify_snap_.attn_k[(size_t)il] =
+                    ggml_dup_tensor(verify_snap_.ctx, cache_.attn_k[(size_t)il]);
+                verify_snap_.attn_v[(size_t)il] =
+                    ggml_dup_tensor(verify_snap_.ctx, cache_.attn_v[(size_t)il]);
+            }
+        }
+        verify_snap_.buf = ggml_backend_alloc_ctx_tensors(verify_snap_.ctx, backend_);
+        if (!verify_snap_.buf) {
+            ggml_free(verify_snap_.ctx);
+            verify_snap_.ctx = nullptr;
+            return false;
+        }
+    }
+    for (int il = 0; il < w_.n_layer; ++il) {
+        if (cache_.attn_k[(size_t)il] && verify_snap_.attn_k[(size_t)il]) {
+            ggml_backend_tensor_copy(cache_.attn_k[(size_t)il], verify_snap_.attn_k[(size_t)il]);
+            ggml_backend_tensor_copy(cache_.attn_v[(size_t)il], verify_snap_.attn_v[(size_t)il]);
+        }
+    }
+    verify_snap_.cur_pos = cache_.cur_pos;
+    verify_snap_.used = true;
+    return true;
+}
+
+bool LagunaDFlashTarget::restore_kv() {
+    if (!verify_snap_.used) return false;
+    for (int il = 0; il < w_.n_layer; ++il) {
+        if (cache_.attn_k[(size_t)il] && verify_snap_.attn_k[(size_t)il]) {
+            ggml_backend_tensor_copy(verify_snap_.attn_k[(size_t)il], cache_.attn_k[(size_t)il]);
+            ggml_backend_tensor_copy(verify_snap_.attn_v[(size_t)il], cache_.attn_v[(size_t)il]);
+        }
+    }
+    cache_.cur_pos = verify_snap_.cur_pos;
+    return true;
+}
+
+bool LagunaDFlashTarget::supports_tree_verify() const {
+    // Laguna tree verify is a logical-position, non-paged pure-attention graph.
+    // The kvflash pager uses relocated slot-space masks, so keep tree verify
+    // disabled under paging until a slot-space tree mask is implemented.
+    return pager_ == nullptr;
+}
+
+bool LagunaDFlashTarget::verify_tree(
+        int committed,
+        const DDTree & tree,
+        const std::vector<int32_t> & flat_tokens,
+        int n_alloc,
+        std::vector<int32_t> & posterior_out,
+        std::vector<float> * logits_out) {
+    const int N = n_alloc;
+    const int N_actual = 1 + tree.n_nodes;
+    if (N <= 0 || N_actual <= 0 || N_actual > N ||
+        (int)flat_tokens.size() < N_actual ||
+        tree.visibility.size() < (size_t)N_actual * (size_t)N_actual) {
+        return false;
+    }
+    if (pager_ != nullptr) return false;
+
+    int kv_cap = 0;
+    for (ggml_tensor * k : cache_.attn_k) {
+        if (k) { kv_cap = (int)k->ne[1]; break; }
+    }
+    if (kv_cap <= 0 || committed + N > kv_cap) {
+        std::fprintf(stderr, "laguna_verify_tree: KV span exceeds cache (committed=%d N=%d cap=%d)\n",
+                     committed, N, kv_cap);
+        return false;
+    }
+
+    static const bool g_no_kvpad = (std::getenv("DFLASH_LAGUNA_NO_KVPAD") != nullptr);
+    static const bool g_pad_cpy = (std::getenv("DFLASH_LAGUNA_PAD_CPY") != nullptr);
+    const int kv_len = committed + N;
+    const int kv_pad = (!g_no_kvpad && kv_cap > 0)
+        ? std::min((kv_len + 255) & ~255, kv_cap) : 0;
+    const int mk_w = kv_pad > 0 ? kv_pad : kv_len;
+    if (kv_pad <= 0 || g_pad_cpy) {
+        std::fprintf(stderr, "laguna_verify_tree: requires kv_pad set_rows path\n");
+        return false;
+    }
+
+    const size_t arena_size =
+        ggml_tensor_overhead() * 32768 + ggml_graph_overhead() + 32 * 1024 * 1024;
+    static thread_local std::vector<uint8_t> g_tree_arena;
+    if (g_tree_arena.size() < arena_size) g_tree_arena.resize(arena_size);
+    ggml_init_params ip{};
+    ip.mem_size = arena_size;
+    ip.mem_buffer = g_tree_arena.data();
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 32768, false);
+
+    ggml_tensor * ie = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, w_.n_embd, N, 1);
+    ggml_set_input(ie);
+    ggml_tensor * pp = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, N);
+    ggml_set_input(pp);
+    ggml_tensor * kvi = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, N);
+    ggml_set_input(kvi);
+
+    ggml_tensor * mk_full = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, mk_w, N, 1, 1);
+    ggml_set_input(mk_full);
+    ggml_tensor * mk_full_cnv = ggml_cast(ctx, mk_full, GGML_TYPE_F16);
+    ggml_tensor * mk_swa = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, mk_w, N, 1, 1);
+    ggml_set_input(mk_swa);
+    ggml_tensor * mk_swa_cnv = ggml_cast(ctx, mk_swa, GGML_TYPE_F16);
+
+    ggml_tensor * feat_rows = nullptr;
+    if (cache_.target_feat && cache_.target_feat_cap > 0) {
+        feat_rows = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, N);
+        ggml_set_input(feat_rows);
+    }
+
+    LagunaGraphInputs gi{};
+    gi.inp_embed        = ie;
+    gi.positions        = pp;
+    gi.attn_mask        = mk_full_cnv;
+    gi.attn_mask_swa    = mk_swa_cnv;
+    gi.n_tokens         = N;
+    gi.kv_start         = committed;
+    gi.kv_pad           = kv_pad;
+    gi.kv_idx           = kvi;
+    gi.output_last_only = false;
+    gi.output_logits    = true;
+    gi.capture_features = feat_rows != nullptr;
+    gi.target_feat_rows = feat_rows;
+    gi.hybrid           = nullptr;
+
+    LagunaGraphOutputs go = build_laguna_graph(ctx, gf, w_, cache_, gi);
+
+    static ggml_gallocr_t galloc_tree = nullptr;
+    if (!galloc_tree) {
+        galloc_tree = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+    }
+    if (!ggml_gallocr_alloc_graph(galloc_tree, gf)) {
+        std::fprintf(stderr, "laguna_verify_tree: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    std::vector<float> embed((size_t)w_.n_embd * (size_t)N, 0.0f);
+    if (!w_.embedder.embed(flat_tokens.data(), N_actual, embed.data())) {
+        std::fprintf(stderr, "laguna_verify_tree: embed failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+    ggml_backend_tensor_set(ie, embed.data(), 0, ggml_nbytes(ie));
+
+    std::vector<int32_t> pos((size_t)N, 0);
+    pos[0] = committed;
+    for (int i = 1; i < N_actual; ++i) {
+        pos[(size_t)i] = committed + tree.depths[(size_t)i - 1];
+    }
+    ggml_backend_tensor_set(pp, pos.data(), 0, ggml_nbytes(pp));
+
+    std::vector<int32_t> rows((size_t)N);
+    for (int i = 0; i < N; ++i) rows[(size_t)i] = committed + i;
+    ggml_backend_tensor_set(kvi, rows.data(), 0, ggml_nbytes(kvi));
+
+    if (feat_rows) {
+        std::vector<int32_t> feat_idx((size_t)N);
+        for (int i = 0; i < N; ++i) {
+            feat_idx[(size_t)i] = (committed + i) % cache_.target_feat_cap;
+        }
+        ggml_backend_tensor_set(feat_rows, feat_idx.data(), 0, ggml_nbytes(feat_rows));
+    }
+
+    std::vector<float> mfull((size_t)mk_w * (size_t)N, -INFINITY);
+    std::vector<float> mswa((size_t)mk_w * (size_t)N, -INFINITY);
+    const int W = w_.sliding_window;
+    for (int q = 0; q < N_actual; ++q) {
+        const int depth_q = (q == 0) ? 0 : tree.depths[(size_t)q - 1];
+        const int abs_q = committed + depth_q;
+
+        for (int k = 0; k < committed && k < mk_w; ++k) {
+            mfull[(size_t)q * (size_t)mk_w + (size_t)k] = 0.0f;
+        }
+
+        const int win_lo = std::max(0, abs_q - W + 1);
+        for (int k = win_lo; k < committed && k < mk_w; ++k) {
+            mswa[(size_t)q * (size_t)mk_w + (size_t)k] = 0.0f;
+        }
+
+        for (int j = 0; j < N_actual; ++j) {
+            if (!tree.visibility[(size_t)q * (size_t)N_actual + (size_t)j]) {
+                continue;
+            }
+            const int slot = committed + j;
+            if (slot < mk_w) {
+                mfull[(size_t)q * (size_t)mk_w + (size_t)slot] = 0.0f;
+                mswa[(size_t)q * (size_t)mk_w + (size_t)slot] = 0.0f;
+            }
+        }
+    }
+    ggml_backend_tensor_set(mk_full, mfull.data(), 0, ggml_nbytes(mk_full));
+    ggml_backend_tensor_set(mk_swa, mswa.data(), 0, ggml_nbytes(mk_swa));
+
+    if (ggml_backend_graph_compute(backend_, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "laguna_verify_tree: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    const int vocab = (int)w_.embedder.n_vocab;
+    std::vector<float> logits((size_t)vocab * (size_t)N_actual);
+    ggml_backend_tensor_get(go.logits, logits.data(), 0,
+                            sizeof(float) * logits.size());
+
+    posterior_out.resize((size_t)N_actual);
+    for (int i = 0; i < N_actual; ++i) {
+        posterior_out[(size_t)i] =
+            laguna_argmax_row(logits.data() + (size_t)i * (size_t)vocab, vocab);
+    }
+    if (logits_out) {
+        *logits_out = std::move(logits);
+    }
+    cache_.cur_pos = committed + N_actual;
+    ggml_free(ctx);
+    return true;
+}
+
+bool LagunaDFlashTarget::rollback_to_tree(
+        int committed,
+        const DDTree & tree,
+        const std::vector<int> & accepted_dfs) {
+    (void)tree;
+    const int commit_n = (int)accepted_dfs.size();
+    if (commit_n <= 0) return false;
+
+    bool contiguous_prefix = true;
+    for (int d = 0; d < commit_n; ++d) {
+        if (accepted_dfs[(size_t)d] != d) {
+            contiguous_prefix = false;
+            break;
+        }
+    }
+    if (contiguous_prefix) {
+        cache_.cur_pos = committed + commit_n;
+        cache_.last_tok = -1;
+        return true;
+    }
+
+    const int n_head_kv = w_.n_head_kv;
+    const size_t arena_size =
+        ggml_tensor_overhead() * 1024 + ggml_graph_overhead() + 4 * 1024 * 1024;
+    static thread_local std::vector<uint8_t> g_rollback_arena;
+    if (g_rollback_arena.size() < arena_size) {
+        g_rollback_arena.resize(arena_size);
+    }
+
+    ggml_init_params ip{};
+    ip.mem_size = arena_size;
+    ip.mem_buffer = g_rollback_arena.data();
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 1024, false);
+
+    ggml_tensor * src_rows_kv = ggml_new_tensor_2d(ctx, GGML_TYPE_I32,
+                                                   commit_n, n_head_kv);
+    ggml_set_input(src_rows_kv);
+    ggml_tensor * dst_rows_kv = ggml_new_tensor_2d(ctx, GGML_TYPE_I32,
+                                                   commit_n, n_head_kv);
+    ggml_set_input(dst_rows_kv);
+
+    ggml_tensor * src_rows_feat = nullptr;
+    ggml_tensor * dst_rows_feat = nullptr;
+    if (cache_.target_feat && cache_.target_feat_cap > 0) {
+        src_rows_feat = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, commit_n);
+        ggml_set_input(src_rows_feat);
+        dst_rows_feat = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, commit_n);
+        ggml_set_input(dst_rows_feat);
+
+        ggml_tensor * feat_gather = ggml_get_rows(ctx, cache_.target_feat, src_rows_feat);
+        feat_gather = ggml_cont(ctx, feat_gather);
+        ggml_build_forward_expand(gf,
+            ggml_set_rows(ctx, cache_.target_feat, feat_gather, dst_rows_feat));
+    }
+
+    for (int il = 0; il < w_.n_layer; ++il) {
+        ggml_tensor * ck = cache_.attn_k[(size_t)il];
+        ggml_tensor * cv = cache_.attn_v[(size_t)il];
+        if (!ck || !cv) continue;
+
+        ggml_tensor * kg = ggml_get_rows(ctx, ck, src_rows_kv);
+        kg = ggml_cont(ctx, kg);
+        ggml_build_forward_expand(gf, ggml_set_rows(ctx, ck, kg, dst_rows_kv));
+
+        ggml_tensor * vg = ggml_get_rows(ctx, cv, src_rows_kv);
+        vg = ggml_cont(ctx, vg);
+        ggml_build_forward_expand(gf, ggml_set_rows(ctx, cv, vg, dst_rows_kv));
+    }
+
+    static ggml_gallocr_t galloc_rollback = nullptr;
+    if (!galloc_rollback) {
+        galloc_rollback =
+            ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+    }
+    if (!ggml_gallocr_alloc_graph(galloc_rollback, gf)) {
+        std::fprintf(stderr, "laguna_rollback_to_tree: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    std::vector<int32_t> src_kv((size_t)commit_n * (size_t)n_head_kv);
+    std::vector<int32_t> dst_kv((size_t)commit_n * (size_t)n_head_kv);
+    for (int h = 0; h < n_head_kv; ++h) {
+        for (int d = 0; d < commit_n; ++d) {
+            src_kv[(size_t)h * (size_t)commit_n + (size_t)d] =
+                committed + accepted_dfs[(size_t)d];
+            dst_kv[(size_t)h * (size_t)commit_n + (size_t)d] =
+                committed + d;
+        }
+    }
+    ggml_backend_tensor_set(src_rows_kv, src_kv.data(), 0, ggml_nbytes(src_rows_kv));
+    ggml_backend_tensor_set(dst_rows_kv, dst_kv.data(), 0, ggml_nbytes(dst_rows_kv));
+
+    if (src_rows_feat && dst_rows_feat) {
+        const int cap = cache_.target_feat_cap;
+        std::vector<int32_t> src_feat((size_t)commit_n);
+        std::vector<int32_t> dst_feat((size_t)commit_n);
+        for (int d = 0; d < commit_n; ++d) {
+            src_feat[(size_t)d] = (committed + accepted_dfs[(size_t)d]) % cap;
+            dst_feat[(size_t)d] = (committed + d) % cap;
+        }
+        ggml_backend_tensor_set(src_rows_feat, src_feat.data(), 0,
+                                ggml_nbytes(src_rows_feat));
+        ggml_backend_tensor_set(dst_rows_feat, dst_feat.data(), 0,
+                                ggml_nbytes(dst_rows_feat));
+    }
+
+    if (ggml_backend_graph_compute(backend_, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "laguna_rollback_to_tree: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    cache_.cur_pos = committed + commit_n;
+    cache_.last_tok = -1;
+    ggml_free(ctx);
+    return true;
+}
+
+bool LagunaDFlashTarget::is_eos(int token) const {
+    return token == w_.eos_id || token == w_.eos_chat_id;
+}
+
+bool LagunaDFlashTarget::embed_tokens(const int32_t * tokens, int n,
+                                      float * out) const {
+    return w_.embedder.embed(tokens, n, out);
+}
+
+bool LagunaDFlashTarget::project_hidden_to_tokens(
+        const float * hidden,
+        int n_tokens,
+        std::vector<int32_t> & tokens_out) {
+    return laguna_project_hidden(backend_, w_, hidden, n_tokens, tokens_out);
+}
+
+bool LagunaDFlashTarget::project_hidden_to_topk(
+        const float * hidden,
+        int n_tokens,
+        int K,
+        float temperature,
+        std::vector<float> & top_log_probs,
+        std::vector<int32_t> & top_token_ids) {
+    if (n_tokens <= 0 || K <= 0) return false;
+
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() * 64 + ggml_graph_overhead() + 1024 * 1024;
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    if (!ctx) return false;
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+
+    ggml_tensor * inp = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, w_.n_embd, n_tokens);
+    ggml_set_input(inp);
+    ggml_tensor * logits = ggml_mul_mat(ctx, w_.output, inp);
+    const float inv_t = 1.0f / std::max(1e-3f, temperature);
+    ggml_tensor * scaled = (inv_t != 1.0f) ? ggml_scale(ctx, logits, inv_t) : logits;
+    ggml_tensor * top_ids = ggml_top_k(ctx, scaled, K);
+    ggml_tensor * probs = ggml_soft_max(ctx, scaled);
+    ggml_tensor * probs_3d = ggml_reshape_3d(ctx, probs, 1, w_.embedder.n_vocab, n_tokens);
+    ggml_tensor * top_probs = ggml_get_rows(ctx, probs_3d, top_ids);
+    top_probs = ggml_cont(ctx, top_probs);
+    ggml_set_output(top_ids);
+    ggml_set_output(top_probs);
+    ggml_build_forward_expand(gf, top_ids);
+    ggml_build_forward_expand(gf, top_probs);
+
+    static ggml_gallocr_t galloc_topk = nullptr;
+    if (!galloc_topk) {
+        galloc_topk = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+    }
+    if (!ggml_gallocr_alloc_graph(galloc_topk, gf)) {
+        std::fprintf(stderr, "laguna_project_hidden_to_topk: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(inp, hidden, 0,
+                            sizeof(float) * (size_t)n_tokens * (size_t)w_.n_embd);
+    if (ggml_backend_graph_compute(backend_, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "laguna_project_hidden_to_topk: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    top_log_probs.assign((size_t)n_tokens * (size_t)K, 0.0f);
+    top_token_ids.assign((size_t)n_tokens * (size_t)K, 0);
+    std::vector<float> top_probs_host((size_t)n_tokens * (size_t)K);
+    ggml_backend_tensor_get(top_ids, top_token_ids.data(), 0,
+                            sizeof(int32_t) * top_token_ids.size());
+    ggml_backend_tensor_get(top_probs, top_probs_host.data(), 0,
+                            sizeof(float) * top_probs_host.size());
+    for (size_t i = 0; i < top_probs_host.size(); ++i) {
+        top_log_probs[i] = std::log(std::max(top_probs_host[i], 1e-30f));
+    }
+
+    ggml_free(ctx);
+    return true;
+}
+
+const std::vector<int> & LagunaDFlashTarget::capture_layer_ids() const {
+    return capture_ids_;
+}
+
+}  // namespace dflash::common

--- a/server/src/laguna/laguna_dflash_target.cpp
+++ b/server/src/laguna/laguna_dflash_target.cpp
@@ -246,6 +246,18 @@ bool LagunaDFlashTarget::verify_tree(
 
     LagunaGraphOutputs go = build_laguna_graph(ctx, gf, w_, cache_, gi);
 
+    // Greedy tree-verify only needs the per-node argmax. Compute it on-GPU
+    // (like the chain path) and read back N_actual int32 indices instead of
+    // copying the full vocab*N_actual logits to host and arg-maxing on the CPU.
+    // The full-logits readback path is kept only when the caller wants logits
+    // (sampled tree-verify).
+    ggml_tensor * argmax_t = nullptr;
+    if (!logits_out) {
+        argmax_t = ggml_argmax(ctx, go.logits);
+        ggml_set_output(argmax_t);
+        ggml_build_forward_expand(gf, argmax_t);
+    }
+
     static ggml_gallocr_t galloc_tree = nullptr;
     if (!galloc_tree) {
         galloc_tree = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
@@ -319,17 +331,21 @@ bool LagunaDFlashTarget::verify_tree(
         return false;
     }
 
-    const int vocab = (int)w_.embedder.n_vocab;
-    std::vector<float> logits((size_t)vocab * (size_t)N_actual);
-    ggml_backend_tensor_get(go.logits, logits.data(), 0,
-                            sizeof(float) * logits.size());
-
     posterior_out.resize((size_t)N_actual);
-    for (int i = 0; i < N_actual; ++i) {
-        posterior_out[(size_t)i] =
-            laguna_argmax_row(logits.data() + (size_t)i * (size_t)vocab, vocab);
-    }
-    if (logits_out) {
+    if (argmax_t) {
+        // On-GPU argmax: read back only N_actual indices.
+        ggml_backend_tensor_get(argmax_t, posterior_out.data(), 0,
+                                sizeof(int32_t) * (size_t)N_actual);
+    } else {
+        // Caller wants the logits (sampled tree-verify): full readback + CPU argmax.
+        const int vocab = (int)w_.embedder.n_vocab;
+        std::vector<float> logits((size_t)vocab * (size_t)N_actual);
+        ggml_backend_tensor_get(go.logits, logits.data(), 0,
+                                sizeof(float) * logits.size());
+        for (int i = 0; i < N_actual; ++i) {
+            posterior_out[(size_t)i] =
+                laguna_argmax_row(logits.data() + (size_t)i * (size_t)vocab, vocab);
+        }
         *logits_out = std::move(logits);
     }
     cache_.cur_pos = committed + N_actual;

--- a/server/src/laguna/laguna_dflash_target.h
+++ b/server/src/laguna/laguna_dflash_target.h
@@ -1,0 +1,83 @@
+// LagunaDFlashTarget - DFlashTarget adapter for Poolside Laguna-XS.2.
+//
+// Laguna is a pure-attention iSWA + MoE model, so speculative verification
+// follows the Gemma4 chain-verify pattern with no SSM rollback path.
+
+#pragma once
+
+#include "common/dflash_target.h"
+#include "laguna_internal.h"
+
+#include "ggml.h"
+#include "ggml-backend.h"
+
+#include <vector>
+
+namespace dflash::common {
+
+class LagunaDFlashTarget : public DFlashTarget {
+public:
+    LagunaDFlashTarget(LagunaTargetWeights & w,
+                       LagunaTargetCache & cache,
+                       ggml_backend_t backend);
+
+    ~LagunaDFlashTarget() override;
+
+    bool verify_batch(const std::vector<int32_t> & tokens,
+                      int base_pos,
+                      int & last_tok,
+                      std::vector<int32_t> * all_argmax = nullptr,
+                      bool capture_ssm_intermediates = false) override;
+
+    bool read_verify_logits(int n_tokens, std::vector<float> & out) override;
+
+    void set_kvflash_pager(class KvFlashPager * p) { pager_ = p; }
+    void set_keep_verify_logits(bool enabled) { keep_verify_logits_ = enabled; }
+
+    bool snapshot_kv() override;
+    bool restore_kv() override;
+
+    bool supports_tree_verify() const override;
+    bool verify_tree(int committed,
+                     const DDTree & tree,
+                     const std::vector<int32_t> & flat_tokens,
+                     int n_alloc,
+                     std::vector<int32_t> & posterior_out,
+                     std::vector<float> * logits_out = nullptr) override;
+    bool rollback_to_tree(int committed,
+                          const DDTree & tree,
+                          const std::vector<int> & accepted_dfs) override;
+
+    bool is_eos(int token) const override;
+
+    bool embed_tokens(const int32_t * tokens, int n,
+                      float * out) const override;
+
+    bool project_hidden_to_tokens(const float * hidden,
+                                  int n_tokens,
+                                  std::vector<int32_t> & tokens_out) override;
+
+    bool project_hidden_to_topk(const float * hidden,
+                                int n_tokens,
+                                int K,
+                                float temperature,
+                                std::vector<float> & top_log_probs,
+                                std::vector<int32_t> & top_token_ids) override;
+
+    int hidden_size() const override { return w_.n_embd; }
+    int mask_token_id() const override { return 12; }
+    const std::vector<int> & capture_layer_ids() const override;
+
+private:
+    LagunaTargetWeights & w_;
+    LagunaTargetCache & cache_;
+    ggml_backend_t backend_;
+    class KvFlashPager * pager_ = nullptr;
+    std::vector<int> capture_ids_;
+    LagunaCacheSnapshot verify_snap_;
+    bool keep_verify_logits_ = false;
+    int verify_logits_n_ = 0;
+    std::vector<float> verify_logits_;
+};
+
+}  // namespace dflash::common

--- a/server/src/laguna/laguna_internal.h
+++ b/server/src/laguna/laguna_internal.h
@@ -166,6 +166,14 @@ struct LagunaTargetCache {
     // Layout: [head_dim, max_ctx, n_head_kv] f16/q8_0, contiguous per layer.
     std::vector<ggml_tensor *> attn_k;   // size = n_layer
     std::vector<ggml_tensor *> attn_v;
+
+    // DFlash feature capture ring buffer (BF16, allocated when draft is active).
+    ggml_tensor *         target_feat = nullptr;  // [n_capture_layers*n_embd, target_feat_cap]
+    int                   target_feat_cap = 0;
+    int                   n_capture_layers = 0;
+    std::vector<int>      capture_layer_ids;
+    ggml_context *        feat_ctx = nullptr;
+    ggml_backend_buffer_t feat_buf = nullptr;
 };
 
 // `ctx_alloc` (kvflash): when > 0 and < max_ctx, the per-layer K/V tensors
@@ -186,6 +194,13 @@ bool create_laguna_target_cache_partial(const LagunaTargetWeights & w,
 void free_laguna_target_cache(LagunaTargetCache & c);
 void reset_laguna_target_cache(LagunaTargetCache & c);
 
+void free_laguna_target_feat(LagunaTargetCache & c);
+bool create_laguna_target_feat(ggml_backend_t backend,
+                                LagunaTargetCache & cache,
+                                int n_capture_layers,
+                                int hidden_size,
+                                int cap);
+
 // ----------------------------------------------------------------------------
 // Cache snapshots for prefix-cache slots (PrefixCache).
 //
@@ -201,6 +216,8 @@ struct LagunaCacheSnapshot {
     ggml_backend_buffer_t buf     = nullptr;
     std::vector<ggml_tensor *> attn_k;  // size = n_layer
     std::vector<ggml_tensor *> attn_v;  // size = n_layer
+    ggml_tensor *         feat_snap = nullptr;
+    int                   feat_cap  = 0;
     int                   cur_pos = 0;
     bool                  used    = false;
 };
@@ -253,6 +270,8 @@ struct LagunaGraphInputs {
     ggml_tensor * kv_idx = nullptr;       // [n_tokens] I32 cache row indices (graph input)
     bool          output_logits = true;
     bool          output_hidden_states = false;
+    bool          capture_features = false;
+    ggml_tensor * target_feat_rows = nullptr;  // optional [n_tokens] I32 ring rows for replay-stable capture
     // If true, lm_head only runs on the LAST token (saves ~6 GB of logit memory
     // at n_tokens=16K, vocab=100352). Standard TTFT optimization.
     bool          output_last_only = false;
@@ -300,7 +319,27 @@ bool laguna_step(
     int                         kv_start,
     bool                        no_mask,
     std::vector<float> &        out_logits,
-    const class KvFlashPager *  kvflash = nullptr);
+    const class KvFlashPager *  kvflash = nullptr,
+    bool                        capture = false);
+
+bool laguna_verify_batch(
+    ggml_backend_t              backend,
+    const LagunaTargetWeights & w,
+    LagunaTargetCache &         cache,
+    const float *               embed,
+    const int32_t *             token_ids,
+    int                         n_tokens,
+    int                         kv_start,
+    std::vector<int32_t> &      out_argmax,
+    const class KvFlashPager *  kvflash = nullptr,
+    std::vector<float> *        out_logits = nullptr);
+
+bool laguna_project_hidden(
+    ggml_backend_t              backend,
+    const LagunaTargetWeights & w,
+    const float *               hidden,
+    int                         n_tokens,
+    std::vector<int32_t> &      out_tokens);
 
 // Forward decl (full definition in common/moe_hybrid_storage.h).
 struct MoeHybridStorage;

--- a/server/src/laguna/laguna_internal.h
+++ b/server/src/laguna/laguna_internal.h
@@ -199,7 +199,8 @@ bool create_laguna_target_feat(ggml_backend_t backend,
                                 LagunaTargetCache & cache,
                                 int n_capture_layers,
                                 int hidden_size,
-                                int cap);
+                                int cap,
+                                const std::vector<int> & explicit_ids = {});
 
 // ----------------------------------------------------------------------------
 // Cache snapshots for prefix-cache slots (PrefixCache).

--- a/server/src/laguna/laguna_target_graph.cpp
+++ b/server/src/laguna/laguna_target_graph.cpp
@@ -140,7 +140,8 @@ bool laguna_snapshot_alloc(const LagunaTargetCache & cache,
                             LagunaCacheSnapshot &     out) {
     if (out.ctx) return true;
     ggml_init_params ip{};
-    ip.mem_size = ggml_tensor_overhead() * (size_t)(n_layer * 2 + 16) + 4096;
+    const int n_feat_tensors = (cache.target_feat && cache.target_feat_cap > 0) ? 1 : 0;
+    ip.mem_size = ggml_tensor_overhead() * (size_t)(n_layer * 2 + n_feat_tensors + 16) + 4096;
     ip.no_alloc = true;
     out.ctx = ggml_init(ip);
     if (!out.ctx) { set_last_error("snapshot: ggml_init failed"); return false; }
@@ -159,10 +160,20 @@ bool laguna_snapshot_alloc(const LagunaTargetCache & cache,
         out.attn_k[il] = k;
         out.attn_v[il] = v;
     }
+    out.feat_snap = nullptr;
+    out.feat_cap = 0;
+    if (cache.target_feat && cache.target_feat_cap > 0) {
+        const int feat_len = std::min(snap_pos, cache.target_feat_cap);
+        out.feat_snap = ggml_new_tensor_2d(out.ctx, cache.target_feat->type,
+                                           cache.target_feat->ne[0], feat_len);
+        out.feat_cap = cache.target_feat_cap;
+    }
     out.buf = ggml_backend_alloc_ctx_tensors(out.ctx, backend);
     if (!out.buf) {
         set_last_error("snapshot: ggml_backend_alloc_ctx_tensors failed");
         ggml_free(out.ctx); out.ctx = nullptr;
+        out.feat_snap = nullptr;
+        out.feat_cap = 0;
         return false;
     }
     out.cur_pos = 0;
@@ -175,6 +186,8 @@ void laguna_snapshot_free(LagunaCacheSnapshot & snap) {
     if (snap.ctx) { ggml_free(snap.ctx); snap.ctx = nullptr; }
     snap.attn_k.clear();
     snap.attn_v.clear();
+    snap.feat_snap = nullptr;
+    snap.feat_cap  = 0;
     snap.cur_pos = 0;
     snap.used    = false;
 }
@@ -193,7 +206,10 @@ bool laguna_snapshot_save(const LagunaTargetCache & cache,
     }
 
     // Realloc if shapes don't match (different cur_pos).
-    if (snap.ctx && snap.cur_pos != snap_pos) {
+    const bool needs_feat = cache.target_feat && cache.target_feat_cap > 0;
+    if (snap.ctx && (snap.cur_pos != snap_pos ||
+                     (needs_feat && !snap.feat_snap) ||
+                     (!needs_feat && snap.feat_snap))) {
         laguna_snapshot_free(snap);
     }
     if (!snap.ctx) {
@@ -224,6 +240,11 @@ bool laguna_snapshot_save(const LagunaTargetCache & cache,
     }
     snap.cur_pos = snap_pos;
     snap.used    = true;
+
+    if (snap.feat_snap && cache.target_feat) {
+        const size_t feat_nbytes = ggml_nbytes(snap.feat_snap);
+        ggml_backend_tensor_get(cache.target_feat, snap.feat_snap->data, 0, feat_nbytes);
+    }
     return true;
 }
 
@@ -254,15 +275,23 @@ bool laguna_snapshot_restore(const LagunaCacheSnapshot & snap,
             ggml_backend_tensor_set(dv, (const char *)sv->data + src_off, dst_off, v_strip);
         }
     }
+    if (snap.feat_snap && cache.target_feat) {
+        const size_t feat_nbytes = ggml_nbytes(snap.feat_snap);
+        ggml_backend_tensor_set(cache.target_feat, snap.feat_snap->data, 0, feat_nbytes);
+    }
     cache.cur_pos = snap_pos;
     return true;
 }
 
 void free_laguna_target_cache(LagunaTargetCache & c) {
+    free_laguna_target_feat(c);
     if (c.base_buf) { ggml_backend_buffer_free(c.base_buf); c.base_buf = nullptr; }
     if (c.base_ctx) { ggml_free(c.base_ctx);                c.base_ctx = nullptr; }
     c.attn_k.clear();
     c.attn_v.clear();
+    c.max_ctx = 0;
+    c.cur_pos = 0;
+    c.last_tok = -1;
 }
 
 void reset_laguna_target_cache(LagunaTargetCache & c) {
@@ -950,10 +979,79 @@ LagunaGraphOutputs build_laguna_graph(
         cur = ggml_reshape_2d(ctx, cur, w.n_embd, in.n_tokens);
     }
 
+    const bool capture_with_rows =
+        in.capture_features && cache.target_feat && in.target_feat_rows;
+    std::vector<ggml_tensor *> capture_slices;
+    if (capture_with_rows) {
+        capture_slices.assign((size_t)cache.n_capture_layers, nullptr);
+    }
+
     for (int il = 0; il < w.n_layer; ++il) {
         cur = build_laguna_layer(ctx, gf, w, cache, il, cur,
                                   in.positions, in.attn_mask, in.kv_start, in.n_tokens,
                                   in.attn_mask_swa, in.hybrid, in.kv_pad, in.kv_idx);
+
+        // Feature capture for DFlash spec-decode: write residual-stream layer
+        // outputs into the BF16 target feature ring.
+        if (in.capture_features && cache.target_feat) {
+            int cap_idx = -1;
+            for (int k = 0; k < cache.n_capture_layers; k++) {
+                if (cache.capture_layer_ids[(size_t)k] == il) { cap_idx = k; break; }
+            }
+            if (cap_idx >= 0) {
+                const int hidden = w.n_embd;
+                ggml_tensor * cur_2d = ggml_reshape_2d(ctx, cur, hidden, in.n_tokens);
+                if (capture_with_rows) {
+                    capture_slices[(size_t)cap_idx] = cur_2d;
+                    continue;
+                }
+
+                const int cap = cache.target_feat_cap;
+                const size_t elt = ggml_element_size(cache.target_feat);
+                const size_t col_stride = cache.target_feat->nb[1];
+                const int slot_start = in.kv_start % cap;
+                const int pre_n = std::min(in.n_tokens, cap - slot_start);
+                const int post_n = in.n_tokens - pre_n;
+
+                {
+                    const size_t offset =
+                        (size_t)slot_start * col_stride +
+                        (size_t)cap_idx * hidden * elt;
+                    ggml_tensor * slot = ggml_view_2d(ctx, cache.target_feat,
+                        hidden, pre_n, col_stride, offset);
+                    ggml_tensor * src = ggml_view_2d(ctx, cur_2d,
+                        hidden, pre_n, cur_2d->nb[1], 0);
+                    ggml_build_forward_expand(gf, ggml_cpy(ctx, src, slot));
+                }
+
+                if (post_n > 0) {
+                    const size_t offset =
+                        (size_t)cap_idx * hidden * elt;
+                    ggml_tensor * slot = ggml_view_2d(ctx, cache.target_feat,
+                        hidden, post_n, col_stride, offset);
+                    ggml_tensor * src = ggml_view_2d(ctx, cur_2d,
+                        hidden, post_n, cur_2d->nb[1],
+                        (size_t)pre_n * cur_2d->nb[1]);
+                    ggml_build_forward_expand(gf, ggml_cpy(ctx, src, slot));
+                }
+            }
+        }
+    }
+
+    if (capture_with_rows && !capture_slices.empty()) {
+        bool have_all = true;
+        for (ggml_tensor * t : capture_slices) {
+            if (!t) { have_all = false; break; }
+        }
+        if (have_all) {
+            ggml_tensor * feat_cat = capture_slices[0];
+            for (int k = 1; k < (int)capture_slices.size(); ++k) {
+                feat_cat = ggml_concat(ctx, feat_cat, capture_slices[(size_t)k], 0);
+            }
+            feat_cat = ggml_cont(ctx, feat_cat);
+            ggml_build_forward_expand(gf, ggml_set_rows(ctx, cache.target_feat,
+                                                        feat_cat, in.target_feat_rows));
+        }
     }
 
     // Final norm + lm_head
@@ -997,7 +1095,8 @@ bool laguna_step(
     int                         kv_start,
     bool                        no_mask,
     std::vector<float> &        out_logits,
-    const KvFlashPager *        kvflash)
+    const KvFlashPager *        kvflash,
+    bool                        capture)
 {
     if (kvflash && no_mask) {
         std::fprintf(stderr, "laguna_step: kvflash requires masks (slots are "
@@ -1063,6 +1162,7 @@ bool laguna_step(
     gi.kv_start      = kv_start;
     gi.kv_pad        = kv_pad;
     gi.kv_idx        = kvi;
+    gi.capture_features = capture;
     gi.output_last_only = true;
 
     LagunaGraphOutputs go = build_laguna_graph(ctx, gf, w, cache, gi);
@@ -1143,6 +1243,222 @@ bool laguna_step(
     return true;
 }
 
+bool laguna_verify_batch(
+    ggml_backend_t              backend,
+    const LagunaTargetWeights & w,
+    LagunaTargetCache &         cache,
+    const float *               embed,
+    const int32_t *             token_ids,
+    int                         n_tokens,
+    int                         kv_start,
+    std::vector<int32_t> &      out_argmax,
+    const KvFlashPager *        kvflash,
+    std::vector<float> *        out_logits)
+{
+    (void)token_ids;
+    if (n_tokens <= 0) return false;
+
+    const size_t arena_size = ggml_tensor_overhead() * 16384 + ggml_graph_overhead() + 16 * 1024 * 1024;
+    static thread_local std::vector<uint8_t> g_arena_block;
+    static thread_local std::vector<uint8_t> g_arena_bonus;
+    std::vector<uint8_t> & g_arena = (n_tokens == 1) ? g_arena_bonus : g_arena_block;
+    if (g_arena.size() < arena_size) g_arena.resize(arena_size);
+    ggml_init_params ip{};
+    ip.mem_size = arena_size;
+    ip.mem_buffer = g_arena.data();
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    ggml_cgraph * gf = ggml_new_graph_custom(ctx, 16384, false);
+
+    ggml_tensor * ie = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, w.n_embd, n_tokens, 1);
+    ggml_set_input(ie);
+    ggml_tensor * pp = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_tokens);
+    ggml_set_input(pp);
+
+    const int kv_len = kv_start + n_tokens;
+    static const bool g_no_kvpad = (std::getenv("DFLASH_LAGUNA_NO_KVPAD") != nullptr);
+    static const bool g_pad_cpy = (std::getenv("DFLASH_LAGUNA_PAD_CPY") != nullptr);
+    int kv_cap = 0;
+    for (int il = 0; il < w.n_layer; ++il) {
+        if (cache.attn_k[(size_t)il]) { kv_cap = (int)cache.attn_k[(size_t)il]->ne[1]; break; }
+    }
+    const int kv_pad = (!g_no_kvpad && kv_cap > 0)
+        ? std::min((kv_len + 255) & ~255, kv_cap) : 0;
+    const int mk_w = kv_pad > 0 ? kv_pad : kv_len;
+
+    ggml_tensor * kvi = nullptr;
+    if (kv_pad > 0 && !g_pad_cpy) {
+        kvi = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_tokens);
+        ggml_set_input(kvi);
+    }
+
+    ggml_tensor * mk_full = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, mk_w, n_tokens, 1, 1);
+    ggml_set_input(mk_full);
+    ggml_tensor * mk_full_cnv = ggml_cast(ctx, mk_full, GGML_TYPE_F16);
+    ggml_tensor * mk_swa = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, mk_w, n_tokens, 1, 1);
+    ggml_set_input(mk_swa);
+    ggml_tensor * mk_swa_cnv = ggml_cast(ctx, mk_swa, GGML_TYPE_F16);
+
+    ggml_tensor * feat_rows = nullptr;
+    if (cache.target_feat && cache.target_feat_cap > 0) {
+        feat_rows = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_tokens);
+        ggml_set_input(feat_rows);
+    }
+
+    LagunaGraphInputs gi{};
+    gi.inp_embed        = ie;
+    gi.positions        = pp;
+    gi.attn_mask        = mk_full_cnv;
+    gi.attn_mask_swa    = mk_swa_cnv;
+    gi.n_tokens         = n_tokens;
+    gi.kv_start         = kv_start;
+    gi.kv_pad           = kv_pad;
+    gi.kv_idx           = kvi;
+    gi.output_last_only = false;
+    gi.output_logits    = true;
+    gi.capture_features = true;
+    gi.target_feat_rows = feat_rows;
+    gi.hybrid           = nullptr;
+
+    LagunaGraphOutputs go = build_laguna_graph(ctx, gf, w, cache, gi);
+    ggml_tensor * argmax = ggml_argmax(ctx, go.logits);
+    ggml_set_output(argmax);
+    ggml_build_forward_expand(gf, argmax);
+
+    static ggml_gallocr_t galloc_verify_block = nullptr;
+    static ggml_gallocr_t galloc_verify_bonus = nullptr;
+    ggml_gallocr_t & galloc_verify = (n_tokens == 1) ? galloc_verify_bonus : galloc_verify_block;
+    if (!galloc_verify) galloc_verify = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    if (!ggml_gallocr_alloc_graph(galloc_verify, gf)) {
+        std::fprintf(stderr, "laguna_verify_batch: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(ie, embed, 0, ggml_nbytes(ie));
+    std::vector<int32_t> pos((size_t)n_tokens);
+    for (int i = 0; i < n_tokens; ++i) pos[(size_t)i] = kv_start + i;
+    ggml_backend_tensor_set(pp, pos.data(), 0, ggml_nbytes(pp));
+    if (feat_rows) {
+        std::vector<int32_t> feat_idx((size_t)n_tokens);
+        for (int i = 0; i < n_tokens; ++i) {
+            feat_idx[(size_t)i] = (kv_start + i) % cache.target_feat_cap;
+        }
+        ggml_backend_tensor_set(feat_rows, feat_idx.data(), 0, ggml_nbytes(feat_rows));
+    }
+
+    if (kvflash) {
+        if (!kvi) {
+            std::fprintf(stderr, "laguna_verify_batch: kvflash requires the kv_pad "
+                                 "set_rows path (NO_KVPAD / PAD_CPY are incompatible)\n");
+            ggml_free(ctx);
+            return false;
+        }
+        std::vector<int32_t> rows;
+        std::vector<float> mfull, mswa;
+        if (!kvflash_fill_rows_and_masks(*kvflash, kv_start, n_tokens, mk_w,
+                                         w.sliding_window, rows, &mfull, &mswa)) {
+            ggml_free(ctx);
+            return false;
+        }
+        ggml_backend_tensor_set(kvi, rows.data(), 0, ggml_nbytes(kvi));
+        ggml_backend_tensor_set(mk_full, mfull.data(), 0, ggml_nbytes(mk_full));
+        ggml_backend_tensor_set(mk_swa, mswa.data(), 0, ggml_nbytes(mk_swa));
+    } else {
+        if (kvi) {
+            ggml_backend_tensor_set(kvi, pos.data(), 0, ggml_nbytes(kvi));
+        }
+
+        std::vector<float> mfull((size_t)mk_w * n_tokens, -INFINITY);
+        for (int q = 0; q < n_tokens; ++q) {
+            const int abs_q = kv_start + q;
+            for (int k = 0; k <= abs_q && k < kv_len; ++k) {
+                mfull[(size_t)q * mk_w + k] = 0.0f;
+            }
+        }
+        ggml_backend_tensor_set(mk_full, mfull.data(), 0, ggml_nbytes(mk_full));
+
+        std::vector<float> mswa((size_t)mk_w * n_tokens, -INFINITY);
+        const int W = w.sliding_window;
+        for (int q = 0; q < n_tokens; ++q) {
+            const int abs_q = kv_start + q;
+            const int win_lo = std::max(0, abs_q - W + 1);
+            for (int k = win_lo; k <= abs_q && k < kv_len; ++k) {
+                mswa[(size_t)q * mk_w + k] = 0.0f;
+            }
+        }
+        ggml_backend_tensor_set(mk_swa, mswa.data(), 0, ggml_nbytes(mk_swa));
+    }
+
+    if (ggml_backend_graph_compute(backend, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "laguna_verify_batch: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    out_argmax.resize((size_t)n_tokens);
+    ggml_backend_tensor_get(argmax, out_argmax.data(), 0,
+                            sizeof(int32_t) * (size_t)n_tokens);
+    if (out_logits) {
+        const int vocab = (int)w.embedder.n_vocab;
+        out_logits->resize((size_t)vocab * (size_t)n_tokens);
+        ggml_backend_tensor_get(go.logits, out_logits->data(), 0,
+                                sizeof(float) * out_logits->size());
+    }
+
+    cache.cur_pos = kv_len;
+    cache.last_tok = out_argmax.empty() ? -1 : out_argmax.back();
+    ggml_free(ctx);
+    return true;
+}
+
+bool laguna_project_hidden(
+    ggml_backend_t              backend,
+    const LagunaTargetWeights & w,
+    const float *               hidden,
+    int                         n_tokens,
+    std::vector<int32_t> &      out_tokens)
+{
+    if (n_tokens <= 0) return false;
+
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() * 64 + ggml_graph_overhead() + 1024 * 1024;
+    ip.no_alloc = true;
+    ggml_context * ctx = ggml_init(ip);
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+
+    ggml_tensor * inp = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, w.n_embd, n_tokens);
+    ggml_set_input(inp);
+
+    ggml_tensor * cur = ggml_mul_mat(ctx, w.output, inp);  // [vocab, n_tokens]
+    cur = ggml_argmax(ctx, cur);                           // [n_tokens]
+    ggml_set_output(cur);
+    ggml_build_forward_expand(gf, cur);
+
+    static ggml_gallocr_t galloc_proj = nullptr;
+    if (!galloc_proj) galloc_proj = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+    if (!ggml_gallocr_alloc_graph(galloc_proj, gf)) {
+        std::fprintf(stderr, "laguna_project_hidden: gallocr_alloc_graph failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    ggml_backend_tensor_set(inp, hidden, 0,
+                            sizeof(float) * (size_t)n_tokens * (size_t)w.n_embd);
+
+    if (ggml_backend_graph_compute(backend, gf) != GGML_STATUS_SUCCESS) {
+        std::fprintf(stderr, "laguna_project_hidden: graph_compute failed\n");
+        ggml_free(ctx);
+        return false;
+    }
+
+    out_tokens.resize((size_t)n_tokens);
+    ggml_backend_tensor_get(cur, out_tokens.data(), 0,
+                            sizeof(int32_t) * (size_t)n_tokens);
+
+    ggml_free(ctx);
+    return true;
+}
 
 // ---- Single-graph hybrid decode forward -----------------------------------
 bool laguna_step_hybrid(

--- a/server/src/laguna/laguna_target_loader.cpp
+++ b/server/src/laguna/laguna_target_loader.cpp
@@ -592,7 +592,8 @@ bool create_laguna_target_feat(ggml_backend_t backend,
                                 LagunaTargetCache & cache,
                                 int n_capture_layers,
                                 int hidden_size,
-                                int cap) {
+                                int cap,
+                                const std::vector<int> & explicit_ids) {
     if (n_capture_layers <= 0 || hidden_size <= 0 || cap <= 0) return false;
 
     free_laguna_target_feat(cache);
@@ -618,12 +619,20 @@ bool create_laguna_target_feat(ggml_backend_t backend,
     cache.target_feat_cap = cap;
     cache.n_capture_layers = n_capture_layers;
 
-    if (n_capture_layers == 5) {
+    if ((int)explicit_ids.size() == n_capture_layers) {
+        // Data-driven: ids shipped in the draft GGUF (dflash.target_layer_ids),
+        // copied by the converter from the drafter's config.json. Works for any
+        // drafter without a hardcoded per-arch set.
+        cache.capture_layer_ids = explicit_ids;
+    } else if (n_capture_layers == 5) {
+        // Legacy fallback for GGUFs converted before target_layer_ids was
+        // emitted (poolside Laguna-XS.2 speculator: {1,9,17,36,39}).
         cache.capture_layer_ids = {1, 9, 17, 36, 39};
     } else {
         std::fprintf(stderr,
-            "[laguna] warning: DFlash draft has %d capture layers; falling back "
-            "to linspace capture ids (Laguna speculator expects 5: 1 9 17 36 39)\n",
+            "[laguna] warning: DFlash draft has %d capture layers and no "
+            "dflash.target_layer_ids in the GGUF; falling back to linspace ids "
+            "(reconvert the drafter to embed its trained capture ids)\n",
             n_capture_layers);
         cache.capture_layer_ids.resize((size_t)n_capture_layers);
         const int n_layer = !cache.attn_k.empty() ? (int)cache.attn_k.size() : 40;

--- a/server/src/laguna/laguna_target_loader.cpp
+++ b/server/src/laguna/laguna_target_loader.cpp
@@ -43,6 +43,7 @@
 
 #include <cinttypes>
 #include <climits>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -576,6 +577,67 @@ void free_laguna_target_weights(LagunaTargetWeights & w) {
     w.tok_embd = nullptr;
     w.out_norm = nullptr;
     w.output   = nullptr;
+}
+
+void free_laguna_target_feat(LagunaTargetCache & c) {
+    if (c.feat_buf) { ggml_backend_buffer_free(c.feat_buf); c.feat_buf = nullptr; }
+    if (c.feat_ctx) { ggml_free(c.feat_ctx); c.feat_ctx = nullptr; }
+    c.target_feat = nullptr;
+    c.target_feat_cap = 0;
+    c.n_capture_layers = 0;
+    c.capture_layer_ids.clear();
+}
+
+bool create_laguna_target_feat(ggml_backend_t backend,
+                                LagunaTargetCache & cache,
+                                int n_capture_layers,
+                                int hidden_size,
+                                int cap) {
+    if (n_capture_layers <= 0 || hidden_size <= 0 || cap <= 0) return false;
+
+    free_laguna_target_feat(cache);
+
+    ggml_init_params ip{};
+    ip.mem_size = ggml_tensor_overhead() * 4 + 4096;
+    ip.no_alloc = true;
+    cache.feat_ctx = ggml_init(ip);
+    if (!cache.feat_ctx) return false;
+
+    const int fc_in = n_capture_layers * hidden_size;
+    cache.target_feat = ggml_new_tensor_2d(cache.feat_ctx, GGML_TYPE_BF16, fc_in, cap);
+    ggml_set_name(cache.target_feat, "laguna_target_feat");
+
+    cache.feat_buf = ggml_backend_alloc_ctx_tensors(cache.feat_ctx, backend);
+    if (!cache.feat_buf) {
+        ggml_free(cache.feat_ctx);
+        cache.feat_ctx = nullptr;
+        cache.target_feat = nullptr;
+        return false;
+    }
+
+    cache.target_feat_cap = cap;
+    cache.n_capture_layers = n_capture_layers;
+
+    if (n_capture_layers == 5) {
+        cache.capture_layer_ids = {1, 9, 17, 36, 39};
+    } else {
+        std::fprintf(stderr,
+            "[laguna] warning: DFlash draft has %d capture layers; falling back "
+            "to linspace capture ids (Laguna speculator expects 5: 1 9 17 36 39)\n",
+            n_capture_layers);
+        cache.capture_layer_ids.resize((size_t)n_capture_layers);
+        const int n_layer = !cache.attn_k.empty() ? (int)cache.attn_k.size() : 40;
+        if (n_capture_layers == 1) {
+            cache.capture_layer_ids[0] = 1;
+        } else {
+            for (int k = 0; k < n_capture_layers; k++) {
+                cache.capture_layer_ids[(size_t)k] = (int)std::round(
+                    1.0 + k * (double)(n_layer - 4) / (n_capture_layers - 1));
+            }
+        }
+    }
+
+    return true;
 }
 
 // ── Partial loader (hybrid mode) ────────────────────────────────────────

--- a/server/src/server/server_main.cpp
+++ b/server/src/server/server_main.cpp
@@ -225,6 +225,7 @@ static void print_usage(const char * prog) {
         "  --no-fast-rollback  Disable speculative fast rollback, even with --ddtree\n"
         "  --ddtree             Enable DDTree speculative decode\n"
         "  --ddtree-budget <N>  DDTree budget (default: 22)\n"
+        "  --verify-width <N>   laguna chain spec verify width (0=auto; default 0)\n"
         "  --no-cors            Disable CORS headers\n"
         "  --think-max-tokens <N>     Phase-1 reasoning cap when a request opts in\n"
         "                             via thinking:{type:enabled} (default: 15488 =\n"
@@ -430,6 +431,8 @@ int main(int argc, char ** argv) {
             bargs.fast_rollback = true;
         } else if (std::strcmp(argv[i], "--ddtree-budget") == 0 && i + 1 < argc) {
             bargs.ddtree_budget = std::atoi(argv[++i]);
+        } else if (std::strcmp(argv[i], "--verify-width") == 0 && i + 1 < argc) {
+            bargs.verify_width = std::atoi(argv[++i]);
         } else if (std::strcmp(argv[i], "--no-fast-rollback") == 0) {
             fast_rollback_forced_off = true;
             bargs.fast_rollback = false;


### PR DESCRIPTION
# feat(laguna): DFlash speculative decoding — chain + DDTree + sampled-verify

## Summary
Adds DFlash speculative decoding support for the `laguna` architecture (Poolside **Laguna-XS.2**), mirroring the existing `qwen35`/`gemma4` integrations. Implements three verify modes, all **lossless** (output is distribution-identical to autoregressive decode):

- **Chain** (greedy) — the standard DFlash block verify
- **DDTree** — tree-structured verify (`--ddtree`)
- **Sampled-verify** — spec decode with an active sampler / temperature (`DFLASH_SAMPLED_VERIFY=1`)

Speculator used for validation: [`poolside/Laguna-XS.2-speculator.dflash`](https://huggingface.co/poolside/Laguna-XS.2-speculator.dflash).

## What's added
- **`LagunaDFlashTarget`** (`server/src/laguna/laguna_dflash_target.{h,cpp}`) — implements the `DFlashTarget` interface for laguna: `verify_batch` (chain), `verify_tree` + `rollback_to_tree` + `project_hidden_to_topk` + `supports_tree_verify` (DDTree), `read_verify_logits` (sampled), `project_hidden_to_tokens`, `embed_tokens`, `snapshot_kv`/`restore_kv`.
- **Feature capture** — a BF16 `target_feat` ring on `LagunaTargetCache`, populated at the speculator's trained capture layers `{1, 9, 17, 36, 39}`. Verify capture is replay-safe (`ggml_set_rows` with data-driven row indices); prefill uses the offset-copy path. `create_laguna_target_feat` / `free_laguna_target_feat`.
- **Graph helpers** (`laguna_target_graph.cpp`) — `laguna_verify_batch` (dual full+SWA masks, kv_pad/set_rows append, optional retained logits), `laguna_project_hidden`, and the ancestor-masked **tree-verify graph** (NeoX positions per node = `committed + depth`, ancestor-only mask for both full and SWA layers).
- **Backend wiring** (`laguna_backend.{h,cpp}`) — draft load/free, `do_spec_decode` (chain / DDTree / sampled branches), dispatch from `generate_impl` + `restore_and_generate_impl`. `LagunaBackendArgs` gains `draft_path`, `draft_gpu`, `draft_ctx_max`, `ddtree_mode`, `ddtree_budget`, `ddtree_temp`.
- **Factory + build** — `backend_factory.cpp` plumbs the draft/ddtree args into the laguna branch; `laguna_dflash_target.cpp` added to `CMakeLists.txt`.

## Design / correctness notes
- **Shared lm_head:** the speculator ships a reduced 32k `lm_head` + `d2t`/`t2d` (the vLLM/speculators serving format), but lucebox-hub's DFlash design projects draft hidden states through the **target's** lm_head (training used `lm_head = target_lm_head`). We follow that — the packaged reduced head is ignored.
- **Capture layers** are hardcoded to the speculator's `aux_hidden_state_layer_ids` `{1,9,17,36,39}` (not a derived linspace); **mask token = 12**; laguna has no logit softcap and no embedding scaling.
- When a draft is loaded, laguna loads **all experts resident** (non-hybrid) so verify forwards are exact.
- Pure-attention arch (no SSM), so tree structure is carried entirely by the attention mask + KV; `rollback_to_tree` compacts KV/features on-device (`get_rows`/`set_rows`) with a fast-path for the common contiguous (chain) case.

## Usage
```sh
# chain
dflash_server <laguna.gguf> --draft <draft.gguf>
# DDTree
dflash_server <laguna.gguf> --draft <draft.gguf> --ddtree --ddtree-budget 24
# sampled-verify (temperature > 0)
DFLASH_SAMPLED_VERIFY=1 dflash_server <laguna.gguf> --draft <draft.gguf>
```

## Validation (RTX 3090, laguna-xs2 Q4_K_M, 256-token steady-state)
| Mode | tok/s | avg_commit |
|---|---|---|
| AR (no draft, all experts resident) | **151** | — |
| DFlash chain | 111 | 2.88 |
| DDTree (budget 16) | 71 | 2.42 |
| DDTree (budget 64) | 44 | 2.91 |
| Sampled-verify (temp 0.7) | 71 | 2.88 |

All modes produce coherent, lossless output.

## Honest performance characterization (important for reviewers)
**On this MoE target, speculative decoding does not beat AR.** This is expected and well-understood, not an implementation defect:

1. **MoE makes batched verify expensive.** Each token independently routes to its own top-8 of 256 experts, so a multi-token verify activates the *union* of experts (≈8 tokens → ~50 experts; a 65-node tree → nearly all 256). Decode is memory-bandwidth-bound, so verify cost scales with the number of distinct experts touched. A single-token AR step touches ~8; the verify batch touches many more. (On a **dense** target — e.g. qwen35, where DDTree wins — one forward reads all weights regardless of token count, so batched verify is effectively free.)
2. **The XS draft's acceptance is modest** (avg_commit ~2.88), so the extra verify cost isn't amortized. DDTree, which maximizes the verify batch width, makes (1) worse while the weak draft gives it nothing back — hence it's a net loss here (avg_commit plateaus ~2.9 while cost grows with budget).

The feature is **correct and complete**; making spec *win* on an MoE target is a separate problem requiring a stronger draft (higher commit) and/or expert-aware verify batching.

## Follow-ups (not in this PR)
- Move DDTree per-node argmax on-GPU (currently a host readback; minor).
- Reduced-vocab head / stronger speculator to lift acceptance.
- Route verify through the hybrid single-graph forward (`laguna_step_hybrid`) to cut per-forward cost.

## Test plan
- Build: `cmake -S server -B server/build -DCMAKE_CUDA_ARCHITECTURES=86 && cmake --build server/build -j -t dflash_server`
- Convert the speculator: `server/scripts/convert_dflash_to_gguf.py` with a flattened config (`block_size=8`, `rope_theta=10000`, `mask_token_id=12`, hidden 2048, 5 layers, 16/8 heads, head_dim 128).
- Run each of the three modes above and confirm coherent output + the `[laguna-spec]` accept stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

