### PR TITLE
fix(server): use standard context overflow error

### DIFF
--- a/server/src/server/http_server.cpp
+++ b/server/src/server/http_server.cpp
@@ -86,6 +86,15 @@ static inline const char* sock_strerror() { return strerror(errno); }
 
 namespace dflash::common {
 
+static std::string context_overflow_message(int max_ctx, int prompt_tokens, int max_output) {
+    const int requested_tokens = prompt_tokens + max_output;
+    return "This model's maximum context length is " + std::to_string(max_ctx) +
+           " tokens. However, you requested " + std::to_string(requested_tokens) +
+           " tokens (" + std::to_string(prompt_tokens) + " in the messages, " +
+           std::to_string(max_output) +
+           " in the completion). Please reduce the length of the messages or completion.";
+}
+
 // ─── piecewise keep-ratio curve ─────────────────────────────────────────
 
 static float pflash_keep_ratio(const ServerConfig & cfg, int n_tokens) {
@@ -1715,7 +1724,9 @@ bool HttpServer::route_request(int fd, const HttpRequest & hr) {
              n_prompt >= config_.pflash_threshold);
         if (should_reject_oversized(n_prompt, req.max_output,
                                     config_.max_ctx, pflash_will_run)) {
-            send_error(fd, 400, "prompt + max_tokens exceeds context window");
+            send_error(fd, 400,
+                       context_overflow_message(config_.max_ctx, n_prompt,
+                                                req.max_output));
             return true;
         }
     }
@@ -2243,7 +2254,11 @@ void HttpServer::worker_loop() {
         if (effective_prompt_overflows((int)effective_prompt.size(),
                                        pflash_full_cache_served_tokens,
                                        req.max_output, config_.max_ctx)) {
-            fail_request(400, "effective prompt + max_tokens exceeds context window after compression");
+            const int prompt_len = pflash_full_cache_served_tokens >= 0
+                ? pflash_full_cache_served_tokens
+                : (int)effective_prompt.size();
+            fail_request(400, context_overflow_message(config_.max_ctx, prompt_len,
+                                                       req.max_output));
             continue;
         }
 


### PR DESCRIPTION
The C++ server returned a terse Lucebox-specific 400 error when a request exceeded the context window:

```text
prompt + max_tokens exceeds context window
```

That is technically correct, but some OpenAI-compatible agent clients detect context overflow by matching the more common OpenAI/OpenRouter-style error wording. With the Lucebox-specific message, clients can treat the failure as a generic hard error instead of triggering their normal auto-compaction flow.

This PR changes the overflow message to include:

- the model context limit
- the total requested tokens
- prompt/message tokens
- completion/output tokens

Example:

```text
This model's maximum context length is 98304 tokens. However, you requested 99819 tokens (67051 in the messages, 32768 in the completion). Please reduce the length of the messages or completion.
```

## Why

This improves compatibility with OpenAI-style clients without changing the server's context accounting or accepting requests that should be rejected.

Observed with Pi against Lucebox:

```text
Error: 400 This model's maximum context length is 98304 tokens. However, you requested 99819 tokens (67051 in the messages, 32768 in the completion). Please reduce the length of the messages or completion.

Context overflow detected, Auto-compacting...
```

Before this change, the same overflow was not recognized as a context-overflow condition by the client.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Luce-Org/lucebox-hub/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

