### PR TITLE
Optimize Topk

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -395,7 +395,11 @@ if(DFLASH27B_GPU_BACKEND STREQUAL "hip")
 elseif(DFLASH27B_GPU_BACKEND STREQUAL "cuda")
     target_sources(dflash_common PRIVATE
         src/flashprefill_select.cpp
-        src/flashprefill.cpp)
+        src/flashprefill.cpp
+        src/common/draft_topk_cuda.cu)
+    # PUBLIC so consumers (e.g. the test_dflash executable) also see the macro
+    # and take the GPU draft top-K path instead of the CPU fallback.
+    target_compile_definitions(dflash_common PUBLIC DFLASH27B_HAVE_DRAFT_TOPK_CUDA=1)
     # Multi-arch: scan all resolved arches and compile every applicable
     # flashprefill kernel variant.  This lets a single binary run on mixed
     # GPUs (e.g. Volta sm_70 + Pascal sm_61) without "no kernel image" errors.

--- a/server/scripts/bench_llm.py
+++ b/server/scripts/bench_llm.py
@@ -35,7 +35,7 @@ _LOCAL_DRAFT_ROOT = ROOT / "models" / "draft"
 DRAFT = None
 TEST_DFLASH = os.environ.get("DFLASH_BIN", str(ROOT / "build" / f"test_dflash{BIN_SUFFIX}"))
 TEST_GENERATE = os.environ.get("DFLASH_BIN_AR", str(ROOT / "build" / f"test_generate{BIN_SUFFIX}"))
-TOKENIZER = os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.5-27B")
+TOKENIZER = os.environ.get("DFLASH_TOKENIZER", "Qwen/Qwen3.6-27B")
 TMPDIR = Path(tempfile.gettempdir()) / "dflash_bench"
 TMPDIR.mkdir(parents=True, exist_ok=True)
 
@@ -53,8 +53,8 @@ def _gsm_gold(x):
 
 
 BENCHES = [
-    ("HumanEval", "openai_humaneval", None, "test", lambda x: x["prompt"], None, N_GEN),
-    ("GSM8K", "gsm8k", "main", "test", lambda x: f"Question: {x['question']}\nAnswer: ", _gsm_gold, 1024),
+    ("HumanEval", "openai/openai_humaneval", None, "test", lambda x: x["prompt"], None, N_GEN),
+    ("GSM8K", "openai/gsm8k", "main", "test", lambda x: f"Question: {x['question']}\nAnswer: ", _gsm_gold, 1024),
     ("Math500", "HuggingFaceH4/MATH-500", None, "test", lambda x: f"Problem: {x['problem']}\nSolution: Put your final answer in \\boxed{{}}.\n", lambda x: x["answer"], 2048),
 ]
 

