### PR TITLE
fix(test_dflash): pad prefill attention mask to the allocated tensor stride

### DIFF
--- a/server/test/test_dflash.cpp
+++ b/server/test/test_dflash.cpp
@@ -2073,7 +2073,8 @@ int main(int argc, char ** argv) {
                 ggml_backend_tensor_set(psg.positions, pf_pos.data(), 0,
                                         sizeof(int32_t) * pf_pos.size());
                 if (with_m) {
-                    build_causal_mask(pf_mask, kv_len_p, nt, start, g_kq_stride_pad);
+                    build_causal_mask(pf_mask, kv_len_p, nt, start, g_kq_stride_pad,
+                                      /*win_start=*/0, /*kv_pad_override=*/(int)psg.attn_mask->ne[0]);
                     ggml_backend_tensor_set(psg.attn_mask, pf_mask.data(), 0,
                                             sizeof(uint16_t) * pf_mask.size());
                 }
@@ -2729,7 +2730,8 @@ int main(int argc, char ** argv) {
 
                 if (is_attn && with_mask && lsg.attn_mask) {
                     std::vector<uint16_t> mask_buf;
-                    build_causal_mask(mask_buf, kv_len, n_tokens, /*kv_start=*/start, g_kq_stride_pad);
+                    build_causal_mask(mask_buf, kv_len, n_tokens, /*kv_start=*/start, g_kq_stride_pad,
+                                      /*win_start=*/0, /*kv_pad_override=*/(int)lsg.attn_mask->ne[0]);
                     ggml_backend_tensor_set(lsg.attn_mask, mask_buf.data(), 0,
                                             sizeof(uint16_t) * mask_buf.size());
                 }
@@ -2935,7 +2937,8 @@ int main(int argc, char ** argv) {
                                          ? (start - g_fa_window) : 0;
             const int pf_win_len = kv_len - pf_win_start;
             build_causal_mask(pf_mask_buf, pf_win_len, n_tokens,
-                              /*kv_start=*/start, g_kq_stride_pad, /*win_start=*/pf_win_start);
+                              /*kv_start=*/start, g_kq_stride_pad, /*win_start=*/pf_win_start,
+                              /*kv_pad_override=*/(int)sg.attn_mask->ne[0]);
             ggml_backend_tensor_set(sg.attn_mask, pf_mask_buf.data(), 0,
                                     sizeof(uint16_t) * pf_mask_buf.size());
         }


### PR DESCRIPTION
## Problem

`bench_llm.py` (HumanEval) on **Qwen3.6-27B** showed a bimodal DFlash collapse: most prompts got `AL = 1.00` (zero draft tokens accepted, model emits token-0 `!` garbage), a couple got `AL ~6.5`. Pure AR (`test_generate`) was perfectly coherent on the same prompts, and the production **server (`dflash_server`) was unaffected** — only the benchmark binary collapsed.

## Root cause

A mask **row-stride mismatch** in `test_dflash`'s prefill. `build_target_step` allocates `sg.attn_mask` pre-sized to `max_ctx`:

```
ne[0] = align_up(max_ctx + n_tokens, kq_stride_pad)
```

but the prefill built the causal mask with a **compact** row stride `align_up(kv_len, kq_stride_pad)` and uploaded only that. The CUDA flash-attention kernel indexes mask rows by the **allocated** tensor stride (`ne[0]`), so every query row > 0 read **uninitialized** mask memory → garbage attention → degenerate logits whose argmax is token 0.

Which `max_ctx` triggered it was allocator-content luck (e.g. for a 92-token prompt: `--max-ctx 256/768` happened to work, `384/512` collapsed). `bench_llm.py`'s `_auto_max_ctx` sizes `max_ctx` for `n_gen=256`, which lands on the bad strides for short prompts — hence the bimodal HumanEval result.

The production server and the verify/replay paths were never affected because they already pass `kv_pad_override = attn_mask->ne[0]` (e.g. `qwen35_backend.cpp:1189`). The three prefill mask builds in `test_dflash` simply forgot it.

## Fix

Pass `kv_pad_override = (int)<sg>.attn_mask->ne[0]` at the three prefill mask builds so the host mask row stride matches the allocated tensor:
- token-segment prefill (`~2938`)
- layer-segment prefill (`~2732`)
- `--test-window` diagnostic prefill (`~2076`)

This matches the existing pattern in the production backend and the verify/replay paths; `build_causal_mask` already supports the param (`attn_masks.h`).

## Verification (RTX 3090, CUDA 12, Qwen3.6-27B-Q4_K_M + matching DFlash draft)

| Binary | Mode | AL before | AL after |
|---|---|---|---|
| `test_dflash` (bench) | DDTree | 1.00 (8/10 collapsed) | **5.3–7.1** |
| `test_dflash` (bench) | chain | collapse | **5.82** |
| `dflash_server` | DDTree | (never broken) | **8.9–11.4** |
| `dflash_server` | chain | (never broken) | **8.9–11.4** |

The exact prompt that collapsed (`below_threshold`) now decodes coherent code at `AL=11.43` on the server / `~6.7` in the (thinking-mode) bench.

A full audit of every `build_causal_mask`/`build_tree_mask` site across qwen35, qwen35moe, laguna, gemma4 and the qwen3 draft found all **server** paths safe; this was the only remaining buggy path and it lives in the benchmark binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