--- a/server/src/common/bench_topk.cu
+++ b/server/src/common/bench_topk.cu
@@ -1,0 +1,100 @@
+// Standalone microbenchmark + correctness check for extract_draft_topk_cuda.
+// Build:
+//   nvcc -O3 -arch=sm_86 -o /tmp/bench_topk \
+//       server/src/common/bench_topk.cu server/src/common/draft_topk_cuda.cu
+// Run:
+//   /tmp/bench_topk [n_positions] [vocab] [K] [iters]
+#include "draft_topk_cuda.h"
+#include <cuda_runtime.h>
+#include <cfloat>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <random>
+#include <algorithm>
+
+using dflash::common::extract_draft_topk_cuda;
+
+// CPU reference matching the documented semantics.
+static void cpu_ref(const float* logits, int n, int vocab, int K, float temp,
+                    std::vector<float>& lp, std::vector<int32_t>& ids) {
+    const float inv_t = 1.0f / std::fmax(1e-3f, temp);
+    lp.assign((size_t)n * K, 0.f);
+    ids.assign((size_t)n * K, -1);
+    for (int r = 0; r < n; r++) {
+        const float* li = logits + (size_t)r * vocab;
+        // online logsumexp
+        float lmax = -FLT_MAX, lsum = 0.f;
+        for (int j = 0; j < vocab; j++) {
+            float l = li[j] * inv_t;
+            if (l > lmax) { lsum = lsum * std::exp(lmax - l) + 1.f; lmax = l; }
+            else lsum += std::exp(l - lmax);
+        }
+        float log_z = lmax + std::log(lsum);
+        // top-K with lower-id-wins on ties
+        std::vector<int> idx(vocab);
+        for (int j = 0; j < vocab; j++) idx[j] = j;
+        std::partial_sort(idx.begin(), idx.begin() + K, idx.end(),
+            [&](int a, int b){
+                float la = li[a]*inv_t, lb = li[b]*inv_t;
+                if (la != lb) return la > lb;
+                return a < b;
+            });
+        for (int k = 0; k < K; k++) {
+            int j = idx[k];
+            lp[(size_t)r*K+k]  = li[j]*inv_t - log_z;
+            ids[(size_t)r*K+k] = j;
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    int n     = argc > 1 ? atoi(argv[1]) : 15;
+    int vocab = argc > 2 ? atoi(argv[2]) : 151936;
+    int K     = argc > 3 ? atoi(argv[3]) : 8;
+    int iters = argc > 4 ? atoi(argv[4]) : 200;
+    float temp = 1.0f;
+
+    printf("n=%d vocab=%d K=%d iters=%d\n", n, vocab, K, iters);
+
+    std::vector<float> h_logits((size_t)n * vocab);
+    std::mt19937 rng(1234);
+    std::normal_distribution<float> dist(0.f, 4.f);
+    for (auto& x : h_logits) x = dist(rng);
+
+    float* d_logits = nullptr;
+    cudaMalloc(&d_logits, h_logits.size() * sizeof(float));
+    cudaMemcpy(d_logits, h_logits.data(), h_logits.size()*sizeof(float), cudaMemcpyHostToDevice);
+
+    std::vector<float>   lp((size_t)n*K);
+    std::vector<int32_t> ids((size_t)n*K);
+
+    // correctness
+    bool ok = extract_draft_topk_cuda(d_logits, n, vocab, K, lp.data(), ids.data(), temp);
+    if (!ok) { printf("FAIL: kernel returned false\n"); return 1; }
+
+    std::vector<float> rlp; std::vector<int32_t> rids;
+    cpu_ref(h_logits.data(), n, vocab, K, temp, rlp, rids);
+    int mism = 0; float maxerr = 0.f;
+    for (size_t i = 0; i < lp.size(); i++) {
+        if (ids[i] != rids[i]) { if (mism < 10) printf("  id mismatch @%zu gpu=%d cpu=%d\n", i, ids[i], rids[i]); mism++; }
+        maxerr = std::fmax(maxerr, std::fabs(lp[i]-rlp[i]));
+    }
+    printf("correctness: id_mismatches=%d  max_lp_err=%.3e\n", mism, maxerr);
+
+    // warmup
+    for (int i = 0; i < 10; i++) extract_draft_topk_cuda(d_logits, n, vocab, K, lp.data(), ids.data(), temp);
+    cudaDeviceSynchronize();
+
+    cudaEvent_t e0, e1; cudaEventCreate(&e0); cudaEventCreate(&e1);
+    cudaEventRecord(e0);
+    for (int i = 0; i < iters; i++)
+        extract_draft_topk_cuda(d_logits, n, vocab, K, lp.data(), ids.data(), temp);
+    cudaEventRecord(e1); cudaEventSynchronize(e1);
+    float ms = 0; cudaEventElapsedTime(&ms, e0, e1);
+    printf("avg full call (kernel+sync+copy): %.4f ms\n", ms / iters);
+
+    cudaFree(d_logits);
+    return 0;
+}

--- a/server/src/common/draft_topk_cuda.cu
+++ b/server/src/common/draft_topk_cuda.cu
@@ -13,91 +13,228 @@ namespace dflash::common {
 
 namespace {
 
-constexpr int kMaxK  = 8;     // ddtree_K is 8 in practice; K>kMaxK → CPU fallback
-constexpr int kBlock = 1024;  // threads per position (power of two for the reduction)
-// With only n_positions (~15) blocks, occupancy is capped by blocks, not
-// threads — so we want many warps per block to hide the vocab read latency.
-// 1024 threads × kMaxK × (float+int32) = 64 KiB dynamic shared, which exceeds
-// the 48 KiB default and needs an opt-in (see ensure_smem_optin below).
+constexpr int kMaxK    = 8;     // ddtree_K is 8 in practice; K>kMaxK → CPU fallback
+constexpr int kBlock   = 256;   // threads per block (power of two for the reduction)
+constexpr int kMaxSplit = 128;  // max vocab splits per position (combine-block cap)
 
-// One block per draft position. A single strided pass over the vocabulary
-// accumulates a per-thread online logsumexp (running max + sum) and a
-// per-thread sorted-descending top-K; a shared-memory tree reduction then
-// merges both across threads. log_prob[k] = scaled_logit[k] - log_z.
-__global__ void draft_topk_kernel(const float * __restrict__ logits,
-                                  int vocab, int K, float inv_t,
-                                  float * __restrict__ out_lp,
-                                  int32_t * __restrict__ out_ids) {
+// The workload is tiny in rows (n_positions ~ 15) but huge in vocab (~152k),
+// so it is purely DRAM-bandwidth bound: ~9 MB to read per call. The original
+// one-block-per-position layout launched only ~15 blocks, leaving most of the
+// GPU's SMs idle and hitting only a fraction of peak bandwidth. We instead
+// split each position's vocab scan across `split` blocks (a 2D grid of
+// n_positions × split) so the whole device stays busy, then a cheap second
+// kernel merges the `split` partials per position into the final top-K.
+
+// Merge two sorted-descending top-K lists (av/ai, bv/bi) into dst (dv/di),
+// keeping the K largest; ties resolve toward the lower id. dst may alias av/ai
+// safely only via the temporary below, so callers pass a distinct dst when the
+// inputs come from shared memory.
+template <int K>
+__device__ __forceinline__ void merge_topk(const float * av, const int * ai,
+                                            const float * bv, const int * bi,
+                                            float * dv, int * di) {
+    int ia = 0, ib = 0;
+#pragma unroll
+    for (int k = 0; k < K; k++) {
+        bool takeA;
+        if      (ib >= K)         takeA = true;
+        else if (ia >= K)         takeA = false;
+        else if (av[ia] > bv[ib]) takeA = true;
+        else if (av[ia] < bv[ib]) takeA = false;
+        else                      takeA = (ai[ia] <= bi[ib]);  // tie → lower id
+        if (takeA) { dv[k] = av[ia]; di[k] = ai[ia]; ia++; }
+        else       { dv[k] = bv[ib]; di[k] = bi[ib]; ib++; }
+    }
+}
+
+// Fold one logit (raw value `LRAW`, vocab id `ID`) into a thread's running
+// online-logsumexp (lmax,lsum) and its register-resident sorted-descending
+// top-K (topv,topi). K is a compile-time constant so the unrolled bubble uses
+// only fixed indices — the arrays stay in registers instead of spilling to
+// local memory the way a data-dependent insertion index would. The new value
+// enters at slot K-1 and bubbles up only past strictly-smaller entries, so on
+// ties the earlier (lower-id, since ids ascend within a thread) entry wins —
+// matching the CPU heap's first-wins behaviour.
+#define DFLASH_TOPK_CONSUME(LRAW, ID)                                          \
+    do {                                                                       \
+        const float _l = (LRAW) * inv_t;                                       \
+        if (_l > lmax) { lsum = lsum * __expf(lmax - _l) + 1.0f; lmax = _l; }  \
+        else           { lsum += __expf(_l - lmax); }                          \
+        if (_l > topv[K - 1]) {                                                \
+            topv[K - 1] = _l; topi[K - 1] = (ID);                              \
+            _Pragma("unroll")                                                  \
+            for (int _p = K - 1; _p > 0; --_p) {                               \
+                if (topv[_p] > topv[_p - 1]) {                                 \
+                    const float _tv = topv[_p];                                \
+                    topv[_p] = topv[_p - 1]; topv[_p - 1] = _tv;               \
+                    const int _ti = topi[_p];                                  \
+                    topi[_p] = topi[_p - 1]; topi[_p - 1] = _ti;               \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
+
+// ---- pass 1: per-(position, split) partial logsumexp + local top-K ---------
+// Grid: (n_positions, split). Block s of row `row` scans its contiguous vocab
+// chunk and writes one partial (max, sum, sorted top-K) to part_* at index
+// row*split + s. Contiguous chunks keep the strided per-warp reads coalesced.
+// VEC selects 16-byte float4 loads (one coalesced transaction per 4 logits) —
+// only used when every row's base pointer is 16-byte aligned (vocab % 4 == 0
+// and an aligned tensor); otherwise the scalar path is used.
+template <int K, bool VEC>
+__global__ void draft_topk_partial(const float * __restrict__ logits,
+                                   int vocab, float inv_t, int split,
+                                   float * __restrict__ part_max,
+                                   float * __restrict__ part_sum,
+                                   float * __restrict__ part_v,
+                                   int32_t * __restrict__ part_i) {
     const int row = blockIdx.x;
+    const int s   = blockIdx.y;
     const int tid = threadIdx.x;
     const float * __restrict__ li = logits + (size_t)row * vocab;
 
     float lmax = -FLT_MAX;
     float lsum = 0.0f;
-    float topv[kMaxK];
-    int   topi[kMaxK];
+    float topv[K];
+    int   topi[K];
 #pragma unroll
-    for (int k = 0; k < kMaxK; k++) { topv[k] = -FLT_MAX; topi[k] = -1; }
+    for (int k = 0; k < K; k++) { topv[k] = -FLT_MAX; topi[k] = -1; }
 
-    // ---- single strided pass: logsumexp + local top-K ------------------
-    // j ascends within a thread, so a strict-greater insert keeps the lower
-    // id on ties (matches the CPU heap's first-wins behaviour).
-    for (int j = tid; j < vocab; j += kBlock) {
-        const float l = li[j] * inv_t;
-        if (l > lmax) { lsum = lsum * __expf(lmax - l) + 1.0f; lmax = l; }
-        else          { lsum += __expf(l - lmax); }
-        if (l > topv[K - 1]) {
-            int p = K - 1;
-            while (p > 0 && topv[p - 1] < l) {
-                topv[p] = topv[p - 1]; topi[p] = topi[p - 1]; --p;
-            }
-            topv[p] = l; topi[p] = j;
+    if (VEC) {
+        // Partition the float4s of the row into `split` contiguous chunks.
+        const int vocab4 = vocab >> 2;                   // # of full float4s
+        const int chunk4 = (vocab4 + split - 1) / split;
+        const int b4 = s * chunk4;
+        const int e4 = min(b4 + chunk4, vocab4);
+        const float4 * __restrict__ li4 = reinterpret_cast<const float4 *>(li);
+        for (int j4 = b4 + tid; j4 < e4; j4 += kBlock) {
+            const float4 f = li4[j4];
+            const int base = j4 << 2;
+            DFLASH_TOPK_CONSUME(f.x, base + 0);
+            DFLASH_TOPK_CONSUME(f.y, base + 1);
+            DFLASH_TOPK_CONSUME(f.z, base + 2);
+            DFLASH_TOPK_CONSUME(f.w, base + 3);
         }
+        // Tail elements past the last full float4 (only when vocab % 4 != 0);
+        // the last split owns them so no id is scanned twice.
+        if (s == split - 1) {
+            for (int j = (vocab4 << 2) + tid; j < vocab; j += kBlock)
+                DFLASH_TOPK_CONSUME(li[j], j);
+        }
+    } else {
+        const int chunk = (vocab + split - 1) / split;
+        const int begin = s * chunk;
+        const int end   = min(begin + chunk, vocab);
+        for (int j = begin + tid; j < end; j += kBlock)
+            DFLASH_TOPK_CONSUME(li[j], j);
     }
 
-    // ---- block reduction --------------------------------------------------
+    // ---- block reduction over kBlock threads ------------------------------
     __shared__ float s_max[kBlock];
     __shared__ float s_sum[kBlock];
-    extern __shared__ char s_raw[];
-    float   * s_topv = reinterpret_cast<float   *>(s_raw);
-    int32_t * s_topi = reinterpret_cast<int32_t *>(s_topv + (size_t)kBlock * K);
+    __shared__ float s_topv[kBlock * K];
+    __shared__ int32_t s_topi[kBlock * K];
 
     s_max[tid] = lmax;
     s_sum[tid] = lsum;
+#pragma unroll
     for (int k = 0; k < K; k++) {
-        s_topv[(size_t)tid * K + k] = topv[k];
-        s_topi[(size_t)tid * K + k] = topi[k];
+        s_topv[tid * K + k] = topv[k];
+        s_topi[tid * K + k] = topi[k];
     }
     __syncthreads();
 
     for (int stride = kBlock / 2; stride > 0; stride >>= 1) {
         if (tid < stride) {
-            // logsumexp merge of (max,sum) pairs
             const float am = s_max[tid],          as = s_sum[tid];
             const float bm = s_max[tid + stride], bs = s_sum[tid + stride];
             const float m = fmaxf(am, bm);
             s_sum[tid] = as * __expf(am - m) + bs * __expf(bm - m);
             s_max[tid] = m;
 
-            // merge two sorted-desc top-K lists, keep the K largest (lower id on tie)
-            float av[kMaxK]; int ai[kMaxK];
-            float bv[kMaxK]; int bi[kMaxK];
+            float dv[K]; int di[K];
+            merge_topk<K>(&s_topv[tid * K],            &s_topi[tid * K],
+                          &s_topv[(tid + stride) * K], &s_topi[(tid + stride) * K],
+                          dv, di);
+#pragma unroll
             for (int k = 0; k < K; k++) {
-                av[k] = s_topv[(size_t)tid * K + k];
-                ai[k] = s_topi[(size_t)tid * K + k];
-                bv[k] = s_topv[(size_t)(tid + stride) * K + k];
-                bi[k] = s_topi[(size_t)(tid + stride) * K + k];
+                s_topv[tid * K + k] = dv[k];
+                s_topi[tid * K + k] = di[k];
             }
-            int ia = 0, ib = 0;
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        const int idx = row * split + s;
+        part_max[idx] = s_max[0];
+        part_sum[idx] = s_sum[0];
+#pragma unroll
+        for (int k = 0; k < K; k++) {
+            part_v[(size_t)idx * K + k] = s_topv[k];
+            part_i[(size_t)idx * K + k] = s_topi[k];
+        }
+    }
+}
+
+#undef DFLASH_TOPK_CONSUME
+
+// ---- pass 2: merge the `split` partials per position into the final top-K --
+// Grid: n_positions blocks of blockDim = pow2_ceil(split) threads. Thread t
+// loads partial t (or an identity when t >= split), then a shared-memory tree
+// reduction merges all partials. log_prob[k] = top_v[k] - log_z.
+template <int K>
+__global__ void draft_topk_combine(const float * __restrict__ part_max,
+                                   const float * __restrict__ part_sum,
+                                   const float * __restrict__ part_v,
+                                   const int32_t * __restrict__ part_i,
+                                   int split,
+                                   float * __restrict__ out_lp,
+                                   int32_t * __restrict__ out_ids) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;     // blockDim is pow2_ceil(split)
+
+    __shared__ float s_max[kMaxSplit];
+    __shared__ float s_sum[kMaxSplit];
+    __shared__ float s_topv[kMaxSplit * K];
+    __shared__ int32_t s_topi[kMaxSplit * K];
+
+    if (tid < split) {
+        const int idx = row * split + tid;
+        s_max[tid] = part_max[idx];
+        s_sum[tid] = part_sum[idx];
+#pragma unroll
+        for (int k = 0; k < K; k++) {
+            s_topv[tid * K + k] = part_v[(size_t)idx * K + k];
+            s_topi[tid * K + k] = part_i[(size_t)idx * K + k];
+        }
+    } else {
+        s_max[tid] = -FLT_MAX;
+        s_sum[tid] = 0.0f;
+#pragma unroll
+        for (int k = 0; k < K; k++) {
+            s_topv[tid * K + k] = -FLT_MAX;
+            s_topi[tid * K + k] = -1;
+        }
+    }
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            const float am = s_max[tid],          as = s_sum[tid];
+            const float bm = s_max[tid + stride], bs = s_sum[tid + stride];
+            const float m = fmaxf(am, bm);
+            s_sum[tid] = as * __expf(am - m) + bs * __expf(bm - m);
+            s_max[tid] = m;
+
+            float dv[K]; int di[K];
+            merge_topk<K>(&s_topv[tid * K],            &s_topi[tid * K],
+                          &s_topv[(tid + stride) * K], &s_topi[(tid + stride) * K],
+                          dv, di);
+#pragma unroll
             for (int k = 0; k < K; k++) {
-                bool takeA;
-                if      (ib >= K)          takeA = true;
-                else if (ia >= K)          takeA = false;
-                else if (av[ia] > bv[ib])  takeA = true;
-                else if (av[ia] < bv[ib])  takeA = false;
-                else                       takeA = (ai[ia] <= bi[ib]);  // tie → lower id
-                if (takeA) { s_topv[(size_t)tid * K + k] = av[ia]; s_topi[(size_t)tid * K + k] = ai[ia]; ia++; }
-                else       { s_topv[(size_t)tid * K + k] = bv[ib]; s_topi[(size_t)tid * K + k] = bi[ib]; ib++; }
+                s_topv[tid * K + k] = dv[k];
+                s_topi[tid * K + k] = di[k];
             }
         }
         __syncthreads();
@@ -105,6 +242,7 @@ __global__ void draft_topk_kernel(const float * __restrict__ logits,
 
     if (tid == 0) {
         const float log_z = s_max[0] + logf(s_sum[0]);
+#pragma unroll
         for (int k = 0; k < K; k++) {
             out_lp[(size_t)row * K + k]  = s_topv[k] - log_z;
             out_ids[(size_t)row * K + k] = s_topi[k];
@@ -112,29 +250,80 @@ __global__ void draft_topk_kernel(const float * __restrict__ logits,
     }
 }
 
-// Per-device scratch for the [n_positions × K] outputs, grown as needed. The
-// decode loop is single-threaded, so a plain static cache is safe and avoids a
+// Per-device scratch for the [n_positions × K] outputs plus the
+// [n_positions × split × K] pass-1 partials, grown as needed. The decode loop
+// is single-threaded, so a plain static cache is safe and avoids a
 // cudaMalloc/cudaFree on every step.
 struct Scratch {
-    int       device = -1;
-    size_t    cap    = 0;       // elements
-    float *   d_lp   = nullptr;
-    int32_t * d_ids  = nullptr;
+    int       device   = -1;
+    size_t    cap       = 0;       // output elements (n_positions*K)
+    size_t    part_cap  = 0;       // partial-list elements (n_positions*split*kMaxK)
+    float *   d_lp      = nullptr;
+    int32_t * d_ids     = nullptr;
+    float *   d_pmax    = nullptr; // [n_positions*split]
+    float *   d_psum    = nullptr; // [n_positions*split]
+    float *   d_pv      = nullptr; // [n_positions*split*kMaxK]
+    int32_t * d_pi      = nullptr; // [n_positions*split*kMaxK]
 };
 Scratch g_scratch;
 
-bool ensure_scratch(int device, size_t n) {
-    if (g_scratch.device == device && g_scratch.cap >= n) return true;
-    if (g_scratch.d_lp)  cudaFree(g_scratch.d_lp);
-    if (g_scratch.d_ids) cudaFree(g_scratch.d_ids);
+void free_scratch() {
+    if (g_scratch.d_lp)   cudaFree(g_scratch.d_lp);
+    if (g_scratch.d_ids)  cudaFree(g_scratch.d_ids);
+    if (g_scratch.d_pmax) cudaFree(g_scratch.d_pmax);
+    if (g_scratch.d_psum) cudaFree(g_scratch.d_psum);
+    if (g_scratch.d_pv)   cudaFree(g_scratch.d_pv);
+    if (g_scratch.d_pi)   cudaFree(g_scratch.d_pi);
     g_scratch = Scratch{};
-    if (cudaMalloc(&g_scratch.d_lp,  n * sizeof(float))   != cudaSuccess) return false;
-    if (cudaMalloc(&g_scratch.d_ids, n * sizeof(int32_t)) != cudaSuccess) {
-        cudaFree(g_scratch.d_lp); g_scratch.d_lp = nullptr; return false;
-    }
-    g_scratch.device = device;
-    g_scratch.cap    = n;
+}
+
+// Allocate output + partial buffers. n = n_positions*K outputs;
+// n_parts = n_positions*split partials (each carrying K entries).
+bool ensure_scratch(int device, size_t n, size_t n_parts) {
+    const size_t n_part_lists = n_parts * (size_t)kMaxK;  // upper bound on K
+    if (g_scratch.device == device && g_scratch.cap >= n &&
+        g_scratch.part_cap >= n_part_lists)
+        return true;
+    free_scratch();
+    if (cudaMalloc(&g_scratch.d_lp,   n            * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&g_scratch.d_ids,  n            * sizeof(int32_t)) != cudaSuccess) goto fail;
+    if (cudaMalloc(&g_scratch.d_pmax, n_parts      * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&g_scratch.d_psum, n_parts      * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&g_scratch.d_pv,   n_part_lists * sizeof(float))   != cudaSuccess) goto fail;
+    if (cudaMalloc(&g_scratch.d_pi,   n_part_lists * sizeof(int32_t)) != cudaSuccess) goto fail;
+    g_scratch.device   = device;
+    g_scratch.cap      = n;
+    g_scratch.part_cap = n_part_lists;
     return true;
+fail:
+    free_scratch();
+    return false;
+}
+
+inline int pow2_ceil(int x) {
+    int p = 1;
+    while (p < x) p <<= 1;
+    return p;
+}
+
+// Choose how many blocks to split each position's vocab scan across. The work
+// is bandwidth bound, so we want enough total blocks (n_positions × split) to
+// saturate the device while keeping each chunk large enough that the strided
+// reads stay coalesced and per-block overhead stays amortized.
+int pick_split(int vocab, int n_positions) {
+    if (const char * v = std::getenv("DFLASH_TOPK_SPLIT")) {
+        int s = std::atoi(v);
+        if (s >= 1 && s <= kMaxSplit) return s;
+    }
+    // Aim for ~240 total blocks (≈3 waves on a ~80-SM device, measured sweet
+    // spot for vocab~150k), but cap the chunk floor at ~2k elements so a block
+    // never scans too little to be worth launching.
+    int by_blocks = (240 + n_positions - 1) / n_positions;
+    int by_chunk  = vocab / 2048;
+    int split = by_blocks < by_chunk ? by_blocks : by_chunk;
+    if (split < 1)         split = 1;
+    if (split > kMaxSplit) split = kMaxSplit;
+    return split;
 }
 
 }  // namespace
@@ -160,25 +349,44 @@ bool extract_draft_topk_cuda(const void * d_logits,
 
     static const bool kProfile = std::getenv("DFLASH_TOPK_PROFILE") != nullptr;
     bool ok = false;
-    const size_t n = (size_t)n_positions * K;
-    if (ensure_scratch(dev, n)) {
-        const float  inv_t = 1.0f / fmaxf(1e-3f, temperature);
-        const size_t smem  = (size_t)kBlock * K * (sizeof(float) + sizeof(int32_t));
-        // Opt in to >48 KiB dynamic shared (once per device). If it fails the
-        // launch below will error and we fall back to the CPU path.
-        static int s_optin_dev = -1;
-        if (s_optin_dev != dev) {
-            constexpr int kMaxSmem = (int)((size_t)kBlock * kMaxK *
-                                           (sizeof(float) + sizeof(int32_t)));
-            cudaFuncSetAttribute(draft_topk_kernel,
-                                 cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxSmem);
-            s_optin_dev = dev;
-        }
+    const int    split   = pick_split(vocab, n_positions);
+    const size_t n       = (size_t)n_positions * K;
+    const size_t n_parts = (size_t)n_positions * split;
+    if (ensure_scratch(dev, n, n_parts)) {
+        const float inv_t = 1.0f / fmaxf(1e-3f, temperature);
         cudaEvent_t e_k0, e_k1, e_c1;
         if (kProfile) { cudaEventCreate(&e_k0); cudaEventCreate(&e_k1); cudaEventCreate(&e_c1); cudaEventRecord(e_k0); }
-        draft_topk_kernel<<<n_positions, kBlock, smem>>>(
-            static_cast<const float *>(d_logits), vocab, K, inv_t,
-            g_scratch.d_lp, g_scratch.d_ids);
+
+        const dim3 grid1(n_positions, split);
+        const int  comb_block = pow2_ceil(split);
+        const float * lp_in = static_cast<const float *>(d_logits);
+        // float4 loads are safe only when every row base is 16-byte aligned:
+        // the tensor base aligned and a vocab stride that is a multiple of 4.
+        const bool use_vec = (vocab % 4 == 0) &&
+                             (reinterpret_cast<uintptr_t>(lp_in) % 16 == 0);
+        // K (and the vectorization flag) are compile-time template parameters
+        // so the per-thread/per-partial top-K stays register-resident; dispatch
+        // the runtime K to its instantiation. K>kMaxK is already rejected above.
+#define DFLASH_TOPK_LAUNCH(KV, VEC)                                                             \
+            draft_topk_partial<KV, VEC><<<grid1, kBlock>>>(                                     \
+                lp_in, vocab, inv_t, split,                                                     \
+                g_scratch.d_pmax, g_scratch.d_psum, g_scratch.d_pv, g_scratch.d_pi);           \
+            draft_topk_combine<KV><<<n_positions, comb_block>>>(                                \
+                g_scratch.d_pmax, g_scratch.d_psum, g_scratch.d_pv, g_scratch.d_pi,            \
+                split, g_scratch.d_lp, g_scratch.d_ids);
+#define DFLASH_TOPK_CASE(KV)                                                                    \
+            case KV:                                                                            \
+                if (use_vec) { DFLASH_TOPK_LAUNCH(KV, true) }                                   \
+                else         { DFLASH_TOPK_LAUNCH(KV, false) }                                  \
+                break;
+        switch (K) {
+            DFLASH_TOPK_CASE(1) DFLASH_TOPK_CASE(2) DFLASH_TOPK_CASE(3) DFLASH_TOPK_CASE(4)
+            DFLASH_TOPK_CASE(5) DFLASH_TOPK_CASE(6) DFLASH_TOPK_CASE(7) DFLASH_TOPK_CASE(8)
+            default: break;
+        }
+#undef DFLASH_TOPK_CASE
+#undef DFLASH_TOPK_LAUNCH
+
         if (kProfile) cudaEventRecord(e_k1);
         if (cudaGetLastError() == cudaSuccess && cudaDeviceSynchronize() == cudaSuccess) {
             const cudaError_t e1 = cudaMemcpy(out_log_probs, g_scratch.d_lp,
@@ -192,8 +400,8 @@ bool extract_draft_topk_cuda(const void * d_logits,
             float k_ms = 0, c_ms = 0;
             cudaEventElapsedTime(&k_ms, e_k0, e_k1);
             cudaEventElapsedTime(&c_ms, e_k1, e_c1);
-            std::fprintf(stderr, "[topk] kernel=%.3f ms  sync+copy=%.3f ms (n_pos=%d vocab=%d)\n",
-                         k_ms, c_ms, n_positions, vocab);
+            std::fprintf(stderr, "[topk] kernels=%.3f ms  sync+copy=%.3f ms (n_pos=%d vocab=%d split=%d)\n",
+                         k_ms, c_ms, n_positions, vocab, split);
             cudaEventDestroy(e_k0); cudaEventDestroy(e_k1); cudaEventDestroy(e_c1);
         }
     }

--- a/server/src/common/draft_topk_cuda.cu
+++ b/server/src/common/draft_topk_cuda.cu
@@ -1,0 +1,205 @@
+// GPU top-K + log-prob extraction for DDTree draft distributions.
+// See draft_topk_cuda.h for the contract. Mirrors extract_draft_topk (ddtree.cpp).
+
+#include "draft_topk_cuda.h"
+
+#include <cuda_runtime.h>
+#include <cfloat>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace dflash::common {
+
+namespace {
+
+constexpr int kMaxK  = 8;     // ddtree_K is 8 in practice; K>kMaxK → CPU fallback
+constexpr int kBlock = 1024;  // threads per position (power of two for the reduction)
+// With only n_positions (~15) blocks, occupancy is capped by blocks, not
+// threads — so we want many warps per block to hide the vocab read latency.
+// 1024 threads × kMaxK × (float+int32) = 64 KiB dynamic shared, which exceeds
+// the 48 KiB default and needs an opt-in (see ensure_smem_optin below).
+
+// One block per draft position. A single strided pass over the vocabulary
+// accumulates a per-thread online logsumexp (running max + sum) and a
+// per-thread sorted-descending top-K; a shared-memory tree reduction then
+// merges both across threads. log_prob[k] = scaled_logit[k] - log_z.
+__global__ void draft_topk_kernel(const float * __restrict__ logits,
+                                  int vocab, int K, float inv_t,
+                                  float * __restrict__ out_lp,
+                                  int32_t * __restrict__ out_ids) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    const float * __restrict__ li = logits + (size_t)row * vocab;
+
+    float lmax = -FLT_MAX;
+    float lsum = 0.0f;
+    float topv[kMaxK];
+    int   topi[kMaxK];
+#pragma unroll
+    for (int k = 0; k < kMaxK; k++) { topv[k] = -FLT_MAX; topi[k] = -1; }
+
+    // ---- single strided pass: logsumexp + local top-K ------------------
+    // j ascends within a thread, so a strict-greater insert keeps the lower
+    // id on ties (matches the CPU heap's first-wins behaviour).
+    for (int j = tid; j < vocab; j += kBlock) {
+        const float l = li[j] * inv_t;
+        if (l > lmax) { lsum = lsum * __expf(lmax - l) + 1.0f; lmax = l; }
+        else          { lsum += __expf(l - lmax); }
+        if (l > topv[K - 1]) {
+            int p = K - 1;
+            while (p > 0 && topv[p - 1] < l) {
+                topv[p] = topv[p - 1]; topi[p] = topi[p - 1]; --p;
+            }
+            topv[p] = l; topi[p] = j;
+        }
+    }
+
+    // ---- block reduction --------------------------------------------------
+    __shared__ float s_max[kBlock];
+    __shared__ float s_sum[kBlock];
+    extern __shared__ char s_raw[];
+    float   * s_topv = reinterpret_cast<float   *>(s_raw);
+    int32_t * s_topi = reinterpret_cast<int32_t *>(s_topv + (size_t)kBlock * K);
+
+    s_max[tid] = lmax;
+    s_sum[tid] = lsum;
+    for (int k = 0; k < K; k++) {
+        s_topv[(size_t)tid * K + k] = topv[k];
+        s_topi[(size_t)tid * K + k] = topi[k];
+    }
+    __syncthreads();
+
+    for (int stride = kBlock / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            // logsumexp merge of (max,sum) pairs
+            const float am = s_max[tid],          as = s_sum[tid];
+            const float bm = s_max[tid + stride], bs = s_sum[tid + stride];
+            const float m = fmaxf(am, bm);
+            s_sum[tid] = as * __expf(am - m) + bs * __expf(bm - m);
+            s_max[tid] = m;
+
+            // merge two sorted-desc top-K lists, keep the K largest (lower id on tie)
+            float av[kMaxK]; int ai[kMaxK];
+            float bv[kMaxK]; int bi[kMaxK];
+            for (int k = 0; k < K; k++) {
+                av[k] = s_topv[(size_t)tid * K + k];
+                ai[k] = s_topi[(size_t)tid * K + k];
+                bv[k] = s_topv[(size_t)(tid + stride) * K + k];
+                bi[k] = s_topi[(size_t)(tid + stride) * K + k];
+            }
+            int ia = 0, ib = 0;
+            for (int k = 0; k < K; k++) {
+                bool takeA;
+                if      (ib >= K)          takeA = true;
+                else if (ia >= K)          takeA = false;
+                else if (av[ia] > bv[ib])  takeA = true;
+                else if (av[ia] < bv[ib])  takeA = false;
+                else                       takeA = (ai[ia] <= bi[ib]);  // tie → lower id
+                if (takeA) { s_topv[(size_t)tid * K + k] = av[ia]; s_topi[(size_t)tid * K + k] = ai[ia]; ia++; }
+                else       { s_topv[(size_t)tid * K + k] = bv[ib]; s_topi[(size_t)tid * K + k] = bi[ib]; ib++; }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        const float log_z = s_max[0] + logf(s_sum[0]);
+        for (int k = 0; k < K; k++) {
+            out_lp[(size_t)row * K + k]  = s_topv[k] - log_z;
+            out_ids[(size_t)row * K + k] = s_topi[k];
+        }
+    }
+}
+
+// Per-device scratch for the [n_positions × K] outputs, grown as needed. The
+// decode loop is single-threaded, so a plain static cache is safe and avoids a
+// cudaMalloc/cudaFree on every step.
+struct Scratch {
+    int       device = -1;
+    size_t    cap    = 0;       // elements
+    float *   d_lp   = nullptr;
+    int32_t * d_ids  = nullptr;
+};
+Scratch g_scratch;
+
+bool ensure_scratch(int device, size_t n) {
+    if (g_scratch.device == device && g_scratch.cap >= n) return true;
+    if (g_scratch.d_lp)  cudaFree(g_scratch.d_lp);
+    if (g_scratch.d_ids) cudaFree(g_scratch.d_ids);
+    g_scratch = Scratch{};
+    if (cudaMalloc(&g_scratch.d_lp,  n * sizeof(float))   != cudaSuccess) return false;
+    if (cudaMalloc(&g_scratch.d_ids, n * sizeof(int32_t)) != cudaSuccess) {
+        cudaFree(g_scratch.d_lp); g_scratch.d_lp = nullptr; return false;
+    }
+    g_scratch.device = device;
+    g_scratch.cap    = n;
+    return true;
+}
+
+}  // namespace
+
+bool extract_draft_topk_cuda(const void * d_logits,
+                             int n_positions, int vocab, int K,
+                             float * out_log_probs,
+                             int32_t * out_token_ids,
+                             float temperature) {
+    if (!d_logits || n_positions <= 0 || vocab <= 0 || K <= 0 || K > kMaxK) return false;
+
+    cudaPointerAttributes attr{};
+    if (cudaPointerGetAttributes(&attr, d_logits) != cudaSuccess) {
+        cudaGetLastError();  // clear the error so we don't poison the next CUDA call
+        return false;
+    }
+    if (attr.type != cudaMemoryTypeDevice) return false;
+
+    int prev = 0;
+    cudaGetDevice(&prev);
+    const int dev = attr.device;
+    if (dev != prev) cudaSetDevice(dev);
+
+    static const bool kProfile = std::getenv("DFLASH_TOPK_PROFILE") != nullptr;
+    bool ok = false;
+    const size_t n = (size_t)n_positions * K;
+    if (ensure_scratch(dev, n)) {
+        const float  inv_t = 1.0f / fmaxf(1e-3f, temperature);
+        const size_t smem  = (size_t)kBlock * K * (sizeof(float) + sizeof(int32_t));
+        // Opt in to >48 KiB dynamic shared (once per device). If it fails the
+        // launch below will error and we fall back to the CPU path.
+        static int s_optin_dev = -1;
+        if (s_optin_dev != dev) {
+            constexpr int kMaxSmem = (int)((size_t)kBlock * kMaxK *
+                                           (sizeof(float) + sizeof(int32_t)));
+            cudaFuncSetAttribute(draft_topk_kernel,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxSmem);
+            s_optin_dev = dev;
+        }
+        cudaEvent_t e_k0, e_k1, e_c1;
+        if (kProfile) { cudaEventCreate(&e_k0); cudaEventCreate(&e_k1); cudaEventCreate(&e_c1); cudaEventRecord(e_k0); }
+        draft_topk_kernel<<<n_positions, kBlock, smem>>>(
+            static_cast<const float *>(d_logits), vocab, K, inv_t,
+            g_scratch.d_lp, g_scratch.d_ids);
+        if (kProfile) cudaEventRecord(e_k1);
+        if (cudaGetLastError() == cudaSuccess && cudaDeviceSynchronize() == cudaSuccess) {
+            const cudaError_t e1 = cudaMemcpy(out_log_probs, g_scratch.d_lp,
+                                              n * sizeof(float), cudaMemcpyDeviceToHost);
+            const cudaError_t e2 = cudaMemcpy(out_token_ids, g_scratch.d_ids,
+                                              n * sizeof(int32_t), cudaMemcpyDeviceToHost);
+            ok = (e1 == cudaSuccess && e2 == cudaSuccess);
+        }
+        if (kProfile) {
+            cudaEventRecord(e_c1); cudaEventSynchronize(e_c1);
+            float k_ms = 0, c_ms = 0;
+            cudaEventElapsedTime(&k_ms, e_k0, e_k1);
+            cudaEventElapsedTime(&c_ms, e_k1, e_c1);
+            std::fprintf(stderr, "[topk] kernel=%.3f ms  sync+copy=%.3f ms (n_pos=%d vocab=%d)\n",
+                         k_ms, c_ms, n_positions, vocab);
+            cudaEventDestroy(e_k0); cudaEventDestroy(e_k1); cudaEventDestroy(e_c1);
+        }
+    }
+    if (!ok) cudaGetLastError();
+    if (dev != prev) cudaSetDevice(prev);
+    return ok;
+}
+
+}  // namespace dflash::common

--- a/server/src/common/draft_topk_cuda.h
+++ b/server/src/common/draft_topk_cuda.h
@@ -1,0 +1,34 @@
+// GPU top-K + log-prob extraction for DDTree draft distributions.
+//
+// Drop-in device-side replacement for extract_draft_topk (ddtree.cpp): instead
+// of D2H-ing the full [vocab × n_positions] draft logits and running an OpenMP
+// heap top-K + online-logsumexp on the CPU, this runs the whole thing on the
+// GPU directly on the logits tensor's device buffer and copies back only the
+// [n_positions × K] results.
+//
+// Semantics match extract_draft_topk exactly:
+//   scaled        = logit * (1 / max(1e-3, temperature))
+//   log_z         = logsumexp_j(scaled_j)                       (per position)
+//   out_log_probs = top-K scaled logits (desc), minus log_z
+//   out_token_ids = matching vocab ids; ties broken toward the lower id
+//
+// Returns false (caller must fall back to the CPU path) when CUDA is
+// unavailable, the pointer is not device memory, K is out of range, or any
+// CUDA call fails. Only compiled into CUDA builds; see CMakeLists.txt.
+
+#pragma once
+
+#include <cstdint>
+
+namespace dflash::common {
+
+// d_logits: device pointer to row-major [n_positions][vocab] f32 logits (the
+//           position stride is `vocab` floats — pass an offset pointer to skip
+//           leading positions). out_* are HOST buffers of size n_positions*K.
+bool extract_draft_topk_cuda(const void * d_logits,
+                             int n_positions, int vocab, int K,
+                             float * out_log_probs,
+                             int32_t * out_token_ids,
+                             float temperature);
+
+}  // namespace dflash::common

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -5,6 +5,7 @@
 #include "graph_builders.h"
 #include "step_graph.h"
 #include "attn_masks.h"
+#include "common/draft_topk_cuda.h"
 // gpu_runtime_compat.h maps the raw cudaStream_t / cudaMemcpy* symbols used
 // below (rollback_to / rollback_to_tree) onto their HIP equivalents. Without
 // it the file only compiles on CUDA via a transitive <cuda_runtime.h>; HIP
@@ -656,12 +657,28 @@ bool Qwen35DFlashTarget::project_hidden_to_topk(
     if (st != GGML_STATUS_SUCCESS) return false;
 
     const int vocab = (int)proj_sg_.logits->ne[0];
+    top_log_probs.assign((size_t)n_tokens * K, 0.0f);
+    top_token_ids.assign((size_t)n_tokens * K, 0);
+
+#ifdef DFLASH27B_HAVE_DRAFT_TOPK_CUDA
+    // GPU path: top-K + logsumexp directly on the logits device buffer, skipping
+    // the vocab×n_tokens D2H and the CPU heap extract. Falls back to the CPU path
+    // on any failure. Escape hatch: DFLASH_GPU_DRAFT_TOPK=0.
+    static const bool kGpuDraftTopk = []() {
+        const char * v = std::getenv("DFLASH_GPU_DRAFT_TOPK");
+        return v == nullptr || v[0] != '0';
+    }();
+    if (kGpuDraftTopk &&
+        extract_draft_topk_cuda(proj_sg_.logits->data, n_tokens, vocab, K,
+                                top_log_probs.data(), top_token_ids.data(),
+                                temperature)) {
+        return true;
+    }
+#endif
+
     std::vector<float> logits((size_t)vocab * n_tokens);
     ggml_backend_tensor_get(proj_sg_.logits, logits.data(), 0,
                             sizeof(float) * (size_t)vocab * n_tokens);
-
-    top_log_probs.assign((size_t)n_tokens * K, 0.0f);
-    top_token_ids.assign((size_t)n_tokens * K, 0);
     extract_draft_topk(logits.data(), n_tokens, vocab, K,
                        top_log_probs.data(), top_token_ids.data(), temperature);
     return true;

--- a/server/src/qwen35/qwen35_dflash_target.cpp
+++ b/server/src/qwen35/qwen35_dflash_target.cpp
@@ -278,13 +278,38 @@ bool Qwen35DFlashTarget::verify_tree(
         return false;
     }
 
-    // Posterior = per-node target argmax. Tree-shaped graphs can return -1 from
-    // the GPU argmax shortcut, so compute argmax on CPU from full logits.
+    // Posterior = per-node target argmax.
+    //
+    // The verify graph already computes a batched per-node GPU argmax
+    // (sg_.argmax_tokens, built by build_target_step_tree). When the caller does
+    // not need the full logits (greedy decode, logits_out == nullptr) we read
+    // those N_actual int32s directly and skip the vocab×N_actual D2H + CPU
+    // argmax entirely — eliminates the verify-logits transfer hotspot.
+    //
+    // Historically the GPU argmax shortcut has returned -1 for tree-shaped
+    // verify graphs on some builds; guard against that by validating every row
+    // and falling back to the CPU path for the step if any index is bad.
+    // Escape hatch: DFLASH_GPU_VERIFY_ARGMAX=0 forces the legacy CPU path.
+    static const bool kGpuVerifyArgmax = []() {
+        const char * v = std::getenv("DFLASH_GPU_VERIFY_ARGMAX");
+        return v == nullptr || v[0] != '0';
+    }();
     const int vocab = (int)sg_.logits->ne[0];
+    posterior_out.resize(N_actual);
+
+    if (kGpuVerifyArgmax && !logits_out && sg_.argmax_tokens) {
+        ggml_backend_tensor_get(sg_.argmax_tokens, posterior_out.data(), 0,
+                                sizeof(int32_t) * N_actual);
+        bool ok = true;
+        for (int i = 0; i < N_actual; i++) {
+            if (posterior_out[i] < 0 || posterior_out[i] >= vocab) { ok = false; break; }
+        }
+        if (ok) return true;  // fast path; otherwise fall through to CPU argmax
+    }
+
     std::vector<float> logits((size_t)vocab * N_actual);
     ggml_backend_tensor_get(sg_.logits, logits.data(), 0,
                             sizeof(float) * (size_t)vocab * N_actual);
-    posterior_out.resize(N_actual);
     for (int i = 0; i < N_actual; i++) {
         const float * row = logits.data() + (size_t)i * vocab;
         int am = 0; float best = row[0];

--- a/server/test/test_dflash.cpp
+++ b/server/test/test_dflash.cpp
@@ -270,6 +270,7 @@ using dflash::common::free_qwen35_layer_split_shards;
 #include "qwen35_layer_split_dflash_target.h"
 #include "common/dflash_spec_decode.h"
 #include "common/gguf_mmap.h"
+#include "common/draft_topk_cuda.h"
 using dflash::common::is_eos_tok;
 
 // ─── Layer-split daemon — extracted to src/qwen35/layer_split_daemon.{h,cpp} ─
@@ -3268,16 +3269,35 @@ int main(int argc, char ** argv) {
                 }
             } else {
                 // DDTree K>1: need real log-probs for best-first tree scoring.
-                // Transfer full logits for positions 1..q_len-1.
-                if (!draft_hidden_bridge) {
-                    ggml_backend_tensor_get(draft_sg.logits, draft_logits_buf.data(), 0,
-                                            sizeof(float) * vocab * q_len);
+                bool topk_done = false;
+#ifdef DFLASH27B_HAVE_DRAFT_TOPK_CUDA
+                // GPU path: top-K + logsumexp on the draft logits device buffer
+                // (positions 1..q_len-1), no full-vocab D2H. Escape: DFLASH_GPU_DRAFT_TOPK=0.
+                static const bool kGpuDraftTopk = [](){
+                    const char * v = std::getenv("DFLASH_GPU_DRAFT_TOPK");
+                    return v == nullptr || v[0] != '0';
+                }();
+                if (kGpuDraftTopk && !draft_hidden_bridge) {
+                    topk_done = dflash::common::extract_draft_topk_cuda(
+                        (const float *)draft_sg.logits->data + (size_t)vocab,
+                        L, vocab, ddtree_K,
+                        ddtree_top_log_probs.data(),
+                        ddtree_top_token_ids.data(),
+                        ddtree_temp);
                 }
-                extract_draft_topk(draft_logits_buf.data() + (size_t)vocab,
-                                   L, vocab, ddtree_K,
-                                   ddtree_top_log_probs.data(),
-                                   ddtree_top_token_ids.data(),
-                                   ddtree_temp);
+#endif
+                if (!topk_done) {
+                    // Transfer full logits for positions 1..q_len-1, extract on CPU.
+                    if (!draft_hidden_bridge) {
+                        ggml_backend_tensor_get(draft_sg.logits, draft_logits_buf.data(), 0,
+                                                sizeof(float) * vocab * q_len);
+                    }
+                    extract_draft_topk(draft_logits_buf.data() + (size_t)vocab,
+                                       L, vocab, ddtree_K,
+                                       ddtree_top_log_probs.data(),
+                                       ddtree_top_token_ids.data(),
+                                       ddtree_temp);
+                }
             }
         }
         auto T_draft_logits = sync_us();

--- a/server/test/test_dflash.cpp
+++ b/server/test/test_dflash.cpp
@@ -3417,16 +3417,40 @@ int main(int argc, char ** argv) {
             T_verify_compute = sync_us();
             tt_verify_compute += std::chrono::duration<double, std::micro>(T_verify_compute - T_verify_set).count();
 
-            // DDTree test mode reads full logits and computes posterior on
-            // CPU. The GPU argmax shortcut has returned -1 for tree-shaped
-            // verify graphs on some builds, which makes the harness stop
-            // after the root even though logits are valid. This is test-only;
-            // server decode paths are unaffected.
+            // DDTree posterior: per-node argmax over the verify logits.
+            //   default        : full vocab×N D2H + CPU argmax (legacy).
+            //   GPU_VERIFY_ARGMAX=1: read the in-graph batched GPU argmax
+            //                        (tree_verify_argmax) — N int32s, no bulk D2H.
+            //   GPU_VERIFY_ARGMAX=2: run BOTH and report per-step mismatches
+            //                        (validates the historical "-1 / tie" concern).
+            static const int kGpuVerifyArgmax = [](){
+                const char * v = std::getenv("DFLASH_GPU_VERIFY_ARGMAX");
+                return v ? std::atoi(v) : 0;
+            }();
             std::vector<int32_t> posterior(N_actual);
-            ggml_backend_tensor_get(sg.logits, verify_logits_buf.data(), 0,
-                                    sizeof(float) * (size_t)vocab * N_actual);
-            for (int i = 0; i < N_actual; i++) {
-                posterior[i] = argmax_f32(verify_logits_buf.data() + (size_t)i * vocab, vocab);
+            bool logits_resident = false;  // verify_logits_buf populated this step?
+            if (kGpuVerifyArgmax == 1 && sg.argmax_tokens) {
+                ggml_backend_tensor_get(sg.argmax_tokens, posterior.data(), 0,
+                                        sizeof(int32_t) * N_actual);
+            } else {
+                ggml_backend_tensor_get(sg.logits, verify_logits_buf.data(), 0,
+                                        sizeof(float) * (size_t)vocab * N_actual);
+                logits_resident = true;
+                for (int i = 0; i < N_actual; i++) {
+                    posterior[i] = argmax_f32(verify_logits_buf.data() + (size_t)i * vocab, vocab);
+                }
+                if (kGpuVerifyArgmax == 2 && sg.argmax_tokens) {
+                    std::vector<int32_t> gpu_post(N_actual);
+                    ggml_backend_tensor_get(sg.argmax_tokens, gpu_post.data(), 0,
+                                            sizeof(int32_t) * N_actual);
+                    int mism = 0, first = -1;
+                    for (int i = 0; i < N_actual; i++)
+                        if (gpu_post[i] != posterior[i]) { mism++; if (first < 0) first = i; }
+                    if (mism)
+                        std::fprintf(stderr, "[verify_argmax cmp] step=%d N=%d mismatches=%d "
+                                     "first@%d gpu=%d cpu=%d\n", n_draft_steps, N_actual, mism,
+                                     first, gpu_post[first], posterior[first]);
+                }
             }
             auto T_verify_logits_ddtree = sync_us();
             tt_verify_logits += std::chrono::duration<double, std::micro>(
@@ -3437,10 +3461,18 @@ int main(int argc, char ** argv) {
             int bonus_node_idx = 0;
             std::vector<int> accepted = follow_verified_tree(tree, posterior.data(), next_token, &bonus_node_idx);
             if (g_sampler.temp > 0.0f) {
+                // Sampling needs the bonus node's full logit row. If we took the
+                // GPU-argmax path we skipped the bulk D2H, so fetch just that row.
                 std::vector<float> bonus_logits(vocab);
-                std::memcpy(bonus_logits.data(),
-                            verify_logits_buf.data() + (size_t)bonus_node_idx * vocab,
-                            (size_t)vocab * sizeof(float));
+                if (logits_resident) {
+                    std::memcpy(bonus_logits.data(),
+                                verify_logits_buf.data() + (size_t)bonus_node_idx * vocab,
+                                (size_t)vocab * sizeof(float));
+                } else {
+                    ggml_backend_tensor_get(sg.logits, bonus_logits.data(),
+                                            (size_t)bonus_node_idx * vocab * sizeof(float),
+                                            (size_t)vocab * sizeof(float));
+                }
                 next_token = sample_logits(bonus_logits.data(), vocab, g_sampler, out_all, g_sampler_rng);
             }
             const int accept_depth = (int)accepted.size();  // includes root


### PR DESCRIPTION
Identifies two optimization opportunities in the current ddtree topk sampling path used in Lucebox.

1. Avoid an unnecessary logit copy since they're already stored.
2. Use gpu kernels for the top-k/p sampling logic instead of cpu.

Results in a 10% increase in tok/s.

Numbers can be reproduced by running `bench_llm.py` after re-building with the changes.

## Results before

[bench] ==== HumanEval (n=10, n_gen=256) ====
  [01/10] n_tok=  92  AR= 35.01  DFlash= 104.78  AL= 6.74
  [02/10] n_tok= 146  AR= 34.87  DFlash=  81.81  AL= 5.33
  [03/10] n_tok= 142  AR= 34.97  DFlash= 109.19  AL= 7.11
  [04/10] n_tok= 128  AR= 34.99  DFlash=  86.16  AL= 5.57
  [05/10] n_tok= 180  AR= 34.97  DFlash= 102.71  AL= 6.74
  [06/10] n_tok= 126  AR= 35.01  DFlash=  83.18  AL= 5.45
  [07/10] n_tok=  59  AR= 34.97  DFlash=  82.19  AL= 5.45
  [08/10] n_tok= 149  AR= 34.84  DFlash=  86.70  AL= 5.69
  [09/10] n_tok= 133  AR= 35.00  DFlash=  92.91  AL= 6.10
  [10/10] n_tok= 103  AR= 34.98  DFlash= 101.09  AL= 6.56
  **HumanEval mean: AR=34.96  DFlash=93.07  AL=6.07  2.66x**

## Results after

[bench] ==== HumanEval (n=10, n_gen=256) ====
  [01/10] n_tok=  92  AR= 34.99  DFlash= 114.57  AL= 6.74
  [02/10] n_tok= 146  AR= 34.99  DFlash=  90.09  AL= 5.33
  [03/10] n_tok= 142  AR= 34.78  DFlash= 119.89  AL= 7.11
  [04/10] n_tok= 128  AR= 35.01  DFlash=  94.21  AL= 5.57
  [05/10] n_tok= 180  AR= 34.99  DFlash= 110.81  AL= 6.74
  [06/10] n_tok= 126  AR= 35.00  DFlash=  91.61  AL= 5.45
  [07/10] n_tok=  59  AR= 34.88  DFlash=  91.96  AL= 5.45
  [08/10] n_tok= 149  AR= 34.98  DFlash=  94.89  AL= 5.69
  [09/10] n_tok= 133  AR= 34.96  DFlash= 102.11  AL= 6.10
  [10/10] n_tok= 103  AR= 34.95  DFlash= 110.48  AL= 6.56
  **HumanEval mean: AR=34.95  DFlash=102.06  AL=6.07  2.92x**

[bench] === SUMMARY ===
Task                AR    DFlash      AL   Speedup     Score
HumanEval        34.95    102.06    6.07     2.92x       

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

